### PR TITLE
fix(tabs): main tab inherits dashboard icon/color, dynamic tabs selection color

### DIFF
--- a/depictio/api/v1/endpoints/dashboards_endpoints/core_functions.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/core_functions.py
@@ -59,6 +59,9 @@ def get_child_tabs(parent_dashboard_id: PyObjectId) -> list[dict[str, Any]]:
         "tab_icon_color": 1,
         "is_main_tab": 1,
         "parent_dashboard_id": 1,
+        # Include icon fields for fallback inheritance
+        "icon": 1,
+        "icon_color": 1,
     }
 
     children = list(

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -1013,7 +1013,7 @@ async def get_tabs(
     # Get child tabs
     child_tabs = get_child_tabs(parent_dashboard_id)
 
-    # Build main tab entry
+    # Build main tab entry - include icon and icon_color for main tab display
     main_tab_entry = {
         "dashboard_id": str(main_tab["dashboard_id"]),
         "title": main_tab.get("title", "Untitled"),
@@ -1022,6 +1022,12 @@ async def get_tabs(
         "main_tab_name": main_tab.get("main_tab_name"),
         "tab_icon": main_tab.get("tab_icon"),
         "tab_icon_color": main_tab.get("tab_icon_color"),
+        # Dashboard's own icon and color (for main tab to inherit)
+        "icon": main_tab.get("icon", "mdi:view-dashboard"),
+        "icon_color": main_tab.get("icon_color", "orange"),
+        # Workflow info for auto-color derivation
+        "workflow_system": main_tab.get("workflow_system"),
+        "workflow_catalog": main_tab.get("workflow_catalog"),
     }
 
     return {

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -405,6 +405,7 @@ async def edit_dashboard_name(
     """
     Edit the name of a dashboard with the given dashboard ID.
     Now uses project-based permissions (editor level required).
+    Deprecated: Use /edit/{dashboard_id} instead.
     """
     new_name = data.get("new_name", None)
     if not new_name:
@@ -435,6 +436,67 @@ async def edit_dashboard_name(
         return {"message": f"Dashboard name updated successfully to '{new_name}'."}
     else:
         raise HTTPException(status_code=500, detail="Failed to update dashboard name.")
+
+
+@dashboards_endpoint_router.post("/edit/{dashboard_id}")
+async def edit_dashboard(
+    dashboard_id: PyObjectId,
+    data: dict,
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Edit a dashboard's properties (title, subtitle, icon, icon_color, workflow_system).
+
+    Does NOT allow changing project_id. Uses project-based permissions (editor level required).
+
+    Args:
+        dashboard_id: The dashboard ID to edit.
+        data: Dictionary with fields to update. Allowed fields:
+            - title: Dashboard title (required if provided)
+            - subtitle: Dashboard subtitle (optional)
+            - icon: Icon identifier (optional)
+            - icon_color: Icon color (optional)
+            - workflow_system: Workflow system (optional)
+    """
+    # Allowed fields to update (project_id is explicitly NOT allowed)
+    allowed_fields = {"title", "subtitle", "icon", "icon_color", "workflow_system"}
+    update_data = {k: v for k, v in data.items() if k in allowed_fields}
+
+    if not update_data:
+        raise HTTPException(status_code=400, detail="No valid fields provided for update.")
+
+    # Validate title is not empty if provided
+    if "title" in update_data and not update_data["title"]:
+        raise HTTPException(status_code=400, detail="Dashboard title cannot be empty.")
+
+    dashboard = dashboards_collection.find_one({"dashboard_id": dashboard_id})
+    if not dashboard:
+        raise HTTPException(
+            status_code=404, detail=f"Dashboard with ID '{dashboard_id}' not found."
+        )
+
+    project_id = dashboard.get("project_id")
+    if not project_id:
+        raise HTTPException(status_code=500, detail="Dashboard is not associated with a project.")
+
+    if not check_project_permission(project_id, current_user, "editor"):
+        raise HTTPException(
+            status_code=403, detail="You don't have permission to edit this dashboard."
+        )
+
+    result = dashboards_collection.find_one_and_update(
+        {"dashboard_id": dashboard_id},
+        {"$set": update_data},
+        return_document=True,
+    )
+
+    if result:
+        return {
+            "message": "Dashboard updated successfully.",
+            "updated_fields": list(update_data.keys()),
+        }
+    else:
+        raise HTTPException(status_code=500, detail="Failed to update dashboard.")
 
 
 @dashboards_endpoint_router.post("/save/{dashboard_id}")

--- a/depictio/dash/layouts/dashboards_management.py
+++ b/depictio/dash/layouts/dashboards_management.py
@@ -34,6 +34,7 @@ from depictio.dash.colors import colors  # Import Depictio color palette
 from depictio.dash.layouts.layouts_toolbox import (
     create_dashboard_modal,
     create_delete_confirmation_modal,
+    create_edit_dashboard_modal,
     get_workflow_icon_color,
     get_workflow_icon_mapping,
 )
@@ -210,44 +211,59 @@ def delete_dashboard(dashboard_id: str, token: str) -> None:
         raise ValueError(f"Failed to delete dashboard from the database. Error: {response.text}")
 
 
-def edit_dashboard_name(new_name: str, dashboard_id: str, dashboards: list, token: str) -> list:
+def edit_dashboard(
+    dashboard_id: str,
+    updates: dict,
+    dashboards: list,
+    token: str,
+) -> list:
     """
-    Edit the name of a dashboard and update in database.
+    Edit dashboard properties and update in database.
 
     Args:
-        new_name: New name for the dashboard.
-        dashboard_id: Unique identifier of the dashboard to rename.
+        dashboard_id: Unique identifier of the dashboard to edit.
+        updates: Dictionary with fields to update (title, subtitle, icon, icon_color, workflow_system).
         dashboards: List of dashboard objects to update locally.
         token: Authentication token for API access.
 
     Returns:
-        list: Updated list of dashboards with the renamed dashboard.
+        list: Updated list of dashboards with the edited dashboard.
 
     Raises:
         ValueError: If API request fails.
     """
-    logger.info(f"Editing dashboard name for dashboard ID: {dashboard_id}")
+    logger.info(f"Editing dashboard for dashboard ID: {dashboard_id}")
+    logger.debug(f"Updates: {updates}")
 
     updated_dashboards = list()
 
-    # Iterate over the dashboards to find the dashboard with the matching ID and update the name
+    # Iterate over the dashboards to find the dashboard with the matching ID and update fields
     for dashboard in dashboards:
-        if dashboard.dashboard_id == dashboard_id:
+        if str(dashboard.dashboard_id) == str(dashboard_id):
             logger.debug(f"Found dashboard to edit: {dashboard}")
-            dashboard.title = new_name
+            if "title" in updates:
+                dashboard.title = updates["title"]
+            if "subtitle" in updates:
+                dashboard.subtitle = updates["subtitle"]
+            if "icon" in updates:
+                dashboard.icon = updates["icon"]
+            if "icon_color" in updates:
+                dashboard.icon_color = updates["icon_color"]
+            if "workflow_system" in updates:
+                dashboard.workflow_system = updates["workflow_system"]
         updated_dashboards.append(dashboard)
 
     response = httpx.post(
-        f"{API_BASE_URL}/depictio/api/v1/dashboards/edit_name/{dashboard_id}",
+        f"{API_BASE_URL}/depictio/api/v1/dashboards/edit/{dashboard_id}",
         headers={"Authorization": f"Bearer {token}"},
-        json={"new_name": new_name},
+        json=updates,
     )
 
     if response.status_code == 200:
-        logger.info(f"Successfully edited dashboard name: {dashboard}")
+        logger.info(f"Successfully edited dashboard: {dashboard_id}")
 
     else:
-        raise ValueError(f"Failed to edit dashboard name in the database. Error: {response.text}")
+        raise ValueError(f"Failed to edit dashboard in the database. Error: {response.text}")
 
     return updated_dashboards
 
@@ -452,124 +468,31 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
         # Create project cache to avoid redundant API calls
         project_cache = {}
 
-        def modal_edit_name_dashboard(dashboard):
+        def modal_edit_dashboard(dashboard):
             """
-            Create a modal dialog for editing a dashboard's name.
+            Create a modal dialog for editing a dashboard's properties.
 
-            Generates a styled modal with a text input field for entering
-            a new dashboard name, along with Cancel and Save buttons.
-            The modal includes proper styling, icons, and error message
-            placeholder for validation feedback.
+            Generates a comprehensive modal for editing all dashboard properties:
+            title, subtitle, icon, icon_color, and workflow_system.
 
             Args:
-                dashboard: Dashboard dictionary containing at minimum the
-                    'dashboard_id' key used for component ID indexing.
+                dashboard: Dashboard dictionary containing dashboard properties
+                    including dashboard_id, title, subtitle, icon, icon_color,
+                    and workflow_system.
 
             Returns:
-                dmc.Modal: A Mantine modal component with:
-                    - Header with rename icon and title
-                    - Text input field for new dashboard name
-                    - Error message text (initially hidden)
-                    - Cancel and Save action buttons
+                dmc.Modal: A Mantine modal component with full edit capabilities.
                     The modal uses pattern-matching IDs based on dashboard_id
                     for callback routing.
             """
-            modal = dmc.Modal(
-                id={"type": "edit-password-modal", "index": dashboard["dashboard_id"]},
+            modal, _ = create_edit_dashboard_modal(
+                dashboard_id=dashboard["dashboard_id"],
+                title=dashboard.get("title", ""),
+                subtitle=dashboard.get("subtitle", ""),
+                icon=dashboard.get("icon", "mdi:view-dashboard"),
+                icon_color=dashboard.get("icon_color", "orange"),
+                workflow_system=dashboard.get("workflow_system", "none"),
                 opened=False,
-                centered=True,
-                withCloseButton=False,
-                # overlayOpacity=0.55,
-                # overlayBlur=3,
-                overlayProps={
-                    "overlayOpacity": 0.55,
-                    "overlayBlur": 3,
-                },
-                shadow="xl",
-                radius="md",
-                size="md",
-                zIndex=1000,
-                styles={
-                    "modal": {
-                        "padding": "24px",
-                    }
-                },
-                children=[
-                    dmc.Stack(
-                        gap="lg",
-                        children=[
-                            # Header with icon and title
-                            dmc.Group(
-                                justify="flex-start",
-                                gap="sm",
-                                children=[
-                                    DashIconify(
-                                        icon="mdi:rename-box",
-                                        width=28,
-                                        height=28,
-                                        color="#228be6",  # Dash Mantine blue color
-                                    ),
-                                    dmc.Title(
-                                        "Edit Dashboard Name",
-                                        order=4,
-                                        style={"margin": 0},
-                                    ),
-                                ],
-                            ),
-                            # Divider
-                            dmc.Divider(),
-                            # Text input field
-                            dmc.TextInput(
-                                placeholder="Enter new dashboard name",
-                                label="Dashboard Name",
-                                id={
-                                    "type": "new-name-dashboard",
-                                    "index": dashboard["dashboard_id"],
-                                },
-                                radius="md",
-                                size="md",
-                            ),
-                            # Error message
-                            dmc.Text(
-                                id={
-                                    "type": "message-edit-name-dashboard",
-                                    "index": dashboard["dashboard_id"],
-                                },
-                                c="red",
-                                size="sm",
-                                style={"display": "none"},
-                            ),
-                            # Buttons
-                            dmc.Group(
-                                justify="flex-end",
-                                gap="md",
-                                mt="md",
-                                children=[
-                                    dmc.Button(
-                                        "Cancel",
-                                        id={
-                                            "type": "cancel-edit-name-dashboard",
-                                            "index": dashboard["dashboard_id"],
-                                        },
-                                        color="gray",
-                                        variant="outline",
-                                        radius="md",
-                                    ),
-                                    dmc.Button(
-                                        "Save",
-                                        id={
-                                            "type": "save-edit-name-dashboard",
-                                            "index": dashboard["dashboard_id"],
-                                        },
-                                        color="blue",
-                                        radius="md",
-                                        leftSection=DashIconify(icon="mdi:content-save", width=16),
-                                    ),
-                                ],
-                            ),
-                        ],
-                    ),
-                ],
             )
             return modal
 
@@ -909,7 +832,7 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
                                 href=f"/dashboard/{dashboard['dashboard_id']}",
                             ),
                             dmc.Button(
-                                "Edit name",
+                                "Edit",
                                 id={
                                     "type": "edit-dashboard-button",
                                     "index": dashboard["dashboard_id"],
@@ -1372,7 +1295,7 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
                     item_id=dashboard["dashboard_id"],
                     title=f"Delete dashboard : {dashboard['title']}",
                 )
-                edit_name_modal = modal_edit_name_dashboard(dashboard)
+                edit_modal = modal_edit_dashboard(dashboard)
                 buttons = create_buttons(dashboard, user_id, current_user)
                 dashboard_header = create_dashboad_view_header(dashboard, user_id, token)
 
@@ -1451,7 +1374,7 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
                             dashboard_header,
                             buttons,
                             delete_modal,
-                            edit_name_modal,
+                            edit_modal,
                         ],
                     )
                 )
@@ -1958,12 +1881,104 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
         return preview, icon_name, icon_color, color_disabled
 
     @app.callback(
+        [
+            Output({"type": "edit-dashboard-icon-preview", "index": MATCH}, "children"),
+            Output({"type": "edit-dashboard-icon", "index": MATCH}, "value"),
+            Output({"type": "edit-dashboard-icon-color", "index": MATCH}, "value"),
+            Output({"type": "edit-dashboard-icon-color", "index": MATCH}, "disabled"),
+        ],
+        [
+            Input({"type": "edit-dashboard-icon", "index": MATCH}, "value"),
+            Input({"type": "edit-dashboard-icon-color", "index": MATCH}, "value"),
+            Input({"type": "edit-dashboard-workflow", "index": MATCH}, "value"),
+        ],
+        prevent_initial_call=True,
+    )
+    def update_edit_icon_preview(icon_name, icon_color, workflow_system):
+        """
+        Update the edit dashboard icon preview in real-time as users modify icon settings.
+        When a workflow system is selected, automatically set the appropriate workflow logo image.
+
+        Args:
+            icon_name: Icon identifier from Iconify (e.g., "mdi:chart-line") or image path
+            icon_color: Color name for the icon (e.g., "orange", "blue")
+            workflow_system: Selected workflow system (e.g., "nextflow", "snakemake", "nf-core", "none")
+
+        Returns:
+            Tuple of (preview component, icon value, color value, color_disabled)
+        """
+        # Get workflow mappings
+        workflow_icons = get_workflow_icon_mapping()
+        workflow_colors = get_workflow_icon_color()
+
+        # Check if a workflow system is selected (not "none")
+        if workflow_system and workflow_system != "none":
+            # Override with workflow-specific logo image path and color
+            icon_name = workflow_icons.get(workflow_system, "mdi:view-dashboard")
+            icon_color = workflow_colors.get(workflow_system, "orange")
+
+            # For workflows, use html.Img instead of DashIconify
+            if icon_name and icon_name.startswith("/assets/"):
+                preview = html.Img(
+                    src=icon_name,
+                    style={
+                        "width": "32px",
+                        "height": "32px",
+                        "objectFit": "contain",
+                    },
+                )
+            else:
+                # Wrap in ActionIcon for consistent UX
+                preview = dmc.ActionIcon(
+                    DashIconify(
+                        icon=icon_name,
+                        width=24,
+                        height=24,
+                    ),
+                    color=icon_color,
+                    radius="xl",
+                    size="lg",
+                    variant="filled",
+                    disabled=True,  # Not clickable - just a preview
+                )
+            # Disable color selector when workflow is selected
+            color_disabled = True
+        else:
+            # Use custom icon/color settings
+            # Default values if inputs are empty/None
+            if not icon_name or icon_name.strip() == "":
+                icon_name = "mdi:view-dashboard"
+
+            # Validate color is in allowed list, default to orange if not
+            allowed_colors = ["blue", "teal", "orange", "red", "purple", "pink", "green", "gray"]
+            if icon_color not in allowed_colors:
+                icon_color = "orange"
+
+            # Wrap in ActionIcon for consistent UX
+            preview = dmc.ActionIcon(
+                DashIconify(
+                    icon=icon_name,
+                    width=24,
+                    height=24,
+                ),
+                color=icon_color,
+                radius="xl",
+                size="lg",
+                variant="filled",
+                disabled=False,
+            )
+            # Enable color selector when no workflow is selected
+            color_disabled = False
+
+        return preview, icon_name, icon_color, color_disabled
+
+    @app.callback(
         Output({"type": "dashboard-list", "index": ALL}, "children"),
         # [Output({"type": "dashboard-list", "index": ALL}, "children"), Output({"type": "dashboard-index-store", "index": ALL}, "data")],
         [
             # Input({"type": "cancel-dashboard-delete-button", "index": ALL}, "n_clicks"),
             Input({"type": "confirm-dashboard-delete-button", "index": ALL}, "n_clicks"),
-            Input({"type": "save-edit-name-dashboard", "index": ALL}, "n_clicks"),
+            Input({"type": "save-edit-dashboard", "index": ALL}, "n_clicks"),
             Input({"type": "duplicate-dashboard-button", "index": ALL}, "n_clicks"),
             Input({"type": "make-public-dashboard-button", "index": ALL}, "n_clicks"),
             Input({"type": "make-public-dashboard-button", "index": ALL}, "children"),
@@ -1973,8 +1988,17 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
             State({"type": "create-dashboard-button", "index": ALL}, "id"),
             # State({"type": "dashboard-index-store", "index": ALL}, "data"),
             State({"type": "confirm-dashboard-delete-button", "index": ALL}, "index"),
-            State({"type": "new-name-dashboard", "index": ALL}, "value"),
-            State({"type": "new-name-dashboard", "index": ALL}, "id"),
+            # Edit dashboard states
+            State({"type": "edit-dashboard-title", "index": ALL}, "value"),
+            State({"type": "edit-dashboard-title", "index": ALL}, "id"),
+            State({"type": "edit-dashboard-subtitle", "index": ALL}, "value"),
+            State({"type": "edit-dashboard-subtitle", "index": ALL}, "id"),
+            State({"type": "edit-dashboard-icon", "index": ALL}, "value"),
+            State({"type": "edit-dashboard-icon", "index": ALL}, "id"),
+            State({"type": "edit-dashboard-icon-color", "index": ALL}, "value"),
+            State({"type": "edit-dashboard-icon-color", "index": ALL}, "id"),
+            State({"type": "edit-dashboard-workflow", "index": ALL}, "value"),
+            State({"type": "edit-dashboard-workflow", "index": ALL}, "id"),
             State("local-store", "data"),
             Input("dashboard-modal-store", "data"),
         ],
@@ -1990,29 +2014,46 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
         # create_ids_list,
         store_data_list,
         delete_ids_list,
-        new_name_list_values,
-        new_name_list_ids,
+        # Edit dashboard values
+        edit_title_values,
+        edit_title_ids,
+        edit_subtitle_values,
+        edit_subtitle_ids,
+        edit_icon_values,
+        edit_icon_ids,
+        edit_icon_color_values,
+        edit_icon_color_ids,
+        edit_workflow_values,
+        edit_workflow_ids,
         user_data,
         modal_data,
     ):
         """
         Main callback for dashboard list updates.
 
-        Handles all dashboard actions: creation, deletion, duplication, name editing,
+        Handles all dashboard actions: creation, deletion, duplication, editing,
         and public/private status toggling. Routes to appropriate handler based on
         which button triggered the callback.
 
         Args:
             delete_n_clicks_list: Click counts for delete confirmation buttons.
-            edit_n_clicks_list: Click counts for save name edit buttons.
+            edit_n_clicks_list: Click counts for save edit buttons.
             duplicate_n_clicks_list: Click counts for duplicate buttons.
             make_public_n_clicks_list: Click counts for public/private toggle buttons.
             make_public_children_list: Button text for public/private buttons.
             make_public_id_list: IDs for public/private buttons.
             store_data_list: Dashboard store data list.
             delete_ids_list: IDs of dashboards to delete.
-            new_name_list_values: New name input values.
-            new_name_list_ids: IDs for name input fields.
+            edit_title_values: Edit dashboard title values.
+            edit_title_ids: IDs for title input fields.
+            edit_subtitle_values: Edit dashboard subtitle values.
+            edit_subtitle_ids: IDs for subtitle input fields.
+            edit_icon_values: Edit dashboard icon values.
+            edit_icon_ids: IDs for icon input fields.
+            edit_icon_color_values: Edit dashboard icon color values.
+            edit_icon_color_ids: IDs for icon color select fields.
+            edit_workflow_values: Edit dashboard workflow values.
+            edit_workflow_ids: IDs for workflow select fields.
             user_data: User session data with access token.
             modal_data: Dashboard creation modal data.
 
@@ -2101,19 +2142,39 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
                 public_current_status,
             )
 
-        if ctx.triggered_id.get("type") == "save-edit-name-dashboard":
-            # Extract the new name from the input field
+        if ctx.triggered_id.get("type") == "save-edit-dashboard":
+            # Extract all edit fields from the input fields
             index = ctx.triggered_id["index"]
 
-            # Iterate over the new_name_list to find the new name corresponding to the index
-            new_name = [
-                value
-                for value, id in zip(new_name_list_values, new_name_list_ids)
-                if id["index"] == index
-            ][0]
+            # Helper function to get value by matching index
+            def get_value_by_index(values, ids, target_index):
+                for value, id_dict in zip(values, ids):
+                    if str(id_dict["index"]) == str(target_index):
+                        return value
+                return None
 
-            return handle_dashboard_edit(
-                new_name, dashboards, user_data, store_data_list, current_userbase
+            # Extract all field values
+            title = get_value_by_index(edit_title_values, edit_title_ids, index)
+            subtitle = get_value_by_index(edit_subtitle_values, edit_subtitle_ids, index)
+            icon = get_value_by_index(edit_icon_values, edit_icon_ids, index)
+            icon_color = get_value_by_index(edit_icon_color_values, edit_icon_color_ids, index)
+            workflow_system = get_value_by_index(edit_workflow_values, edit_workflow_ids, index)
+
+            # Build updates dict with non-None values
+            updates = {}
+            if title is not None:
+                updates["title"] = title
+            if subtitle is not None:
+                updates["subtitle"] = subtitle
+            if icon is not None:
+                updates["icon"] = icon
+            if icon_color is not None:
+                updates["icon_color"] = icon_color
+            if workflow_system is not None:
+                updates["workflow_system"] = workflow_system
+
+            return handle_dashboard_edit_full(
+                index, updates, dashboards, user_data, store_data_list, current_userbase
             )
 
         return generate_dashboard_view_response(
@@ -2303,18 +2364,33 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
         )
         # return generate_dashboard_view_response(updated_dashboards, len(updated_dashboards) + 1, store_data_list, current_userbase)
 
-    def handle_dashboard_edit(new_name, dashboards, user_data, store_data_list, current_userbase):
-        logger.info("Edit dashboard button clicked")
-        ctx_triggered_dict = ctx.triggered[0]
-        index_edit = eval(ctx_triggered_dict["prop_id"].split(".")[0])["index"]
-        updated_dashboards = edit_dashboard_name(
-            new_name, index_edit, dashboards, user_data["access_token"]
+    def handle_dashboard_edit_full(
+        dashboard_id, updates, dashboards, user_data, store_data_list, current_userbase
+    ):
+        """
+        Handle editing a dashboard with all fields (title, subtitle, icon, icon_color, workflow_system).
+
+        Args:
+            dashboard_id: The dashboard ID to edit.
+            updates: Dictionary of fields to update.
+            dashboards: List of current dashboard objects.
+            user_data: User session data with access token.
+            store_data_list: Dashboard store data list.
+            current_userbase: Current user base object.
+
+        Returns:
+            list: Updated dashboard view components.
+        """
+        logger.info(f"Edit dashboard button clicked for dashboard: {dashboard_id}")
+        logger.debug(f"Updates: {updates}")
+
+        updated_dashboards = edit_dashboard(
+            dashboard_id, updates, dashboards, user_data["access_token"]
         )
 
         return generate_dashboard_view_response(
             updated_dashboards, store_data_list, current_userbase, user_data
         )
-        # return generate_dashboard_view_response(updated_dashboards, len(updated_dashboards) + 1, store_data_list, current_userbase)
 
     def generate_dashboard_view_response(dashboards, store_data_list, current_userbase, user_data):
         dashboards = [convert_objectid_to_str(dashboard.mongo()) for dashboard in dashboards]
@@ -2325,23 +2401,25 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
         return [dashboards_view] * len(store_data_list)
 
     @app.callback(
-        Output({"type": "edit-password-modal", "index": MATCH}, "opened"),
+        Output({"type": "edit-dashboard-modal", "index": MATCH}, "opened"),
         [
             Input({"type": "edit-dashboard-button", "index": MATCH}, "n_clicks"),
-            Input({"type": "cancel-edit-name-dashboard", "index": MATCH}, "n_clicks"),
+            Input({"type": "cancel-edit-dashboard", "index": MATCH}, "n_clicks"),
+            Input({"type": "save-edit-dashboard", "index": MATCH}, "n_clicks"),
         ],
-        [State({"type": "edit-password-modal", "index": MATCH}, "opened")],
+        [State({"type": "edit-dashboard-modal", "index": MATCH}, "opened")],
         prevent_initial_call=True,
     )
-    def handle_edit_name_modal(edit_clicks, cancel_clicks, opened):
+    def handle_edit_dashboard_modal(edit_clicks, cancel_clicks, save_clicks, opened):
         """
-        Handle the edit name modal open/close state.
+        Handle the edit dashboard modal open/close state.
 
-        Opens modal when edit button clicked, closes when cancel clicked.
+        Opens modal when edit button clicked, closes when cancel or save clicked.
 
         Args:
             edit_clicks: Click count for edit button.
             cancel_clicks: Click count for cancel button.
+            save_clicks: Click count for save button.
             opened: Current modal open state.
 
         Returns:
@@ -2357,8 +2435,8 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
         # If edit button was clicked, toggle modal
         if "edit-dashboard-button" in triggered_id:
             return not opened
-        # If cancel button was clicked, close modal
-        elif "cancel-edit-name-dashboard" in triggered_id:
+        # If cancel or save button was clicked, close modal
+        elif "cancel-edit-dashboard" in triggered_id or "save-edit-dashboard" in triggered_id:
             return False
 
         return opened

--- a/depictio/dash/layouts/header.py
+++ b/depictio/dash/layouts/header.py
@@ -1013,47 +1013,70 @@ def _create_header_left_section(data: dict) -> dmc.Group:
             variant="filled",
         )
 
-    # Build title: show "Dashboard / Tab" format for all dashboards
+    # Build title: show "Dashboard / Tab" format only when meaningful
+    # For main tabs with no custom name and no child tabs, just show dashboard title
     is_main_tab = data.get("is_main_tab", True)
     dashboard_title = data["title"]
+    custom_main_tab_name = data.get("main_tab_name")
 
     if is_main_tab:
-        # Main tab: show "Dashboard Title / Main" (or custom main_tab_name)
-        tab_name = data.get("main_tab_name") or "Main"
+        # Main tab: only show "/ Main" if user set a custom main_tab_name
+        # Otherwise, just show the dashboard title (cleaner for single-tab dashboards)
+        if custom_main_tab_name:
+            # User customized the main tab name, show it
+            tab_name = custom_main_tab_name
+            show_tab_separator = True
+        else:
+            # No custom name - just show dashboard title without "/ Main"
+            tab_name = None
+            show_tab_separator = False
     else:
-        # Child tab: show "Parent Dashboard / Tab Name"
+        # Child tab: always show "Parent Dashboard / Tab Name"
         dashboard_title = data.get("parent_dashboard_title", data["title"])
         tab_name = data["title"]
+        show_tab_separator = True
 
-    title = dmc.Group(
-        [
-            dmc.Text(
-                dashboard_title,
-                fw="bold",
-                fz=20,
-                c="dimmed",
-                style={"lineHeight": "1.2"},
-            ),
-            dmc.Text(
-                "/",
-                fw="normal",
-                fz=18,
-                c="dimmed",
-                style={"lineHeight": "1.2", "margin": "0 4px"},
-            ),
-            dmc.Title(
-                tab_name,
-                order=3,
-                id="dashboard-title",
-                fw="bold",
-                fz=20,
-                m=0,
-                style={"lineHeight": "1.2"},
-            ),
-        ],
-        gap=0,
-        align="baseline",
-    )
+    if show_tab_separator and tab_name:
+        title = dmc.Group(
+            [
+                dmc.Text(
+                    dashboard_title,
+                    fw="bold",
+                    fz=20,
+                    c="dimmed",
+                    style={"lineHeight": "1.2"},
+                ),
+                dmc.Text(
+                    "/",
+                    fw="normal",
+                    fz=18,
+                    c="dimmed",
+                    style={"lineHeight": "1.2", "margin": "0 4px"},
+                ),
+                dmc.Title(
+                    tab_name,
+                    order=3,
+                    id="dashboard-title",
+                    fw="bold",
+                    fz=20,
+                    m=0,
+                    style={"lineHeight": "1.2"},
+                ),
+            ],
+            gap=0,
+            align="baseline",
+        )
+    else:
+        # Just show dashboard title (no tab separator)
+        title = dmc.Title(
+            dashboard_title,
+            order=3,
+            id="dashboard-title",
+            fw="bold",
+            fz=20,
+            m=0,
+            style={"lineHeight": "1.2"},
+        )
 
     return dmc.Group(
         [burger_button, icon_component, title],

--- a/depictio/dash/layouts/layouts_toolbox.py
+++ b/depictio/dash/layouts/layouts_toolbox.py
@@ -521,6 +521,375 @@ def create_delete_confirmation_modal(
     return modal, modal_id
 
 
+def create_edit_dashboard_modal(
+    dashboard_id: str,
+    title: str = "",
+    subtitle: str = "",
+    icon: str = "mdi:view-dashboard",
+    icon_color: str = "orange",
+    workflow_system: str = "none",
+    opened: bool = False,
+) -> tuple[dmc.Modal, dict]:
+    """Create a dashboard edit modal with all editable fields.
+
+    The modal includes:
+    - Title input (required)
+    - Subtitle textarea (optional)
+    - Icon customization (icon identifier and color)
+    - Workflow system selection
+
+    Args:
+        dashboard_id: The unique dashboard ID for pattern matching.
+        title: Pre-filled dashboard title.
+        subtitle: Pre-filled dashboard subtitle.
+        icon: Pre-filled icon identifier.
+        icon_color: Pre-filled icon color.
+        workflow_system: Pre-filled workflow system.
+        opened: Whether the modal starts open.
+
+    Returns:
+        Tuple of (modal component, modal ID dict for pattern matching).
+    """
+    modal_id = {
+        "type": "edit-dashboard-modal",
+        "index": dashboard_id,
+    }
+
+    modal = dmc.Modal(
+        id=modal_id,
+        opened=opened,
+        centered=True,
+        withCloseButton=True,
+        closeOnClickOutside=False,
+        closeOnEscape=True,
+        overlayProps={
+            "overlayOpacity": 0.55,
+            "overlayBlur": 3,
+        },
+        shadow="xl",
+        radius="md",
+        size="lg",
+        zIndex=1000,
+        styles={
+            "modal": {
+                "padding": "24px",
+            }
+        },
+        children=[
+            dmc.Stack(
+                gap="lg",
+                children=[
+                    # Header with icon and title
+                    dmc.Group(
+                        justify="flex-start",
+                        gap="sm",
+                        children=[
+                            DashIconify(
+                                icon="mdi:pencil-box-outline",
+                                width=28,
+                                height=28,
+                                color="#228be6",
+                            ),
+                            dmc.Title(
+                                "Edit Dashboard",
+                                order=4,
+                                style={"margin": 0},
+                            ),
+                        ],
+                    ),
+                    # Divider
+                    dmc.Divider(),
+                    # Two-column grid layout
+                    dmc.Grid(
+                        gutter="xl",
+                        children=[
+                            # Left column - Main form fields
+                            dmc.GridCol(
+                                span=7,
+                                children=[
+                                    dmc.Stack(
+                                        gap="md",
+                                        children=[
+                                            # Dashboard title input
+                                            dmc.TextInput(
+                                                label="Dashboard Title",
+                                                description="Give your dashboard a descriptive name",
+                                                placeholder="Enter dashboard title",
+                                                id={
+                                                    "type": "edit-dashboard-title",
+                                                    "index": dashboard_id,
+                                                },
+                                                value=title,
+                                                required=True,
+                                                leftSection=DashIconify(
+                                                    icon="mdi:text-box-outline"
+                                                ),
+                                                style={"width": "100%"},
+                                            ),
+                                            # Dashboard subtitle input
+                                            dmc.Textarea(
+                                                label="Dashboard Subtitle (Optional)",
+                                                description="Add a brief description for your dashboard",
+                                                placeholder="Enter subtitle (optional)",
+                                                id={
+                                                    "type": "edit-dashboard-subtitle",
+                                                    "index": dashboard_id,
+                                                },
+                                                value=subtitle,
+                                                autosize=True,
+                                                minRows=2,
+                                                maxRows=4,
+                                                style={"width": "100%"},
+                                            ),
+                                            # Error message placeholder
+                                            dmc.Text(
+                                                id={
+                                                    "type": "edit-dashboard-error",
+                                                    "index": dashboard_id,
+                                                },
+                                                c="red",
+                                                size="sm",
+                                                style={"display": "none"},
+                                            ),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                            # Right column - Icon customization
+                            dmc.GridCol(
+                                span=5,
+                                children=[
+                                    dmc.Paper(
+                                        shadow="sm",
+                                        radius="md",
+                                        withBorder=True,
+                                        p="md",
+                                        style={
+                                            "height": "100%",
+                                        },
+                                        children=[
+                                            dmc.Stack(
+                                                gap="md",
+                                                children=[
+                                                    # Section header
+                                                    dmc.Group(
+                                                        justify="space-between",
+                                                        children=[
+                                                            dmc.Text(
+                                                                "Icon Customization",
+                                                                size="sm",
+                                                                fw="bold",
+                                                                c="gray",
+                                                            ),
+                                                        ],
+                                                    ),
+                                                    # Compact preview
+                                                    dmc.Group(
+                                                        justify="space-between",
+                                                        align="center",
+                                                        children=[
+                                                            dmc.Stack(
+                                                                gap="2px",
+                                                                children=[
+                                                                    dmc.Text(
+                                                                        "Preview",
+                                                                        size="xs",
+                                                                        c="gray",
+                                                                    ),
+                                                                    html.Div(
+                                                                        id={
+                                                                            "type": "edit-dashboard-icon-preview",
+                                                                            "index": dashboard_id,
+                                                                        },
+                                                                        children=[
+                                                                            dmc.ActionIcon(
+                                                                                DashIconify(
+                                                                                    icon=icon,
+                                                                                    width=24,
+                                                                                    height=24,
+                                                                                ),
+                                                                                color=icon_color,
+                                                                                radius="xl",
+                                                                                size="lg",
+                                                                                variant="filled",
+                                                                                disabled=False,
+                                                                            ),
+                                                                        ],
+                                                                    ),
+                                                                ],
+                                                                align="center",
+                                                            ),
+                                                        ],
+                                                    ),
+                                                    dmc.Divider(),
+                                                    # Icon input
+                                                    dmc.TextInput(
+                                                        label="Dashboard Icon",
+                                                        description="Icon from Iconify (e.g., mdi:chart-line)",
+                                                        placeholder="mdi:view-dashboard",
+                                                        id={
+                                                            "type": "edit-dashboard-icon",
+                                                            "index": dashboard_id,
+                                                        },
+                                                        value=icon,
+                                                        leftSection=DashIconify(
+                                                            icon="mdi:emoticon-outline", width=16
+                                                        ),
+                                                        size="sm",
+                                                        style={"width": "100%"},
+                                                    ),
+                                                    # Link to browse icons
+                                                    html.A(
+                                                        dmc.Group(
+                                                            [
+                                                                DashIconify(
+                                                                    icon="mdi:open-in-new",
+                                                                    width=14,
+                                                                ),
+                                                                dmc.Text(
+                                                                    "Browse MDI icons",
+                                                                    size="xs",
+                                                                    c="blue",
+                                                                    style={
+                                                                        "textDecoration": "none",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            gap="4px",
+                                                            style={
+                                                                "marginTop": "-8px",
+                                                                "marginBottom": "4px",
+                                                            },
+                                                        ),
+                                                        href="https://pictogrammers.com/library/mdi/",
+                                                        target="_blank",
+                                                        style={
+                                                            "textDecoration": "none",
+                                                            "display": "inline-block",
+                                                        },
+                                                    ),
+                                                    # Icon color selection
+                                                    dmc.Select(
+                                                        label="Icon Color",
+                                                        description="Color for the dashboard icon",
+                                                        data=[
+                                                            {"value": "blue", "label": "Blue"},
+                                                            {"value": "teal", "label": "Teal"},
+                                                            {"value": "orange", "label": "Orange"},
+                                                            {"value": "red", "label": "Red"},
+                                                            {"value": "purple", "label": "Purple"},
+                                                            {"value": "pink", "label": "Pink"},
+                                                            {"value": "green", "label": "Green"},
+                                                            {"value": "gray", "label": "Gray"},
+                                                        ],
+                                                        id={
+                                                            "type": "edit-dashboard-icon-color",
+                                                            "index": dashboard_id,
+                                                        },
+                                                        value=icon_color,
+                                                        leftSection=DashIconify(
+                                                            icon="mdi:palette", width=16
+                                                        ),
+                                                        size="sm",
+                                                        style={"width": "100%"},
+                                                        comboboxProps={"withinPortal": False},
+                                                    ),
+                                                    # Workflow system selection
+                                                    dmc.Divider(
+                                                        label="Workflow System (Optional)",
+                                                        labelPosition="center",
+                                                        style={"marginTop": "16px"},
+                                                    ),
+                                                    dmc.Select(
+                                                        label="Workflow System",
+                                                        description="Auto-set icon based on workflow",
+                                                        data=[
+                                                            {
+                                                                "value": "none",
+                                                                "label": "None (Use Custom Icon)",
+                                                            },
+                                                            {
+                                                                "value": "nextflow",
+                                                                "label": "Nextflow",
+                                                            },
+                                                            {
+                                                                "value": "snakemake",
+                                                                "label": "Snakemake",
+                                                            },
+                                                            {
+                                                                "value": "nf-core",
+                                                                "label": "nf-core",
+                                                            },
+                                                            {
+                                                                "value": "galaxy",
+                                                                "label": "Galaxy",
+                                                            },
+                                                            {
+                                                                "value": "iwc",
+                                                                "label": "IWC (Intergalactic Workflow Commission)",
+                                                            },
+                                                        ],
+                                                        id={
+                                                            "type": "edit-dashboard-workflow",
+                                                            "index": dashboard_id,
+                                                        },
+                                                        value=workflow_system,
+                                                        leftSection=DashIconify(
+                                                            icon="mdi:cog-outline", width=16
+                                                        ),
+                                                        size="sm",
+                                                        comboboxProps={"withinPortal": False},
+                                                    ),
+                                                    dmc.Text(
+                                                        "Selecting a workflow will override the custom icon",
+                                                        size="xs",
+                                                        c="gray",
+                                                        style={"marginTop": "4px"},
+                                                    ),
+                                                ],
+                                            ),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    # Buttons
+                    dmc.Group(
+                        justify="flex-end",
+                        gap="md",
+                        mt="md",
+                        children=[
+                            dmc.Button(
+                                "Cancel",
+                                id={
+                                    "type": "cancel-edit-dashboard",
+                                    "index": dashboard_id,
+                                },
+                                color="gray",
+                                variant="outline",
+                                radius="md",
+                            ),
+                            dmc.Button(
+                                "Save Changes",
+                                id={
+                                    "type": "save-edit-dashboard",
+                                    "index": dashboard_id,
+                                },
+                                color="blue",
+                                radius="md",
+                                leftSection=DashIconify(icon="mdi:content-save", width=16),
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    return modal, modal_id
+
+
 def create_add_with_input_modal(
     id_prefix: str,
     input_field,

--- a/depictio/dash/layouts/layouts_toolbox.py
+++ b/depictio/dash/layouts/layouts_toolbox.py
@@ -19,6 +19,28 @@ from dash_iconify import DashIconify
 
 from depictio.dash.colors import colors
 
+# Shared options for icon color selection across create and edit modals
+ICON_COLOR_OPTIONS = [
+    {"value": "blue", "label": "Blue"},
+    {"value": "teal", "label": "Teal"},
+    {"value": "orange", "label": "Orange"},
+    {"value": "red", "label": "Red"},
+    {"value": "purple", "label": "Purple"},
+    {"value": "pink", "label": "Pink"},
+    {"value": "green", "label": "Green"},
+    {"value": "gray", "label": "Gray"},
+]
+
+# Shared options for workflow system selection
+WORKFLOW_SYSTEM_OPTIONS = [
+    {"value": "none", "label": "None (Use Custom Icon)"},
+    {"value": "nextflow", "label": "Nextflow"},
+    {"value": "snakemake", "label": "Snakemake"},
+    {"value": "nf-core", "label": "nf-core"},
+    {"value": "galaxy", "label": "Galaxy"},
+    {"value": "iwc", "label": "IWC (Intergalactic Workflow Commission)"},
+]
+
 
 def get_workflow_icon_mapping() -> dict[str, str | None]:
     """Map workflow systems to their logo image paths.
@@ -300,16 +322,7 @@ def create_dashboard_modal(
                                                     dmc.Select(
                                                         label="Icon Color",
                                                         description="Color for the dashboard icon",
-                                                        data=[
-                                                            {"value": "blue", "label": "Blue"},
-                                                            {"value": "teal", "label": "Teal"},
-                                                            {"value": "orange", "label": "Orange"},
-                                                            {"value": "red", "label": "Red"},
-                                                            {"value": "purple", "label": "Purple"},
-                                                            {"value": "pink", "label": "Pink"},
-                                                            {"value": "green", "label": "Green"},
-                                                            {"value": "gray", "label": "Gray"},
-                                                        ],
+                                                        data=ICON_COLOR_OPTIONS,
                                                         id=f"{id_prefix}-icon-color-select",
                                                         value="orange",
                                                         leftSection=DashIconify(
@@ -328,32 +341,7 @@ def create_dashboard_modal(
                                                     dmc.Select(
                                                         label="Workflow System",
                                                         description="Auto-set icon based on workflow",
-                                                        data=[
-                                                            {
-                                                                "value": "none",
-                                                                "label": "None (Use Custom Icon)",
-                                                            },
-                                                            {
-                                                                "value": "nextflow",
-                                                                "label": "Nextflow",
-                                                            },
-                                                            {
-                                                                "value": "snakemake",
-                                                                "label": "Snakemake",
-                                                            },
-                                                            {
-                                                                "value": "nf-core",
-                                                                "label": "nf-core",
-                                                            },
-                                                            {
-                                                                "value": "galaxy",
-                                                                "label": "Galaxy",
-                                                            },
-                                                            {
-                                                                "value": "iwc",
-                                                                "label": "IWC (Intergalactic Workflow Commission)",
-                                                            },
-                                                        ],
+                                                        data=WORKFLOW_SYSTEM_OPTIONS,
                                                         id=f"{id_prefix}-workflow-system-select",
                                                         value="none",
                                                         leftSection=DashIconify(
@@ -772,16 +760,7 @@ def create_edit_dashboard_modal(
                                                     dmc.Select(
                                                         label="Icon Color",
                                                         description="Color for the dashboard icon",
-                                                        data=[
-                                                            {"value": "blue", "label": "Blue"},
-                                                            {"value": "teal", "label": "Teal"},
-                                                            {"value": "orange", "label": "Orange"},
-                                                            {"value": "red", "label": "Red"},
-                                                            {"value": "purple", "label": "Purple"},
-                                                            {"value": "pink", "label": "Pink"},
-                                                            {"value": "green", "label": "Green"},
-                                                            {"value": "gray", "label": "Gray"},
-                                                        ],
+                                                        data=ICON_COLOR_OPTIONS,
                                                         id={
                                                             "type": "edit-dashboard-icon-color",
                                                             "index": dashboard_id,
@@ -803,32 +782,7 @@ def create_edit_dashboard_modal(
                                                     dmc.Select(
                                                         label="Workflow System",
                                                         description="Auto-set icon based on workflow",
-                                                        data=[
-                                                            {
-                                                                "value": "none",
-                                                                "label": "None (Use Custom Icon)",
-                                                            },
-                                                            {
-                                                                "value": "nextflow",
-                                                                "label": "Nextflow",
-                                                            },
-                                                            {
-                                                                "value": "snakemake",
-                                                                "label": "Snakemake",
-                                                            },
-                                                            {
-                                                                "value": "nf-core",
-                                                                "label": "nf-core",
-                                                            },
-                                                            {
-                                                                "value": "galaxy",
-                                                                "label": "Galaxy",
-                                                            },
-                                                            {
-                                                                "value": "iwc",
-                                                                "label": "IWC (Intergalactic Workflow Commission)",
-                                                            },
-                                                        ],
+                                                        data=WORKFLOW_SYSTEM_OPTIONS,
                                                         id={
                                                             "type": "edit-dashboard-workflow",
                                                             "index": dashboard_id,

--- a/depictio/tests/e2e-tests/cypress/e2e/unauthenticated/dashboard-access-restrictions.cy.js
+++ b/depictio/tests/e2e-tests/cypress/e2e/unauthenticated/dashboard-access-restrictions.cy.js
@@ -51,7 +51,7 @@ describe('Unauthenticated Mode - Dashboard Access Restrictions', () => {
         cy.get('button').contains('View').should('be.visible').should('not.be.disabled')
 
         // Check that other buttons are disabled - need to check the button element, not the span
-        cy.contains('button', 'Edit name').should('be.disabled')
+        cy.contains('button', 'Edit').should('be.disabled')
         cy.contains('button', 'Duplicate').should('be.disabled')
         cy.contains('button', 'Delete').should('be.disabled')
         cy.contains('button', 'Make private').should('be.disabled')

--- a/depictio/tests/e2e-tests/cypress/e2e/unauthenticated/enable-interactive-mode.cy.js
+++ b/depictio/tests/e2e-tests/cypress/e2e/unauthenticated/enable-interactive-mode.cy.js
@@ -164,7 +164,7 @@ describe('Unauthenticated Mode - Login as a temporary user Flow', () => {
 
         // Other buttons should still be disabled for temporary users
         cy.contains('button', 'Delete').should('be.disabled')
-        cy.contains('button', 'Edit name').should('be.disabled')
+        cy.contains('button', 'Edit').should('be.disabled')
       })
 
     cy.screenshot('duplicate_button_enabled_after_interactive_mode')


### PR DESCRIPTION
## Summary

- Fix main tab to use dashboard's own icon and color instead of separate tab_icon fields
- Add dynamic tabs selection highlight color based on dashboard's icon_color
- Simplify header title for single-tab dashboards

## Changes

### API Fixes
- `/tabs/{parent_dashboard_id}` endpoint now returns `icon`, `icon_color`, `workflow_system`, `workflow_catalog` for main tab
- `get_child_tabs` function includes `icon` and `icon_color` in projection for fallback inheritance

### Frontend Fixes
- Main tab now always uses dashboard's `icon` and `icon_color` (the main tab IS the dashboard)
- Child tabs use `tab_icon`/`tab_icon_color` if set, otherwise fall back to parent's `icon_color`
- `sidebar-tabs` color property dynamically set from parent dashboard's `icon_color`
- Header title only shows "/ tab_name" when user set a custom `main_tab_name`
- Single-tab dashboards just show the dashboard title (cleaner, no redundant "/ Main")

## Test plan

- [ ] Create dashboard with custom icon_color (e.g., green)
- [ ] Verify main tab in sidebar shows the dashboard's icon and color
- [ ] Verify tabs selection highlight matches dashboard's icon_color
- [ ] Verify single-tab dashboard header shows just title (no "/ Main")
- [ ] Add child tab, verify it inherits parent's color if not explicitly set
- [ ] Verify child tabs with explicit tab_icon_color use their own color

🤖 Generated with [Claude Code](https://claude.com/claude-code)