### PR TITLE
Add title & description headers to table components

### DIFF
--- a/depictio/models/components/lite.py
+++ b/depictio/models/components/lite.py
@@ -52,6 +52,15 @@ class BaseLiteComponent(BaseModel):
 
     # Display
     title: str = Field(default="", description="Component title")
+    description: str = Field(default="", description="Component description/subtitle")
+    title_size: str = Field(
+        default="sm",
+        description="Title size: 'h1', 'h2', 'h3', or 'sm' (default)",
+    )
+    title_align: str = Field(
+        default="left",
+        description="Title alignment: 'left' (default), 'center', or 'right'",
+    )
 
     # Data source references (human-readable tags)
     workflow_tag: str = Field(default="", description="Workflow tag (e.g., 'python/iris_workflow')")

--- a/depictio/projects/init/iris/dashboard.json
+++ b/depictio/projects/init/iris/dashboard.json
@@ -971,6 +971,10 @@
     {
       "index": "7b8eed81-a0db-42a9-869b-707a9d6d2714",
       "component_type": "table",
+      "title": "Iris Dataset",
+      "description": "Complete iris flower measurements across three species",
+      "title_size": "h3",
+      "title_align": "left",
       "wf_id": {
         "$oid": "646b0f3c1e4a2d7f8e5b8c9b"
       },

--- a/depictio/projects/init/iris/dashboard.yaml
+++ b/depictio/projects/init/iris/dashboard.yaml
@@ -191,6 +191,10 @@ components:
 -   component_type: table
     workflow_tag: iris_workflow
     data_collection_tag: iris_table
+    title: Iris Dataset
+    description: Complete iris flower measurements across three species
+    title_size: h3
+    title_align: left
     # --- optional ---
     row_selection_enabled: false
     # --- generated on export ---

--- a/depictio/projects/init/iris/dashboard_lite.yaml
+++ b/depictio/projects/init/iris/dashboard_lite.yaml
@@ -101,4 +101,8 @@ components:
     component_type: table
     workflow_tag: python/iris_workflow
     data_collection_tag: iris_table
+    title: Iris Dataset
+    description: Complete iris flower measurements across three species
+    title_size: h3
+    title_align: left
     page_size: 15

--- a/depictio/projects/reference/penguins/dashboard.json
+++ b/depictio/projects/reference/penguins/dashboard.json
@@ -343,6 +343,10 @@
     {
       "index": "0c386b67-7594-4599-8f71-99195c14a6a9",
       "component_type": "table",
+      "title": "Palmer Penguins Data",
+      "description": "Physical measurements and demographics of penguin populations",
+      "title_size": "h3",
+      "title_align": "left",
       "wf_id": {
         "$oid": "646b0f3c1e4a2d7f8e5b8c9e"
       },

--- a/depictio/projects/reference/penguins/dashboard.yaml
+++ b/depictio/projects/reference/penguins/dashboard.yaml
@@ -282,6 +282,10 @@ components:
 -   component_type: table
     workflow_tag: penguin_species_analysis
     data_collection_tag: joined_penguins_complete
+    title: Palmer Penguins Data
+    description: Physical measurements and demographics of penguin populations
+    title_size: h3
+    title_align: left
     # --- optional ---
     row_selection_enabled: false
     # --- generated on export ---


### PR DESCRIPTION
## Summary
- Add configurable title/description rendered above AG Grid tables with YAML-definable `title_size` (h1/h2/h3/sm) and `title_align` (left/center/right)
- Add `description`, `title_size`, and `title_align` fields to `BaseLiteComponent` model so all component types inherit them
- Auto-generate title from `data_collection_tag` when not explicitly set (e.g. `general_stats` → "General Stats")
- Update iris and penguins project files (YAML, JSON) with example titles

## Test plan
- [ ] Load iris dashboard → verify "Iris Dataset" title with description renders above the table
- [ ] Load penguins dashboard → verify "Palmer Penguins Data" title renders
- [ ] Load a table without explicit title → verify auto-generated title from `data_collection_tag`
- [ ] Load a table with no title and no `data_collection_tag` → verify no header (clean layout)
- [ ] Verify AG Grid still renders and scrolls correctly with title header present
- [ ] Test both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)