### PR TITLE
fix(auth): make triangle background animations visible immediately

### DIFF
--- a/depictio/dash/assets/css/components/auth.css
+++ b/depictio/dash/assets/css/components/auth.css
@@ -103,29 +103,48 @@ body.auth-page .mantine-AppShell-header {
 }
 
 /* Auth-specific triangle animation classes
-   Base .triangle-particle styles and size classes are defined in animations.css */
+   Base .triangle-particle styles and size classes are defined in animations.css
+   Using individual properties so inline animationDelay can work */
 .triangle-anim-1 {
-    animation: triangleFloat 8s infinite linear !important;
+    animation-name: triangleFloat !important;
+    animation-duration: 8s !important;
+    animation-iteration-count: infinite !important;
+    animation-timing-function: ease-in-out !important;
 }
 
 .triangle-anim-2 {
-    animation: triangleDrift 9s infinite linear !important;
+    animation-name: triangleDrift !important;
+    animation-duration: 9s !important;
+    animation-iteration-count: infinite !important;
+    animation-timing-function: ease-in-out !important;
 }
 
 .triangle-anim-3 {
-    animation: trianglePulse 7s infinite linear !important;
+    animation-name: trianglePulse !important;
+    animation-duration: 7s !important;
+    animation-iteration-count: infinite !important;
+    animation-timing-function: ease-in-out !important;
 }
 
 .triangle-anim-4 {
-    animation: triangleRotate 10s infinite linear !important;
+    animation-name: triangleRotate !important;
+    animation-duration: 10s !important;
+    animation-iteration-count: infinite !important;
+    animation-timing-function: ease-in-out !important;
 }
 
 .triangle-anim-5 {
-    animation: triangleOrbit 8.5s infinite linear !important;
+    animation-name: triangleOrbit !important;
+    animation-duration: 8.5s !important;
+    animation-iteration-count: infinite !important;
+    animation-timing-function: ease-in-out !important;
 }
 
 .triangle-anim-6 {
-    animation: triangleWave 9.5s infinite linear !important;
+    animation-name: triangleWave !important;
+    animation-duration: 9.5s !important;
+    animation-iteration-count: infinite !important;
+    animation-timing-function: ease-in-out !important;
 }
 
 /* =============================================================================

--- a/depictio/dash/layouts/users_management.py
+++ b/depictio/dash/layouts/users_management.py
@@ -449,14 +449,18 @@ def create_triangle_background() -> html.Div:
         animation_class = ANIMATION_CLASSES[i % len(ANIMATION_CLASSES)]
         x, y = _calculate_particle_position(i, grid_cols, grid_rows)
 
+        initial_rotation = (i * 73) % 360
+        # Negative delay starts animation mid-cycle so movement is visible immediately
+        animation_offset = -((i * 1.7) % 8)
         triangle = html.Div(
             className=f"triangle-particle triangle-{size_key} {animation_class}",
             style={
                 "left": f"{x}%",
                 "top": f"{y}%",
                 "background": _create_triangle_svg(size_key, color_hex),
-                "--initial-rotation": f"{(i * 73) % 360}deg",
-                "animation-delay": f"{(i * 0.2) % 3}s",
+                "transform": f"rotate({initial_rotation}deg) translateZ(0)",
+                "--initial-rotation": f"{initial_rotation}deg",
+                "animationDelay": f"{animation_offset}s",
             },
         )
         triangle_particles.append(triangle)


### PR DESCRIPTION
## Summary
- Add initial transform with rotation so triangles start at different angles instead of all pointing up
- Use individual CSS animation properties instead of shorthand to allow inline animationDelay to work
- Add negative animation delays to start triangles mid-cycle, making movement visible immediately on page load
- Change timing function from linear to ease-in-out for smoother motion

## Test plan
- [x] Navigate to /auth page
- [x] Verify triangles are at different rotations (not all pointing up)
- [x] Verify triangles are moving/animating immediately on page load

🤖 Generated with [Claude Code](https://claude.ai/code)