### PR TITLE
fix: enable single-user mode in Helm chart CI to fix screenshot 401

### DIFF
--- a/helm-charts/depictio/values-gh-actions.yaml
+++ b/helm-charts/depictio/values-gh-actions.yaml
@@ -34,6 +34,7 @@ backend:
       cpu: "1"
   env:
     DEPICTIO_LOGGING_VERBOSITY_LEVEL: "DEBUG"
+    DEPICTIO_AUTH_SINGLE_USER_MODE: "true"
 
 frontend:
   resources:


### PR DESCRIPTION
## Summary

- Fixes 401 Unauthorized error in Helm chart CI screenshot generation test
- Enables single-user mode for CI testing environment
- Aligns Helm chart CI with docker-compose CI authentication approach

## Problem

The Helm chart CI test was failing with:
```
127.0.0.1:55378 - "GET /depictio/api/v1/utils/screenshot-dash-fixed/6824cb3b89d2b72169309737 HTTP/1.1" 401
```

The screenshot endpoint requires authentication in multi-user mode, but the CI test doesn't provide credentials.

## Solution

Added `DEPICTIO_AUTH_SINGLE_USER_MODE: "true"` to the backend environment configuration in `helm-charts/depictio/values-gh-actions.yaml`. This:
- Makes all endpoints public during testing (no authentication required)
- Aligns with other CI environments (docker-compose CI uses single-user mode)
- Simplifies test setup by removing token management complexity

## Test plan

- [ ] Verify Helm chart CI workflow passes
- [ ] Confirm screenshot endpoint returns 200 (not 401)
- [ ] Check backend logs show single-user mode enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)