### PR TITLE
fix(dash): correct debug-menu-control.js path in HTML templates

### DIFF
--- a/depictio/dash/components/google_analytics.py
+++ b/depictio/dash/components/google_analytics.py
@@ -186,6 +186,7 @@ class GoogleAnalyticsIntegration:
             {{%config%}}
             {{%scripts%}}
             {{%renderer%}}
+            <script src="/assets/debug-menu-control.js"></script>
         </footer>
     </body>
 </html>"""

--- a/depictio/dash/flask_dispatcher.py
+++ b/depictio/dash/flask_dispatcher.py
@@ -58,7 +58,7 @@ DASH_INDEX_STRING = """
             {%config%}
             {%scripts%}
             {%renderer%}
-            <script src="/assets/js/debug-menu-control.js"></script>
+            <script src="/assets/debug-menu-control.js"></script>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
## Summary
Fixed path mismatch preventing the debug menu auto-collapse script from loading. The script exists at `/assets/debug-menu-control.js` but HTML templates referenced `/assets/js/debug-menu-control.js`, causing 404 errors and preventing the debug menu from auto-collapsing.

## Problem
**Symptoms**:
- Debug menu stayed expanded on page load (both local and K8s)
- Browser network tab showed no request for debug-menu-control.js (or 404 if requested)
- Browser console showed no script execution logs
- Manual toggle button click worked, confirming script wasn't running

**Root cause investigation**:
1. File accessible at: `https://dev.demo.depictio.embl.org/assets/debug-menu-control.js` ✅
2. HTML referenced: `/assets/js/debug-menu-control.js` ❌
3. Result: Script never loaded (404 or not requested)

**Dual template issue**:
- Production (`flask_dispatcher.py`): Wrong path in template
- Local dev (`app.py` → `google_analytics.py`): Script tag missing entirely

## Solution
**Fixed both HTML templates**:
1. `flask_dispatcher.py` line 61: Changed path from `/assets/js/debug-menu-control.js` → `/assets/debug-menu-control.js`
2. `google_analytics.py` line 189: Added `<script src="/assets/debug-menu-control.js"></script>`

## Impact
- ✅ Local development: Script now loads and executes
- ✅ K8s production: Script now loads from correct path
- ✅ Consistent behavior across all environments
- ✅ Debug menu auto-collapses within ~1 second on page load

## Testing
**Browser console confirms script execution**:
```
🔍 Attempt 1/50 to collapse debug menu
✓ Debug menu found - collapsing via toggle button
✓ Debug menu successfully collapsed
```

**Network tab confirms file loads**:
- Request: `/assets/debug-menu-control.js`
- Status: 200 OK
- Size: ~5.6KB

## Related
- Fixes issue introduced when script was reorganized into assets structure
- Complements PR #678 (tour popover global component + enhanced debug menu script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)