### PR TITLE
feat: add YAML dashboard versions for iris, penguins & ampliseq reference projects

### DIFF
--- a/depictio/models/models/dashboards.py
+++ b/depictio/models/models/dashboards.py
@@ -234,17 +234,53 @@ class DashboardDataLite(BaseModel):
 
         return self
 
-    def to_yaml(self) -> str:
-        """Export to YAML string.
+    # Sentinel key names used to inject YAML comment separators between sections.
+    # After yaml.dump(), these are replaced by comment lines via _apply_section_comments().
+    SENTINEL_OPTIONAL: ClassVar[str] = "__section_optional__"
+    SENTINEL_GENERATED: ClassVar[str] = "__section_generated_on_export__"
 
-        Returns:
-            YAML string with mandatory fields first, then optional user-defined
-            fields, then export-generated metadata (dashboard_id last).
-            The UUID index is omitted from YAML output (managed internally).
+    # Dashboard-level optional user fields (non-mandatory, non-generated)
+    OPTIONAL_DASHBOARD_FIELDS: ClassVar[list[str]] = [
+        "subtitle",
+        "project_tag",
+        "main_tab_name",
+        "tab_order",
+        "tab_icon",
+        "tab_icon_color",
+        "is_main_tab",
+        "parent_dashboard_tag",
+        "icon",
+        "icon_color",
+        "icon_variant",
+        "workflow_system",
+    ]
+
+    @staticmethod
+    def _apply_section_comments(yaml_str: str) -> str:
+        """Replace sentinel keys with YAML comment separators.
+
+        Converts ``__section_optional__: null`` and
+        ``__section_generated_on_export__: null`` lines (at any indent level)
+        into human-readable comment lines preserving the original indentation.
         """
-        data = self.model_dump(exclude_none=True, mode="json")
+        import re
 
-        # Strip fields that match their default values to keep YAML minimal
+        labels = {
+            DashboardDataLite.SENTINEL_OPTIONAL: "optional",
+            DashboardDataLite.SENTINEL_GENERATED: "generated on export",
+        }
+        for sentinel, label in labels.items():
+            yaml_str = re.sub(
+                rf"^(\s*){re.escape(sentinel)}: null\n",
+                lambda m, lbl=label: f"{m.group(1)}# --- {lbl} ---\n",
+                yaml_str,
+                flags=re.MULTILINE,
+            )
+        return yaml_str
+
+    @classmethod
+    def _strip_dashboard_defaults(cls, data: dict[str, Any]) -> None:
+        """Strip dashboard-level fields that equal their defaults (in-place)."""
         default_value_fields = {
             "subtitle": "",
             "project_tag": "",
@@ -259,57 +295,79 @@ class DashboardDataLite(BaseModel):
         for field, default in default_value_fields.items():
             if not data.get(field) or data.get(field) == default:
                 data.pop(field, None)
-
-        # Strip tab fields at their defaults
         if data.get("is_main_tab", True) is True:
             data.pop("is_main_tab", None)
         if data.get("tab_order", 0) == 0:
             data.pop("tab_order", None)
-
-        # Strip workflow_system if empty or "none"
         if not data.get("workflow_system") or data.get("workflow_system") == "none":
             data.pop("workflow_system", None)
 
-        # Clean up components - remove empty values and order fields
+    @classmethod
+    def _build_ordered_dashboard_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Build an ordered dashboard dict with sentinel section separators.
+
+        Sections:
+          - Mandatory  : title
+          - Optional   : user-defined metadata (subtitle, project_tag, icon …)
+          - Generated  : dashboard_id (set by the system on export)
+          - Content    : components list (last, it's large)
+
+        Sentinel keys (``__section_optional__``, ``__section_generated_on_export__``)
+        are replaced by comment lines after ``yaml.dump()`` via
+        ``_apply_section_comments()``.
+        """
+        ordered: dict[str, Any] = {}
+
+        # --- mandatory ---
+        if "title" in data:
+            ordered["title"] = data["title"]
+
+        # --- optional ---
+        optional_data = {f: data[f] for f in cls.OPTIONAL_DASHBOARD_FIELDS if f in data}
+        if optional_data:
+            ordered[cls.SENTINEL_OPTIONAL] = None
+            ordered.update(optional_data)
+
+        # --- generated on export ---
+        if "dashboard_id" in data:
+            ordered[cls.SENTINEL_GENERATED] = None
+            ordered["dashboard_id"] = data["dashboard_id"]
+
+        # --- content ---
+        if "components" in data:
+            ordered["components"] = data["components"]
+
+        # Catch-all for any unexpected fields
+        known = {"title", "dashboard_id", "components"} | set(cls.OPTIONAL_DASHBOARD_FIELDS)
+        for key, val in data.items():
+            if key not in known and key not in ordered:
+                ordered[key] = val
+
+        return ordered
+
+    def to_yaml(self) -> str:
+        """Export to YAML string with section comment separators.
+
+        Sections are separated by ``# --- optional ---`` and
+        ``# --- generated on export ---`` comment lines for clarity.
+        Mandatory fields come first, generated export metadata last.
+        """
+        data = self.model_dump(exclude_none=True, mode="json")
+
+        self._strip_dashboard_defaults(data)
+
+        # Clean and order each component
         if "components" in data:
             data["components"] = [
                 self._clean_component_for_yaml(comp) for comp in data["components"]
             ]
 
-        # Reorder dashboard-level fields: mandatory → optional user → generated → components
-        dashboard_field_order = [
-            # Mandatory
-            "title",
-            # Optional user-defined
-            "subtitle",
-            "project_tag",
-            "main_tab_name",
-            "tab_order",
-            "tab_icon",
-            "tab_icon_color",
-            "is_main_tab",
-            "parent_dashboard_tag",
-            "icon",
-            "icon_color",
-            "icon_variant",
-            "workflow_system",
-            # Generated on export (not needed for import)
-            "dashboard_id",
-            # Main content last (it's a large list)
-            "components",
-        ]
-        ordered: dict[str, Any] = {}
-        for key in dashboard_field_order:
-            if key in data:
-                ordered[key] = data[key]
-        # Append any unexpected keys not in the order list
-        for key in data:
-            if key not in ordered:
-                ordered[key] = data[key]
+        ordered = self._build_ordered_dashboard_dict(data)
 
-        return yaml.dump(
+        raw = yaml.dump(
             ordered, default_flow_style=False, sort_keys=False, allow_unicode=True, indent=4
         )
+        return self._apply_section_comments(raw)
 
     @staticmethod
     def _is_uuid_like(value: str) -> bool:
@@ -395,24 +453,45 @@ class DashboardDataLite(BaseModel):
     def _clean_component_for_yaml(comp: dict[str, Any]) -> dict[str, Any]:
         """Clean a single component dict for YAML export.
 
-        Applies per-type field ordering (mandatory → optional → generated),
-        strips empty values and auto-generated UUIDs, and omits default table
-        settings.
+        Applies per-type field ordering with sentinel section separators:
+          1. Mandatory common + type-specific required fields
+          2. ``# --- optional ---`` sentinel (if optional fields are present)
+          3. Optional user-defined fields
+          4. ``# --- generated on export ---`` sentinel (if generated fields are present)
+          5. Export-generated fields (tag, layout)
+
+        Also strips empty values, auto-generated UUIDs, and table defaults.
+        Sentinels are replaced by comment lines via ``_apply_section_comments()``.
         """
         comp_type = comp.get("component_type", "")
-        field_order = DashboardDataLite._get_component_field_order(comp_type)
 
-        # Table fields that should be omitted when at their defaults
+        # Per-type mandatory field sets
+        _MANDATORY_COMMON: set[str] = {"component_type", "workflow_tag", "data_collection_tag"}
+        _MANDATORY_BY_TYPE: dict[str, set[str]] = {
+            "figure": {"visu_type"},
+            "card": {"aggregation", "column_name"},
+            "interactive": {"interactive_component_type", "column_name"},
+            "image": {"image_column"},
+            "multiqc": {"selected_module", "selected_plot"},
+            "table": set(),
+        }
+        _GENERATED: set[str] = {"tag", "index", "layout", "title"}
+
+        mandatory_keys = _MANDATORY_COMMON | _MANDATORY_BY_TYPE.get(comp_type, set())
         table_defaults = {"page_size": 10, "sortable": True, "filterable": True}
         is_table = comp_type == "table"
 
-        cleaned: dict[str, Any] = {}
-
-        # Collect all keys: ordered fields first, then any remainder
+        field_order = DashboardDataLite._get_component_field_order(comp_type)
         all_keys = list(field_order) + [k for k in comp if k not in field_order]
 
+        mandatory: dict[str, Any] = {}
+        optional: dict[str, Any] = {}
+        generated: dict[str, Any] = {}
+
         for key in all_keys:
-            if key not in comp or key in cleaned:
+            if key in mandatory or key in optional or key in generated:
+                continue
+            if key not in comp:
                 continue
             value = comp[key]
             if DashboardDataLite._is_empty_value(value):
@@ -421,9 +500,23 @@ class DashboardDataLite(BaseModel):
                 continue
             if is_table and key in table_defaults and value == table_defaults[key]:
                 continue
-            cleaned[key] = value
+            if key in mandatory_keys:
+                mandatory[key] = value
+            elif key in _GENERATED:
+                generated[key] = value
+            else:
+                optional[key] = value
 
-        return cleaned
+        # Assemble with sentinel separators between non-empty sections
+        result: dict[str, Any] = dict(mandatory)
+        if optional:
+            result[DashboardDataLite.SENTINEL_OPTIONAL] = None
+            result.update(optional)
+        if generated:
+            result[DashboardDataLite.SENTINEL_GENERATED] = None
+            result.update(generated)
+
+        return result
 
     @classmethod
     def from_yaml(cls, content: str) -> "DashboardDataLite":

--- a/depictio/projects/init/iris/dashboard.yaml
+++ b/depictio/projects/init/iris/dashboard.yaml
@@ -1,0 +1,200 @@
+dashboard_id: 6824cb3b89d2b72169309737
+project_tag: Iris Dataset Project Data Analysis
+title: Iris Dashboard demo
+icon: /assets/images/icons/favicon.png
+components:
+-   tag: figure-box_variety_sepal_length-04c6c1
+    component_type: figure
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 0
+        y: 2
+        w: 4
+        h: 5
+    visu_type: box
+    figure_params:
+        x: variety
+        y: sepal.length
+        color_discrete_map: '{"Setosa": "#1f77b4", "Versicolor": "#ff7f0e", "Virginica":
+            "#2ca02c"}'
+        boxmode: group
+        points: all
+        notched: true
+    mode: ui
+    selection_enabled: false
+-   tag: figure-scatter_sepal_length_sepal_width-8399c0
+    component_type: figure
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 4
+        y: 2
+        w: 4
+        h: 5
+    visu_type: scatter
+    figure_params:
+        x: sepal.length
+        y: sepal.width
+        color: variety
+        color_discrete_map: '{"Setosa": "#1f77b4", "Versicolor": "#ff7f0e", "Virginica":
+            "#2ca02c"}'
+        size: petal.length
+        trendline_scope: trace
+        render_mode: auto
+        size_max: 20
+        marginal_x: histogram
+        marginal_y: rug
+        trendline: lowess
+    mode: ui
+    selection_enabled: false
+-   tag: card-sepal_length_average-ed1ba1
+    component_type: card
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 0
+        y: 0
+        w: 2
+        h: 2
+    aggregation: average
+    column_name: sepal.length
+    column_type: float64
+    display:
+        icon_name: mdi:flower-outline
+        icon_color: '#9C27B0'
+        title_color: '#9C27B0'
+        title_font_size: xl
+        value_font_size: xl
+-   tag: card-sepal_width_median-3b1970
+    component_type: card
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 2
+        y: 0
+        w: 2
+        h: 2
+    aggregation: median
+    column_name: sepal.width
+    column_type: float64
+    display:
+        icon_name: mdi:ruler-square
+        icon_color: '#673AB7'
+        title_color: '#673AB7'
+        title_font_size: xl
+        value_font_size: xl
+-   tag: card-variety_nunique-546238
+    component_type: card
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 4
+        y: 0
+        w: 2
+        h: 2
+    aggregation: nunique
+    column_name: variety
+    column_type: object
+    display:
+        icon_name: mdi:flower-tulip
+        icon_color: '#4CAF50'
+        title_color: '#4CAF50'
+        title_font_size: xl
+        value_font_size: xl
+-   tag: card-variety_count-f4f525
+    component_type: card
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 6
+        y: 0
+        w: 2
+        h: 2
+    aggregation: count
+    column_name: variety
+    column_type: object
+    display:
+        icon_name: mdi:flower-tulip
+        icon_color: '#4CAF50'
+        title_color: '#4CAF50'
+        title_font_size: lg
+        value_font_size: xl
+-   tag: interactive-sepal_length-2b680a
+    component_type: interactive
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 0
+        y: 0
+        w: 1
+        h: 3
+    column_name: sepal.length
+    column_type: float64
+    interactive_component_type: RangeSlider
+    display:
+        title_size: md
+        custom_color: '#9C27B0'
+        icon_name: mdi:flower-outline
+-   tag: interactive-petal_length-a5a82f
+    component_type: interactive
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 0
+        y: 3
+        w: 1
+        h: 3
+    column_name: petal.length
+    column_type: float64
+    interactive_component_type: RangeSlider
+    display:
+        title_size: md
+        custom_color: '#E91E63'
+        icon_name: mdi:flower
+-   tag: interactive-variety-56d49c
+    component_type: interactive
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 0
+        y: 6
+        w: 1
+        h: 2
+    column_name: variety
+    column_type: object
+    interactive_component_type: MultiSelect
+    display:
+        title_size: md
+        custom_color: '#4CAF50'
+        icon_name: mdi:flower-tulip
+-   tag: table-table-467b27
+    component_type: table
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 0
+        y: 12
+        w: 8
+        h: 5
+    row_selection_enabled: false
+-   tag: figure-histogram_sepal_length-ef601e
+    component_type: figure
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
+    layout:
+        x: 0
+        y: 7
+        w: 8
+        h: 5
+    visu_type: histogram
+    figure_params:
+        x: sepal.length
+        color: variety
+        color_discrete_map: '{"Setosa": "#1f77b4", "Versicolor": "#ff7f0e", "Virginica":
+            "#2ca02c"}'
+        nbins: 30
+        barmode: relative
+        cumulative: true
+    mode: ui
+    selection_enabled: false

--- a/depictio/projects/init/iris/dashboard.yaml
+++ b/depictio/projects/init/iris/dashboard.yaml
@@ -1,17 +1,11 @@
-dashboard_id: 6824cb3b89d2b72169309737
-project_tag: Iris Dataset Project Data Analysis
 title: Iris Dashboard demo
+project_tag: Iris Dataset Project Data Analysis
 icon: /assets/images/icons/favicon.png
+dashboard_id: 6824cb3b89d2b72169309737
 components:
--   tag: figure-box_variety_sepal_length-04c6c1
-    component_type: figure
+-   component_type: figure
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
-    layout:
-        x: 0
-        y: 2
-        w: 4
-        h: 5
     visu_type: box
     figure_params:
         x: variety
@@ -23,15 +17,15 @@ components:
         notched: true
     mode: ui
     selection_enabled: false
--   tag: figure-scatter_sepal_length_sepal_width-8399c0
-    component_type: figure
-    workflow_tag: iris_workflow
-    data_collection_tag: iris_table
+    tag: figure-box_variety_sepal_length-04c6c1
     layout:
-        x: 4
+        x: 0
         y: 2
         w: 4
         h: 5
+-   component_type: figure
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
     visu_type: scatter
     figure_params:
         x: sepal.length
@@ -48,15 +42,15 @@ components:
         trendline: lowess
     mode: ui
     selection_enabled: false
--   tag: card-sepal_length_average-ed1ba1
-    component_type: card
+    tag: figure-scatter_sepal_length_sepal_width-8399c0
+    layout:
+        x: 4
+        y: 2
+        w: 4
+        h: 5
+-   component_type: card
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
-    layout:
-        x: 0
-        y: 0
-        w: 2
-        h: 2
     aggregation: average
     column_name: sepal.length
     column_type: float64
@@ -66,15 +60,15 @@ components:
         title_color: '#9C27B0'
         title_font_size: xl
         value_font_size: xl
--   tag: card-sepal_width_median-3b1970
-    component_type: card
-    workflow_tag: iris_workflow
-    data_collection_tag: iris_table
+    tag: card-sepal_length_average-ed1ba1
     layout:
-        x: 2
+        x: 0
         y: 0
         w: 2
         h: 2
+-   component_type: card
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
     aggregation: median
     column_name: sepal.width
     column_type: float64
@@ -84,15 +78,15 @@ components:
         title_color: '#673AB7'
         title_font_size: xl
         value_font_size: xl
--   tag: card-variety_nunique-546238
-    component_type: card
-    workflow_tag: iris_workflow
-    data_collection_tag: iris_table
+    tag: card-sepal_width_median-3b1970
     layout:
-        x: 4
+        x: 2
         y: 0
         w: 2
         h: 2
+-   component_type: card
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
     aggregation: nunique
     column_name: variety
     column_type: object
@@ -102,15 +96,15 @@ components:
         title_color: '#4CAF50'
         title_font_size: xl
         value_font_size: xl
--   tag: card-variety_count-f4f525
-    component_type: card
-    workflow_tag: iris_workflow
-    data_collection_tag: iris_table
+    tag: card-variety_nunique-546238
     layout:
-        x: 6
+        x: 4
         y: 0
         w: 2
         h: 2
+-   component_type: card
+    workflow_tag: iris_workflow
+    data_collection_tag: iris_table
     aggregation: count
     column_name: variety
     column_type: object
@@ -120,73 +114,73 @@ components:
         title_color: '#4CAF50'
         title_font_size: lg
         value_font_size: xl
--   tag: interactive-sepal_length-2b680a
-    component_type: interactive
+    tag: card-variety_count-f4f525
+    layout:
+        x: 6
+        y: 0
+        w: 2
+        h: 2
+-   component_type: interactive
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
+    interactive_component_type: RangeSlider
+    column_name: sepal.length
+    column_type: float64
+    display:
+        title_size: md
+        custom_color: '#9C27B0'
+        icon_name: mdi:flower-outline
+    tag: interactive-sepal_length-2b680a
     layout:
         x: 0
         y: 0
         w: 1
         h: 3
-    column_name: sepal.length
-    column_type: float64
-    interactive_component_type: RangeSlider
-    display:
-        title_size: md
-        custom_color: '#9C27B0'
-        icon_name: mdi:flower-outline
--   tag: interactive-petal_length-a5a82f
-    component_type: interactive
+-   component_type: interactive
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
+    interactive_component_type: RangeSlider
+    column_name: petal.length
+    column_type: float64
+    display:
+        title_size: md
+        custom_color: '#E91E63'
+        icon_name: mdi:flower
+    tag: interactive-petal_length-a5a82f
     layout:
         x: 0
         y: 3
         w: 1
         h: 3
-    column_name: petal.length
-    column_type: float64
-    interactive_component_type: RangeSlider
-    display:
-        title_size: md
-        custom_color: '#E91E63'
-        icon_name: mdi:flower
--   tag: interactive-variety-56d49c
-    component_type: interactive
+-   component_type: interactive
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
+    interactive_component_type: MultiSelect
+    column_name: variety
+    column_type: object
+    display:
+        title_size: md
+        custom_color: '#4CAF50'
+        icon_name: mdi:flower-tulip
+    tag: interactive-variety-56d49c
     layout:
         x: 0
         y: 6
         w: 1
         h: 2
-    column_name: variety
-    column_type: object
-    interactive_component_type: MultiSelect
-    display:
-        title_size: md
-        custom_color: '#4CAF50'
-        icon_name: mdi:flower-tulip
--   tag: table-table-467b27
-    component_type: table
+-   component_type: table
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
+    row_selection_enabled: false
+    tag: table-table-467b27
     layout:
         x: 0
         y: 12
         w: 8
         h: 5
-    row_selection_enabled: false
--   tag: figure-histogram_sepal_length-ef601e
-    component_type: figure
+-   component_type: figure
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
-    layout:
-        x: 0
-        y: 7
-        w: 8
-        h: 5
     visu_type: histogram
     figure_params:
         x: sepal.length
@@ -198,3 +192,9 @@ components:
         cumulative: true
     mode: ui
     selection_enabled: false
+    tag: figure-histogram_sepal_length-ef601e
+    layout:
+        x: 0
+        y: 7
+        w: 8
+        h: 5

--- a/depictio/projects/init/iris/dashboard.yaml
+++ b/depictio/projects/init/iris/dashboard.yaml
@@ -1,12 +1,15 @@
 title: Iris Dashboard demo
+# --- optional ---
 project_tag: Iris Dataset Project Data Analysis
 icon: /assets/images/icons/favicon.png
+# --- generated on export ---
 dashboard_id: 6824cb3b89d2b72169309737
 components:
 -   component_type: figure
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
     visu_type: box
+    # --- optional ---
     figure_params:
         x: variety
         y: sepal.length
@@ -17,6 +20,7 @@ components:
         notched: true
     mode: ui
     selection_enabled: false
+    # --- generated on export ---
     tag: figure-box_variety_sepal_length-04c6c1
     layout:
         x: 0
@@ -27,6 +31,7 @@ components:
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
     visu_type: scatter
+    # --- optional ---
     figure_params:
         x: sepal.length
         y: sepal.width
@@ -42,6 +47,7 @@ components:
         trendline: lowess
     mode: ui
     selection_enabled: false
+    # --- generated on export ---
     tag: figure-scatter_sepal_length_sepal_width-8399c0
     layout:
         x: 4
@@ -53,6 +59,7 @@ components:
     data_collection_tag: iris_table
     aggregation: average
     column_name: sepal.length
+    # --- optional ---
     column_type: float64
     display:
         icon_name: mdi:flower-outline
@@ -60,6 +67,7 @@ components:
         title_color: '#9C27B0'
         title_font_size: xl
         value_font_size: xl
+    # --- generated on export ---
     tag: card-sepal_length_average-ed1ba1
     layout:
         x: 0
@@ -71,6 +79,7 @@ components:
     data_collection_tag: iris_table
     aggregation: median
     column_name: sepal.width
+    # --- optional ---
     column_type: float64
     display:
         icon_name: mdi:ruler-square
@@ -78,6 +87,7 @@ components:
         title_color: '#673AB7'
         title_font_size: xl
         value_font_size: xl
+    # --- generated on export ---
     tag: card-sepal_width_median-3b1970
     layout:
         x: 2
@@ -89,6 +99,7 @@ components:
     data_collection_tag: iris_table
     aggregation: nunique
     column_name: variety
+    # --- optional ---
     column_type: object
     display:
         icon_name: mdi:flower-tulip
@@ -96,6 +107,7 @@ components:
         title_color: '#4CAF50'
         title_font_size: xl
         value_font_size: xl
+    # --- generated on export ---
     tag: card-variety_nunique-546238
     layout:
         x: 4
@@ -107,6 +119,7 @@ components:
     data_collection_tag: iris_table
     aggregation: count
     column_name: variety
+    # --- optional ---
     column_type: object
     display:
         icon_name: mdi:flower-tulip
@@ -114,6 +127,7 @@ components:
         title_color: '#4CAF50'
         title_font_size: lg
         value_font_size: xl
+    # --- generated on export ---
     tag: card-variety_count-f4f525
     layout:
         x: 6
@@ -125,11 +139,13 @@ components:
     data_collection_tag: iris_table
     interactive_component_type: RangeSlider
     column_name: sepal.length
+    # --- optional ---
     column_type: float64
     display:
         title_size: md
         custom_color: '#9C27B0'
         icon_name: mdi:flower-outline
+    # --- generated on export ---
     tag: interactive-sepal_length-2b680a
     layout:
         x: 0
@@ -141,11 +157,13 @@ components:
     data_collection_tag: iris_table
     interactive_component_type: RangeSlider
     column_name: petal.length
+    # --- optional ---
     column_type: float64
     display:
         title_size: md
         custom_color: '#E91E63'
         icon_name: mdi:flower
+    # --- generated on export ---
     tag: interactive-petal_length-a5a82f
     layout:
         x: 0
@@ -157,11 +175,13 @@ components:
     data_collection_tag: iris_table
     interactive_component_type: MultiSelect
     column_name: variety
+    # --- optional ---
     column_type: object
     display:
         title_size: md
         custom_color: '#4CAF50'
         icon_name: mdi:flower-tulip
+    # --- generated on export ---
     tag: interactive-variety-56d49c
     layout:
         x: 0
@@ -171,7 +191,9 @@ components:
 -   component_type: table
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
+    # --- optional ---
     row_selection_enabled: false
+    # --- generated on export ---
     tag: table-table-467b27
     layout:
         x: 0
@@ -182,6 +204,7 @@ components:
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
     visu_type: histogram
+    # --- optional ---
     figure_params:
         x: sepal.length
         color: variety
@@ -192,6 +215,7 @@ components:
         cumulative: true
     mode: ui
     selection_enabled: false
+    # --- generated on export ---
     tag: figure-histogram_sepal_length-ef601e
     layout:
         x: 0

--- a/depictio/projects/reference/ampliseq/dashboard.yaml
+++ b/depictio/projects/reference/ampliseq/dashboard.yaml
@@ -66,7 +66,7 @@ main_dashboard:
             custom_color: '#45B8AC'
             icon_name: mdi:flask
     -   tag: multiqc-cutadapt_filtered-reads-d421ae
-        index: e2db1471-3076-4f3e-aaf3-d2631da98167
+        index: 51f1c24c-81cf-484f-8dc6-e1746f45dccf
         component_type: multiqc
         title: ''
         workflow_tag: ampliseq
@@ -79,7 +79,7 @@ main_dashboard:
             w: 8
             h: 4
     -   tag: multiqc-fastqc_sequence-counts-52bd04
-        index: 4c53ffb5-eb66-428d-8eea-d519877c5fa0
+        index: 02c2b09e-fcc4-49d9-a0df-fdfe079d7597
         component_type: multiqc
         title: ''
         workflow_tag: ampliseq
@@ -92,7 +92,7 @@ main_dashboard:
             w: 8
             h: 4
     -   tag: multiqc-fastqc_sequence-quality-histograms-ce2a02
-        index: 90654027-0423-4abc-9026-296b6ba78bc9
+        index: 1acfa105-7334-4ca4-b904-38a74b406d44
         component_type: multiqc
         title: ''
         workflow_tag: ampliseq
@@ -105,7 +105,7 @@ main_dashboard:
             w: 4
             h: 5
     -   tag: multiqc-fastqc_per-sequence-gc-content-359f73
-        index: 09ce8e50-03f9-4285-b0d2-83d7912d8d6a
+        index: 59588a55-476f-4db2-a01e-29825551dd11
         component_type: multiqc
         title: ''
         workflow_tag: ampliseq
@@ -118,7 +118,7 @@ main_dashboard:
             w: 4
             h: 5
     -   tag: multiqc-fastqc_adapter-content-6dd1a9
-        index: af2cd16d-ce8e-40d0-8e9e-49a1fa0bc8a3
+        index: d428d6fd-a79d-4a14-b3bf-8e818a3e42a5
         component_type: multiqc
         title: ''
         workflow_tag: ampliseq
@@ -131,7 +131,7 @@ main_dashboard:
             w: 4
             h: 5
     -   tag: multiqc-cutadapt_trimmed-sequence-lengths-5-e5e50a
-        index: fdb76dba-8205-4373-b96f-b06dab9c75ad
+        index: c6d9355b-c421-4d60-a6e6-8da7a77e3fab
         component_type: multiqc
         title: ''
         workflow_tag: ampliseq
@@ -156,7 +156,7 @@ tabs:
     workflow_system: nf-core
     components:
     -   tag: card-sample_nunique-faa7e6
-        index: 778be777-e177-4dd0-858f-d0e945c3e535
+        index: 798d3f8f-aa54-486e-8c8c-7337f05817c7
         component_type: card
         title: Total Samples
         workflow_tag: ampliseq
@@ -176,7 +176,7 @@ tabs:
             title_font_size: xl
             value_font_size: xl
     -   tag: card-taxonomy_nunique-d2ba1c
-        index: e7ae0c0e-88fc-4c94-8b66-4ed4f06031ec
+        index: 01655e5a-155b-4d9b-a39a-f74764f7282e
         component_type: card
         title: Total Taxa
         workflow_tag: ampliseq
@@ -196,7 +196,7 @@ tabs:
             title_font_size: xl
             value_font_size: xl
     -   tag: card-faith_pd_average-66fb50
-        index: a386e270-1705-433c-91c2-e651a5885fb2
+        index: e9f153a8-1d30-4f42-bbc3-a86bb94b190c
         component_type: card
         title: Mean Faith PD
         workflow_tag: ampliseq
@@ -216,7 +216,7 @@ tabs:
             title_font_size: xl
             value_font_size: xl
     -   tag: card-habitat_nunique-1fc891
-        index: 3c8541b2-f741-48bb-a42c-f9f6bed0f384
+        index: 76f12e20-482b-4d4c-bae1-cb65804016d6
         component_type: card
         title: Habitat Types
         workflow_tag: ampliseq
@@ -236,7 +236,7 @@ tabs:
             title_font_size: xl
             value_font_size: xl
     -   tag: figure-line_depth_faith_pd-5d9f17
-        index: 3fa381f6-42d3-4566-ad8f-89b239ed3266
+        index: 5e3c7df0-b58b-440e-bdde-e84df0eaddfe
         component_type: figure
         title: ''
         workflow_tag: ampliseq
@@ -266,7 +266,7 @@ tabs:
                 depth: Rarefaction Depth
                 faith_pd: Faith's Phylogenetic Diversity
     -   tag: figure-box_sample_faith_pd-5b8018
-        index: 0d2f8c0d-e6c5-46c0-b769-479835cb9524
+        index: e3918bea-5fed-4d2b-ae90-be4962d93cfd
         component_type: figure
         title: ''
         workflow_tag: ampliseq
@@ -293,7 +293,7 @@ tabs:
                 sample: Sample
                 faith_pd: Faith's Phylogenetic Diversity
     -   tag: figure-sunburst-e651a9
-        index: e3b23ce8-4f93-4524-8a22-669e274b8d3e
+        index: 5ed044d5-7364-4f36-9e40-4f9098bdc6dd
         component_type: figure
         title: ''
         workflow_tag: ampliseq
@@ -319,7 +319,7 @@ tabs:
             values: count
             title: Taxonomic Composition - Hierarchical View
     -   tag: figure-bar_phylum_count-de4c39
-        index: deca7ec8-f516-444f-b784-2d36e3934176
+        index: 301f7ef7-b617-4e46-b661-263b2403b153
         component_type: figure
         title: ''
         workflow_tag: ampliseq
@@ -344,7 +344,7 @@ tabs:
                 habitat: Habitat
             barmode: stack
     -   tag: figure-bar_sample_count-de4c39
-        index: 61692fe9-e58e-4013-a3ff-472a4f0984e8
+        index: 8055c181-d8c3-483e-a179-a4c008fcb5ce
         component_type: figure
         title: ''
         workflow_tag: ampliseq
@@ -369,7 +369,7 @@ tabs:
                 Phylum: Phylum
             barmode: stack
     -   tag: table-table-df4371
-        index: a7231fa5-8654-40a9-b53c-9bb3c564a507
+        index: 6084ade7-ad17-4166-8265-15d6612a4fc8
         component_type: table
         title: ''
         workflow_tag: ampliseq
@@ -385,7 +385,7 @@ tabs:
             w: 8
             h: 6
     -   tag: table-table-02f050
-        index: 8c024af9-c766-471e-b306-e231ba8c9510
+        index: be0b13ba-0241-4086-a1f1-2953040cfb53
         component_type: table
         title: ''
         workflow_tag: ampliseq
@@ -401,7 +401,7 @@ tabs:
             w: 8
             h: 6
     -   tag: interactive-habitat-d8ca83
-        index: aa6035ff-380b-43f7-b6f5-3556acaccce7
+        index: 22665c8a-928f-4b62-a54d-c379ea1b5c9d
         component_type: interactive
         title: Habitat Type
         workflow_tag: ampliseq
@@ -419,7 +419,7 @@ tabs:
             custom_color: '#984EA3'
             icon_name: mdi:earth
     -   tag: interactive-sample-78c9c2
-        index: 289fc672-6e2d-4177-8825-e5f67aa48647
+        index: 301abd2e-2c74-439a-ac74-4b63a7021293
         component_type: interactive
         title: Sample ID
         workflow_tag: ampliseq
@@ -437,7 +437,7 @@ tabs:
             custom_color: '#45B8AC'
             icon_name: mdi:flask
     -   tag: interactive-kingdom-b112bb
-        index: e0e87f73-e79d-491d-915f-88d35e49bc4f
+        index: ed42fd5b-9d53-4493-a1cd-7bb38a335cdc
         component_type: interactive
         title: Kingdom
         workflow_tag: ampliseq
@@ -455,7 +455,7 @@ tabs:
             custom_color: '#377EB8'
             icon_name: mdi:bacteria
     -   tag: interactive-phylum-f89384
-        index: cea045f5-b3ee-47d3-9a8a-1a75c9874347
+        index: 35b843da-93f9-4f42-bc97-1a44305ce931
         component_type: interactive
         title: Phylum
         workflow_tag: ampliseq
@@ -473,7 +473,7 @@ tabs:
             custom_color: '#8BC34A'
             icon_name: mdi:bacteria-outline
     -   tag: interactive-sampling_date-b9d091
-        index: 4eaab9c4-e816-41bf-8718-e7f43a0b1263
+        index: dd4f8f9a-211f-4cea-acc6-d28d7aa54751
         component_type: interactive
         title: Sampling Period
         workflow_tag: ampliseq
@@ -690,7 +690,7 @@ tabs:
             title_font_size: xl
             value_font_size: xl
     -   tag: figure-scatter_clr_w-734503
-        index: 36269bf4-3b51-4d59-bffd-26dcdc7c9086
+        index: d07985d5-37cb-4f94-a8c3-d97d977226f1
         component_type: figure
         title: ''
         workflow_tag: ampliseq

--- a/depictio/projects/reference/ampliseq/dashboard.yaml
+++ b/depictio/projects/reference/ampliseq/dashboard.yaml
@@ -1,248 +1,259 @@
 main_dashboard:
-    dashboard_id: 646b0f3c1e4a2d7f8e5b8ca2
-    project_tag: Ampliseq Microbial Community Analysis
     title: nf-core/ampliseq
+    # --- optional ---
     subtitle: MultiQC Analysis - Cutadapt & FastQC
+    project_tag: Ampliseq Microbial Community Analysis
     main_tab_name: MultiQC
     tab_icon: /assets/images/logos/multiqc.png
     tab_icon_color: orange
     icon: /assets/images/workflows/nf-core.png
     icon_color: green
-    icon_variant: filled
     workflow_system: nf-core
+    # --- generated on export ---
+    dashboard_id: 646b0f3c1e4a2d7f8e5b8ca2
     components:
-    -   tag: interactive-multiqc-sampling-date-b9d091
-        index: multiqc-sampling-date
-        component_type: interactive
-        title: Sampling Period
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: metadata
         interactive_component_type: DateRangePicker
         column_name: sampling_date
+        # --- optional ---
         column_type: datetime
+        display:
+            title_size: md
+            custom_color: '#FF6B6B'
+            icon_name: mdi:calendar-range
+        # --- generated on export ---
+        tag: interactive-multiqc-sampling-date-b9d091
+        index: multiqc-sampling-date
         layout:
             x: 0
             y: 0
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#FF6B6B'
-            icon_name: mdi:calendar-range
-    -   tag: interactive-multiqc-habitat-filter-d8ca83
-        index: multiqc-habitat-filter
-        component_type: interactive
-        title: Habitat Type
+        title: Sampling Period
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: metadata
         interactive_component_type: MultiSelect
         column_name: habitat
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#984EA3'
+            icon_name: mdi:earth
+        # --- generated on export ---
+        tag: interactive-multiqc-habitat-filter-d8ca83
+        index: multiqc-habitat-filter
         layout:
             x: 0
             y: 3
             w: 1
             h: 2
-        display:
-            title_size: md
-            custom_color: '#984EA3'
-            icon_name: mdi:earth
-    -   tag: interactive-multiqc-sample-filter-78c9c2
-        index: multiqc-sample-filter
-        component_type: interactive
-        title: Sample ID
+        title: Habitat Type
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: metadata
         interactive_component_type: MultiSelect
         column_name: sample
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#45B8AC'
+            icon_name: mdi:flask
+        # --- generated on export ---
+        tag: interactive-multiqc-sample-filter-78c9c2
+        index: multiqc-sample-filter
         layout:
             x: 0
             y: 5
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#45B8AC'
-            icon_name: mdi:flask
-    -   tag: multiqc-cutadapt_filtered-reads-d421ae
-        index: 51f1c24c-81cf-484f-8dc6-e1746f45dccf
-        component_type: multiqc
-        title: ''
+        title: Sample ID
+    -   component_type: multiqc
         workflow_tag: ampliseq
         data_collection_tag: multiqc_data
         selected_module: cutadapt
         selected_plot: Filtered Reads
+        # --- generated on export ---
+        tag: multiqc-cutadapt_filtered-reads-d421ae
         layout:
             x: 0
             y: 0
             w: 8
             h: 4
-    -   tag: multiqc-fastqc_sequence-counts-52bd04
-        index: 02c2b09e-fcc4-49d9-a0df-fdfe079d7597
-        component_type: multiqc
-        title: ''
+    -   component_type: multiqc
         workflow_tag: ampliseq
         data_collection_tag: multiqc_data
         selected_module: fastqc
         selected_plot: Sequence Counts
+        # --- generated on export ---
+        tag: multiqc-fastqc_sequence-counts-52bd04
         layout:
             x: 0
             y: 4
             w: 8
             h: 4
-    -   tag: multiqc-fastqc_sequence-quality-histograms-ce2a02
-        index: 1acfa105-7334-4ca4-b904-38a74b406d44
-        component_type: multiqc
-        title: ''
+    -   component_type: multiqc
         workflow_tag: ampliseq
         data_collection_tag: multiqc_data
         selected_module: fastqc
         selected_plot: Sequence Quality Histograms
+        # --- generated on export ---
+        tag: multiqc-fastqc_sequence-quality-histograms-ce2a02
         layout:
             x: 0
             y: 8
             w: 4
             h: 5
-    -   tag: multiqc-fastqc_per-sequence-gc-content-359f73
-        index: 59588a55-476f-4db2-a01e-29825551dd11
-        component_type: multiqc
-        title: ''
+    -   component_type: multiqc
         workflow_tag: ampliseq
         data_collection_tag: multiqc_data
         selected_module: fastqc
         selected_plot: Per Sequence GC Content
+        # --- generated on export ---
+        tag: multiqc-fastqc_per-sequence-gc-content-359f73
         layout:
             x: 4
             y: 8
             w: 4
             h: 5
-    -   tag: multiqc-fastqc_adapter-content-6dd1a9
-        index: d428d6fd-a79d-4a14-b3bf-8e818a3e42a5
-        component_type: multiqc
-        title: ''
+    -   component_type: multiqc
         workflow_tag: ampliseq
         data_collection_tag: multiqc_data
         selected_module: fastqc
         selected_plot: Adapter Content
+        # --- generated on export ---
+        tag: multiqc-fastqc_adapter-content-6dd1a9
         layout:
             x: 0
             y: 13
             w: 4
             h: 5
-    -   tag: multiqc-cutadapt_trimmed-sequence-lengths-5-e5e50a
-        index: c6d9355b-c421-4d60-a6e6-8da7a77e3fab
-        component_type: multiqc
-        title: ''
+    -   component_type: multiqc
         workflow_tag: ampliseq
         data_collection_tag: multiqc_data
         selected_module: cutadapt
         selected_plot: Trimmed Sequence Lengths (5')
+        # --- generated on export ---
+        tag: multiqc-cutadapt_trimmed-sequence-lengths-5-e5e50a
         layout:
             x: 4
             y: 13
             w: 4
             h: 5
 tabs:
--   dashboard_id: 646b0f3c1e4a2d7f8e5b8cb3
-    title: Community Analysis
+-   title: Community Analysis
+    # --- optional ---
     subtitle: Alpha Diversity & Taxonomic Composition
     tab_order: 1
     tab_icon: mdi:bacteria-outline
     tab_icon_color: teal
     icon: /assets/images/workflows/nf-core.png
     icon_color: green
-    icon_variant: filled
     workflow_system: nf-core
+    # --- generated on export ---
+    dashboard_id: 646b0f3c1e4a2d7f8e5b8cb3
     components:
-    -   tag: card-sample_nunique-faa7e6
-        index: 798d3f8f-aa54-486e-8c8c-7337f05817c7
-        component_type: card
-        title: Total Samples
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: metadata
         aggregation: nunique
         column_name: sample
+        # --- optional ---
         column_type: object
-        layout:
-            x: 0
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:flask
             icon_color: '#45B8AC'
             title_color: '#45B8AC'
             title_font_size: xl
             value_font_size: xl
-    -   tag: card-taxonomy_nunique-d2ba1c
-        index: 01655e5a-155b-4d9b-a39a-f74764f7282e
-        component_type: card
-        title: Total Taxa
+        # --- generated on export ---
+        tag: card-sample_nunique-faa7e6
+        layout:
+            x: 0
+            y: 0
+            w: 2
+            h: 2
+        title: Total Samples
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
         aggregation: nunique
         column_name: taxonomy
+        # --- optional ---
         column_type: object
-        layout:
-            x: 2
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:bacteria
             icon_color: '#8BC34A'
             title_color: '#8BC34A'
             title_font_size: xl
             value_font_size: xl
-    -   tag: card-faith_pd_average-66fb50
-        index: e9f153a8-1d30-4f42-bbc3-a86bb94b190c
-        component_type: card
-        title: Mean Faith PD
+        # --- generated on export ---
+        tag: card-taxonomy_nunique-d2ba1c
+        layout:
+            x: 2
+            y: 0
+            w: 2
+            h: 2
+        title: Total Taxa
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: alpha_rarefaction
         aggregation: average
         column_name: faith_pd
+        # --- optional ---
         column_type: float64
-        layout:
-            x: 4
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:chart-line
             icon_color: '#F68B33'
             title_color: '#F68B33'
             title_font_size: xl
             value_font_size: xl
-    -   tag: card-habitat_nunique-1fc891
-        index: 76f12e20-482b-4d4c-bae1-cb65804016d6
-        component_type: card
-        title: Habitat Types
+        # --- generated on export ---
+        tag: card-faith_pd_average-66fb50
+        layout:
+            x: 4
+            y: 0
+            w: 2
+            h: 2
+        title: Mean Faith PD
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: metadata
         aggregation: nunique
         column_name: habitat
+        # --- optional ---
         column_type: object
-        layout:
-            x: 6
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:earth
             icon_color: '#984EA3'
             title_color: '#984EA3'
             title_font_size: xl
             value_font_size: xl
-    -   tag: figure-line_depth_faith_pd-5d9f17
-        index: 5e3c7df0-b58b-440e-bdde-e84df0eaddfe
-        component_type: figure
-        title: ''
+        # --- generated on export ---
+        tag: card-habitat_nunique-1fc891
+        layout:
+            x: 6
+            y: 0
+            w: 2
+            h: 2
+        title: Habitat Types
+    -   component_type: figure
         workflow_tag: ampliseq
         data_collection_tag: alpha_rarefaction
         visu_type: line
-        dict_kwargs: {}
+        # --- optional ---
+        figure_params:
+            x: depth
+            y: faith_pd
+            color: sample
+            title: Alpha Diversity Rarefaction Curves
+            labels:
+                depth: Rarefaction Depth
+                faith_pd: Faith's Phylogenetic Diversity
         mode: code
         code_content: "df_modified = df.group_by([\"sample\", \"depth\"]).agg([\n\
             \    pl.col(\"faith_pd\").mean().alias(\"mean\"),\n    pl.col(\"faith_pd\"\
@@ -252,34 +263,18 @@ tabs:
             : \"Faith's Phylogenetic Diversity\"},\n    title=\"Alpha Diversity Rarefaction\
             \ Curves\"\n)\nfig.update_traces(mode=\"lines+markers\")"
         selection_enabled: false
+        # --- generated on export ---
+        tag: figure-line_depth_faith_pd-5d9f17
         layout:
             x: 0
             y: 2
             w: 8
             h: 5
-        figure_params:
-            x: depth
-            y: faith_pd
-            color: sample
-            title: Alpha Diversity Rarefaction Curves
-            labels:
-                depth: Rarefaction Depth
-                faith_pd: Faith's Phylogenetic Diversity
-    -   tag: figure-box_sample_faith_pd-5b8018
-        index: e3918bea-5fed-4d2b-ae90-be4962d93cfd
-        component_type: figure
-        title: ''
+    -   component_type: figure
         workflow_tag: ampliseq
         data_collection_tag: alpha_rarefaction
         visu_type: box
-        dict_kwargs: {}
-        mode: ui
-        selection_enabled: false
-        layout:
-            x: 0
-            y: 7
-            w: 8
-            h: 5
+        # --- optional ---
         figure_params:
             x: sample
             y: faith_pd
@@ -292,14 +287,26 @@ tabs:
             labels:
                 sample: Sample
                 faith_pd: Faith's Phylogenetic Diversity
-    -   tag: figure-sunburst-e651a9
-        index: 5ed044d5-7364-4f36-9e40-4f9098bdc6dd
-        component_type: figure
-        title: ''
+        mode: ui
+        selection_enabled: false
+        # --- generated on export ---
+        tag: figure-box_sample_faith_pd-5b8018
+        layout:
+            x: 0
+            y: 7
+            w: 8
+            h: 5
+    -   component_type: figure
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
         visu_type: sunburst
-        dict_kwargs: {}
+        # --- optional ---
+        figure_params:
+            path:
+            - Kingdom
+            - Phylum
+            values: count
+            title: Taxonomic Composition - Hierarchical View
         mode: code
         code_content: 'df_modified = df.filter((pl.col(''Phylum'').is_not_null())
             & (pl.col(''Phylum'') != '''')).group_by([''Kingdom'', ''Phylum'']).agg(pl.col(''count'').sum())
@@ -307,32 +314,18 @@ tabs:
             fig = px.sunburst(df_modified.to_dicts(), path=[''Kingdom'', ''Phylum''],
             values=''count'', title=''Taxonomic Composition - Hierarchical View'')'
         selection_enabled: false
+        # --- generated on export ---
+        tag: figure-sunburst-e651a9
         layout:
             x: 0
             y: 12
             w: 4
             h: 6
-        figure_params:
-            path:
-            - Kingdom
-            - Phylum
-            values: count
-            title: Taxonomic Composition - Hierarchical View
-    -   tag: figure-bar_phylum_count-de4c39
-        index: 301f7ef7-b617-4e46-b661-263b2403b153
-        component_type: figure
-        title: ''
+    -   component_type: figure
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
         visu_type: bar
-        dict_kwargs: {}
-        mode: ui
-        selection_enabled: false
-        layout:
-            x: 4
-            y: 12
-            w: 4
-            h: 6
+        # --- optional ---
         figure_params:
             x: Phylum
             y: count
@@ -343,21 +336,20 @@ tabs:
                 count: Read Count
                 habitat: Habitat
             barmode: stack
-    -   tag: figure-bar_sample_count-de4c39
-        index: 8055c181-d8c3-483e-a179-a4c008fcb5ce
-        component_type: figure
-        title: ''
+        mode: ui
+        selection_enabled: false
+        # --- generated on export ---
+        tag: figure-bar_phylum_count-de4c39
+        layout:
+            x: 4
+            y: 12
+            w: 4
+            h: 6
+    -   component_type: figure
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
         visu_type: bar
-        dict_kwargs: {}
-        mode: ui
-        selection_enabled: false
-        layout:
-            x: 0
-            y: 18
-            w: 8
-            h: 6
+        # --- optional ---
         figure_params:
             x: sample
             y: count
@@ -368,342 +360,359 @@ tabs:
                 count: Read Count
                 Phylum: Phylum
             barmode: stack
-    -   tag: table-table-df4371
-        index: 6084ade7-ad17-4166-8265-15d6612a4fc8
-        component_type: table
-        title: ''
+        mode: ui
+        selection_enabled: false
+        # --- generated on export ---
+        tag: figure-bar_sample_count-de4c39
+        layout:
+            x: 0
+            y: 18
+            w: 8
+            h: 6
+    -   component_type: table
         workflow_tag: ampliseq
         data_collection_tag: metadata
-        columns: []
-        page_size: 10
-        sortable: true
-        filterable: true
+        # --- optional ---
         row_selection_enabled: false
+        # --- generated on export ---
+        tag: table-table-df4371
         layout:
             x: 0
             y: 24
             w: 8
             h: 6
-    -   tag: table-table-02f050
-        index: be0b13ba-0241-4086-a1f1-2953040cfb53
-        component_type: table
-        title: ''
+    -   component_type: table
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
-        columns: []
-        page_size: 10
-        sortable: true
-        filterable: true
+        # --- optional ---
         row_selection_enabled: false
+        # --- generated on export ---
+        tag: table-table-02f050
         layout:
             x: 0
             y: 30
             w: 8
             h: 6
-    -   tag: interactive-habitat-d8ca83
-        index: 22665c8a-928f-4b62-a54d-c379ea1b5c9d
-        component_type: interactive
-        title: Habitat Type
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: metadata
         interactive_component_type: MultiSelect
         column_name: habitat
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#984EA3'
+            icon_name: mdi:earth
+        # --- generated on export ---
+        tag: interactive-habitat-d8ca83
         layout:
             x: 0
             y: 3
             w: 1
             h: 2
-        display:
-            title_size: md
-            custom_color: '#984EA3'
-            icon_name: mdi:earth
-    -   tag: interactive-sample-78c9c2
-        index: 301abd2e-2c74-439a-ac74-4b63a7021293
-        component_type: interactive
-        title: Sample ID
+        title: Habitat Type
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: metadata
         interactive_component_type: MultiSelect
         column_name: sample
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#45B8AC'
+            icon_name: mdi:flask
+        # --- generated on export ---
+        tag: interactive-sample-78c9c2
         layout:
             x: 0
             y: 5
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#45B8AC'
-            icon_name: mdi:flask
-    -   tag: interactive-kingdom-b112bb
-        index: ed42fd5b-9d53-4493-a1cd-7bb38a335cdc
-        component_type: interactive
-        title: Kingdom
+        title: Sample ID
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
         interactive_component_type: MultiSelect
         column_name: Kingdom
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#377EB8'
+            icon_name: mdi:bacteria
+        # --- generated on export ---
+        tag: interactive-kingdom-b112bb
         layout:
             x: 0
             y: 8
             w: 1
             h: 2
-        display:
-            title_size: md
-            custom_color: '#377EB8'
-            icon_name: mdi:bacteria
-    -   tag: interactive-phylum-f89384
-        index: 35b843da-93f9-4f42-bc97-1a44305ce931
-        component_type: interactive
-        title: Phylum
+        title: Kingdom
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
         interactive_component_type: MultiSelect
         column_name: Phylum
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#8BC34A'
+            icon_name: mdi:bacteria-outline
+        # --- generated on export ---
+        tag: interactive-phylum-f89384
         layout:
             x: 0
             y: 10
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#8BC34A'
-            icon_name: mdi:bacteria-outline
-    -   tag: interactive-sampling_date-b9d091
-        index: dd4f8f9a-211f-4cea-acc6-d28d7aa54751
-        component_type: interactive
-        title: Sampling Period
+        title: Phylum
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: metadata
         interactive_component_type: DateRangePicker
         column_name: sampling_date
+        # --- optional ---
         column_type: datetime
+        display:
+            title_size: md
+            custom_color: '#45B8AC'
+            icon_name: mdi:calendar-range
+        # --- generated on export ---
+        tag: interactive-sampling_date-b9d091
         layout:
             x: 0
             y: 0
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#45B8AC'
-            icon_name: mdi:calendar-range
-    -   tag: interactive-range-faith-pd-slider-5cf75b
-        index: range-faith-pd-slider
-        component_type: interactive
-        title: Faith PD Range
+        title: Sampling Period
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: alpha_rarefaction
         interactive_component_type: RangeSlider
         column_name: faith_pd
+        # --- optional ---
         column_type: float64
+        display:
+            title_size: md
+            custom_color: '#9C27B0'
+            icon_name: mdi:chart-box-outline
+        # --- generated on export ---
+        tag: interactive-range-faith-pd-slider-5cf75b
+        index: range-faith-pd-slider
         layout:
             x: 0
             y: 13
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#9C27B0'
-            icon_name: mdi:chart-box-outline
-    -   tag: interactive-range-count-slider-7e70dc
-        index: range-count-slider
-        component_type: interactive
-        title: Taxon Count
+        title: Faith PD Range
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: taxonomy_composition
         interactive_component_type: RangeSlider
         column_name: count
+        # --- optional ---
         column_type: float64
+        display:
+            title_size: md
+            custom_color: '#FF9800'
+            icon_name: mdi:counter
+        # --- generated on export ---
+        tag: interactive-range-count-slider-7e70dc
+        index: range-count-slider
         layout:
             x: 0
             y: 16
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#FF9800'
-            icon_name: mdi:counter
--   dashboard_id: 646b0f3c1e4a2d7f8e5b8cb4
-    title: Diff. Abundance
+        title: Taxon Count
+-   title: Diff. Abundance
+    # --- optional ---
     subtitle: ANCOM Volcano Plot
     tab_order: 2
     tab_icon: mdi:chart-scatter-plot
     tab_icon_color: red
     icon: /assets/images/workflows/nf-core.png
     icon_color: green
-    icon_variant: filled
     workflow_system: nf-core
+    # --- generated on export ---
+    dashboard_id: 646b0f3c1e4a2d7f8e5b8cb4
     components:
-    -   tag: interactive-diff-filter-phylum-19799f
-        index: diff-filter-phylum
-        component_type: interactive
-        title: Phylum
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         interactive_component_type: MultiSelect
         column_name: Phylum
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#8BC34A'
+            icon_name: mdi:bacteria-outline
+        # --- generated on export ---
+        tag: interactive-diff-filter-phylum-19799f
+        index: diff-filter-phylum
         layout:
             x: 0
             y: 0
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#8BC34A'
-            icon_name: mdi:bacteria-outline
-    -   tag: interactive-diff-kingdom-filter-06c93a
-        index: diff-kingdom-filter
-        component_type: interactive
-        title: Kingdom
+        title: Phylum
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         interactive_component_type: MultiSelect
         column_name: Kingdom
+        # --- optional ---
         column_type: object
+        display:
+            title_size: md
+            custom_color: '#377EB8'
+            icon_name: mdi:bacteria
+        # --- generated on export ---
+        tag: interactive-diff-kingdom-filter-06c93a
+        index: diff-kingdom-filter
         layout:
             x: 0
             y: 3
             w: 1
             h: 2
-        display:
-            title_size: md
-            custom_color: '#377EB8'
-            icon_name: mdi:bacteria
-    -   tag: interactive-diff-w-slider-39626c
-        index: diff-w-slider
-        component_type: interactive
-        title: W Statistic Range
+        title: Kingdom
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         interactive_component_type: RangeSlider
         column_name: W
+        # --- optional ---
         column_type: int64
+        display:
+            title_size: md
+            custom_color: '#E74C3C'
+            icon_name: mdi:chart-line
+        # --- generated on export ---
+        tag: interactive-diff-w-slider-39626c
+        index: diff-w-slider
         layout:
             x: 0
             y: 5
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#E74C3C'
-            icon_name: mdi:chart-line
-    -   tag: interactive-diff-clr-slider-151c9f
-        index: diff-clr-slider
-        component_type: interactive
-        title: CLR Effect Size Range
+        title: W Statistic Range
+    -   component_type: interactive
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         interactive_component_type: RangeSlider
         column_name: clr
+        # --- optional ---
         column_type: float64
+        display:
+            title_size: md
+            custom_color: '#F68B33'
+            icon_name: mdi:chart-bell-curve
+        # --- generated on export ---
+        tag: interactive-diff-clr-slider-151c9f
+        index: diff-clr-slider
         layout:
             x: 0
             y: 8
             w: 1
             h: 3
-        display:
-            title_size: md
-            custom_color: '#F68B33'
-            icon_name: mdi:chart-bell-curve
-    -   tag: card-diff-card-total-taxa-92484f
-        index: diff-card-total-taxa
-        component_type: card
-        title: Total Taxa Analyzed
+        title: CLR Effect Size Range
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         aggregation: count
         column_name: id
+        # --- optional ---
         column_type: object
-        layout:
-            x: 0
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:bacteria
             icon_color: '#45B8AC'
             title_color: '#45B8AC'
             title_font_size: xl
             value_font_size: xl
-    -   tag: card-diff-card-significant-2550e3
-        index: diff-card-significant
-        component_type: card
-        title: Significant Taxa (W>100)
+        # --- generated on export ---
+        tag: card-diff-card-total-taxa-92484f
+        index: diff-card-total-taxa
+        layout:
+            x: 0
+            y: 0
+            w: 2
+            h: 2
+        title: Total Taxa Analyzed
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         aggregation: count
         column_name: id
+        # --- optional ---
         column_type: object
-        layout:
-            x: 2
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:alert-circle
             icon_color: '#E74C3C'
             title_color: '#E74C3C'
             title_font_size: xl
             value_font_size: xl
-    -   tag: card-diff-card-phyla-80b1ba
-        index: diff-card-phyla
-        component_type: card
-        title: Unique Phyla
+        # --- generated on export ---
+        tag: card-diff-card-significant-2550e3
+        index: diff-card-significant
+        layout:
+            x: 2
+            y: 0
+            w: 2
+            h: 2
+        title: Significant Taxa (W>100)
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         aggregation: nunique
         column_name: Phylum
+        # --- optional ---
         column_type: object
-        layout:
-            x: 4
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:bacteria-outline
             icon_color: '#8BC34A'
             title_color: '#8BC34A'
             title_font_size: xl
             value_font_size: xl
-    -   tag: card-diff-card-max-effect-da2320
-        index: diff-card-max-effect
-        component_type: card
-        title: Max Effect Size (CLR)
+        # --- generated on export ---
+        tag: card-diff-card-phyla-80b1ba
+        index: diff-card-phyla
+        layout:
+            x: 4
+            y: 0
+            w: 2
+            h: 2
+        title: Unique Phyla
+    -   component_type: card
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         aggregation: max
         column_name: clr
+        # --- optional ---
         column_type: float64
-        layout:
-            x: 6
-            y: 0
-            w: 2
-            h: 2
         display:
             icon_name: mdi:chart-line-variant
             icon_color: '#F68B33'
             title_color: '#F68B33'
             title_font_size: xl
             value_font_size: xl
-    -   tag: figure-scatter_clr_w-734503
-        index: d07985d5-37cb-4f94-a8c3-d97d977226f1
-        component_type: figure
-        title: ''
+        # --- generated on export ---
+        tag: card-diff-card-max-effect-da2320
+        index: diff-card-max-effect
+        layout:
+            x: 6
+            y: 0
+            w: 2
+            h: 2
+        title: Max Effect Size (CLR)
+    -   component_type: figure
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         visu_type: scatter
-        dict_kwargs: {}
-        mode: ui
-        selection_enabled: false
-        layout:
-            x: 0
-            y: 2
-            w: 8
-            h: 10
+        # --- optional ---
         figure_params:
             x: clr
             y: W
@@ -716,26 +725,20 @@ tabs:
                 clr: Centered Log-Ratio (Effect Size)
                 W: ANCOM W-Statistic
                 Phylum: Phylum
-    -   tag: figure-diff-bar-top-taxa-145fd5
-        index: diff-bar-top-taxa
-        component_type: figure
-        title: ''
+        mode: ui
+        selection_enabled: false
+        # --- generated on export ---
+        tag: figure-scatter_clr_w-734503
+        layout:
+            x: 0
+            y: 2
+            w: 8
+            h: 10
+    -   component_type: figure
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
         visu_type: bar
-        dict_kwargs: {}
-        mode: code
-        code_content: "df_modified = df.sort('W', descending=True).head(20)\nfig =\
-            \ px.bar(\n    df_modified.to_pandas(),\n    x='taxonomy', y='W', color='Phylum',\n\
-            \    title='Top 20 Most Significant Taxa (by W-statistic)',\n    labels={'taxonomy':\
-            \ 'Taxonomy', 'W': 'ANCOM W-Statistic', 'Phylum': 'Phylum'}\n)\nfig.update_layout(xaxis={'tickangle':\
-            \ -45, 'tickfont': {'size': 10}})"
-        selection_enabled: false
-        layout:
-            x: 0
-            y: 12
-            w: 8
-            h: 8
+        # --- optional ---
         figure_params:
             x: taxonomy
             y: W
@@ -745,17 +748,29 @@ tabs:
                 taxonomy: Taxonomy
                 W: ANCOM W-Statistic
                 Phylum: Phylum
-    -   tag: table-diff-table-results-6655ac
-        index: diff-table-results
-        component_type: table
-        title: ''
+        mode: code
+        code_content: "df_modified = df.sort('W', descending=True).head(20)\nfig =\
+            \ px.bar(\n    df_modified.to_pandas(),\n    x='taxonomy', y='W', color='Phylum',\n\
+            \    title='Top 20 Most Significant Taxa (by W-statistic)',\n    labels={'taxonomy':\
+            \ 'Taxonomy', 'W': 'ANCOM W-Statistic', 'Phylum': 'Phylum'}\n)\nfig.update_layout(xaxis={'tickangle':\
+            \ -45, 'tickfont': {'size': 10}})"
+        selection_enabled: false
+        # --- generated on export ---
+        tag: figure-diff-bar-top-taxa-145fd5
+        index: diff-bar-top-taxa
+        layout:
+            x: 0
+            y: 12
+            w: 8
+            h: 8
+    -   component_type: table
         workflow_tag: ampliseq
         data_collection_tag: ancom_volcano
-        columns: []
-        page_size: 10
-        sortable: true
-        filterable: true
+        # --- optional ---
         row_selection_enabled: false
+        # --- generated on export ---
+        tag: table-diff-table-results-6655ac
+        index: diff-table-results
         layout:
             x: 0
             y: 20

--- a/depictio/projects/reference/ampliseq/dashboard.yaml
+++ b/depictio/projects/reference/ampliseq/dashboard.yaml
@@ -1,0 +1,763 @@
+main_dashboard:
+    dashboard_id: 646b0f3c1e4a2d7f8e5b8ca2
+    project_tag: Ampliseq Microbial Community Analysis
+    title: nf-core/ampliseq
+    subtitle: MultiQC Analysis - Cutadapt & FastQC
+    main_tab_name: MultiQC
+    tab_icon: /assets/images/logos/multiqc.png
+    tab_icon_color: orange
+    icon: /assets/images/workflows/nf-core.png
+    icon_color: green
+    icon_variant: filled
+    workflow_system: nf-core
+    components:
+    -   tag: interactive-multiqc-sampling-date-b9d091
+        index: multiqc-sampling-date
+        component_type: interactive
+        title: Sampling Period
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        interactive_component_type: DateRangePicker
+        column_name: sampling_date
+        column_type: datetime
+        layout:
+            x: 0
+            y: 0
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#FF6B6B'
+            icon_name: mdi:calendar-range
+    -   tag: interactive-multiqc-habitat-filter-d8ca83
+        index: multiqc-habitat-filter
+        component_type: interactive
+        title: Habitat Type
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        interactive_component_type: MultiSelect
+        column_name: habitat
+        column_type: object
+        layout:
+            x: 0
+            y: 3
+            w: 1
+            h: 2
+        display:
+            title_size: md
+            custom_color: '#984EA3'
+            icon_name: mdi:earth
+    -   tag: interactive-multiqc-sample-filter-78c9c2
+        index: multiqc-sample-filter
+        component_type: interactive
+        title: Sample ID
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        interactive_component_type: MultiSelect
+        column_name: sample
+        column_type: object
+        layout:
+            x: 0
+            y: 5
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#45B8AC'
+            icon_name: mdi:flask
+    -   tag: multiqc-cutadapt_filtered-reads-d421ae
+        index: e2db1471-3076-4f3e-aaf3-d2631da98167
+        component_type: multiqc
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: multiqc_data
+        selected_module: cutadapt
+        selected_plot: Filtered Reads
+        layout:
+            x: 0
+            y: 0
+            w: 8
+            h: 4
+    -   tag: multiqc-fastqc_sequence-counts-52bd04
+        index: 4c53ffb5-eb66-428d-8eea-d519877c5fa0
+        component_type: multiqc
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: multiqc_data
+        selected_module: fastqc
+        selected_plot: Sequence Counts
+        layout:
+            x: 0
+            y: 4
+            w: 8
+            h: 4
+    -   tag: multiqc-fastqc_sequence-quality-histograms-ce2a02
+        index: 90654027-0423-4abc-9026-296b6ba78bc9
+        component_type: multiqc
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: multiqc_data
+        selected_module: fastqc
+        selected_plot: Sequence Quality Histograms
+        layout:
+            x: 0
+            y: 8
+            w: 4
+            h: 5
+    -   tag: multiqc-fastqc_per-sequence-gc-content-359f73
+        index: 09ce8e50-03f9-4285-b0d2-83d7912d8d6a
+        component_type: multiqc
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: multiqc_data
+        selected_module: fastqc
+        selected_plot: Per Sequence GC Content
+        layout:
+            x: 4
+            y: 8
+            w: 4
+            h: 5
+    -   tag: multiqc-fastqc_adapter-content-6dd1a9
+        index: af2cd16d-ce8e-40d0-8e9e-49a1fa0bc8a3
+        component_type: multiqc
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: multiqc_data
+        selected_module: fastqc
+        selected_plot: Adapter Content
+        layout:
+            x: 0
+            y: 13
+            w: 4
+            h: 5
+    -   tag: multiqc-cutadapt_trimmed-sequence-lengths-5-e5e50a
+        index: fdb76dba-8205-4373-b96f-b06dab9c75ad
+        component_type: multiqc
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: multiqc_data
+        selected_module: cutadapt
+        selected_plot: Trimmed Sequence Lengths (5')
+        layout:
+            x: 4
+            y: 13
+            w: 4
+            h: 5
+tabs:
+-   dashboard_id: 646b0f3c1e4a2d7f8e5b8cb3
+    title: Community Analysis
+    subtitle: Alpha Diversity & Taxonomic Composition
+    tab_order: 1
+    tab_icon: mdi:bacteria-outline
+    tab_icon_color: teal
+    icon: /assets/images/workflows/nf-core.png
+    icon_color: green
+    icon_variant: filled
+    workflow_system: nf-core
+    components:
+    -   tag: card-sample_nunique-faa7e6
+        index: 778be777-e177-4dd0-858f-d0e945c3e535
+        component_type: card
+        title: Total Samples
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        aggregation: nunique
+        column_name: sample
+        column_type: object
+        layout:
+            x: 0
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:flask
+            icon_color: '#45B8AC'
+            title_color: '#45B8AC'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: card-taxonomy_nunique-d2ba1c
+        index: e7ae0c0e-88fc-4c94-8b66-4ed4f06031ec
+        component_type: card
+        title: Total Taxa
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        aggregation: nunique
+        column_name: taxonomy
+        column_type: object
+        layout:
+            x: 2
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:bacteria
+            icon_color: '#8BC34A'
+            title_color: '#8BC34A'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: card-faith_pd_average-66fb50
+        index: a386e270-1705-433c-91c2-e651a5885fb2
+        component_type: card
+        title: Mean Faith PD
+        workflow_tag: ampliseq
+        data_collection_tag: alpha_rarefaction
+        aggregation: average
+        column_name: faith_pd
+        column_type: float64
+        layout:
+            x: 4
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:chart-line
+            icon_color: '#F68B33'
+            title_color: '#F68B33'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: card-habitat_nunique-1fc891
+        index: 3c8541b2-f741-48bb-a42c-f9f6bed0f384
+        component_type: card
+        title: Habitat Types
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        aggregation: nunique
+        column_name: habitat
+        column_type: object
+        layout:
+            x: 6
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:earth
+            icon_color: '#984EA3'
+            title_color: '#984EA3'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: figure-line_depth_faith_pd-5d9f17
+        index: 3fa381f6-42d3-4566-ad8f-89b239ed3266
+        component_type: figure
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: alpha_rarefaction
+        visu_type: line
+        dict_kwargs: {}
+        mode: code
+        code_content: "df_modified = df.group_by([\"sample\", \"depth\"]).agg([\n\
+            \    pl.col(\"faith_pd\").mean().alias(\"mean\"),\n    pl.col(\"faith_pd\"\
+            ).std().alias(\"std\")\n]).sort(\"depth\")\n\nfig = px.line(\n    df_modified.to_pandas(),\n\
+            \    x=\"depth\", y=\"mean\", color=\"sample\",\n    error_y=\"std\",\
+            \ markers=True,\n    labels={\"depth\": \"Rarefaction Depth\", \"mean\"\
+            : \"Faith's Phylogenetic Diversity\"},\n    title=\"Alpha Diversity Rarefaction\
+            \ Curves\"\n)\nfig.update_traces(mode=\"lines+markers\")"
+        selection_enabled: false
+        layout:
+            x: 0
+            y: 2
+            w: 8
+            h: 5
+        figure_params:
+            x: depth
+            y: faith_pd
+            color: sample
+            title: Alpha Diversity Rarefaction Curves
+            labels:
+                depth: Rarefaction Depth
+                faith_pd: Faith's Phylogenetic Diversity
+    -   tag: figure-box_sample_faith_pd-5b8018
+        index: 0d2f8c0d-e6c5-46c0-b769-479835cb9524
+        component_type: figure
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: alpha_rarefaction
+        visu_type: box
+        dict_kwargs: {}
+        mode: ui
+        selection_enabled: false
+        layout:
+            x: 0
+            y: 7
+            w: 8
+            h: 5
+        figure_params:
+            x: sample
+            y: faith_pd
+            color: sample
+            hover_data:
+                sample: true
+                faith_pd: :.2f
+                depth: true
+            title: Alpha Diversity by Sample
+            labels:
+                sample: Sample
+                faith_pd: Faith's Phylogenetic Diversity
+    -   tag: figure-sunburst-e651a9
+        index: e3b23ce8-4f93-4524-8a22-669e274b8d3e
+        component_type: figure
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        visu_type: sunburst
+        dict_kwargs: {}
+        mode: code
+        code_content: 'df_modified = df.filter((pl.col(''Phylum'').is_not_null())
+            & (pl.col(''Phylum'') != '''')).group_by([''Kingdom'', ''Phylum'']).agg(pl.col(''count'').sum())
+
+            fig = px.sunburst(df_modified.to_dicts(), path=[''Kingdom'', ''Phylum''],
+            values=''count'', title=''Taxonomic Composition - Hierarchical View'')'
+        selection_enabled: false
+        layout:
+            x: 0
+            y: 12
+            w: 4
+            h: 6
+        figure_params:
+            path:
+            - Kingdom
+            - Phylum
+            values: count
+            title: Taxonomic Composition - Hierarchical View
+    -   tag: figure-bar_phylum_count-de4c39
+        index: deca7ec8-f516-444f-b784-2d36e3934176
+        component_type: figure
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        visu_type: bar
+        dict_kwargs: {}
+        mode: ui
+        selection_enabled: false
+        layout:
+            x: 4
+            y: 12
+            w: 4
+            h: 6
+        figure_params:
+            x: Phylum
+            y: count
+            color: habitat
+            title: Taxonomic Abundance by Habitat
+            labels:
+                Phylum: Phylum
+                count: Read Count
+                habitat: Habitat
+            barmode: stack
+    -   tag: figure-bar_sample_count-de4c39
+        index: 61692fe9-e58e-4013-a3ff-472a4f0984e8
+        component_type: figure
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        visu_type: bar
+        dict_kwargs: {}
+        mode: ui
+        selection_enabled: false
+        layout:
+            x: 0
+            y: 18
+            w: 8
+            h: 6
+        figure_params:
+            x: sample
+            y: count
+            color: Phylum
+            title: Taxonomic Composition by Sample
+            labels:
+                sample: Sample ID
+                count: Read Count
+                Phylum: Phylum
+            barmode: stack
+    -   tag: table-table-df4371
+        index: a7231fa5-8654-40a9-b53c-9bb3c564a507
+        component_type: table
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        columns: []
+        page_size: 10
+        sortable: true
+        filterable: true
+        row_selection_enabled: false
+        layout:
+            x: 0
+            y: 24
+            w: 8
+            h: 6
+    -   tag: table-table-02f050
+        index: 8c024af9-c766-471e-b306-e231ba8c9510
+        component_type: table
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        columns: []
+        page_size: 10
+        sortable: true
+        filterable: true
+        row_selection_enabled: false
+        layout:
+            x: 0
+            y: 30
+            w: 8
+            h: 6
+    -   tag: interactive-habitat-d8ca83
+        index: aa6035ff-380b-43f7-b6f5-3556acaccce7
+        component_type: interactive
+        title: Habitat Type
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        interactive_component_type: MultiSelect
+        column_name: habitat
+        column_type: object
+        layout:
+            x: 0
+            y: 3
+            w: 1
+            h: 2
+        display:
+            title_size: md
+            custom_color: '#984EA3'
+            icon_name: mdi:earth
+    -   tag: interactive-sample-78c9c2
+        index: 289fc672-6e2d-4177-8825-e5f67aa48647
+        component_type: interactive
+        title: Sample ID
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        interactive_component_type: MultiSelect
+        column_name: sample
+        column_type: object
+        layout:
+            x: 0
+            y: 5
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#45B8AC'
+            icon_name: mdi:flask
+    -   tag: interactive-kingdom-b112bb
+        index: e0e87f73-e79d-491d-915f-88d35e49bc4f
+        component_type: interactive
+        title: Kingdom
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        interactive_component_type: MultiSelect
+        column_name: Kingdom
+        column_type: object
+        layout:
+            x: 0
+            y: 8
+            w: 1
+            h: 2
+        display:
+            title_size: md
+            custom_color: '#377EB8'
+            icon_name: mdi:bacteria
+    -   tag: interactive-phylum-f89384
+        index: cea045f5-b3ee-47d3-9a8a-1a75c9874347
+        component_type: interactive
+        title: Phylum
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        interactive_component_type: MultiSelect
+        column_name: Phylum
+        column_type: object
+        layout:
+            x: 0
+            y: 10
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#8BC34A'
+            icon_name: mdi:bacteria-outline
+    -   tag: interactive-sampling_date-b9d091
+        index: 4eaab9c4-e816-41bf-8718-e7f43a0b1263
+        component_type: interactive
+        title: Sampling Period
+        workflow_tag: ampliseq
+        data_collection_tag: metadata
+        interactive_component_type: DateRangePicker
+        column_name: sampling_date
+        column_type: datetime
+        layout:
+            x: 0
+            y: 0
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#45B8AC'
+            icon_name: mdi:calendar-range
+    -   tag: interactive-range-faith-pd-slider-5cf75b
+        index: range-faith-pd-slider
+        component_type: interactive
+        title: Faith PD Range
+        workflow_tag: ampliseq
+        data_collection_tag: alpha_rarefaction
+        interactive_component_type: RangeSlider
+        column_name: faith_pd
+        column_type: float64
+        layout:
+            x: 0
+            y: 13
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#9C27B0'
+            icon_name: mdi:chart-box-outline
+    -   tag: interactive-range-count-slider-7e70dc
+        index: range-count-slider
+        component_type: interactive
+        title: Taxon Count
+        workflow_tag: ampliseq
+        data_collection_tag: taxonomy_composition
+        interactive_component_type: RangeSlider
+        column_name: count
+        column_type: float64
+        layout:
+            x: 0
+            y: 16
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#FF9800'
+            icon_name: mdi:counter
+-   dashboard_id: 646b0f3c1e4a2d7f8e5b8cb4
+    title: Diff. Abundance
+    subtitle: ANCOM Volcano Plot
+    tab_order: 2
+    tab_icon: mdi:chart-scatter-plot
+    tab_icon_color: red
+    icon: /assets/images/workflows/nf-core.png
+    icon_color: green
+    icon_variant: filled
+    workflow_system: nf-core
+    components:
+    -   tag: interactive-diff-filter-phylum-19799f
+        index: diff-filter-phylum
+        component_type: interactive
+        title: Phylum
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        interactive_component_type: MultiSelect
+        column_name: Phylum
+        column_type: object
+        layout:
+            x: 0
+            y: 0
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#8BC34A'
+            icon_name: mdi:bacteria-outline
+    -   tag: interactive-diff-kingdom-filter-06c93a
+        index: diff-kingdom-filter
+        component_type: interactive
+        title: Kingdom
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        interactive_component_type: MultiSelect
+        column_name: Kingdom
+        column_type: object
+        layout:
+            x: 0
+            y: 3
+            w: 1
+            h: 2
+        display:
+            title_size: md
+            custom_color: '#377EB8'
+            icon_name: mdi:bacteria
+    -   tag: interactive-diff-w-slider-39626c
+        index: diff-w-slider
+        component_type: interactive
+        title: W Statistic Range
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        interactive_component_type: RangeSlider
+        column_name: W
+        column_type: int64
+        layout:
+            x: 0
+            y: 5
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#E74C3C'
+            icon_name: mdi:chart-line
+    -   tag: interactive-diff-clr-slider-151c9f
+        index: diff-clr-slider
+        component_type: interactive
+        title: CLR Effect Size Range
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        interactive_component_type: RangeSlider
+        column_name: clr
+        column_type: float64
+        layout:
+            x: 0
+            y: 8
+            w: 1
+            h: 3
+        display:
+            title_size: md
+            custom_color: '#F68B33'
+            icon_name: mdi:chart-bell-curve
+    -   tag: card-diff-card-total-taxa-92484f
+        index: diff-card-total-taxa
+        component_type: card
+        title: Total Taxa Analyzed
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        aggregation: count
+        column_name: id
+        column_type: object
+        layout:
+            x: 0
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:bacteria
+            icon_color: '#45B8AC'
+            title_color: '#45B8AC'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: card-diff-card-significant-2550e3
+        index: diff-card-significant
+        component_type: card
+        title: Significant Taxa (W>100)
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        aggregation: count
+        column_name: id
+        column_type: object
+        layout:
+            x: 2
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:alert-circle
+            icon_color: '#E74C3C'
+            title_color: '#E74C3C'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: card-diff-card-phyla-80b1ba
+        index: diff-card-phyla
+        component_type: card
+        title: Unique Phyla
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        aggregation: nunique
+        column_name: Phylum
+        column_type: object
+        layout:
+            x: 4
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:bacteria-outline
+            icon_color: '#8BC34A'
+            title_color: '#8BC34A'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: card-diff-card-max-effect-da2320
+        index: diff-card-max-effect
+        component_type: card
+        title: Max Effect Size (CLR)
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        aggregation: max
+        column_name: clr
+        column_type: float64
+        layout:
+            x: 6
+            y: 0
+            w: 2
+            h: 2
+        display:
+            icon_name: mdi:chart-line-variant
+            icon_color: '#F68B33'
+            title_color: '#F68B33'
+            title_font_size: xl
+            value_font_size: xl
+    -   tag: figure-scatter_clr_w-734503
+        index: 36269bf4-3b51-4d59-bffd-26dcdc7c9086
+        component_type: figure
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        visu_type: scatter
+        dict_kwargs: {}
+        mode: ui
+        selection_enabled: false
+        layout:
+            x: 0
+            y: 2
+            w: 8
+            h: 10
+        figure_params:
+            x: clr
+            y: W
+            color: Phylum
+            hover_data:
+            - id
+            - taxonomy
+            title: ANCOM Differential Abundance
+            labels:
+                clr: Centered Log-Ratio (Effect Size)
+                W: ANCOM W-Statistic
+                Phylum: Phylum
+    -   tag: figure-diff-bar-top-taxa-145fd5
+        index: diff-bar-top-taxa
+        component_type: figure
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        visu_type: bar
+        dict_kwargs: {}
+        mode: code
+        code_content: "df_modified = df.sort('W', descending=True).head(20)\nfig =\
+            \ px.bar(\n    df_modified.to_pandas(),\n    x='taxonomy', y='W', color='Phylum',\n\
+            \    title='Top 20 Most Significant Taxa (by W-statistic)',\n    labels={'taxonomy':\
+            \ 'Taxonomy', 'W': 'ANCOM W-Statistic', 'Phylum': 'Phylum'}\n)\nfig.update_layout(xaxis={'tickangle':\
+            \ -45, 'tickfont': {'size': 10}})"
+        selection_enabled: false
+        layout:
+            x: 0
+            y: 12
+            w: 8
+            h: 8
+        figure_params:
+            x: taxonomy
+            y: W
+            color: Phylum
+            title: Top 20 Most Significant Taxa (by W-statistic)
+            labels:
+                taxonomy: Taxonomy
+                W: ANCOM W-Statistic
+                Phylum: Phylum
+    -   tag: table-diff-table-results-6655ac
+        index: diff-table-results
+        component_type: table
+        title: ''
+        workflow_tag: ampliseq
+        data_collection_tag: ancom_volcano
+        columns: []
+        page_size: 10
+        sortable: true
+        filterable: true
+        row_selection_enabled: false
+        layout:
+            x: 0
+            y: 20
+            w: 8
+            h: 8

--- a/depictio/projects/reference/penguins/dashboard.yaml
+++ b/depictio/projects/reference/penguins/dashboard.yaml
@@ -1,0 +1,263 @@
+dashboard_id: 6824cb3b89d2b72169309738
+project_tag: Palmer Penguins Species Comparison
+title: Penguins Species Analysis
+icon: /assets/images/icons/favicon.png
+components:
+-   tag: figure-scatter_flipper_length_mm_body_mass_g-1d5516
+    component_type: figure
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 2
+        w: 8
+        h: 5
+    visu_type: scatter
+    figure_params:
+        x: flipper_length_mm
+        y: body_mass_g
+        color: species
+        symbol: island
+        size: bill_length_mm
+        color_discrete_map: '{"Adelie": "#6366f1", "Chinstrap": "#f59e0b", "Gentoo":
+            "#10b981"}'
+        title: Body Mass vs Flipper Length by Species and Island
+        size_max: 15
+        marginal_x: box
+        marginal_y: violin
+        trendline: lowess
+        labels: '{"flipper_length_mm": "Flipper Length (mm)", "body_mass_g": "Body
+            Mass (g)", "bill_length_mm": "Bill Length (mm)", "island": "Island", "species":
+            "Species"}'
+    mode: ui
+    selection_enabled: false
+-   tag: figure-box_species_bill_length_mm-410375
+    component_type: figure
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 7
+        w: 4
+        h: 5
+    visu_type: box
+    figure_params:
+        x: species
+        y: bill_length_mm
+        color: sex
+        color_discrete_map: '{"male": "#1976D2", "female": "#E91E63"}'
+        title: Bill Length Distribution by Species and Sex
+        boxmode: group
+        points: all
+        notched: true
+        labels: '{"bill_length_mm": "Bill Length (mm)", "species": "Species", "sex":
+            "Sex"}'
+    mode: ui
+    selection_enabled: false
+-   tag: figure-histogram_bill_depth_mm-4b8718
+    component_type: figure
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 4
+        y: 7
+        w: 4
+        h: 5
+    visu_type: histogram
+    figure_params:
+        x: bill_depth_mm
+        color: species
+        color_discrete_map: '{"Adelie": "#6366f1", "Chinstrap": "#f59e0b", "Gentoo":
+            "#10b981"}'
+        title: Bill Depth Distribution by Species
+        barmode: overlay
+        opacity: 0.7
+        nbins: 30
+        marginal: rug
+        labels: '{"bill_depth_mm": "Bill Depth (mm)", "species": "Species"}'
+    mode: ui
+    selection_enabled: false
+-   tag: figure-figure-7b5ffb
+    component_type: figure
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 12
+        w: 8
+        h: 5
+    visu_type: scatter
+    mode: code
+    code_content: 'df_modified = df.to_pandas().groupby([''island'',''species'']).agg({''body_mass_g'':''mean'',''bill_length_mm'':''count''}).reset_index().rename(columns={''bill_length_mm'':''count''})
+
+        fig = px.sunburst(df_modified,path=[''island'',''species''],values=''count'',color=''island'',color_discrete_map={"Biscoe":"#6366f1","Dream":"#f59e0b","Torgersen":"#10b981"},title=''Palmer
+        Penguins: Island & Species Distribution'',hover_data={''body_mass_g'':'':.0f''})
+
+        '
+    selection_enabled: false
+-   tag: card-species_nunique-d8c047
+    component_type: card
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 0
+        w: 2
+        h: 2
+    title: Species Diversity
+    aggregation: nunique
+    column_name: species
+    column_type: object
+    display:
+        icon_name: mdi:penguin
+        icon_color: '#8BC34A'
+        title_color: '#8BC34A'
+        title_font_size: xl
+        value_font_size: xl
+-   tag: card-body_mass_g_average-553e4a
+    component_type: card
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 2
+        y: 0
+        w: 2
+        h: 2
+    title: Avg Body Mass (g)
+    aggregation: average
+    column_name: body_mass_g
+    column_type: float64
+    display:
+        icon_name: mdi:weight
+        icon_color: '#F68B33'
+        title_color: '#F68B33'
+        title_font_size: xl
+        value_font_size: xl
+-   tag: card-individual_id_count-36d79d
+    component_type: card
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 4
+        y: 0
+        w: 2
+        h: 2
+    title: Total Individuals
+    aggregation: count
+    column_name: individual_id
+    column_type: object
+    display:
+        icon_name: mdi:counter
+        icon_color: '#5C6BC0'
+        title_color: '#5C6BC0'
+        title_font_size: xl
+        value_font_size: xl
+-   tag: card-flipper_length_mm_average-178663
+    component_type: card
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 6
+        y: 0
+        w: 2
+        h: 2
+    title: '`avg_flipper_length_mm`'
+    aggregation: average
+    column_name: flipper_length_mm
+    column_type: float64
+    display:
+        icon_name: mdi:ruler
+        icon_color: '#26A69A'
+        title_color: '#26A69A'
+        title_font_size: md
+        value_font_size: xl
+-   tag: interactive-species-db9b8e
+    component_type: interactive
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 0
+        w: 1
+        h: 2
+    column_name: species
+    column_type: object
+    interactive_component_type: MultiSelect
+    display:
+        title_size: md
+        custom_color: '#858585'
+        icon_name: mdi:filter
+-   tag: interactive-body_mass_g-0dfbd8
+    component_type: interactive
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 2
+        w: 1
+        h: 3
+    column_name: body_mass_g
+    column_type: float64
+    interactive_component_type: RangeSlider
+    display:
+        title_size: md
+        custom_color: '#45B8AC'
+        icon_name: bx:slider-alt
+-   tag: interactive-island-0c5e99
+    component_type: interactive
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 5
+        w: 1
+        h: 2
+    column_name: island
+    column_type: object
+    interactive_component_type: MultiSelect
+    display:
+        title_size: md
+        custom_color: '#7E57C2'
+        icon_name: mdi:island
+-   tag: interactive-sex-adab8a
+    component_type: interactive
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 7
+        w: 1
+        h: 2
+    column_name: sex
+    column_type: object
+    interactive_component_type: MultiSelect
+    display:
+        title_size: md
+        custom_color: '#EC407A'
+        icon_name: mdi:gender-male-female
+-   tag: interactive-bill_length_mm-5fb4eb
+    component_type: interactive
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 9
+        w: 1
+        h: 3
+    column_name: bill_length_mm
+    column_type: float64
+    interactive_component_type: RangeSlider
+    display:
+        title_size: md
+        custom_color: '#FF7043'
+        icon_name: bx:slider
+-   tag: table-table-82ce8c
+    component_type: table
+    workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    layout:
+        x: 0
+        y: 17
+        w: 8
+        h: 5
+    row_selection_enabled: false

--- a/depictio/projects/reference/penguins/dashboard.yaml
+++ b/depictio/projects/reference/penguins/dashboard.yaml
@@ -1,17 +1,10 @@
-dashboard_id: 6824cb3b89d2b72169309738
-project_tag: Palmer Penguins Species Comparison
 title: Penguins Species Analysis
+project_tag: Palmer Penguins Species Comparison
 icon: /assets/images/icons/favicon.png
+dashboard_id: 6824cb3b89d2b72169309738
 components:
--   tag: figure-scatter_flipper_length_mm_body_mass_g-1d5516
-    component_type: figure
+-   component_type: figure
     workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
-    layout:
-        x: 0
-        y: 2
-        w: 8
-        h: 5
     visu_type: scatter
     figure_params:
         x: flipper_length_mm
@@ -31,15 +24,14 @@ components:
             "Species"}'
     mode: ui
     selection_enabled: false
--   tag: figure-box_species_bill_length_mm-410375
-    component_type: figure
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    tag: figure-scatter_flipper_length_mm_body_mass_g-88662c
     layout:
         x: 0
-        y: 7
-        w: 4
+        y: 2
+        w: 8
         h: 5
+-   component_type: figure
+    workflow_tag: penguin_species_analysis
     visu_type: box
     figure_params:
         x: species
@@ -54,15 +46,14 @@ components:
             "Sex"}'
     mode: ui
     selection_enabled: false
--   tag: figure-histogram_bill_depth_mm-4b8718
-    component_type: figure
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    tag: figure-box_species_bill_length_mm-008158
     layout:
-        x: 4
+        x: 0
         y: 7
         w: 4
         h: 5
+-   component_type: figure
+    workflow_tag: penguin_species_analysis
     visu_type: histogram
     figure_params:
         x: bill_depth_mm
@@ -77,15 +68,14 @@ components:
         labels: '{"bill_depth_mm": "Bill Depth (mm)", "species": "Species"}'
     mode: ui
     selection_enabled: false
--   tag: figure-figure-7b5ffb
-    component_type: figure
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    tag: figure-histogram_bill_depth_mm-518c7e
     layout:
-        x: 0
-        y: 12
-        w: 8
+        x: 4
+        y: 7
+        w: 4
         h: 5
+-   component_type: figure
+    workflow_tag: penguin_species_analysis
     visu_type: scatter
     mode: code
     code_content: 'df_modified = df.to_pandas().groupby([''island'',''species'']).agg({''body_mass_g'':''mean'',''bill_length_mm'':''count''}).reset_index().rename(columns={''bill_length_mm'':''count''})
@@ -95,16 +85,14 @@ components:
 
         '
     selection_enabled: false
--   tag: card-species_nunique-d8c047
-    component_type: card
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    tag: figure-figure-413737
     layout:
         x: 0
-        y: 0
-        w: 2
-        h: 2
-    title: Species Diversity
+        y: 12
+        w: 8
+        h: 5
+-   component_type: card
+    workflow_tag: penguin_species_analysis
     aggregation: nunique
     column_name: species
     column_type: object
@@ -114,16 +102,15 @@ components:
         title_color: '#8BC34A'
         title_font_size: xl
         value_font_size: xl
--   tag: card-body_mass_g_average-553e4a
-    component_type: card
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    tag: card-species_nunique-a8ca80
     layout:
-        x: 2
+        x: 0
         y: 0
         w: 2
         h: 2
-    title: Avg Body Mass (g)
+    title: Species Diversity
+-   component_type: card
+    workflow_tag: penguin_species_analysis
     aggregation: average
     column_name: body_mass_g
     column_type: float64
@@ -133,16 +120,15 @@ components:
         title_color: '#F68B33'
         title_font_size: xl
         value_font_size: xl
--   tag: card-individual_id_count-36d79d
-    component_type: card
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    tag: card-body_mass_g_average-5df5ac
     layout:
-        x: 4
+        x: 2
         y: 0
         w: 2
         h: 2
-    title: Total Individuals
+    title: Avg Body Mass (g)
+-   component_type: card
+    workflow_tag: penguin_species_analysis
     aggregation: count
     column_name: individual_id
     column_type: object
@@ -152,16 +138,15 @@ components:
         title_color: '#5C6BC0'
         title_font_size: xl
         value_font_size: xl
--   tag: card-flipper_length_mm_average-178663
-    component_type: card
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    tag: card-individual_id_count-e67f3e
     layout:
-        x: 6
+        x: 4
         y: 0
         w: 2
         h: 2
-    title: '`avg_flipper_length_mm`'
+    title: Total Individuals
+-   component_type: card
+    workflow_tag: penguin_species_analysis
     aggregation: average
     column_name: flipper_length_mm
     column_type: float64
@@ -171,93 +156,94 @@ components:
         title_color: '#26A69A'
         title_font_size: md
         value_font_size: xl
--   tag: interactive-species-db9b8e
-    component_type: interactive
+    tag: card-flipper_length_mm_average-53694d
+    layout:
+        x: 6
+        y: 0
+        w: 2
+        h: 2
+    title: '`avg_flipper_length_mm`'
+-   component_type: interactive
     workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    interactive_component_type: MultiSelect
+    column_name: species
+    column_type: object
+    display:
+        title_size: md
+        custom_color: '#858585'
+        icon_name: mdi:filter
+    tag: interactive-species-902bcd
     layout:
         x: 0
         y: 0
         w: 1
         h: 2
-    column_name: species
-    column_type: object
-    interactive_component_type: MultiSelect
+-   component_type: interactive
+    workflow_tag: penguin_species_analysis
+    interactive_component_type: RangeSlider
+    column_name: body_mass_g
+    column_type: float64
     display:
         title_size: md
-        custom_color: '#858585'
-        icon_name: mdi:filter
--   tag: interactive-body_mass_g-0dfbd8
-    component_type: interactive
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+        custom_color: '#45B8AC'
+        icon_name: bx:slider-alt
+    tag: interactive-body_mass_g-71a978
     layout:
         x: 0
         y: 2
         w: 1
         h: 3
-    column_name: body_mass_g
-    column_type: float64
-    interactive_component_type: RangeSlider
+-   component_type: interactive
+    workflow_tag: penguin_species_analysis
+    interactive_component_type: MultiSelect
+    column_name: island
+    column_type: object
     display:
         title_size: md
-        custom_color: '#45B8AC'
-        icon_name: bx:slider-alt
--   tag: interactive-island-0c5e99
-    component_type: interactive
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+        custom_color: '#7E57C2'
+        icon_name: mdi:island
+    tag: interactive-island-763599
     layout:
         x: 0
         y: 5
         w: 1
         h: 2
-    column_name: island
-    column_type: object
+-   component_type: interactive
+    workflow_tag: penguin_species_analysis
     interactive_component_type: MultiSelect
+    column_name: sex
+    column_type: object
     display:
         title_size: md
-        custom_color: '#7E57C2'
-        icon_name: mdi:island
--   tag: interactive-sex-adab8a
-    component_type: interactive
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+        custom_color: '#EC407A'
+        icon_name: mdi:gender-male-female
+    tag: interactive-sex-3acadc
     layout:
         x: 0
         y: 7
         w: 1
         h: 2
-    column_name: sex
-    column_type: object
-    interactive_component_type: MultiSelect
+-   component_type: interactive
+    workflow_tag: penguin_species_analysis
+    interactive_component_type: RangeSlider
+    column_name: bill_length_mm
+    column_type: float64
     display:
         title_size: md
-        custom_color: '#EC407A'
-        icon_name: mdi:gender-male-female
--   tag: interactive-bill_length_mm-5fb4eb
-    component_type: interactive
-    workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+        custom_color: '#FF7043'
+        icon_name: bx:slider
+    tag: interactive-bill_length_mm-5273f3
     layout:
         x: 0
         y: 9
         w: 1
         h: 3
-    column_name: bill_length_mm
-    column_type: float64
-    interactive_component_type: RangeSlider
-    display:
-        title_size: md
-        custom_color: '#FF7043'
-        icon_name: bx:slider
--   tag: table-table-82ce8c
-    component_type: table
+-   component_type: table
     workflow_tag: penguin_species_analysis
-    data_collection_tag: joined_penguins_complete
+    row_selection_enabled: false
+    tag: table-table-172246
     layout:
         x: 0
         y: 17
         w: 8
         h: 5
-    row_selection_enabled: false

--- a/depictio/projects/reference/penguins/dashboard.yaml
+++ b/depictio/projects/reference/penguins/dashboard.yaml
@@ -1,11 +1,15 @@
 title: Penguins Species Analysis
+# --- optional ---
 project_tag: Palmer Penguins Species Comparison
 icon: /assets/images/icons/favicon.png
+# --- generated on export ---
 dashboard_id: 6824cb3b89d2b72169309738
 components:
 -   component_type: figure
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     visu_type: scatter
+    # --- optional ---
     figure_params:
         x: flipper_length_mm
         y: body_mass_g
@@ -24,7 +28,8 @@ components:
             "Species"}'
     mode: ui
     selection_enabled: false
-    tag: figure-scatter_flipper_length_mm_body_mass_g-88662c
+    # --- generated on export ---
+    tag: figure-scatter_flipper_length_mm_body_mass_g-1d5516
     layout:
         x: 0
         y: 2
@@ -32,7 +37,9 @@ components:
         h: 5
 -   component_type: figure
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     visu_type: box
+    # --- optional ---
     figure_params:
         x: species
         y: bill_length_mm
@@ -46,7 +53,8 @@ components:
             "Sex"}'
     mode: ui
     selection_enabled: false
-    tag: figure-box_species_bill_length_mm-008158
+    # --- generated on export ---
+    tag: figure-box_species_bill_length_mm-410375
     layout:
         x: 0
         y: 7
@@ -54,7 +62,9 @@ components:
         h: 5
 -   component_type: figure
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     visu_type: histogram
+    # --- optional ---
     figure_params:
         x: bill_depth_mm
         color: species
@@ -68,7 +78,8 @@ components:
         labels: '{"bill_depth_mm": "Bill Depth (mm)", "species": "Species"}'
     mode: ui
     selection_enabled: false
-    tag: figure-histogram_bill_depth_mm-518c7e
+    # --- generated on export ---
+    tag: figure-histogram_bill_depth_mm-4b8718
     layout:
         x: 4
         y: 7
@@ -76,7 +87,9 @@ components:
         h: 5
 -   component_type: figure
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     visu_type: scatter
+    # --- optional ---
     mode: code
     code_content: 'df_modified = df.to_pandas().groupby([''island'',''species'']).agg({''body_mass_g'':''mean'',''bill_length_mm'':''count''}).reset_index().rename(columns={''bill_length_mm'':''count''})
 
@@ -85,7 +98,8 @@ components:
 
         '
     selection_enabled: false
-    tag: figure-figure-413737
+    # --- generated on export ---
+    tag: figure-figure-7b5ffb
     layout:
         x: 0
         y: 12
@@ -93,8 +107,10 @@ components:
         h: 5
 -   component_type: card
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     aggregation: nunique
     column_name: species
+    # --- optional ---
     column_type: object
     display:
         icon_name: mdi:penguin
@@ -102,7 +118,8 @@ components:
         title_color: '#8BC34A'
         title_font_size: xl
         value_font_size: xl
-    tag: card-species_nunique-a8ca80
+    # --- generated on export ---
+    tag: card-species_nunique-d8c047
     layout:
         x: 0
         y: 0
@@ -111,8 +128,10 @@ components:
     title: Species Diversity
 -   component_type: card
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     aggregation: average
     column_name: body_mass_g
+    # --- optional ---
     column_type: float64
     display:
         icon_name: mdi:weight
@@ -120,7 +139,8 @@ components:
         title_color: '#F68B33'
         title_font_size: xl
         value_font_size: xl
-    tag: card-body_mass_g_average-5df5ac
+    # --- generated on export ---
+    tag: card-body_mass_g_average-553e4a
     layout:
         x: 2
         y: 0
@@ -129,8 +149,10 @@ components:
     title: Avg Body Mass (g)
 -   component_type: card
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     aggregation: count
     column_name: individual_id
+    # --- optional ---
     column_type: object
     display:
         icon_name: mdi:counter
@@ -138,7 +160,8 @@ components:
         title_color: '#5C6BC0'
         title_font_size: xl
         value_font_size: xl
-    tag: card-individual_id_count-e67f3e
+    # --- generated on export ---
+    tag: card-individual_id_count-36d79d
     layout:
         x: 4
         y: 0
@@ -147,8 +170,10 @@ components:
     title: Total Individuals
 -   component_type: card
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     aggregation: average
     column_name: flipper_length_mm
+    # --- optional ---
     column_type: float64
     display:
         icon_name: mdi:ruler
@@ -156,7 +181,8 @@ components:
         title_color: '#26A69A'
         title_font_size: md
         value_font_size: xl
-    tag: card-flipper_length_mm_average-53694d
+    # --- generated on export ---
+    tag: card-flipper_length_mm_average-178663
     layout:
         x: 6
         y: 0
@@ -165,14 +191,17 @@ components:
     title: '`avg_flipper_length_mm`'
 -   component_type: interactive
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     interactive_component_type: MultiSelect
     column_name: species
+    # --- optional ---
     column_type: object
     display:
         title_size: md
         custom_color: '#858585'
         icon_name: mdi:filter
-    tag: interactive-species-902bcd
+    # --- generated on export ---
+    tag: interactive-species-db9b8e
     layout:
         x: 0
         y: 0
@@ -180,14 +209,17 @@ components:
         h: 2
 -   component_type: interactive
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     interactive_component_type: RangeSlider
     column_name: body_mass_g
+    # --- optional ---
     column_type: float64
     display:
         title_size: md
         custom_color: '#45B8AC'
         icon_name: bx:slider-alt
-    tag: interactive-body_mass_g-71a978
+    # --- generated on export ---
+    tag: interactive-body_mass_g-0dfbd8
     layout:
         x: 0
         y: 2
@@ -195,14 +227,17 @@ components:
         h: 3
 -   component_type: interactive
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     interactive_component_type: MultiSelect
     column_name: island
+    # --- optional ---
     column_type: object
     display:
         title_size: md
         custom_color: '#7E57C2'
         icon_name: mdi:island
-    tag: interactive-island-763599
+    # --- generated on export ---
+    tag: interactive-island-0c5e99
     layout:
         x: 0
         y: 5
@@ -210,14 +245,17 @@ components:
         h: 2
 -   component_type: interactive
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     interactive_component_type: MultiSelect
     column_name: sex
+    # --- optional ---
     column_type: object
     display:
         title_size: md
         custom_color: '#EC407A'
         icon_name: mdi:gender-male-female
-    tag: interactive-sex-3acadc
+    # --- generated on export ---
+    tag: interactive-sex-adab8a
     layout:
         x: 0
         y: 7
@@ -225,14 +263,17 @@ components:
         h: 2
 -   component_type: interactive
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
     interactive_component_type: RangeSlider
     column_name: bill_length_mm
+    # --- optional ---
     column_type: float64
     display:
         title_size: md
         custom_color: '#FF7043'
         icon_name: bx:slider
-    tag: interactive-bill_length_mm-5273f3
+    # --- generated on export ---
+    tag: interactive-bill_length_mm-5fb4eb
     layout:
         x: 0
         y: 9
@@ -240,8 +281,11 @@ components:
         h: 3
 -   component_type: table
     workflow_tag: penguin_species_analysis
+    data_collection_tag: joined_penguins_complete
+    # --- optional ---
     row_selection_enabled: false
-    tag: table-table-172246
+    # --- generated on export ---
+    tag: table-table-82ce8c
     layout:
         x: 0
         y: 17


### PR DESCRIPTION
## Summary

- Exports validated YAML dashboards for all 3 reference/init projects using `depictio-cli dashboard export`
- All YAMLs pass both offline schema validation and online server validation
- Fixes a `column_type` normalization bug that prevented ampliseq export

## Changes

### New YAML files
- **`depictio/projects/init/iris/dashboard.yaml`** – 200 lines, 10 components (iris demo)
- **`depictio/projects/reference/penguins/dashboard.yaml`** – 263 lines (penguins species analysis)
- **`depictio/projects/reference/ampliseq/dashboard.yaml`** – 763 lines, multi-tab (nf-core/ampliseq)

### Bug fix: `depictio/models/models/dashboards.py`
Added `normalize_column_type()` helper in `DashboardDataLite.from_full()` to map raw pandas/numpy dtype strings to valid `ColumnType` literals:
- `datetime64` / `datetime64[ns]` → `datetime`
- `timedelta64` / `timedelta64[ns]` → `timedelta`
- `int32` / `int16` / `uint32` / `uint64` → `int64`
- `float32` → `float64`

This was triggered by the ampliseq dashboard having a `datetime64` column stored in MongoDB, which caused a `ValidationError` on export.

## Validation

```
depictio-cli dashboard validate depictio/projects/init/iris/dashboard.yaml --config ...
✓ Schema + domain OK  ✓ Server schema OK  ✓ Validation passed

depictio-cli dashboard validate depictio/projects/reference/penguins/dashboard.yaml --config ...
✓ Schema + domain OK  ✓ Server schema OK  ✓ Validation passed

depictio-cli dashboard validate depictio/projects/reference/ampliseq/dashboard.yaml --config ...
✓ Schema + domain OK  ✓ Server schema OK  ✓ Validation passed
```

## Test plan

- [ ] Verify YAML files round-trip: `depictio-cli dashboard import dashboard.yaml --overwrite` succeeds for each project
- [ ] Confirm ampliseq multi-tab structure imports correctly (main + child tabs)
- [ ] Run offline validation: `depictio-cli dashboard validate dashboard.yaml` (no config needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)