### PR TITLE
Update tests for revised S3 settings

### DIFF
--- a/depictio/tests/api/v1/test_settings_models.py
+++ b/depictio/tests/api/v1/test_settings_models.py
@@ -3,15 +3,15 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from depictio.api.v1.configs.settings_models import (
-    Auth,
+    AuthConfig,
     Collections,
     DashConfig,
     FastAPIConfig,
-    JbrowseConfig,
-    MongoConfig,
+    JBrowseConfig,
+    MongoDBConfig,
+    S3DepictioCLIConfig,
     Settings,
 )
-from depictio.models.models.s3 import S3DepictioCLIConfig
 
 
 @contextmanager
@@ -71,54 +71,64 @@ class TestCollections:
         assert collections.workflow_collection == "workflows"
 
 
-class TestMongoConfig:
+class TestMongoDBConfig:
     def test_default_values(self):
         """Test MongoConfig with default values."""
         env_to_clear = {
-            "DEPICTIO_MONGODB_PORT": None,
+            "DEPICTIO_MONGODB_SERVICE_PORT": None,
+            "DEPICTIO_MONGODB_EXTERNAL_PORT": None,
             "DEPICTIO_MONGODB_DB_NAME": None,
             "DEPICTIO_MONGODB_WIPE": None,
         }
 
         with env_vars(env_to_clear):
-            config = MongoConfig()
+            config = MongoDBConfig()
 
             assert isinstance(config.collections, Collections)
             assert config.service_name == "mongo"
-            assert config.port == 27018
+            assert config.service_port == 27018
+            assert config.external_port == 27018
             assert config.db_name == "depictioDB"
             assert config.wipe is False
 
     def test_custom_values(self):
         """Test MongoConfig with custom values."""
         env_to_clear = {
-            "DEPICTIO_MONGODB_PORT": None,
+            "DEPICTIO_MONGODB_SERVICE_PORT": None,
+            "DEPICTIO_MONGODB_EXTERNAL_PORT": None,
             "DEPICTIO_MONGODB_DB_NAME": None,
             "DEPICTIO_MONGODB_WIPE": None,
         }
 
         with env_vars(env_to_clear):
-            config = MongoConfig(
-                service_name="custom_mongo", port=12345, db_name="custom_db", wipe=True
+            config = MongoDBConfig(
+                service_name="custom_mongo",
+                service_port=12345,
+                external_port=12345,
+                db_name="custom_db",
+                wipe=True,
             )
 
             assert config.service_name == "custom_mongo"
-            assert config.port == 12345
+            assert config.service_port == 12345
+            assert config.external_port == 12345
             assert config.db_name == "custom_db"
             assert config.wipe is True
 
     def test_env_variables(self):
         """Test MongoConfig with environment variables."""
         env = {
-            "DEPICTIO_MONGODB_PORT": "54321",
+            "DEPICTIO_MONGODB_SERVICE_PORT": "54321",
+            "DEPICTIO_MONGODB_EXTERNAL_PORT": "54321",
             "DEPICTIO_MONGODB_DB_NAME": "env_db",
             "DEPICTIO_MONGODB_WIPE": "true",
         }
 
         with env_vars(env):
-            config = MongoConfig()
+            config = MongoDBConfig()
 
-            assert config.port == 54321
+            assert config.service_port == 54321
+            assert config.external_port == 54321
             assert config.db_name == "env_db"
             assert config.wipe is True
 
@@ -127,7 +137,7 @@ class TestFastAPIConfig:
     def test_default_values(self):
         """Test FastAPIConfig with default values."""
         env_to_clear = {
-            "DEPICTIO_FASTAPI_PORT": None,
+            "DEPICTIO_FASTAPI_EXTERNAL_PORT": None,
             "DEPICTIO_FASTAPI_LOGGING_LEVEL": None,
             "DEPICTIO_FASTAPI_WORKERS": None,
             "DEPICTIO_FASTAPI_SSL": None,
@@ -139,7 +149,7 @@ class TestFastAPIConfig:
 
             assert config.host == "0.0.0.0"
             assert config.service_name == "depictio-backend"
-            assert config.port == 8058
+            assert config.external_port == 8058
             assert config.logging_level == "INFO"
             assert config.workers == 1
             assert config.ssl is False
@@ -149,7 +159,7 @@ class TestFastAPIConfig:
     def test_custom_values(self):
         """Test FastAPIConfig with custom values."""
         env_to_clear = {
-            "DEPICTIO_FASTAPI_PORT": None,
+            "DEPICTIO_FASTAPI_EXTERNAL_PORT": None,
             "DEPICTIO_FASTAPI_LOGGING_LEVEL": None,
             "DEPICTIO_FASTAPI_WORKERS": None,
             "DEPICTIO_FASTAPI_SSL": None,
@@ -160,7 +170,8 @@ class TestFastAPIConfig:
             config = FastAPIConfig(
                 host="127.0.0.1",
                 service_name="custom_backend",
-                port=9000,
+                service_port=9000,
+                external_port=9000,
                 logging_level="DEBUG",
                 workers=4,
                 ssl=True,
@@ -170,7 +181,7 @@ class TestFastAPIConfig:
 
             assert config.host == "127.0.0.1"
             assert config.service_name == "custom_backend"
-            assert config.port == 9000
+            assert config.external_port == 9000
             assert config.logging_level == "DEBUG"
             assert config.workers == 4
             assert config.ssl is True
@@ -180,7 +191,7 @@ class TestFastAPIConfig:
     def test_env_variables(self):
         """Test FastAPIConfig with environment variables."""
         env = {
-            "DEPICTIO_FASTAPI_PORT": "7000",
+            "DEPICTIO_FASTAPI_EXTERNAL_PORT": "7000",
             "DEPICTIO_FASTAPI_LOGGING_LEVEL": "ERROR",
             "DEPICTIO_FASTAPI_WORKERS": "2",
             "DEPICTIO_FASTAPI_SSL": "true",
@@ -191,7 +202,7 @@ class TestFastAPIConfig:
         with env_vars(env):
             config = FastAPIConfig()
 
-            assert config.port == 7000
+            assert config.external_port == 7000
             assert config.logging_level == "ERROR"
             assert config.workers == 2
             assert config.ssl is True
@@ -204,7 +215,7 @@ class TestDashConfig:
         """Test DashConfig with default values."""
         env_to_clear = {
             "DEPICTIO_DASH_DEBUG": None,
-            "DEPICTIO_DASH_PORT": None,
+            "DEPICTIO_DASH_EXTERNAL_PORT": None,
             "DEPICTIO_DASH_WORKERS": None,
         }
 
@@ -215,13 +226,13 @@ class TestDashConfig:
             assert config.host == "0.0.0.0"
             assert config.service_name == "depictio-frontend"
             assert config.workers == 1
-            assert config.port == 5080
+            assert config.external_port == 5080
 
     def test_custom_values(self):
         """Test DashConfig with custom values."""
         env_to_clear = {
             "DEPICTIO_DASH_DEBUG": None,
-            "DEPICTIO_DASH_PORT": None,
+            "DEPICTIO_DASH_EXTERNAL_PORT": None,
             "DEPICTIO_DASH_WORKERS": None,
         }
 
@@ -231,20 +242,21 @@ class TestDashConfig:
                 host="127.0.0.1",
                 service_name="custom_frontend",
                 workers=4,
-                port=3000,
+                service_port=3000,
+                external_port=3000,
             )
 
             assert config.debug is False
             assert config.host == "127.0.0.1"
             assert config.service_name == "custom_frontend"
             assert config.workers == 4
-            assert config.port == 3000
+            assert config.external_port == 3000
 
     def test_env_variables(self):
         """Test DashConfig with environment variables."""
         env = {
             "DEPICTIO_DASH_DEBUG": "false",
-            "DEPICTIO_DASH_PORT": "4000",
+            "DEPICTIO_DASH_EXTERNAL_PORT": "4000",
             "DEPICTIO_DASH_WORKERS": "2",
         }
 
@@ -252,13 +264,13 @@ class TestDashConfig:
             config = DashConfig()
 
             assert config.debug is False
-            assert config.port == 4000
+            assert config.external_port == 4000
             assert config.workers == 2
 
 
-class TestJbrowseConfig:
+class TestJBrowseConfig:
     def test_default_values(self):
-        """Test JbrowseConfig with default values."""
+        """Test JBrowseConfig with default values."""
         env_to_clear = {
             "DEPICTIO_JBROWSE_ENABLED": None,
             "DEPICTIO_JBROWSE_DATA_DIR": None,
@@ -266,7 +278,7 @@ class TestJbrowseConfig:
         }
 
         with env_vars(env_to_clear):
-            config = JbrowseConfig()
+            config = JBrowseConfig()
 
             assert config.enabled is True
             assert config.instance == {"host": "http://localhost", "port": 3000}
@@ -275,7 +287,7 @@ class TestJbrowseConfig:
             assert config.config_dir == "/jbrowse-watcher-plugin/sessions"
 
     def test_custom_values(self):
-        """Test JbrowseConfig with custom values."""
+        """Test JBrowseConfig with custom values."""
         env_to_clear = {
             "DEPICTIO_JBROWSE_ENABLED": None,
             "DEPICTIO_JBROWSE_DATA_DIR": None,
@@ -283,7 +295,7 @@ class TestJbrowseConfig:
         }
 
         with env_vars(env_to_clear):
-            config = JbrowseConfig(
+            config = JBrowseConfig(
                 enabled=False,
                 instance={"host": "http://jbrowse", "port": 4000},
                 data_dir="/custom/data",
@@ -296,7 +308,7 @@ class TestJbrowseConfig:
             assert config.config_dir == "/custom/config"
 
     def test_env_variables(self):
-        """Test JbrowseConfig with environment variables."""
+        """Test JBrowseConfig with environment variables."""
         env = {
             "DEPICTIO_JBROWSE_ENABLED": "false",
             "DEPICTIO_JBROWSE_DATA_DIR": "/env/data",
@@ -304,18 +316,17 @@ class TestJbrowseConfig:
         }
 
         with env_vars(env):
-            config = JbrowseConfig()
+            config = JBrowseConfig()
 
             assert config.enabled is False
             assert config.data_dir == "/env/data"
             assert config.config_dir == "/env/config"
 
 
-class TestAuth:
+class TestAuthConfig:
     def test_default_values(self):
         """Test Auth with default values."""
         env_to_clear = {
-            "DEPICTIO_AUTH_TMP_TOKEN": None,
             "DEPICTIO_AUTH_KEYS_DIR": None,
             "DEPICTIO_AUTH_KEYS_ALGORITHM": None,
             "DEPICTIO_AUTH_CLI_CONFIG_DIR": None,
@@ -323,9 +334,8 @@ class TestAuth:
         }
 
         with env_vars(env_to_clear):
-            config = Auth()
+            config = AuthConfig()
 
-            assert config.tmp_token == "eyJhb..."
             assert config.keys_dir == Path("depictio/keys")
             assert config.keys_algorithm == "RS256"
             assert config.cli_config_dir == Path("depictio/.depictio")
@@ -334,7 +344,6 @@ class TestAuth:
     def test_custom_values(self):
         """Test Auth with custom values."""
         env_to_clear = {
-            "DEPICTIO_AUTH_TMP_TOKEN": None,
             "DEPICTIO_AUTH_KEYS_DIR": None,
             "DEPICTIO_AUTH_KEYS_ALGORITHM": None,
             "DEPICTIO_AUTH_CLI_CONFIG_DIR": None,
@@ -350,15 +359,13 @@ class TestAuth:
 
         try:
             with env_vars(env_to_clear):
-                config = Auth(
-                    tmp_token="custom_token",
+                config = AuthConfig(
                     keys_dir=custom_keys_dir,
                     keys_algorithm="RS256",
                     cli_config_dir=custom_config_dir,
                     internal_api_key="custom_api_key",
                 )
 
-                assert config.tmp_token == "custom_token"
                 assert config.keys_dir == Path(custom_keys_dir)
                 assert config.keys_algorithm == "RS256"
                 assert config.cli_config_dir == Path(custom_config_dir)
@@ -381,7 +388,6 @@ class TestAuth:
 
         try:
             env = {
-                "DEPICTIO_AUTH_TMP_TOKEN": "env_token",
                 "DEPICTIO_AUTH_KEYS_DIR": env_keys_dir,
                 "DEPICTIO_AUTH_KEYS_ALGORITHM": "ES256",
                 "DEPICTIO_AUTH_CLI_CONFIG_DIR": env_config_dir,
@@ -389,9 +395,8 @@ class TestAuth:
             }
 
             with env_vars(env):
-                config = Auth()
+                config = AuthConfig()
 
-                assert config.tmp_token == "env_token"
                 assert config.keys_dir == Path(env_keys_dir)
                 assert config.keys_algorithm == "ES256"
                 assert config.cli_config_dir == Path(env_config_dir)
@@ -408,50 +413,52 @@ class TestSettings:
         """Test Settings with default values."""
         env_to_clear = {
             # Clear all relevant environment variables
-            "DEPICTIO_MONGODB_PORT": None,
-            "DEPICTIO_FASTAPI_PORT": None,
-            "DEPICTIO_DASH_PORT": None,
-            "DEPICTIO_MINIO_ENDPOINT_URL": None,
+            "DEPICTIO_MONGODB_SERVICE_PORT": None,
+            "DEPICTIO_MONGODB_EXTERNAL_PORT": None,
+            "DEPICTIO_FASTAPI_EXTERNAL_PORT": None,
+            "DEPICTIO_DASH_EXTERNAL_PORT": None,
+            "DEPICTIO_MINIO_PUBLIC_URL": None,
             "DEPICTIO_JBROWSE_ENABLED": None,
-            "DEPICTIO_AUTH_TMP_TOKEN": None,
+            "DEPICTIO_AUTH_INTERNAL_API_KEY": None,
         }
 
         with env_vars(env_to_clear):
             settings = Settings()
 
-            assert isinstance(settings.mongodb, MongoConfig)
+            assert isinstance(settings.mongodb, MongoDBConfig)
             assert isinstance(settings.fastapi, FastAPIConfig)
             assert isinstance(settings.dash, DashConfig)
             assert isinstance(settings.minio, S3DepictioCLIConfig)
-            assert isinstance(settings.jbrowse, JbrowseConfig)
-            assert isinstance(settings.auth, Auth)
+            assert isinstance(settings.jbrowse, JBrowseConfig)
+            assert isinstance(settings.auth, AuthConfig)
 
             # Check a few representative values
-            assert settings.mongodb.port == 27018
-            assert settings.fastapi.port == 8058
-            assert settings.dash.port == 5080
+            assert settings.mongodb.external_port == 27018
+            assert settings.fastapi.external_port == 8058
+            assert settings.dash.external_port == 5080
             assert settings.jbrowse.enabled is True
 
     def test_custom_values(self):
         """Test Settings with custom values."""
         env_to_clear = {
             # Clear all relevant environment variables
-            "DEPICTIO_MONGODB_PORT": None,
-            "DEPICTIO_FASTAPI_PORT": None,
-            "DEPICTIO_DASH_PORT": None,
-            "DEPICTIO_MINIO_ENDPOINT_URL": None,
+            "DEPICTIO_MONGODB_SERVICE_PORT": None,
+            "DEPICTIO_MONGODB_EXTERNAL_PORT": None,
+            "DEPICTIO_FASTAPI_EXTERNAL_PORT": None,
+            "DEPICTIO_DASH_EXTERNAL_PORT": None,
+            "DEPICTIO_MINIO_PUBLIC_URL": None,
             "DEPICTIO_JBROWSE_ENABLED": None,
-            "DEPICTIO_AUTH_TMP_TOKEN": None,
+            "DEPICTIO_AUTH_INTERNAL_API_KEY": None,
         }
 
         with env_vars(env_to_clear):
             # Create custom configs
-            mongo_config = MongoConfig(port=12345)
-            fastapi_config = FastAPIConfig(port=9000)
-            dash_config = DashConfig(port=4000)
-            minio_config = S3DepictioCLIConfig(endpoint_url="https://custom-s3.example.com")
-            jbrowse_config = JbrowseConfig(enabled=False)
-            auth_config = Auth(tmp_token="custom_token")
+            mongo_config = MongoDBConfig(service_port=12345, external_port=12345)
+            fastapi_config = FastAPIConfig(service_port=9000, external_port=9000)
+            dash_config = DashConfig(service_port=4000, external_port=4000)
+            minio_config = S3DepictioCLIConfig(public_url="https://custom-s3.example.com")
+            jbrowse_config = JBrowseConfig(enabled=False)
+            auth_config = AuthConfig()
 
             settings = Settings(
                 mongodb=mongo_config,
@@ -462,40 +469,41 @@ class TestSettings:
                 auth=auth_config,
             )
 
-            assert settings.mongodb.port == 12345
-            assert settings.fastapi.port == 9000
-            assert settings.dash.port == 4000
+            assert settings.mongodb.external_port == 12345
+            assert settings.fastapi.external_port == 9000
+            assert settings.dash.external_port == 4000
             assert settings.minio.endpoint_url == "https://custom-s3.example.com"
             assert settings.jbrowse.enabled is False
-            assert settings.auth.tmp_token == "custom_token"
+            assert isinstance(settings.auth, AuthConfig)
 
     def test_env_variables(self):
         """Test Settings with environment variables."""
         env = {
-            "DEPICTIO_MONGODB_PORT": "54321",
-            "DEPICTIO_FASTAPI_PORT": "7000",
-            "DEPICTIO_DASH_PORT": "6000",
-            "DEPICTIO_MINIO_ENDPOINT_URL": "https://env-s3.example.com",
+            "DEPICTIO_MONGODB_SERVICE_PORT": "54321",
+            "DEPICTIO_MONGODB_EXTERNAL_PORT": "54321",
+            "DEPICTIO_FASTAPI_EXTERNAL_PORT": "7000",
+            "DEPICTIO_DASH_EXTERNAL_PORT": "6000",
+            "DEPICTIO_MINIO_PUBLIC_URL": "https://env-s3.example.com",
             "DEPICTIO_JBROWSE_ENABLED": "false",
-            "DEPICTIO_AUTH_TMP_TOKEN": "env_token",
+            "DEPICTIO_AUTH_INTERNAL_API_KEY": "env_token",
         }
 
         with env_vars(env):
             # Instead of using the composite Settings class, test each component individually
             # to ensure each one is initialized with the current environment variables
-            mongodb = MongoConfig()
+            mongodb = MongoDBConfig()
             fastapi = FastAPIConfig()
             dash = DashConfig()
             minio = S3DepictioCLIConfig()
-            jbrowse = JbrowseConfig()
-            auth = Auth()
+            jbrowse = JBrowseConfig()
+            auth = AuthConfig()
 
-            assert mongodb.port == 54321
-            assert fastapi.port == 7000
-            assert dash.port == 6000
+            assert mongodb.external_port == 54321
+            assert fastapi.external_port == 7000
+            assert dash.external_port == 6000
             assert minio.endpoint_url == "https://env-s3.example.com"
             assert jbrowse.enabled is False
-            assert auth.tmp_token == "env_token"
+            assert auth.internal_api_key == "env_token"
 
             # Create Settings instance explicitly with our configs
             settings = Settings(
@@ -508,9 +516,9 @@ class TestSettings:
             )
 
             # Verify settings contains our configs
-            assert settings.mongodb.port == 54321
-            assert settings.fastapi.port == 7000
-            assert settings.dash.port == 6000
+            assert settings.mongodb.external_port == 54321
+            assert settings.fastapi.external_port == 7000
+            assert settings.dash.external_port == 6000
             assert settings.minio.endpoint_url == "https://env-s3.example.com"
             assert settings.jbrowse.enabled is False
-            assert settings.auth.tmp_token == "env_token"
+            assert settings.auth.internal_api_key == "env_token"

--- a/depictio/tests/models/test_s3_utils.py
+++ b/depictio/tests/models/test_s3_utils.py
@@ -1,3 +1,4 @@
+import os
 import re
 from unittest.mock import MagicMock, patch
 
@@ -5,127 +6,48 @@ import pytest
 from pydantic import ValidationError
 
 # from depictio.models.config import DEPICTIO_CONTEXT
-from depictio.models.models.s3 import PolarsStorageOptions, S3DepictioCLIConfig
+from depictio.models.models.s3 import PolarsStorageOptions
+from depictio.api.v1.configs.settings_models import S3DepictioCLIConfig
 from depictio.models.s3_utils import S3_storage_checks, turn_S3_config_into_polars_storage_options
 
 
 class TestS3DepictioCLIConfig:
-    def test_endpoint_url_with_client_context(self):
-        """Test that endpoint URL remains unchanged in client context."""
-        with patch("depictio.models.models.s3.DEPICTIO_CONTEXT", "cli"):
-            config = S3DepictioCLIConfig(
-                service_name="test-service",
-                endpoint_url="http://original-endpoint:8000",
-                on_premise_service=False,
+    def test_url_client_and_server_context(self):
+        with patch.dict(os.environ, {"DEPICTIO_CONTEXT": "client"}):
+            cfg = S3DepictioCLIConfig(
+                service_name="svc",
+                service_port=9000,
+                external_host="example.com",
+                external_port=1234,
             )
+            assert cfg.url == "http://example.com:1234"
+            assert cfg.endpoint_url == "http://example.com:1234"
 
-            # Verify endpoint_url remains unchanged in client context
-            assert config.endpoint_url == "http://original-endpoint:8000"
-            # Verify port was extracted correctly
-            assert config.port == 8000
+        with patch.dict(os.environ, {"DEPICTIO_CONTEXT": "server"}):
+            cfg = S3DepictioCLIConfig(service_name="svc", service_port=9000)
+            assert cfg.url == "http://svc:9000"
 
-    def test_endpoint_url_with_server_context(self):
-        """Test that endpoint URL is updated in server context with on-premise service."""
-        with patch("depictio.models.models.s3.DEPICTIO_CONTEXT", "server"):
-            config = S3DepictioCLIConfig(
-                service_name="test-service",
-                endpoint_url="http://original-endpoint:8000",
-                on_premise_service=True,
-            )
+    def test_public_url_override(self):
+        with patch.dict(os.environ, {"DEPICTIO_CONTEXT": "client"}):
+            cfg = S3DepictioCLIConfig(public_url="https://public.example")
+            assert cfg.url == "https://public.example"
 
-            # Verify endpoint_url was updated in server context with on-premise service
-            assert config.endpoint_url == "http://test-service:8000"
-
-    def test_endpoint_url_with_server_context_but_not_on_premise(self):
-        """Test that endpoint URL remains unchanged in server context but not on-premise."""
-        with patch("depictio.models.models.s3.DEPICTIO_CONTEXT", "server"):
-            config = S3DepictioCLIConfig(
-                service_name="test-service",
-                endpoint_url="http://original-endpoint:8000",
-                on_premise_service=False,
-            )
-
-            # Verify endpoint_url remains unchanged when not on-premise
-            assert config.endpoint_url == "http://original-endpoint:8000"
-
-    def test_default_port_when_not_specified(self):
-        """Test that default port is used when not specified in the endpoint URL."""
-        with patch("depictio.models.models.s3.DEPICTIO_CONTEXT", "server"):
-            config = S3DepictioCLIConfig(
-                service_name="test-service",
-                endpoint_url="http://original-endpoint",
-                on_premise_service=True,
-            )
-
-            # Verify default port is used
-            assert config.endpoint_url == "http://test-service:9000"
-            assert config.port == 0  # Default value from Field
-
-    def test_custom_port_override(self):
-        """Test that explicitly setting port overrides extracted port."""
-        with patch("depictio.models.models.s3.DEPICTIO_CONTEXT", "server"):
-            config = S3DepictioCLIConfig(
-                service_name="test-service",
-                endpoint_url="http://original-endpoint:8000",
-                port=7000,  # Explicitly set different port
-                on_premise_service=True,
-            )
-
-            # Port from URL should be extracted, but endpoint should use the port field value
-            assert config.port == 8000  # Port extracted from URL
-            assert config.endpoint_url == "http://test-service:8000"  # Uses extracted port
-
-    def test_with_none_context(self):
-        """Test behavior when DEPICTIO_CONTEXT is None."""
-        with patch("depictio.models.models.s3.DEPICTIO_CONTEXT", None):
-            config = S3DepictioCLIConfig(
-                service_name="test-service",
-                endpoint_url="http://original-endpoint:8000",
-                on_premise_service=False,
-            )
-
-            # Verify endpoint_url remains unchanged when context is None
-            assert config.endpoint_url == "http://original-endpoint:8000"
+    def test_aliases(self):
+        cfg = S3DepictioCLIConfig(external_host="host", external_port=9999)
+        assert cfg.host == "host"
+        assert cfg.port == 9999
 
     def test_environment_variable_override(self):
-        """Test that environment variables override default values."""
-        with (
-            patch("depictio.models.models.s3.DEPICTIO_CONTEXT", "server"),
-            patch.dict(
-                "os.environ",
-                {
-                    "DEPICTIO_MINIO_SERVICE_NAME": "env-service",
-                    "DEPICTIO_MINIO_ENDPOINT_URL": "http://env-endpoint:9999",
-                    "DEPICTIO_MINIO_ON_PREMISE_SERVICE": "true",
-                },
-            ),
-        ):
-            # Force reload of settings from environment
-            config = S3DepictioCLIConfig()
-
-            # Verify values from environment are used
-            assert config.service_name == "env-service"
-            assert config.endpoint_url == "http://env-service:9999"  # Updated by validator
-            assert config.port == 9999
-            assert config.on_premise_service is True
-
-    def test_port_extraction_from_complex_url(self):
-        """Test port extraction from URLs with various formats."""
-        test_cases = [
-            # URL, expected port
-            ("http://localhost:1234", 1234),
-            ("https://service.domain.com:443", 443),
-            ("http://service:80", 80),
-            # No port cases
-            ("http://localhost", 0),  # Should use default
-        ]
-
-        for url, expected_port in test_cases:
-            config = S3DepictioCLIConfig(endpoint_url=url)
-            port_match = re.search(r":(\d+)(?:/|$)", config.endpoint_url)
-            extracted_port = int(port_match.group(1)) if port_match else 0
-
-            assert extracted_port == expected_port, f"Failed to extract port from {url}"
+        env = {
+            "DEPICTIO_MINIO_SERVICE_NAME": "env",
+            "DEPICTIO_MINIO_EXTERNAL_HOST": "envhost",
+            "DEPICTIO_MINIO_EXTERNAL_PORT": "1111",
+        }
+        with patch.dict(os.environ, env):
+            cfg = S3DepictioCLIConfig()
+            assert cfg.service_name == "env"
+            assert cfg.external_host == "envhost"
+            assert cfg.external_port == 1111
 
 
 class TestS3Utils:
@@ -135,7 +57,8 @@ class TestS3Utils:
     def sample_s3_config(self):
         """Sample S3 configuration"""
         return S3DepictioCLIConfig(
-            endpoint_url="http://localhost:9000",
+            external_host="localhost",
+            external_port=9000,
             root_user="minio",
             root_password="minio123",
             bucket="depictio-bucket",
@@ -240,9 +163,7 @@ class TestS3Utils:
             """Test with a different endpoint URL"""
 
             # Modify the sample config
-            sample_s3_config.endpoint_url = "https://custom-s3.example.com"
-            # drop the port from model
-            sample_s3_config.port = 0
+            sample_s3_config.public_url = "https://custom-s3.example.com"
 
             print(sample_s3_config.endpoint_url)
             print(f"Sample config: {sample_s3_config}")


### PR DESCRIPTION
## Summary
- adjust tests to import `S3DepictioCLIConfig` from new settings module
- rewrite S3 settings tests for new fields and behaviour
- update Settings model tests for renamed classes and ports

## Testing
- `pytest depictio/tests/models/test_s3_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_683f68b1bf2c832095214ca64b7053a6