### PR TITLE
Enhance bump2version automation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,24 @@
+[bumpversion]
+current_version = 0.0.5-beta1
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-beta(?P<beta>\d+))?
+serialize =
+    {major}.{minor}.{patch}-beta{beta}
+    {major}.{minor}.{patch}
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:depictio/cli/pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:helm-charts/depictio/Chart.yaml]
+search =
+    version: {current_version}
+    appVersion: "v{current_version}"
+replace =
+    version: {new_version}
+    appVersion: "v{new_version}"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@
 
 </div>
 
+## Versioning
+
+Use `bump2version` to update the project version and automatically create a Git tag.
+For example, to bump the patch number:
+
+```bash
+bump2version patch
+```
+
+To bump the minor version while staying in the beta channel, specify the new version explicitly:
+
+```bash
+bump2version --new-version 0.1.0-beta1 minor
+```
+
 <!-- markdownlint-disable MD033 MD041 -->
 <p align="center">
   <img src="https://depictio.github.io/depictio-docs/images/Demo.gif" alt="Demo" width=800>

--- a/helm-charts/depictio/Chart.yaml
+++ b/helm-charts/depictio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: depictio
 description: A Helm chart for Depictio application
 type: application
-version: 0.0.4
-appVersion: "v0.0.4"
+version: 0.0.5-beta1
+appVersion: "v0.0.5-beta1"
 icon: https://github.com/depictio/depictio/raw/main/docs/images/logo.png
 maintainers:
   - name: Thomas Weber

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
   "pytest-xdist",
   "mongomock",
   "mongomock-motor",
+  "bump2version",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- configure bump2version to modify CLI and Helm chart versions
- document how to run a beta minor bump
- sync Helm chart version with the Python package

## Testing
- `pre-commit run --files README.md .bumpversion.cfg helm-charts/depictio/Chart.yaml depictio/cli/pyproject.toml` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68405bb83d5883208baef3b84454bb91