### PR TITLE
fix: Load debug-menu-control.js in multi-app dispatcher

### DIFF
--- a/depictio/dash/flask_dispatcher.py
+++ b/depictio/dash/flask_dispatcher.py
@@ -58,6 +58,7 @@ DASH_INDEX_STRING = """
             {%config%}
             {%scripts%}
             {%renderer%}
+            <script src="/assets/js/debug-menu-control.js"></script>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
## Summary

- Fix debug menu remaining expanded in K8s deployments
- The multi-app dispatcher uses `include_assets_files=False`, so JS files in `assets/js/` were not loaded
- Add script tag for `debug-menu-control.js` to `DASH_INDEX_STRING` template

## Problem

The Dash debug menu was expanded by default in K8s deployments but collapsed in local dev. This was because:
- Local dev uses standalone app with `include_assets_files=True` → JS assets auto-loaded
- K8s uses multi-app dispatcher with `include_assets_files=False` → JS assets NOT loaded

## Solution

Add explicit script tag in the HTML template used by the multi-app dispatcher.

## Test plan

- [ ] Deploy to K8s and verify debug menu is collapsed by default
- [ ] Verify local dev still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)