### PR TITLE
Fix typo related to .env leading to token issue

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
       - ./configs:/configs
       - ./data:/app/data
       - ./minio_data:/minio_data
-      - ./env:/app/.env
+      - ./.env:/app/.env
     command: ["python", "depictio/dash/app.py"]
     depends_on:
       - mongo


### PR DESCRIPTION
This pull request fixes a typo in the docker-compose.yml file that was causing a token issue. The typo was related to the volume mapping for the .env file. This fix ensures that the correct .env file is used by the application.