### PR TITLE
feat: Update depictio dash app.py to load depictio data based on dash…

### DIFF
--- a/depictio/dash/app.py
+++ b/depictio/dash/app.py
@@ -105,7 +105,7 @@ def create_management_layout():
 
 def create_dashboard_layout(dashboard_id=None):
     # Load depictio depictio_dash_data from JSON
-    depictio_dash_data = load_depictio_data()
+    depictio_dash_data = load_depictio_data(dashboard_id)
 
     # Init layout and children if depictio_dash_data is available, else set to empty
     init_layout = depictio_dash_data["stored_layout_data"] if depictio_dash_data else {}

--- a/depictio/dash/layouts/dashboards_management.py
+++ b/depictio/dash/layouts/dashboards_management.py
@@ -18,8 +18,8 @@ logger.info(dashboards_collection.count_documents({}))
 layout = html.Div(
     [
         dcc.Location(id="url", refresh=False),
-        dcc.Location(id="redirect-url", refresh=True),  # Add this component for redirection
-        dcc.Store(id="modal-store", storage_type="session", data={"email": "", "submitted": False}),
+        # dcc.Location(id="redirect-url", refresh=True),  # Add this component for redirection
+        dcc.Store(id="modal-store", storage_type="local", data={"email": "", "submitted": False}),
         dcc.Store(id="dashboard-modal-store", storage_type="memory", data={"title": ""}),  # Store for new dashboard data
         dmc.Modal(
             opened=False,
@@ -416,13 +416,14 @@ def register_callbacks_management(app):
                 if pathname.startswith("/dashboard/"):
                     dashboard_id = pathname.split("/")[-1]
                     # Fetch dashboard data based on dashboard_id and return the appropriate layout
-                    return html.Div([f"Displaying Dashboard {dashboard_id}", dbc.Button("Go back", href="/", color="black", external_link=True)])
+                    # return html.Div([f"Displaying Dashboard {dashboard_id}", dbc.Button("Go back", href="/", color="black", external_link=True)])
+                    return None
                 # Add more conditions for other routes
                 # return html.Div("This is the home page")
                 return dash.no_update
 
         # Respond to modal-store data changes
-        elif trigger_id == "modal-store":
+        if trigger_id == "modal-store":
             if data and data.get("submitted"):
                 return html.Div(
                     [

--- a/depictio/dash/layouts/draggable_scenarios/restore_dashboard.py
+++ b/depictio/dash/layouts/draggable_scenarios/restore_dashboard.py
@@ -9,7 +9,7 @@ from depictio.dash.modules.jbrowse_component.utils import build_jbrowse
 from depictio.dash.modules.table_component.utils import build_table
 
 
-def load_depictio_data():
+def load_depictio_data(dashboard_id):
     build_functions = {
         "card": build_card,
         "figure": build_figure,
@@ -18,48 +18,49 @@ def load_depictio_data():
         "jbrowse": build_jbrowse,
     }
 
-    dashboard_id = "1"
+    # dashboard_id = "1"
     dashboard_data = dashboards_collection.find_one({"dashboard_id": dashboard_id})
     logger.info("load_depictio_data")
     # logger.info(f"dashboard_data : {dashboard_data}")
 
     if dashboard_data:
         children = list()
-        for child_metadata in dashboard_data["stored_metadata"]:
-            child_metadata["build_frame"] = True
-            logger.info(child_metadata)
-            logger.info(f"type of child_metadata : {type(child_metadata)}")
+        if "stored_metadata" in dashboard_data:
+            for child_metadata in dashboard_data["stored_metadata"]:
+                child_metadata["build_frame"] = True
+                logger.info(child_metadata)
+                logger.info(f"type of child_metadata : {type(child_metadata)}")
 
-            # Extract the type of the child (assuming there is a type key in the metadata)
-            component_type = child_metadata.get("component_type", None)
-            logger.info(f"component_type : {component_type}")
-            if component_type not in build_functions:
-                logger.warning(f"Unsupported child type: {component_type}")
-                raise ValueError(f"Unsupported child type: {component_type}")
+                # Extract the type of the child (assuming there is a type key in the metadata)
+                component_type = child_metadata.get("component_type", None)
+                logger.info(f"component_type : {component_type}")
+                if component_type not in build_functions:
+                    logger.warning(f"Unsupported child type: {component_type}")
+                    raise ValueError(f"Unsupported child type: {component_type}")
 
-            # Get the build function based on the type
-            build_function = build_functions[component_type]
-            logger.info(f"build_function : {build_function.__name__}")
+                # Get the build function based on the type
+                build_function = build_functions[component_type]
+                logger.info(f"build_function : {build_function.__name__}")
 
-            # Build the child using the appropriate function and kwargs
-            child = build_function(**child_metadata)
-            logger.info(f"child : ")
-            # logger.info(child)
-            children.append(child)
+                # Build the child using the appropriate function and kwargs
+                child = build_function(**child_metadata)
+                logger.info(f"child : ")
+                # logger.info(child)
+                children.append(child)
 
-        if children:
-            logger.info(f"BEFORE child :")
+            if children:
+                logger.info(f"BEFORE child :")
 
-            # Convert children to their plotly JSON representation
-            children = [enable_box_edit_mode(child.to_plotly_json(), switch_state=True) for child in children]
-            # children = enable_box_edit_mode(children[0].to_plotly_json(), switch_state=True)
-            # logger.info(f"AFTER child : {children}")
+                # Convert children to their plotly JSON representation
+                children = [enable_box_edit_mode(child.to_plotly_json(), switch_state=True) for child in children]
+                # children = enable_box_edit_mode(children[0].to_plotly_json(), switch_state=True)
+                # logger.info(f"AFTER child : {children}")
 
-            dashboard_data["stored_children_data"] = children
-            # logger.info(f"dashboard_data['stored_children_data'] : {dashboard_data['stored_children_data']}")
-            logger.info(f"dashboard_data['stored_layout_data'] : {dashboard_data['stored_layout_data']}")
+                dashboard_data["stored_children_data"] = children
+                # logger.info(f"dashboard_data['stored_children_data'] : {dashboard_data['stored_children_data']}")
+                logger.info(f"dashboard_data['stored_layout_data'] : {dashboard_data['stored_layout_data']}")
 
-            return dashboard_data
+                return dashboard_data
         else:
             return None
 

--- a/depictio/dash/layouts/header.py
+++ b/depictio/dash/layouts/header.py
@@ -29,6 +29,7 @@ def register_callbacks_header(app):
         State("stored-edit-dashboard-mode-button", "data"),
         State("stored-add-button", "data"),
         State({"type": "interactive-component-value", "index": ALL}, "value"),
+        State("second-url", "pathname"),
         prevent_initial_call=True,
     )
     def save_data_dashboard(
@@ -39,6 +40,7 @@ def register_callbacks_header(app):
         edit_dashboard_mode_button,
         add_button,
         interactive_component_values,
+        pathname
     ):
         if n_clicks > 0:
             logger.info("\n\n\n")
@@ -75,7 +77,8 @@ def register_callbacks_header(app):
                 "stored_add_button": add_button,
                 "version": "1",
             }
-            dashboard_id = "1"
+            # dashboard_id = "1"
+            dashboard_id = pathname.split("/")[-1]
             dashboard_data["dashboard_id"] = dashboard_id
             logger.info("Dashboard data:")
             logger.info(dashboard_data)


### PR DESCRIPTION
* User authentication (with only email adress)
* Dashboards listing and management UI
* Routing to individual dashboard
* Save/restore metadata at the dashboard level using helpers

## TODO

### Major fixes

* Fix dcc.Store for `draggable_children` that share content over dashboards without starting a clean new session

### Aesthetics

* Display properly metadata: user, dashboard title, ID