### PR TITLE
Switch to new Dockerfile

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
   jbrowse2:
     image: jbrowse2:latest
     build:
-      dockerfile: docker-images/Dockerfile_jbrowse.dev.plugin.dockerfile
+      dockerfile: docker-images/Dockerfile_jbrowse.dev.240424.dockerfile
     ports: 
       - 3000:3000
       - 9010:9010

--- a/docker-images/Dockerfile_jbrowse.dev.240424.dockerfile
+++ b/docker-images/Dockerfile_jbrowse.dev.240424.dockerfile
@@ -1,0 +1,27 @@
+# Use a stable Node.js base image
+FROM node:16
+
+# Install the JBrowse CLI globally
+RUN npm install -g @jbrowse/cli
+
+# Create a directory for JBrowse
+WORKDIR /usr/src/jbrowse
+RUN jbrowse create jbrowse2
+WORKDIR /usr/src/jbrowse/jbrowse2
+
+# Clone and set up the plugin in a separate directory
+WORKDIR /usr/src/jbrowse/plugin
+RUN git clone https://github.com/depictio/jbrowse-watcher-plugin.git .
+
+# Install all dependencies including npm-run-all
+# Remove the yarn.lock if it exists to ensure npm is used for installation
+RUN rm -f yarn.lock && npm install --force
+
+# Now run build
+RUN npm run build
+
+# Expose the necessary ports
+# EXPOSE 3000 9010
+
+# Command to start the service
+CMD ["sh", "-c", "cd /usr/src/jbrowse/jbrowse2 && npx serve -S . & cd /usr/src/jbrowse/plugin && npm start"]

--- a/docker-images/Dockerfile_jbrowse.dev.plugin.dockerfile
+++ b/docker-images/Dockerfile_jbrowse.dev.plugin.dockerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/src/jbrowse/jbrowse2
 
 # Clone and set up the plugin in a separate directory
 WORKDIR /usr/src/plugin
-RUN git clone https://github.com/weber8thomas/jbrowse-watcher-plugin.git .
+RUN git clone https://github.com/depictio/jbrowse-watcher-plugin.git .
 RUN npm install --force
 # Uncomment if a build step is required for your plugin
 # RUN npm run build


### PR DESCRIPTION
This pull request updates the Dockerfile used for the jbrowse2 service. The new Dockerfile is located at `docker-images/Dockerfile_jbrowse.dev.240424.dockerfile`. Additionally, the plugin repository has been changed to `https://github.com/depictio/jbrowse-watcher-plugin.git`.