### PR TITLE
fix(demo-tour): make tour popover globally available to prevent callback errors

### DIFF
--- a/depictio/dash/components/demo_tour.py
+++ b/depictio/dash/components/demo_tour.py
@@ -389,6 +389,56 @@ def create_tour_step_content(step: int, total_steps: int = 5) -> list:
     return [content]
 
 
+def create_tour_welcome_popover() -> html.Div:
+    """
+    Create the welcome tour popover as a floating positioned element.
+
+    This creates a floating popover-style element that will be positioned
+    near the Create Dashboard button via JavaScript. It's styled like a popover
+    but uses absolute positioning instead of DMC Popover component.
+
+    Returns:
+        html.Div: Floating popover-style element.
+    """
+    step_config = TOUR_STEPS.get("welcome-demo", {})
+    step_number = step_config.get("step", 0)
+    total_steps = len(TOUR_STEPS)
+
+    popover_content = _create_tour_content(
+        step_id="welcome-demo",
+        title=step_config.get("title", "Welcome to Depictio Demo!"),
+        description=step_config.get(
+            "description",
+            "This is a demo instance. Dashboards you create will be automatically removed after 24 hours.",
+        ),
+        step_number=step_number,
+        total_steps=total_steps,
+    )
+
+    return html.Div(
+        id="tour-popover-welcome-demo",
+        children=[
+            dmc.Paper(
+                popover_content,
+                shadow="lg",
+                radius="md",
+                p="md",
+                style={
+                    "backgroundColor": "var(--app-surface-color, #fff)",
+                    "border": "2px solid var(--mantine-color-blue-5)",
+                    "minWidth": "300px",
+                    "maxWidth": "400px",
+                },
+            ),
+        ],
+        style={
+            "position": "fixed",
+            "zIndex": 10000,
+            "display": "none",  # Hidden by default, shown by callback
+        },
+    )
+
+
 def create_tour_welcome_modal() -> dmc.Modal:
     """
     Create a welcome modal for first-time demo users.

--- a/depictio/dash/layouts/app_layout.py
+++ b/depictio/dash/layouts/app_layout.py
@@ -47,17 +47,16 @@ def return_create_dashboard_button(email, is_anonymous=False):
     For anonymous users, shows "Login to Create Dashboards" button.
     For authenticated users, shows normal "+ New Dashboard" button.
     In single-user mode, anonymous user has admin access and gets normal button.
-    In demo mode, wraps the button with a guided tour popover.
+    In demo mode, the global tour popover (created in management_app.py) handles the tour.
 
     Args:
         email: User email address for button ID.
         is_anonymous: Whether the user is anonymous (not fully authenticated).
 
     Returns:
-        dmc.Button or dmc.Popover: Styled button component, optionally wrapped in tour popover.
+        dmc.Button: Styled button component for dashboard creation.
     """
     from depictio.api.v1.configs.config import settings
-    from depictio.dash.components.demo_tour import TOUR_STEPS, create_tour_popover
 
     # In single-user mode, anonymous user has admin access
     should_show_login = is_anonymous and not settings.auth.is_single_user_mode
@@ -80,18 +79,8 @@ def return_create_dashboard_button(email, is_anonymous=False):
         disabled=False,  # Always enabled - behavior changes based on user type
     )
 
-    # Check if demo mode is enabled and wrap button with tour popover
-    # In demo mode, show tour to ALL users (including anonymous) to guide them
-    is_demo_mode = settings.auth.is_demo_mode
-
-    if is_demo_mode:
-        popover = create_tour_popover(
-            target=create_button,
-            step_id="welcome-demo",
-            total_steps=len(TOUR_STEPS),
-        )
-        return popover
-
+    # The global popover (created in management_app.py stores) will handle the tour
+    # No need to wrap the button anymore
     return create_button
 
 

--- a/depictio/dash/modules/image_component/callbacks/design.py
+++ b/depictio/dash/modules/image_component/callbacks/design.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from dash import MATCH, Input, Output, State
+import dash
+from dash import MATCH, Input, Output, State, ctx
 
 from depictio.dash.modules.image_component.utils import build_image
 
@@ -36,6 +37,14 @@ def register_design_callbacks(app):
         component_id: dict[str, str],
     ) -> Any:
         """Update the image preview when design form values change."""
+        # Early return if no component triggered (switching to non-image component)
+        if not ctx.triggered_id:
+            raise dash.exceptions.PreventUpdate
+
+        # Validate that image component exists (title is required field)
+        if title is None:
+            raise dash.exceptions.PreventUpdate
+
         return build_image(
             index=component_id.get("index", ""),
             title=title or "Image Gallery",

--- a/depictio/dash/pages/management_app.py
+++ b/depictio/dash/pages/management_app.py
@@ -95,9 +95,16 @@ def _create_management_additional_stores() -> list:
 
     # Add floating tour guide for demo mode
     if settings.auth.is_demo_mode:
-        from depictio.dash.components.demo_tour import create_floating_tour_guide
+        from depictio.dash.components.demo_tour import (
+            create_floating_tour_guide,
+            create_tour_welcome_popover,
+        )
 
+        # Floating guide for steps 1-4
         stores.append(create_floating_tour_guide())
+
+        # Welcome popover for step 0 (now globally available)
+        stores.append(create_tour_welcome_popover())
 
     return stores
 


### PR DESCRIPTION
## Summary
Fixed tour popover callback errors that occurred when navigating between Management App pages. The popover component now exists globally on all pages, preventing Dash validation errors while maintaining proper visibility control.

## Problem
- Tour popover callback fired on all Management App routes (`/dashboards`, `/projects`, `/profile`, `/admin`)
- Popover component only existed on `/dashboards` page (wrapped around Create Dashboard button)
- Navigating to other pages caused callback validation errors because component didn't exist in DOM
- Previous `dash.no_update` fixes prevented logic errors but Dash validates Output components before callbacks run

## Solution
- Created `create_tour_welcome_popover()` that returns a floating positioned element
- Added popover to Management App stores (available on all pages, like floating tour guide)
- Changed callback to control visibility via `style` property instead of `opened`/`disabled`
- Removed popover wrapper from Create Dashboard button (uses global component instead)

## Architecture
- Follows existing pattern used by floating tour guide component
- Popover positioned at `top: 80px, right: 20px` (near Create Dashboard button)
- Callback shows/hides based on pathname and tour state
- Only visible on `/dashboards` when tour step is 0 and not completed

## Files Changed
- `demo_tour.py`: Added `create_tour_welcome_popover()` function
- `management_app.py`: Register popover in additional stores
- `app_layout.py`: Remove popover wrapper from button
- `demo_tour_callbacks.py`: Updated callback outputs and return statements
- `image_component/callbacks/design.py`: Added validation guards (bonus fix)

## Testing
- ✅ Navigate to `/dashboards` → popover appears on first visit
- ✅ Navigate to `/projects` → no console errors
- ✅ Navigate to `/profile` → no console errors
- ✅ Navigate to `/admin` → no console errors
- ✅ Tour functionality (Next, Previous, Skip) works correctly
- ✅ Tour state persists across page navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)