### PR TITLE
Expose MinIO creds in ConfigMap

### DIFF
--- a/helm-charts/depictio/README.md
+++ b/helm-charts/depictio/README.md
@@ -82,6 +82,8 @@ helm uninstall depictio
 | `secrets.minioRootUser` | MinIO root username | `"minio"` |
 | `secrets.minioRootPassword` | MinIO root password | `"minio123"` |
 
+These credentials are also stored in the Kubernetes Secret named `<release-name>-depictio-secrets`. Override them only if custom values are required.
+
 ### MongoDB parameters
 
 | Parameter | Description | Default |

--- a/helm-charts/depictio/templates/configmaps.yaml
+++ b/helm-charts/depictio/templates/configmaps.yaml
@@ -1,3 +1,5 @@
+{{- $access := default .Release.Name .Values.secrets.minioRootUser }}
+{{- $secret := default (randAlphaNum 32) .Values.secrets.minioRootPassword }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,6 +12,8 @@ data:
   DEPICTIO_FASTAPI_PORT: {{ .Values.backend.env.DEPICTIO_FASTAPI_PORT | quote }}
   DEPICTIO_DASH_PORT: {{ .Values.backend.env.DEPICTIO_DASH_PORT | quote }}
   DEPICTIO_DASH_SERVICE_NAME: {{ printf "%s-depictio-frontend" .Release.Name | quote }}
+  DEPICTIO_MINIO_ROOT_USER: {{ $access | quote }}
+  DEPICTIO_MINIO_ROOT_PASSWORD: {{ $secret | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -21,3 +25,5 @@ data:
   DEPICTIO_FASTAPI_SERVICE_NAME: {{ printf "%s-depictio-backend" .Release.Name | quote }}
   DEPICTIO_FASTAPI_PORT: {{ .Values.frontend.env.DEPICTIO_FASTAPI_PORT | quote }}
   DEPICTIO_DASH_PORT: {{ .Values.frontend.env.DEPICTIO_DASH_PORT | quote }}
+  DEPICTIO_MINIO_ROOT_USER: {{ $access | quote }}
+  DEPICTIO_MINIO_ROOT_PASSWORD: {{ $secret | quote }}


### PR DESCRIPTION
## Summary
- reuse MinIO credentials in configmap template
- document where the credentials come from

## Testing
- `pre-commit` *(fails: command not found)*
- `helm lint helm-charts/depictio` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684040b6a8bc8320b440eca0ad48874d