### PR TITLE
feat(docs): add automated OpenAPI spec extraction for documentation

### DIFF
--- a/.github/workflows/update-api-docs.yaml
+++ b/.github/workflows/update-api-docs.yaml
@@ -1,0 +1,132 @@
+name: Update API Documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v0.1.0)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  update-openapi:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+
+    steps:
+      - name: Checkout depictio-docs
+        uses: actions/checkout@v4
+        with:
+          repository: depictio/depictio-docs
+          path: depictio-docs
+          token: ${{ secrets.DOCS_PAT }}
+
+      - name: Get version info
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          # Remove 'v' prefix for image tag
+          echo "image_tag=${VERSION#v}" >> $GITHUB_OUTPUT
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start Depictio API container
+        run: |
+          # Pull the released image
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.image_tag }}
+
+          # Start container with minimal config (just need FastAPI to respond)
+          docker run -d --name depictio-api \
+            -p 8058:8058 \
+            -e DEPICTIO_CONTEXT=server \
+            -e MONGO_HOST=localhost \
+            -e MONGO_PORT=27017 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.image_tag }} \
+            uvicorn depictio.api.main:app --host 0.0.0.0 --port 8058 || true
+
+          # Wait for API to be ready (max 60 seconds)
+          echo "Waiting for API to start..."
+          for i in {1..30}; do
+            if curl -s http://localhost:8058/openapi.json > /dev/null 2>&1; then
+              echo "API is ready!"
+              break
+            fi
+            echo "Attempt $i/30..."
+            sleep 2
+          done
+
+      - name: Extract OpenAPI specification
+        run: |
+          # Fetch OpenAPI spec from running container
+          curl -s http://localhost:8058/openapi.json | jq '.' > depictio-docs/docs/api/openapi.json
+
+          # Verify the file is valid JSON
+          if ! jq empty depictio-docs/docs/api/openapi.json 2>/dev/null; then
+            echo "Error: Invalid JSON in openapi.json"
+            cat depictio-docs/docs/api/openapi.json
+            exit 1
+          fi
+
+          # Add generation metadata
+          jq --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+             --arg version "${{ steps.version.outputs.version }}" \
+             '.info["x-generated-at"] = $date | .info["x-depictio-version"] = $version' \
+             depictio-docs/docs/api/openapi.json > /tmp/openapi.json
+          mv /tmp/openapi.json depictio-docs/docs/api/openapi.json
+
+          echo "OpenAPI spec extracted successfully"
+          echo "Endpoints count: $(jq '.paths | keys | length' depictio-docs/docs/api/openapi.json)"
+
+      - name: Stop container
+        if: always()
+        run: |
+          docker stop depictio-api || true
+          docker rm depictio-api || true
+
+      - name: Commit and push to depictio-docs
+        working-directory: depictio-docs
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+          # Check if there are changes
+          if git diff --quiet docs/api/openapi.json; then
+            echo "No changes to OpenAPI specification"
+            exit 0
+          fi
+
+          git add docs/api/openapi.json
+          git commit -m "Update OpenAPI spec for ${{ steps.version.outputs.version }}
+
+          Automatically generated from depictio release.
+          Release: ${{ github.event.release.html_url || 'Manual trigger' }}"
+
+          git push origin main
+
+      - name: Summary
+        run: |
+          echo "## API Documentation Updated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **OpenAPI spec**: Updated in depictio-docs" >> $GITHUB_STEP_SUMMARY
+          echo "- **Endpoints**: $(jq '.paths | keys | length' depictio-docs/docs/api/openapi.json)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The documentation will be automatically deployed via GitHub Pages." >> $GITHUB_STEP_SUMMARY

--- a/scripts/extract_openapi.py
+++ b/scripts/extract_openapi.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Extract OpenAPI specification from a running Depictio API instance.
+
+This script fetches the openapi.json from a running API server.
+Use this for local development or manual documentation updates.
+
+Usage:
+    python scripts/extract_openapi.py [output_path] [api_url]
+
+Examples:
+    # Fetch from local instance and save to docs
+    python scripts/extract_openapi.py ../depictio-docs/docs/api/openapi.json
+
+    # Fetch from specific URL
+    python scripts/extract_openapi.py openapi.json http://localhost:8058
+
+    # Print to stdout
+    python scripts/extract_openapi.py
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+
+def fetch_openapi(api_url: str = "http://localhost:8058") -> dict:
+    """
+    Fetch OpenAPI specification from a running API instance.
+
+    Args:
+        api_url: Base URL of the Depictio API.
+
+    Returns:
+        The OpenAPI specification as a dictionary.
+
+    Raises:
+        URLError: If the API is not reachable.
+    """
+    openapi_url = f"{api_url.rstrip('/')}/openapi.json"
+
+    try:
+        with urlopen(openapi_url, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except URLError as e:
+        print(f"Error: Could not connect to {openapi_url}", file=sys.stderr)
+        print("Make sure the Depictio API is running.", file=sys.stderr)
+        print(f"Details: {e}", file=sys.stderr)
+        raise
+
+
+def extract_openapi(
+    output_path: str | None = None,
+    api_url: str = "http://localhost:8058",
+) -> dict:
+    """
+    Extract and optionally save OpenAPI specification.
+
+    Args:
+        output_path: Optional path to write the JSON file.
+        api_url: Base URL of the Depictio API.
+
+    Returns:
+        The OpenAPI specification as a dictionary.
+    """
+    openapi_schema = fetch_openapi(api_url)
+
+    # Add generation metadata
+    openapi_schema["info"]["x-generated-at"] = datetime.now(tz=timezone.utc).isoformat()
+
+    if output_path:
+        output_file = Path(output_path)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(openapi_schema, f, indent=2, ensure_ascii=False)
+        print(f"OpenAPI specification written to: {output_file}")
+        print(f"Endpoints: {len(openapi_schema.get('paths', {}))}")
+    else:
+        print(json.dumps(openapi_schema, indent=2, ensure_ascii=False))
+
+    return openapi_schema
+
+
+def main() -> None:
+    """Main entry point."""
+    output_path = sys.argv[1] if len(sys.argv) > 1 else None
+    api_url = sys.argv[2] if len(sys.argv) > 2 else "http://localhost:8058"
+
+    try:
+        extract_openapi(output_path, api_url)
+    except URLError:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically extract OpenAPI spec on releases and commit to depictio-docs
- Add Python script for local/manual OpenAPI extraction during development

## Details

### GitHub Workflow (`update-api-docs.yaml`)
- Triggers on release publication or manual dispatch
- Pulls the released Docker image from GHCR
- Starts the API container and waits for readiness
- Extracts `openapi.json` with generation metadata (timestamp, version)
- Validates JSON and commits to depictio-docs repository
- Includes proper cleanup and job summary

### Local Script (`scripts/extract_openapi.py`)
- Stdlib-only implementation (no external dependencies)
- Fetches OpenAPI spec from running API instance
- Supports custom output path and API URL
- Adds UTC timestamp metadata

## Test plan

- [ ] Verify workflow YAML is valid with `act --list`
- [ ] Test local script against running API: `python scripts/extract_openapi.py openapi.json`
- [ ] Manual workflow dispatch after merging to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)