### PR TITLE
feat: add EMBL self-hosted deployment workflow

### DIFF
--- a/.github/workflows/deploy-embl-selfhosted.yaml
+++ b/.github/workflows/deploy-embl-selfhosted.yaml
@@ -1,0 +1,128 @@
+name: Deploy to EMBL (Self-Hosted)
+
+# SECURITY NOTE: This workflow uses self-hosted runners.
+# It only triggers on tags (not PRs) to prevent fork-based attacks.
+# Only users with write access can push tags.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-b*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 0.6.0-b8 or 0.6.1)'
+        required: true
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - dev
+          - demo
+          - both
+
+# Prevent concurrent deployments
+concurrency:
+  group: embl-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Dev environment - ALL tags deploy here
+  deploy-dev:
+    name: Deploy to Dev (dev.demo.depictio.embl.org)
+    runs-on: [self-hosted, embl-deploy]
+    environment: embl-demo-dev  # Requires environment to be created in repo settings
+    # Run for all tags OR manual dispatch targeting dev/both
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'dev' || github.event.inputs.environment == 'both'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            # Extract version from tag (remove 'v' prefix)
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Deploying version: ${VERSION}"
+
+      - name: Deploy to Dev environment
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "🚀 Deploying version ${VERSION} to dev.demo.depictio.embl.org"
+
+          helm upgrade --install devdemo ./helm-charts/depictio \
+            --namespace datasci-depictio-project-demo-dev \
+            -f helm-charts/depictio/values.yaml \
+            -f helm-charts/depictio/values-embl-unauth.yaml \
+            -f helm-charts/depictio/values-embl-demo-dev.yaml \
+            -f helm-charts/depictio/values-embl-secrets.yaml \
+            --set backend.image.tag="${VERSION}" \
+            --set frontend.image.tag="${VERSION}" \
+            --wait --timeout 10m --atomic \
+            --insecure-skip-tls-verify
+
+          echo "✅ Dev deployment complete"
+
+      - name: Verify deployment
+        run: |
+          echo "📋 Checking deployment status..."
+          kubectl get pods -n datasci-depictio-project-demo-dev -l app.kubernetes.io/instance=devdemo
+          kubectl get ingress -n datasci-depictio-project-demo-dev
+
+  # Demo environment - Only STABLE tags (no -b* suffix) deploy here
+  deploy-demo:
+    name: Deploy to Demo (demo.depictio.embl.org)
+    runs-on: [self-hosted, embl-deploy]
+    environment: embl-demo  # Requires environment to be created in repo settings
+    # Run only for stable tags (not containing -b) OR manual dispatch targeting demo/both
+    if: |
+      (github.event_name == 'push' && !contains(github.ref, '-b')) ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'demo' || github.event.inputs.environment == 'both'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            # Extract version from tag (remove 'v' prefix)
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Deploying version: ${VERSION}"
+
+      - name: Deploy to Demo environment
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "🚀 Deploying version ${VERSION} to demo.depictio.embl.org"
+
+          helm upgrade --install demo ./helm-charts/depictio \
+            --namespace datasci-depictio-project-demo \
+            -f helm-charts/depictio/values.yaml \
+            -f helm-charts/depictio/values-embl-unauth.yaml \
+            -f helm-charts/depictio/values-embl-demo.yaml \
+            -f helm-charts/depictio/values-embl-secrets.yaml \
+            --set backend.image.tag="${VERSION}" \
+            --set frontend.image.tag="${VERSION}" \
+            --wait --timeout 10m --atomic \
+            --insecure-skip-tls-verify
+
+          echo "✅ Demo deployment complete"
+
+      - name: Verify deployment
+        run: |
+          echo "📋 Checking deployment status..."
+          kubectl get pods -n datasci-depictio-project-demo -l app.kubernetes.io/instance=demo
+          kubectl get ingress -n datasci-depictio-project-demo

--- a/depictio/dash/celery_lock.py
+++ b/depictio/dash/celery_lock.py
@@ -8,9 +8,9 @@ import time
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
-import redis
 from dash import no_update
 
+import redis
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
 

--- a/helm-charts/depictio/values-embl-demo-dev.yaml
+++ b/helm-charts/depictio/values-embl-demo-dev.yaml
@@ -1,0 +1,67 @@
+# EMBL Dev Environment - dev.demo.depictio.embl.org
+# All tags (including beta) deploy to this environment
+#
+# Layered on top of:
+#   - values.yaml (base configuration)
+#   - values-embl-unauth.yaml (EMBL infrastructure + unauthenticated mode)
+#   - values-embl-secrets.yaml (S3 credentials)
+
+# Celery worker (enabled for background tasks)
+celery:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"
+
+# Google Analytics - Dev Tracking ID
+backend:
+  env:
+    DEPICTIO_GOOGLE_ANALYTICS_ENABLED: "true"
+    DEPICTIO_GOOGLE_ANALYTICS_TRACKING_ID: "G-MCC33FDF2Z"
+
+frontend:
+  env:
+    DEPICTIO_GOOGLE_ANALYTICS_ENABLED: "true"
+    DEPICTIO_GOOGLE_ANALYTICS_TRACKING_ID: "G-MCC33FDF2Z"
+
+# Ingress - Dev Environment
+ingress:
+  enabled: true
+  ingressClassName: "external-users"
+
+  annotations:
+    cert-manager.io/cluster-issuer: harica-issuer
+
+  hosts:
+    - host: "dev.demo.depictio.embl.org"
+      paths:
+        - path: /
+          pathType: Prefix
+          service:
+            name: depictio-frontend
+            portName: http
+    - host: "dev.api.demo.depictio.embl.org"
+      paths:
+        - path: /
+          pathType: Prefix
+          service:
+            name: depictio-backend
+            portName: http
+
+  tls:
+    - hosts:
+        - "dev.demo.depictio.embl.org"
+        - "dev.api.demo.depictio.embl.org"
+      secretName: devdemo-depictio-tls
+
+# Global domain settings
+global:
+  domain: "depictio.embl.org"
+  urlPattern:
+    type: "subdomain"
+    subdomain: "dev"

--- a/helm-charts/depictio/values-embl-demo.yaml
+++ b/helm-charts/depictio/values-embl-demo.yaml
@@ -1,0 +1,67 @@
+# EMBL Stable Demo Environment - demo.depictio.embl.org
+# Only stable tags (without -b* suffix) deploy to this environment
+#
+# Layered on top of:
+#   - values.yaml (base configuration)
+#   - values-embl-unauth.yaml (EMBL infrastructure + unauthenticated mode)
+#   - values-embl-secrets.yaml (S3 credentials)
+
+# Celery worker (enabled for background tasks)
+celery:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"
+
+# Google Analytics - Production Tracking ID
+backend:
+  env:
+    DEPICTIO_GOOGLE_ANALYTICS_ENABLED: "true"
+    DEPICTIO_GOOGLE_ANALYTICS_TRACKING_ID: "G-GM8MYRJDHL"
+
+frontend:
+  env:
+    DEPICTIO_GOOGLE_ANALYTICS_ENABLED: "true"
+    DEPICTIO_GOOGLE_ANALYTICS_TRACKING_ID: "G-GM8MYRJDHL"
+
+# Ingress - Stable Demo Environment
+ingress:
+  enabled: true
+  ingressClassName: "external-users"
+
+  annotations:
+    cert-manager.io/cluster-issuer: harica-issuer
+
+  hosts:
+    - host: "demo.depictio.embl.org"
+      paths:
+        - path: /
+          pathType: Prefix
+          service:
+            name: depictio-frontend
+            portName: http
+    - host: "api.demo.depictio.embl.org"
+      paths:
+        - path: /
+          pathType: Prefix
+          service:
+            name: depictio-backend
+            portName: http
+
+  tls:
+    - hosts:
+        - "demo.depictio.embl.org"
+        - "api.demo.depictio.embl.org"
+      secretName: demo-depictio-tls
+
+# Global domain settings
+global:
+  domain: "depictio.embl.org"
+  urlPattern:
+    type: "prefix"
+    subdomain: ""

--- a/pixi.lock
+++ b/pixi.lock
@@ -2557,8 +2557,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: depictio
-  version: 0.6.0b4
-  sha256: 77db169edc97ae7d7af45d161581ebfe31bd7b528cb6452188c885553ce933d5
+  version: 0.6.0b7
+  sha256: c22395f71edb28114800716658f0c1bbb477bf0f0b7e5d3bdfb7cac0f7bfdba4
   requires_dist:
   - bcrypt==4.2.1
   - bleach

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "depictio"
-version = "0.6.0b4"
+version = "0.6.0b8"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## Summary

- Add automated Helm deployment to EMBL demo environments using self-hosted GitHub Actions runner
- All version tags deploy to dev environment (dev.demo.depictio.embl.org)
- Only stable tags (without -b suffix) deploy to demo environment (demo.depictio.embl.org)
- Uses GitHub Environments (`embl-demo-dev`, `embl-demo`) for protection rules

## Test plan

- [ ] Push a beta tag (e.g., `v0.6.0-b9`) and verify only dev deploys
- [ ] Push a stable tag (e.g., `v0.6.1`) and verify both environments deploy
- [ ] Verify environment protection rules require approval

🤖 Generated with [Claude Code](https://claude.ai/code)