### PR TITLE
Fix Claude settings schema validation error

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://github.com/anthropics/claude-code/blob/main/schemas/settings.schema.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(pytest:*)",


### PR DESCRIPTION
Update $schema to use official JSON Schema Store URL instead of GitHub raw file path, which was causing settings validation errors.