### PR TITLE
fix(websocket): enable callback on initial page load and remove NGINX…

### DIFF
--- a/depictio/dash/layouts/realtime_callbacks.py
+++ b/depictio/dash/layouts/realtime_callbacks.py
@@ -77,7 +77,7 @@ def register_websocket_url_callback(app: Dash) -> None:
         Output("ws", "url"),
         Input("url", "pathname"),
         State("local-store", "data"),
-        prevent_initial_call=True,
+        prevent_initial_call=False,  # Allow callback to run on page load for direct dashboard navigation
     )
 
 

--- a/helm-charts/depictio/values-embl-demo-base.yaml
+++ b/helm-charts/depictio/values-embl-demo-base.yaml
@@ -180,13 +180,7 @@ ingress:
   # EMBL specific annotations
   annotations:
     cert-manager.io/cluster-issuer: harica-issuer
-    # WebSocket support for Dash real-time updates over HTTPS
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/websocket-services: "depictio-frontend"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+    # Traefik automatically handles WebSocket upgrades
 
   # Host configuration for split frontend/backend setup
   # NOTE: Two approaches are available:

--- a/helm-charts/depictio/values-embl-demo-dev.yaml
+++ b/helm-charts/depictio/values-embl-demo-dev.yaml
@@ -80,13 +80,7 @@ ingress:
 
   annotations:
     cert-manager.io/cluster-issuer: harica-issuer
-    # WebSocket support for Dash real-time updates over HTTPS
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/websocket-services: "devdemo-depictio-frontend"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+    # Traefik automatically handles WebSocket upgrades
 
   hosts:
     - host: "dev.demo.depictio.embl.org"

--- a/helm-charts/depictio/values-embl-demo.yaml
+++ b/helm-charts/depictio/values-embl-demo.yaml
@@ -59,13 +59,7 @@ ingress:
 
   annotations:
     cert-manager.io/cluster-issuer: harica-issuer
-    # WebSocket support for Dash real-time updates over HTTPS
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/websocket-services: "demo-depictio-frontend"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+    # Traefik automatically handles WebSocket upgrades
 
   hosts:
     - host: "demo.depictio.embl.org"


### PR DESCRIPTION
… annotations

**Critical Fix:**
The clientside callback had `prevent_initial_call=True`, which prevented the WebSocket URL from being set when users navigated directly to a dashboard URL (e.g., https://demo.depictio.embl.org/dashboard/abc123).

**Changes:**
1. Set `prevent_initial_call=False` on WebSocket URL callback
   - Allows callback to run on page load
   - Properly sets wss:// protocol for HTTPS connections
   - Callback already has guards for missing token/pathname

2. Removed NGINX WebSocket annotations
   - EMBL cluster uses Traefik, not NGINX
   - Traefik automatically handles WebSocket upgrades
   - Annotations were unnecessary and potentially conflicting

**Impact:**
- WebSocket connections now properly use wss:// on HTTPS
- Real-time dashboard updates work on production

**Testing:**
- Load dashboard directly: ✅ WebSocket connects with wss://
- Navigate between dashboards: ✅ WebSocket URL updates
- Missing token: ✅ Callback returns no_update (as intended)