### PR TITLE
feat(ui): improve MultiQC display, tab colors, and Cytoscape visualization

### DIFF
--- a/depictio/dash/component_metadata.py
+++ b/depictio/dash/component_metadata.py
@@ -135,7 +135,7 @@ COMPONENT_METADATA = {
         },  # Adjusted for 48-column grid with rowHeight=20 - full-featured MultiQC reports
     },
     "image": {
-        "icon": "mdi:image-multiple",
+        "icon": "mdi:image-area",  # Gallery-style icon for image data collections
         "display_name": "Image Gallery",
         "description": "Interactive image grid with modal viewer",
         "color": colors["teal"],

--- a/depictio/dash/layouts/tab_modal.py
+++ b/depictio/dash/layouts/tab_modal.py
@@ -4,6 +4,71 @@ import dash_mantine_components as dmc
 from dash import Input, Output, dcc, html
 from dash_iconify import DashIconify
 
+# =============================================================================
+# Workflow-based Color Mapping
+# =============================================================================
+# Maps workflow engines/catalogs to DMC tab colors for visual consistency
+
+WORKFLOW_COLORS = {
+    # Nextflow ecosystem
+    "nf-core": "green",
+    "nextflow": "green",
+    # Snakemake ecosystem
+    "snakemake": "lime",
+    # Galaxy ecosystem
+    "galaxy": "yellow",
+    # Python-based
+    "python": "blue",
+    # R-based
+    "r": "violet",
+    # Shell/Bash
+    "bash": "gray",
+    # CWL
+    "cwl": "cyan",
+    # Default fallback
+    "default": "orange",
+}
+
+
+def get_workflow_tab_color(workflow_data: dict | None) -> str:
+    """
+    Get the tab color based on workflow engine/catalog.
+
+    Checks for catalog first (e.g., nf-core), then falls back to engine.
+    Returns default color if no workflow data or no matching mapping.
+
+    Args:
+        workflow_data: Workflow dict containing 'catalog' and/or 'engine' fields.
+
+    Returns:
+        DMC color name (e.g., 'green', 'yellow', 'orange').
+    """
+    if not workflow_data:
+        return WORKFLOW_COLORS["default"]
+
+    # Check catalog first (more specific)
+    catalog = workflow_data.get("catalog", {})
+    if isinstance(catalog, dict):
+        catalog_name = catalog.get("name", "").lower()
+    else:
+        catalog_name = str(catalog).lower() if catalog else ""
+
+    if catalog_name and catalog_name in WORKFLOW_COLORS:
+        return WORKFLOW_COLORS[catalog_name]
+
+    # Check engine
+    engine = workflow_data.get("engine", {})
+    if isinstance(engine, dict):
+        engine_name = engine.get("name", "").lower()
+    else:
+        engine_name = str(engine).lower() if engine else ""
+
+    if engine_name and engine_name in WORKFLOW_COLORS:
+        return WORKFLOW_COLORS[engine_name]
+
+    return WORKFLOW_COLORS["default"]
+
+
 # Icon options for tab icon selection
 TAB_ICON_OPTIONS = [
     {"value": "mdi:view-dashboard", "label": "Dashboard"},
@@ -26,6 +91,7 @@ TAB_ICON_OPTIONS = [
 
 # Color options for tab icon color picker
 TAB_COLOR_OPTIONS = [
+    {"value": "", "label": "Auto (from workflow)"},  # Empty string = auto-derive
     {"value": "orange", "label": "Orange"},
     {"value": "blue", "label": "Blue"},
     {"value": "green", "label": "Green"},


### PR DESCRIPTION
## Summary

- Redesign MultiQC metadata display with accordion-based UI supporting multiple reports per DC
- Add workflow-based tab color mapping for visual consistency
- Fix MultiQC API integration issues (404 errors, document-based collection handling)

## Changes

### MultiQC Display Improvements
- Support multiple reports per data collection with selector dropdown
- Collapsible accordion for samples with scrollable area (150px height)
- Combined modules & plots view showing hierarchy (e.g., "cutadapt > cutadapt visualizations")
- Removed badge-based display in favor of clean text lists

### Tab Color System
- Add workflow-based color mapping (nf-core=green, snakemake=lime, galaxy=yellow, etc.)
- Add "Auto (from workflow)" option in tab icon color picker
- Colors derive from workflow engine/catalog when auto is selected

### Bug Fixes
- Fix MultiQC API endpoint URL (was causing 404 errors)
- Skip deltatable API calls for document-based MultiQC collections
- Add `api_call_fetch_all_multiqc_reports` function for multi-report support

## Test plan

- [ ] Navigate to a MultiQC data collection and verify accordion-based metadata display
- [ ] Test report selector when multiple reports exist
- [ ] Verify samples section is scrollable
- [ ] Check modules & plots show hierarchical structure
- [ ] Create dashboard with nf-core workflow and verify tabs use green color
- [ ] Test manual color override still works in tab modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)