### PR TITLE
fix: Resolve three demo mode issues

### DIFF
--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -1973,7 +1973,6 @@ jobs:
       - name: Run Cypress tests
         run: |
           cd depictio/tests/e2e-tests
-          export CYPRESS_UNAUTHENTICATED_MODE=false
           # Set Chrome flags for better CI rendering and stability
           export CYPRESS_BROWSER_ARGS="--disable-gpu --no-sandbox --disable-dev-shm-usage --disable-extensions --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows"
           # Run Chrome in headless mode for CI with improved stability
@@ -1981,7 +1980,7 @@ jobs:
             --browser chrome \
             --headless \
             --config screenshotsFolder=cypress/screenshots,videosFolder=cypress/videos,trashAssetsBeforeRuns=false,video=true,screenshotOnRunFailure=true,viewportWidth=1920,viewportHeight=1080,chromeWebSecurity=false \
-            --spec "cypress/e2e/!(unauthenticated)/**/*.cy.js"
+            --spec "cypress/e2e/auth/standard/**/*.cy.js"
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
@@ -1999,7 +1998,7 @@ jobs:
           path: depictio/tests/e2e-tests/cypress/videos
           retention-days: 7
 
-  e2e-tests-unauthenticated:
+  e2e-tests-public-mode:
     needs: [docker-build]
     if: always() && needs.docker-build.result == 'success'
     runs-on: ubuntu-22.04
@@ -2015,7 +2014,7 @@ jobs:
           echo "UID=$(id -u)" >> $GITHUB_ENV
           echo "GID=$(id -g)" >> $GITHUB_ENV
           cp .env.example .env
-          # Enable PUBLIC_MODE for unauthenticated tests (disable SINGLE_USER_MODE)
+          # Enable PUBLIC_MODE for public mode tests (disable SINGLE_USER_MODE)
           sed -i 's/DEPICTIO_AUTH_SINGLE_USER_MODE=true/DEPICTIO_AUTH_SINGLE_USER_MODE=false/' docker-compose/.env
           sed -i 's/DEPICTIO_AUTH_PUBLIC_MODE=false/DEPICTIO_AUTH_PUBLIC_MODE=true/' docker-compose/.env
           sed -i 's/# DEPICTIO_DEV_MODE=false/DEPICTIO_DEV_MODE=true/' docker-compose/.env
@@ -2133,14 +2132,14 @@ jobs:
             npm ci
           fi
 
-      - name: Install Chrome for unauthenticated tests
+      - name: Install Chrome for public mode tests
         run: |
           wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
           echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y google-chrome-stable
 
-      - name: Run Cypress unauthenticated tests
+      - name: Run Cypress public mode tests
         run: |
           cd depictio/tests/e2e-tests
           # Set environment variable for cypress to know it's public mode
@@ -2150,23 +2149,23 @@ jobs:
           npx cypress run \
             --browser chrome \
             --headless \
-            --config screenshotsFolder=cypress/screenshots-unauthenticated,videosFolder=cypress/videos-unauthenticated,trashAssetsBeforeRuns=false,video=true,screenshotOnRunFailure=true,viewportWidth=1920,viewportHeight=1080,chromeWebSecurity=false \
+            --config screenshotsFolder=cypress/screenshots-public-mode,videosFolder=cypress/videos-public-mode,trashAssetsBeforeRuns=false,video=true,screenshotOnRunFailure=true,viewportWidth=1920,viewportHeight=1080,chromeWebSecurity=false \
             --spec "cypress/e2e/auth/public/**/*.cy.js"
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-screenshots-unauthenticated
-          path: depictio/tests/e2e-tests/cypress/screenshots-unauthenticated
+          name: cypress-screenshots-public-mode
+          path: depictio/tests/e2e-tests/cypress/screenshots-public-mode
           retention-days: 30
 
       - name: Upload videos on failure
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-videos-unauthenticated
-          path: depictio/tests/e2e-tests/cypress/videos-unauthenticated
+          name: cypress-videos-public-mode
+          path: depictio/tests/e2e-tests/cypress/videos-public-mode
           retention-days: 7
 
   e2e-tests-demo-mode:

--- a/.github/workflows/deploy-embl-selfhosted.yaml
+++ b/.github/workflows/deploy-embl-selfhosted.yaml
@@ -156,7 +156,7 @@ jobs:
           helm upgrade --install devdemo ./helm-charts/depictio \
             --namespace datasci-depictio-project-demo-dev \
             -f helm-charts/depictio/values.yaml \
-            -f helm-charts/depictio/values-embl-unauth.yaml \
+            -f helm-charts/depictio/values-embl-demo-base.yaml \
             -f helm-charts/depictio/values-embl-demo-dev.yaml \
             -f ~/actions-runner-embl/secrets/values-embl-secrets.yaml \
             --set backend.image.tag="${VERSION}" \
@@ -335,7 +335,7 @@ jobs:
           helm upgrade --install demo ./helm-charts/depictio \
             --namespace datasci-depictio-project-demo \
             -f helm-charts/depictio/values.yaml \
-            -f helm-charts/depictio/values-embl-unauth.yaml \
+            -f helm-charts/depictio/values-embl-demo-base.yaml \
             -f helm-charts/depictio/values-embl-demo.yaml \
             -f ~/actions-runner-embl/secrets/values-embl-secrets.yaml \
             --set backend.image.tag="${VERSION}" \

--- a/depictio/dash/layouts/dashboards_management.py
+++ b/depictio/dash/layouts/dashboards_management.py
@@ -2345,7 +2345,7 @@ def register_callbacks_dashboards_management(app: dash.Dash) -> None:
                                 original_child_id = new_child.id  # Save for thumbnail copy
                                 new_child.id = ObjectId()
                                 new_child.dashboard_id = str(new_child.id)
-                                new_child.title = f"{child_tab.get('title', 'Tab')} (copy)"
+                                new_child.title = child_tab.get("title", "Tab")
 
                                 # CRITICAL: Update parent_dashboard_id to point to NEW main dashboard
                                 new_child.parent_dashboard_id = new_dashboard.id


### PR DESCRIPTION
## Summary

Three bugs reported on the demo deployment (`dev.demo.depictio.embl.org`):

- **Fix 1 — Owner edit button in view mode** (`tab_callbacks.py`): Ownership was only checked when `is_edit_mode=True`, so dashboard owners never saw the Add Tab / Edit controls when viewing their own dashboard. Decoupled the `is_owner` check from `is_edit_mode` so it runs whenever `dashboard_cache` is available. Added a `_create_switch_to_edit_button()` helper that renders an "Edit Dashboard" link in the sidebar for view-mode owners. Single-user mode fallback preserved (`is_owner = is_edit_mode` when no `user_permissions` exist).

- **Fix 2 — Tab titles on duplication** (`dashboards_management.py`): Child tabs inside a duplicated dashboard incorrectly had `(copy)` appended to their titles (line 2348). Only the parent dashboard title should receive the `(copy)` suffix.

- **Fix 3a — MultiQC "No data available" fallback** (`restore_dashboard.py`): When `dc_specific_properties.s3_location` is `null` (K8s DB wipe scenario), added a fallback that queries the `/depictio/api/v1/multiqc/reports/data-collection/{dc_id}` API to retrieve valid S3 locations. This is an immediate fix for the demo without requiring a K8s restart.

- **Fix 3b — MongoDB update root cause** (`multiqc_processor.py`): The `array_filters`-based `update_one()` silently failed on K8s (`matched_count=1`, `modified_count=0`), leaving `dc_specific_properties.s3_location = null` in the projects collection. Replaced with an index-based approach that first finds the exact `wf_idx`/`dc_idx` and updates using positional dot-notation paths, which reliably writes the S3 location after background processing.

## Test plan

- [ ] **Fix 1**: Create a dashboard as a user, navigate to `/dashboard/{id}` (view mode). Verify "Edit Dashboard" button appears in sidebar. Click → redirects to `/dashboard-edit/{id}`.
- [ ] **Fix 2**: Duplicate a dashboard with multiple tabs. Verify the duplicated dashboard title has `(copy)` but all child tab names are unchanged.
- [ ] **Fix 3a**: Load the demo dashboard at `https://dev.demo.depictio.embl.org/dashboard/646b0f3c1e4a2d7f8e5b8ca2`. Verify MultiQC plots render. Check frontend logs for `Found N S3 location(s) from multiqc reports API`.
- [ ] **Fix 3b**: After next K8s restart with `DEPICTIO_MONGODB_WIPE=true`, check `projects` collection — `dc_specific_properties.s3_location` should be populated (not `null`) after background processing completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)