### PR TITLE
Add project template system for reusable pipeline configurations

### DIFF
--- a/depictio/cli/cli/utils/config.py
+++ b/depictio/cli/cli/utils/config.py
@@ -190,3 +190,138 @@ def local_validate_project_config(CLI_config: CLIConfig, project_yaml_config_pat
     except ValueError as e:
         logger.error(f"Pipeline configuration validation failed: {e}")
         return {"success": False}
+
+
+def validate_template_project_config(
+    CLI_config_path: str,
+    resolved_config: dict[str, Any],
+) -> tuple[CLIConfig, dict[str, Any]]:
+    """Validate a template-resolved config dict (already resolved, not from YAML file).
+
+    Similar to validate_project_config_and_check_S3_storage but works from a dict
+    instead of a YAML file path. Adds permissions, validates against Project model,
+    and merges existing IDs if the project already exists.
+
+    Args:
+        CLI_config_path: Path to CLI config YAML.
+        resolved_config: Template-resolved project config dict.
+
+    Returns:
+        Tuple of (CLIConfig, validation_response dict).
+
+    Raises:
+        typer.Exit: If login fails.
+    """
+    response = api_login(CLI_config_path)
+    logger.info(response)
+
+    if not response["success"]:
+        raise typer.Exit(code=1)
+
+    CLI_config_dict = response["CLI_config"]
+    CLI_config = CLIConfig(
+        user=CLI_config_dict["user"],
+        api_base_url=CLI_config_dict["api_base_url"],
+        s3_storage=CLI_config_dict["s3_storage"],
+    )
+
+    try:
+        # Add permissions from CLI user
+        user_light = CLI_config.user.model_copy()
+        user_light.token = None
+        user_light_dict = user_light.model_dump()
+
+        resolved_config["permissions"] = {
+            "owners": [user_light_dict],
+            "editors": [],
+            "viewers": [],
+        }
+
+        # Resolve tag-based links to placeholder IDs (tags will be resolved after ID assignment)
+        _resolve_link_tags_to_ids(resolved_config)
+
+        # Validate against Project model
+        validated_config = validate_model_config(resolved_config, Project)
+
+        # Merge existing IDs if project already exists on server
+        api_response = api_get_project_from_name(resolved_config["name"], CLI_config)
+        if api_response.status_code == 200:
+            remote_project = api_response.json()
+            validated_config_dict = merge_existing_ids(
+                remote_project, convert_objectid_to_str(validated_config.model_dump())
+            )
+            validated_config = Project.from_mongo(validated_config_dict)
+
+            # Re-resolve link tags now that we have real DC IDs
+            _resolve_link_tags_after_id_assignment(validated_config)
+
+        logger.info(f"Template project configuration validated: {validated_config}")
+        return CLI_config, {
+            "success": True,
+            "config": validated_config,
+            "project_config": validated_config,
+        }
+
+    except ValueError as e:
+        logger.error(f"Template project configuration validation failed: {e}")
+        return CLI_config, {"success": False}
+
+
+def _resolve_link_tags_to_ids(config: dict[str, Any]) -> None:
+    """Resolve tag-based link references to DC IDs within a config dict.
+
+    For templates, links use source_dc_tag/target_dc_tag instead of source_dc_id/target_dc_id.
+    This function builds a tag-to-ID mapping from workflow data collections and resolves
+    the links in-place.
+
+    Args:
+        config: Project config dict (modified in-place).
+    """
+    # Build tag -> temp-id mapping from data collections
+    tag_to_id: dict[str, str] = {}
+    for workflow in config.get("workflows", []):
+        for dc in workflow.get("data_collections", []):
+            tag = dc.get("data_collection_tag")
+            dc_id = dc.get("id")
+            if tag and dc_id:
+                tag_to_id[tag] = dc_id
+
+    # Resolve links
+    for link in config.get("links", []):
+        source_tag = link.get("source_dc_tag")
+        target_tag = link.get("target_dc_tag")
+
+        if source_tag and source_tag in tag_to_id:
+            link["source_dc_id"] = tag_to_id[source_tag]
+        elif source_tag and not link.get("source_dc_id"):
+            # Tag exists but no ID yet - set a placeholder
+            link["source_dc_id"] = f"tag:{source_tag}"
+
+        if target_tag and target_tag in tag_to_id:
+            link["target_dc_id"] = tag_to_id[target_tag]
+        elif target_tag and not link.get("target_dc_id"):
+            link["target_dc_id"] = f"tag:{target_tag}"
+
+
+def _resolve_link_tags_after_id_assignment(project: Project) -> None:
+    """Re-resolve tag-based links after ID assignment from server.
+
+    After merging with existing IDs, data collections have real IDs.
+    This updates any remaining tag-based link references.
+
+    Args:
+        project: Validated Project model (modified in-place).
+    """
+    # Build tag -> real-id mapping
+    tag_to_id: dict[str, str] = {}
+    for workflow in project.workflows:
+        for dc in workflow.data_collections:
+            if dc.data_collection_tag and dc.id:
+                tag_to_id[dc.data_collection_tag] = str(dc.id)
+
+    # Update links
+    for link in project.links:
+        if link.source_dc_tag and link.source_dc_tag in tag_to_id:
+            link.source_dc_id = tag_to_id[link.source_dc_tag]
+        if link.target_dc_tag and link.target_dc_tag in tag_to_id:
+            link.target_dc_id = tag_to_id[link.target_dc_tag]

--- a/depictio/cli/cli/utils/template_validator.py
+++ b/depictio/cli/cli/utils/template_validator.py
@@ -1,0 +1,192 @@
+"""
+Template data validator for depictio-cli.
+
+Validates that a user's data root directory matches the expected structure
+defined in a template's metadata. Supports two validation levels:
+
+- Level 1 (default): Check directory exists, expected files/directories present
+- Level 2 (--deep):  Also read file headers to verify column names match
+
+Usage:
+    result = validate_data_root(template_metadata, "/path/to/data")
+    result = validate_data_root(template_metadata, "/path/to/data", deep=True)
+"""
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from depictio.cli.cli_logging import logger
+from depictio.models.models.templates import TemplateMetadata
+
+
+class ValidationResult(BaseModel):
+    """Result of validating user data against a template's expected structure."""
+
+    valid: bool = Field(..., description="Whether validation passed")
+    errors: list[str] = Field(
+        default_factory=list, description="Critical errors that prevent usage"
+    )
+    warnings: list[str] = Field(default_factory=list, description="Non-critical warnings")
+
+
+def validate_data_root(
+    template_metadata: TemplateMetadata,
+    data_root: str,
+    deep: bool = False,
+) -> ValidationResult:
+    """Validate user's data root against template expectations.
+
+    Level 1 (always):
+    - data_root directory exists and is accessible
+    - Expected files exist at their relative paths
+    - Expected directories exist (with glob expansion for wildcard patterns)
+
+    Level 2 (when deep=True):
+    - Read TSV/CSV headers and check expected columns exist
+    - Check parquet schema for expected columns
+
+    Args:
+        template_metadata: Template metadata with expected structure.
+        data_root: Absolute path to user's data root directory.
+        deep: Whether to enable Level 2 schema validation.
+
+    Returns:
+        ValidationResult with errors and warnings.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+    root = Path(data_root)
+
+    # Level 1: Check data_root exists
+    if not root.exists():
+        errors.append(f"Data root directory does not exist: {data_root}")
+        return ValidationResult(valid=False, errors=errors, warnings=warnings)
+
+    if not root.is_dir():
+        errors.append(f"Data root is not a directory: {data_root}")
+        return ValidationResult(valid=False, errors=errors, warnings=warnings)
+
+    # Level 1: Check expected files
+    for expected_file in template_metadata.expected_files:
+        file_path = root / expected_file.relative_path
+        if not file_path.exists():
+            errors.append(
+                f"Expected file not found: {expected_file.relative_path} "
+                f"({expected_file.description})"
+            )
+        elif not file_path.is_file():
+            errors.append(f"Expected file is not a regular file: {expected_file.relative_path}")
+        else:
+            logger.debug(f"Found expected file: {expected_file.relative_path}")
+
+    # Level 1: Check expected directories
+    for expected_dir in template_metadata.expected_directories:
+        if expected_dir.glob_pattern:
+            # Use glob to find matching directories
+            matches = list(root.glob(expected_dir.relative_path))
+            if not matches:
+                warnings.append(
+                    f"No directories matching pattern '{expected_dir.relative_path}' found "
+                    f"({expected_dir.description}). "
+                    "This may be expected if no sequencing runs are available yet."
+                )
+            else:
+                logger.debug(
+                    f"Found {len(matches)} directories matching: {expected_dir.relative_path}"
+                )
+        else:
+            dir_path = root / expected_dir.relative_path
+            if not dir_path.exists():
+                errors.append(
+                    f"Expected directory not found: {expected_dir.relative_path} "
+                    f"({expected_dir.description})"
+                )
+            elif not dir_path.is_dir():
+                errors.append(
+                    f"Expected directory is not a directory: {expected_dir.relative_path}"
+                )
+
+    # Level 2: Deep schema validation
+    if deep:
+        for expected_file in template_metadata.expected_files:
+            if not expected_file.columns:
+                continue
+
+            file_path = root / expected_file.relative_path
+            if not file_path.exists():
+                continue  # Already reported in Level 1
+
+            column_errors = _validate_file_columns(
+                file_path=file_path,
+                expected_columns=expected_file.columns,
+                file_format=expected_file.format,
+                relative_path=expected_file.relative_path,
+            )
+            errors.extend(column_errors)
+
+    valid = len(errors) == 0
+    return ValidationResult(valid=valid, errors=errors, warnings=warnings)
+
+
+def _validate_file_columns(
+    file_path: Path,
+    expected_columns: list[str],
+    file_format: str | None,
+    relative_path: str,
+) -> list[str]:
+    """Validate that a file contains expected columns.
+
+    Supports TSV, CSV, and Parquet formats.
+
+    Args:
+        file_path: Absolute path to the file.
+        expected_columns: List of column names expected in the file.
+        file_format: File format hint ('TSV', 'CSV', 'parquet').
+        relative_path: Relative path for error messages.
+
+    Returns:
+        List of error strings (empty if all columns found).
+    """
+    errors: list[str] = []
+
+    try:
+        import polars as pl
+
+        fmt = (file_format or "").upper()
+
+        if fmt == "TSV":
+            df = pl.read_csv(file_path, separator="\t", n_rows=0)
+        elif fmt == "CSV":
+            df = pl.read_csv(file_path, n_rows=0)
+        elif fmt in ("PARQUET", ""):
+            if file_path.suffix == ".parquet":
+                df = pl.read_parquet(file_path, n_rows=0)
+            elif file_path.suffix in (".tsv", ".txt"):
+                df = pl.read_csv(file_path, separator="\t", n_rows=0)
+            elif file_path.suffix == ".csv":
+                df = pl.read_csv(file_path, n_rows=0)
+            else:
+                logger.warning(
+                    f"Cannot determine format for {relative_path}, skipping column check"
+                )
+                return errors
+        else:
+            logger.warning(f"Unsupported format '{file_format}' for {relative_path}, skipping")
+            return errors
+
+        actual_columns = set(df.columns)
+        missing = [col for col in expected_columns if col not in actual_columns]
+
+        if missing:
+            errors.append(
+                f"File '{relative_path}' is missing expected columns: {', '.join(missing)}. "
+                f"Found columns: {', '.join(sorted(actual_columns))}"
+            )
+
+    except ImportError:
+        logger.warning("polars not available, skipping deep column validation")
+    except Exception as e:
+        errors.append(f"Error reading '{relative_path}' for column validation: {e}")
+
+    return errors

--- a/depictio/cli/cli/utils/templates.py
+++ b/depictio/cli/cli/utils/templates.py
@@ -1,0 +1,227 @@
+"""
+Template resolver for depictio-cli.
+
+Handles loading template project.yaml files, substituting {DATA_ROOT} variables,
+and producing resolved config dicts ready for Project model validation.
+
+Usage:
+    resolved = resolve_template("nf-core/ampliseq/2.14.0", "/path/to/data")
+"""
+
+import copy
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from depictio.cli.cli_logging import logger
+from depictio.models.models.templates import TemplateMetadata, TemplateOrigin
+from depictio.models.utils import get_config
+
+
+def locate_template(template_id: str) -> Path:
+    """Find template YAML by template_id (e.g., 'nf-core/ampliseq/2.14.0').
+
+    Searches in the depictio/projects/ directory relative to the package installation.
+    Looks for template.yaml first (dedicated template file), then falls back to
+    project.yaml (for backwards compatibility).
+
+    Args:
+        template_id: Template identifier (e.g., 'nf-core/ampliseq/2.14.0').
+
+    Returns:
+        Path to the template YAML file.
+
+    Raises:
+        FileNotFoundError: If no template YAML exists.
+    """
+    # Resolve relative to depictio package root
+    package_root = Path(__file__).resolve().parents[4]  # cli/cli/utils/ -> depictio/
+    template_dir = package_root / "depictio" / "projects" / template_id
+
+    # Prefer template.yaml (dedicated template file) over project.yaml (fixture)
+    for filename in ("template.yaml", "project.yaml"):
+        candidate = template_dir / filename
+        if candidate.is_file():
+            return candidate
+
+    # Also try without the package nesting (for installed packages)
+    alt_root = Path(__file__).resolve().parents[3]  # cli/cli/utils/ -> cli/
+    alt_dir = alt_root / "projects" / template_id
+    for filename in ("template.yaml", "project.yaml"):
+        candidate = alt_dir / filename
+        if candidate.is_file():
+            return candidate
+
+    available = _list_available_templates(package_root)
+    available_str = ", ".join(available) if available else "none found"
+    raise FileNotFoundError(
+        f"Template '{template_id}' not found at {template_dir}. "
+        f"Available templates: {available_str}"
+    )
+
+
+def _list_available_templates(package_root: Path) -> list[str]:
+    """List available template IDs by scanning the projects directory.
+
+    Args:
+        package_root: Root of the depictio package.
+
+    Returns:
+        List of template ID strings.
+    """
+    projects_dir = package_root / "depictio" / "projects"
+    templates: list[str] = []
+
+    if not projects_dir.is_dir():
+        return templates
+
+    for pattern in ("template.yaml", "project.yaml"):
+        for yaml_path in projects_dir.rglob(pattern):
+            try:
+                config = get_config(str(yaml_path))
+                if "template" in config:
+                    template_id = config["template"].get("template_id", "")
+                    if template_id and template_id not in templates:
+                        templates.append(template_id)
+            except Exception:
+                continue
+
+    return sorted(templates)
+
+
+def substitute_template_variables(config: Any, variables: dict[str, str]) -> Any:
+    """Recursively substitute {VAR_NAME} placeholders in config dict/list/str.
+
+    Uses the same {VAR_NAME} pattern as WorkflowDataLocation env var expansion,
+    but resolves from an explicit variables dict rather than os.environ.
+
+    Args:
+        config: Configuration structure (dict, list, or string).
+        variables: Mapping of variable names to values (e.g., {"DATA_ROOT": "/path"}).
+
+    Returns:
+        Config with all placeholders resolved.
+
+    Raises:
+        ValueError: If a required variable placeholder has no corresponding value.
+    """
+    if isinstance(config, dict):
+        return {k: substitute_template_variables(v, variables) for k, v in config.items()}
+    elif isinstance(config, list):
+        return [substitute_template_variables(item, variables) for item in config]
+    elif isinstance(config, str):
+        env_var_pattern = re.compile(r"\{([A-Z0-9_]+)\}")
+        matches = env_var_pattern.findall(config)
+        result = config
+        for match in matches:
+            if match in variables:
+                result = result.replace(f"{{{match}}}", variables[match])
+            else:
+                logger.warning(f"Variable '{match}' not provided for placeholder in: {config}")
+        return result
+    else:
+        return config
+
+
+def _strip_ids(config: dict[str, Any]) -> dict[str, Any]:
+    """Remove hardcoded 'id' fields from config so fresh IDs are generated.
+
+    Template project.yaml may contain example IDs that should not be reused
+    when a new project is instantiated from the template.
+
+    Args:
+        config: Project config dict.
+
+    Returns:
+        Config with 'id' fields removed at all levels.
+    """
+    if isinstance(config, dict):
+        return {k: _strip_ids(v) for k, v in config.items() if k != "id"}
+    elif isinstance(config, list):
+        return [_strip_ids(item) for item in config]
+    else:
+        return config
+
+
+def resolve_template(
+    template_id: str,
+    data_root: str,
+    project_name: str | None = None,
+) -> tuple[dict[str, Any], TemplateMetadata, TemplateOrigin]:
+    """Load template YAML, substitute {DATA_ROOT}, return resolved config.
+
+    This is the main entry point for the template system. It:
+    1. Locates the template YAML
+    2. Extracts and validates template metadata
+    3. Substitutes {DATA_ROOT} in all paths
+    4. Strips hardcoded IDs
+    5. Sets project name
+    6. Builds TemplateOrigin for DB tracking
+
+    Args:
+        template_id: Template identifier (e.g., 'nf-core/ampliseq/2.14.0').
+        data_root: Absolute path to user's data root directory.
+        project_name: Custom project name. If None, auto-generated from template.
+
+    Returns:
+        Tuple of (resolved_config_dict, template_metadata, template_origin).
+
+    Raises:
+        FileNotFoundError: If template not found.
+        ValueError: If template metadata is invalid or required variables missing.
+    """
+    # 1. Locate and load template YAML
+    template_path = locate_template(template_id)
+    logger.info(f"Loading template from: {template_path}")
+    raw_config = get_config(str(template_path))
+
+    # 2. Extract and validate template metadata
+    template_section = raw_config.pop("template", None)
+    if template_section is None:
+        raise ValueError(
+            f"YAML at {template_path} does not contain a 'template' section. "
+            "This file is not a valid template."
+        )
+
+    template_metadata = TemplateMetadata(**template_section)
+    logger.info(f"Template: {template_metadata.template_id} v{template_metadata.version}")
+
+    # 3. Validate required variables are available
+    data_root_abs = str(Path(data_root).resolve())
+    variables: dict[str, str] = {"DATA_ROOT": data_root_abs}
+
+    required_vars = template_metadata.get_required_variable_names()
+    missing_vars = [v for v in required_vars if v not in variables]
+    if missing_vars:
+        raise ValueError(
+            f"Missing required template variables: {', '.join(missing_vars)}. "
+            f"Provided: {', '.join(variables.keys())}"
+        )
+
+    # 4. Substitute template variables in all paths
+    resolved_config = substitute_template_variables(raw_config, variables)
+
+    # 5. Strip hardcoded IDs (fresh project gets new ones)
+    resolved_config = _strip_ids(resolved_config)
+
+    # 6. Set project name
+    if project_name:
+        resolved_config["name"] = project_name
+    elif "name" not in resolved_config or not resolved_config.get("name"):
+        resolved_config["name"] = f"{template_id} - {Path(data_root).name}"
+
+    # 7. Build TemplateOrigin for DB tracking
+    template_origin = TemplateOrigin(
+        template_id=template_metadata.template_id,
+        template_version=template_metadata.version,
+        data_root=data_root_abs,
+        applied_at=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        config_snapshot=copy.deepcopy(resolved_config),
+    )
+
+    # 8. Inject template_origin into config
+    resolved_config["template_origin"] = template_origin.model_dump()
+
+    logger.info(f"Template resolved successfully. Project name: {resolved_config['name']}")
+    return resolved_config, template_metadata, template_origin

--- a/depictio/models/models/projects.py
+++ b/depictio/models/models/projects.py
@@ -13,6 +13,7 @@ from depictio.models.models.data_collections import DataCollection, DataCollecti
 from depictio.models.models.joins import JoinDefinition
 from depictio.models.models.links import DCLink
 from depictio.models.models.realtime import RealtimeConfig
+from depictio.models.models.templates import TemplateOrigin
 from depictio.models.models.users import Permission
 from depictio.models.models.workflows import Workflow, WorkflowResponse
 
@@ -37,6 +38,7 @@ class Project(MongoModel):
     registration_time: str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     project_type: Literal["basic", "advanced"] = "basic"
     realtime: RealtimeConfig | None = None  # Optional real-time event configuration
+    template_origin: TemplateOrigin | None = None  # Tracks if project was created from a template
 
     @field_validator("name")
     @classmethod

--- a/depictio/models/models/templates.py
+++ b/depictio/models/models/templates.py
@@ -1,0 +1,194 @@
+"""
+Models for the project template system.
+
+Templates allow users to reuse predefined project configurations (e.g., nf-core/ampliseq)
+with their own data by providing a data root directory. The template system resolves
+path variables like {DATA_ROOT} and validates that user data matches the expected structure.
+
+Key concepts:
+- TemplateMetadata: Declared in template project.yaml, describes variables and expected structure
+- TemplateOrigin: Stored on Project model to track that a template was used
+- TemplateVariable: A required variable (e.g., DATA_ROOT) with description
+- ExpectedFile/ExpectedDirectory: Used by the validator to check user data placement
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class TemplateVariable(BaseModel):
+    """A variable required by a template (e.g., DATA_ROOT).
+
+    Variables are declared in the template metadata section and must be provided
+    by the user at template instantiation time (e.g., via --data-root CLI flag).
+    """
+
+    name: str = Field(..., description="Variable name (e.g., 'DATA_ROOT')")
+    description: str = Field(..., description="Human-readable description of this variable")
+    required: bool = Field(default=True, description="Whether this variable must be provided")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Ensure variable name is non-empty and uppercase with underscores."""
+        if not v or not v.strip():
+            raise ValueError("Variable name cannot be empty")
+        v = v.strip()
+        if not all(c.isalnum() or c == "_" for c in v):
+            raise ValueError(
+                "Variable name must contain only alphanumeric characters and underscores"
+            )
+        return v
+
+
+class ExpectedFile(BaseModel):
+    """A file expected at a relative path under DATA_ROOT.
+
+    Used by the template validator to verify that user data is correctly placed.
+    The relative_path is relative to DATA_ROOT (e.g., 'merged_metadata.tsv').
+    """
+
+    relative_path: str = Field(
+        ..., description="Path relative to DATA_ROOT (e.g., 'merged_metadata.tsv')"
+    )
+    description: str = Field(..., description="Human-readable description of this file")
+    format: str | None = Field(
+        default=None, description="Expected file format (e.g., 'TSV', 'parquet')"
+    )
+    columns: list[str] = Field(
+        default_factory=list, description="Expected column names (for deep validation)"
+    )
+
+    @field_validator("relative_path")
+    @classmethod
+    def validate_relative_path(cls, v: str) -> str:
+        """Ensure relative path is non-empty and not absolute."""
+        if not v or not v.strip():
+            raise ValueError("Relative path cannot be empty")
+        v = v.strip()
+        if v.startswith("/"):
+            raise ValueError("Expected file path must be relative, not absolute")
+        return v
+
+
+class ExpectedDirectory(BaseModel):
+    """A directory expected under DATA_ROOT.
+
+    Supports glob patterns for directories with variable names (e.g., 'run_*').
+    """
+
+    relative_path: str = Field(
+        ..., description="Path relative to DATA_ROOT (e.g., 'run_*/multiqc_data')"
+    )
+    description: str = Field(..., description="Human-readable description of this directory")
+    glob_pattern: bool = Field(
+        default=False, description="Whether relative_path contains wildcards (*, ?, **)"
+    )
+
+    @field_validator("relative_path")
+    @classmethod
+    def validate_relative_path(cls, v: str) -> str:
+        """Ensure relative path is non-empty and not absolute."""
+        if not v or not v.strip():
+            raise ValueError("Relative path cannot be empty")
+        v = v.strip()
+        if v.startswith("/"):
+            raise ValueError("Expected directory path must be relative, not absolute")
+        return v
+
+
+class TemplateMetadata(BaseModel):
+    """Metadata section declared in a template project.yaml.
+
+    This section is parsed from the top-level 'template' key in the YAML file.
+    It describes the template identity, required variables, and expected data structure.
+
+    Example YAML:
+        template:
+          template_id: "nf-core/ampliseq/2.14.0"
+          description: "nf-core/ampliseq microbial community analysis template"
+          version: "1.0.0"
+          variables:
+            - name: "DATA_ROOT"
+              description: "Root directory containing ampliseq output data"
+          expected_files:
+            - relative_path: "merged_metadata.tsv"
+              description: "Sample metadata file"
+              format: "TSV"
+              columns: ["sample", "name", "habitat"]
+    """
+
+    template_id: str = Field(
+        ..., description="Unique template identifier (e.g., 'nf-core/ampliseq/2.14.0')"
+    )
+    description: str = Field(..., description="Human-readable description of this template")
+    version: str = Field(..., description="Template schema version (semver)")
+    variables: list[TemplateVariable] = Field(
+        default_factory=list, description="Variables required by this template"
+    )
+    expected_files: list[ExpectedFile] = Field(
+        default_factory=list, description="Files expected under DATA_ROOT"
+    )
+    expected_directories: list[ExpectedDirectory] = Field(
+        default_factory=list, description="Directories expected under DATA_ROOT"
+    )
+
+    @field_validator("template_id")
+    @classmethod
+    def validate_template_id(cls, v: str) -> str:
+        """Ensure template_id is non-empty."""
+        if not v or not v.strip():
+            raise ValueError("Template ID cannot be empty")
+        return v.strip()
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, v: str) -> str:
+        """Ensure version is non-empty."""
+        if not v or not v.strip():
+            raise ValueError("Template version cannot be empty")
+        return v.strip()
+
+    def get_required_variable_names(self) -> list[str]:
+        """Return names of all required variables."""
+        return [var.name for var in self.variables if var.required]
+
+
+class TemplateOrigin(BaseModel):
+    """Stored on Project model to track that a template was used to create the project.
+
+    This enables the DB and UI to distinguish template-instantiated projects from
+    manually configured ones, and to show which template was used.
+    """
+
+    template_id: str = Field(
+        ..., description="Template identifier (e.g., 'nf-core/ampliseq/2.14.0')"
+    )
+    template_version: str = Field(..., description="Template schema version at time of use")
+    data_root: str = Field(..., description="The actual --data-root value provided by the user")
+    applied_at: str = Field(
+        default_factory=lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        description="Timestamp when template was applied",
+    )
+    config_snapshot: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Frozen copy of the resolved template config (for reproducibility)",
+    )
+
+    @field_validator("template_id")
+    @classmethod
+    def validate_template_id(cls, v: str) -> str:
+        """Ensure template_id is non-empty."""
+        if not v or not v.strip():
+            raise ValueError("Template ID cannot be empty")
+        return v.strip()
+
+    @field_validator("data_root")
+    @classmethod
+    def validate_data_root(cls, v: str) -> str:
+        """Ensure data_root is non-empty."""
+        if not v or not v.strip():
+            raise ValueError("Data root cannot be empty")
+        return v.strip()

--- a/depictio/projects/nf-core/ampliseq/2.14.0/template.yaml
+++ b/depictio/projects/nf-core/ampliseq/2.14.0/template.yaml
@@ -1,0 +1,321 @@
+# nf-core/ampliseq Template - Microbial Community Analysis
+# ============================================================================
+# This is a TEMPLATE project configuration. Use with:
+#   depictio-cli run --template nf-core/ampliseq/2.14.0 --data-root /path/to/your/data
+#
+# The original project.yaml (with hardcoded paths) is kept as a fixture for
+# Docker init. This template.yaml uses {DATA_ROOT} placeholders for reuse.
+# ============================================================================
+
+# Template metadata (parsed and removed before Project model validation)
+template:
+  template_id: "nf-core/ampliseq/2.14.0"
+  description: "nf-core/ampliseq microbial community analysis template for 16S/ITS amplicon sequencing"
+  version: "1.0.0"
+  variables:
+    - name: "DATA_ROOT"
+      description: "Root directory containing ampliseq pipeline output data"
+      required: true
+  expected_files:
+    - relative_path: "merged_metadata.tsv"
+      description: "Sample metadata with sample IDs and experimental factors"
+      format: "TSV"
+      columns: ["sample", "name", "habitat"]
+    - relative_path: "faith_pd_long.tsv"
+      description: "Alpha diversity rarefaction curves (Faith PD)"
+      format: "TSV"
+      columns: ["sample", "depth", "iter", "faith_pd"]
+    - relative_path: "taxonomy_long.tsv"
+      description: "Taxonomic composition across samples"
+      format: "TSV"
+      columns: ["sample", "taxonomy", "count", "habitat"]
+    - relative_path: "ancom_volcano.tsv"
+      description: "ANCOM differential abundance results"
+      format: "TSV"
+      columns: ["id", "taxonomy", "W", "clr"]
+    - relative_path: "alpha_diversity.tsv"
+      description: "Per-sample alpha diversity metrics"
+      format: "TSV"
+      columns: ["sample", "habitat", "faith_pd"]
+    - relative_path: "taxonomy_rel_abundance_long.tsv"
+      description: "Taxonomic relative abundance at Phylum level"
+      format: "TSV"
+      columns: ["sample", "taxonomy", "rel_abundance", "habitat"]
+    - relative_path: "ancombc_habitat_level2.tsv"
+      description: "ANCOM-BC differential abundance at Phylum level"
+      format: "TSV"
+      columns: ["id", "contrast", "lfc", "q_val"]
+  expected_directories:
+    - relative_path: "run_*"
+      description: "Sequencing run directories containing pipeline outputs"
+      glob_pattern: true
+    - relative_path: "run_*/multiqc_data"
+      description: "MultiQC output directories within each run"
+      glob_pattern: true
+
+# ============================================================================
+# PROJECT CONFIGURATION
+# ============================================================================
+
+name: "Ampliseq Microbial Community Analysis"
+project_type: "advanced"
+is_public: true
+workflows:
+  - name: "ampliseq"
+    version: "2.14.0"
+    engine:
+      name: "nextflow"
+      version: "24.10.4"
+    catalog:
+      name: "nf-core"
+      url: "https://nf-co.re"
+    repository_url: "https://github.com/nf-core/ampliseq"
+    data_location:
+      structure: "sequencing-runs"
+      runs_regex: "run_*"
+      locations:
+        - "{DATA_ROOT}"
+    data_collections:
+      - data_collection_tag: "multiqc_data"
+        description: "MultiQC report data"
+        config:
+          type: "MultiQC"
+          scan:
+            mode: "recursive"
+            scan_parameters:
+              regex_config:
+                pattern: "multiqc_data/multiqc.parquet"
+          dc_specific_properties:
+            s3_location: null
+            modules:
+              - "cutadapt"
+              - "fastqc"
+            plots:
+              cutadapt:
+                - "Filtered Reads"
+                - "Trimmed Sequence Lengths (5')":
+                    - "Counts"
+                    - "Obs/Exp"
+              fastqc:
+                - "Sequence Counts"
+                - "Sequence Quality Histograms"
+                - "Per Sequence Quality Scores"
+                - "Per Sequence GC Content":
+                    - "Percentages"
+                    - "Counts"
+                - "Per Base N Content"
+                - "Sequence Length Distribution"
+                - "Sequence Duplication Levels"
+                - "Overrepresented sequences by sample"
+                - "Top overrepresented sequences"
+                - "Adapter Content"
+                - "Status Checks"
+
+      - data_collection_tag: "metadata"
+        description: "Sample metadata for ampliseq analysis"
+        config:
+          type: "Table"
+          metatype: "Metadata"
+          scan:
+            mode: "single"
+            scan_parameters:
+              filename: "{DATA_ROOT}/merged_metadata.tsv"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+              try_parse_dates: true
+            columns_description:
+              "sample": "Sample identifier (SRR accession)"
+              "name": "Sample name"
+              "habitat": "Sample habitat type"
+              "Riv_vs_Gro": "Habitat comparison group 1"
+              "Sed_vs_Soil": "Habitat comparison group 2"
+              "sampling_date": "Sample collection date (YYYY-MM-DD)"
+
+      - data_collection_tag: "alpha_rarefaction"
+        description: "Alpha diversity rarefaction curves"
+        config:
+          type: "Table"
+          metatype: "Metadata"
+          scan:
+            mode: "single"
+            scan_parameters:
+              filename: "{DATA_ROOT}/faith_pd_long.tsv"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+            columns_description:
+              "sample": "Sample identifier"
+              "depth": "Sequencing depth"
+              "iter": "Iteration number"
+              "faith_pd": "Faith's Phylogenetic Diversity metric"
+
+      - data_collection_tag: "taxonomy_composition"
+        description: "Taxonomic composition across samples"
+        config:
+          type: "Table"
+          metatype: "Metadata"
+          scan:
+            mode: "single"
+            scan_parameters:
+              filename: "{DATA_ROOT}/taxonomy_long.tsv"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+            columns_description:
+              "sample": "Sample identifier"
+              "taxonomy": "Taxonomic classification (Kingdom;Phylum)"
+              "count": "Raw sequence count for this taxonomy"
+              "habitat": "Habitat type of the sample"
+
+      - data_collection_tag: "ancom_volcano"
+        description: "ANCOM differential abundance analysis results"
+        config:
+          type: "Table"
+          metatype: "Metadata"
+          scan:
+            mode: "single"
+            scan_parameters:
+              filename: "{DATA_ROOT}/ancom_volcano.tsv"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+            columns_description:
+              "id": "ASV identifier"
+              "taxonomy": "Taxonomic classification (Kingdom;Phylum)"
+              "Kingdom": "Kingdom level classification"
+              "Phylum": "Phylum level classification"
+              "W": "W statistic from ANCOM analysis"
+              "clr": "Centered log-ratio transformed abundance"
+
+      - data_collection_tag: "alpha_diversity"
+        description: "Per-sample alpha diversity metrics (Faith PD)"
+        config:
+          type: "Table"
+          metatype: "Metadata"
+          scan:
+            mode: "single"
+            scan_parameters:
+              filename: "{DATA_ROOT}/alpha_diversity.tsv"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+            columns_description:
+              "sample": "Sample identifier"
+              "habitat": "Habitat type"
+              "faith_pd": "Faith's Phylogenetic Diversity (single value per sample)"
+
+      - data_collection_tag: "taxonomy_rel_abundance"
+        description: "Taxonomic relative abundance (Phylum level)"
+        config:
+          type: "Table"
+          metatype: "Metadata"
+          scan:
+            mode: "single"
+            scan_parameters:
+              filename: "{DATA_ROOT}/taxonomy_rel_abundance_long.tsv"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+            columns_description:
+              "sample": "Sample identifier"
+              "taxonomy": "Taxonomic classification (Kingdom;Phylum)"
+              "rel_abundance": "Relative abundance (0-1)"
+              "habitat": "Habitat type"
+              "Kingdom": "Kingdom level"
+              "Phylum": "Phylum level"
+
+      - data_collection_tag: "ancombc_results"
+        description: "ANCOM-BC differential abundance (habitat, Phylum level)"
+        config:
+          type: "Table"
+          metatype: "Metadata"
+          scan:
+            mode: "single"
+            scan_parameters:
+              filename: "{DATA_ROOT}/ancombc_habitat_level2.tsv"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+            columns_description:
+              "id": "Taxonomy identifier"
+              "contrast": "Statistical contrast (habitat comparison)"
+              "lfc": "Log-fold change"
+              "q_val": "FDR-adjusted p-value"
+              "w": "ANCOM-BC test statistic"
+              "Kingdom": "Kingdom level"
+              "Phylum": "Phylum level"
+              "neg_log10_qval": "-log10(q-value) for volcano plot"
+              "significant": "q < 0.05"
+
+# ============================================================================
+# RUNTIME LINKS CONFIGURATION
+# ============================================================================
+# Links use data_collection_tag references (resolved to IDs at instantiation)
+# ============================================================================
+
+links:
+  # Link 1: Metadata -> MultiQC (for MultiQC component filtering)
+  - source_dc_tag: "metadata"
+    source_column: "sample"
+    target_dc_tag: "multiqc_data"
+    target_type: "multiqc"
+    link_config:
+      resolver: "sample_mapping"
+      target_field: "sample_name"
+    description: "Filter MultiQC by metadata samples (habitat selections)"
+    enabled: true
+
+  # Link 2: Metadata -> Alpha Rarefaction (for Faith PD figure)
+  - source_dc_tag: "metadata"
+    source_column: "sample"
+    target_dc_tag: "alpha_rarefaction"
+    target_type: "table"
+    link_config:
+      resolver: "direct"
+      target_field: "sample"
+    description: "Filter alpha rarefaction by metadata samples"
+    enabled: true
+
+  # Link 3: Metadata -> Taxonomy Composition (for taxonomy figure)
+  - source_dc_tag: "metadata"
+    source_column: "sample"
+    target_dc_tag: "taxonomy_composition"
+    target_type: "table"
+    link_config:
+      resolver: "direct"
+      target_field: "sample"
+    description: "Filter taxonomy by metadata samples"
+    enabled: true
+
+  # Link 4: Metadata -> Alpha Diversity
+  - source_dc_tag: "metadata"
+    source_column: "sample"
+    target_dc_tag: "alpha_diversity"
+    target_type: "table"
+    link_config:
+      resolver: "direct"
+      target_field: "sample"
+    description: "Filter alpha diversity by metadata samples"
+    enabled: true
+
+  # Link 5: Metadata -> Taxonomy Rel Abundance
+  - source_dc_tag: "metadata"
+    source_column: "sample"
+    target_dc_tag: "taxonomy_rel_abundance"
+    target_type: "table"
+    link_config:
+      resolver: "direct"
+      target_field: "sample"
+    description: "Filter taxonomy rel abundance by metadata samples"
+    enabled: true
+
+  # Note: ANCOM volcano is not linked because it shows
+  # habitat-independent differential abundance analysis and has no sample column

--- a/depictio/tests/cli/utils/test_templates.py
+++ b/depictio/tests/cli/utils/test_templates.py
@@ -1,0 +1,285 @@
+"""
+Minimal tests for the project template system.
+
+Tests cover the core template functions:
+- Template location
+- Variable substitution
+- Template resolution
+- Data root validation
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from depictio.cli.cli.utils.template_validator import validate_data_root
+from depictio.cli.cli.utils.templates import (
+    _strip_ids,
+    locate_template,
+    substitute_template_variables,
+)
+from depictio.models.models.templates import (
+    ExpectedDirectory,
+    ExpectedFile,
+    TemplateMetadata,
+    TemplateOrigin,
+    TemplateVariable,
+)
+
+
+class TestLocateTemplate:
+    """Tests for template file location."""
+
+    def test_locate_known_template(self) -> None:
+        """Locate the nf-core/ampliseq template that exists in the repo."""
+        path = locate_template("nf-core/ampliseq/2.14.0")
+        assert path.is_file()
+        assert path.name == "project.yaml"
+
+    def test_locate_unknown_template_raises(self) -> None:
+        """Unknown template ID raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="not found"):
+            locate_template("nonexistent/template/1.0.0")
+
+
+class TestSubstituteTemplateVariables:
+    """Tests for recursive variable substitution."""
+
+    def test_substitute_string(self) -> None:
+        """Simple string substitution."""
+        result = substitute_template_variables("{DATA_ROOT}/file.tsv", {"DATA_ROOT": "/my/data"})
+        assert result == "/my/data/file.tsv"
+
+    def test_substitute_nested_dict(self) -> None:
+        """Substitution in nested dict structures."""
+        config = {
+            "locations": ["{DATA_ROOT}"],
+            "scan": {
+                "filename": "{DATA_ROOT}/metadata.tsv",
+            },
+        }
+        result = substitute_template_variables(config, {"DATA_ROOT": "/data"})
+        assert result["locations"] == ["/data"]
+        assert result["scan"]["filename"] == "/data/metadata.tsv"
+
+    def test_substitute_list(self) -> None:
+        """Substitution in list elements."""
+        result = substitute_template_variables(
+            ["{DATA_ROOT}/a.tsv", "{DATA_ROOT}/b.tsv"],
+            {"DATA_ROOT": "/root"},
+        )
+        assert result == ["/root/a.tsv", "/root/b.tsv"]
+
+    def test_no_substitution_for_non_matching(self) -> None:
+        """Strings without placeholders are unchanged."""
+        result = substitute_template_variables("no_vars_here", {"DATA_ROOT": "/data"})
+        assert result == "no_vars_here"
+
+    def test_substitute_preserves_non_string_types(self) -> None:
+        """Non-string values (int, bool, None) pass through unchanged."""
+        config = {"count": 42, "enabled": True, "value": None}
+        result = substitute_template_variables(config, {"DATA_ROOT": "/data"})
+        assert result == config
+
+
+class TestStripIds:
+    """Tests for ID stripping from template configs."""
+
+    def test_strip_top_level_id(self) -> None:
+        """Top-level id field is removed."""
+        config = {"id": "abc123", "name": "test"}
+        result = _strip_ids(config)
+        assert "id" not in result
+        assert result["name"] == "test"
+
+    def test_strip_nested_ids(self) -> None:
+        """IDs in nested structures are removed."""
+        config = {
+            "workflows": [
+                {
+                    "id": "wf1",
+                    "name": "ampliseq",
+                    "data_collections": [
+                        {"id": "dc1", "data_collection_tag": "metadata"},
+                    ],
+                }
+            ]
+        }
+        result = _strip_ids(config)
+        assert "id" not in result["workflows"][0]
+        assert "id" not in result["workflows"][0]["data_collections"][0]
+        assert result["workflows"][0]["name"] == "ampliseq"
+
+
+class TestTemplateMetadataModel:
+    """Tests for TemplateMetadata Pydantic model."""
+
+    def test_valid_metadata(self) -> None:
+        """Valid metadata parses successfully."""
+        metadata = TemplateMetadata(
+            template_id="nf-core/ampliseq/2.14.0",
+            description="Test template",
+            version="1.0.0",
+            variables=[
+                TemplateVariable(name="DATA_ROOT", description="Data root dir"),
+            ],
+        )
+        assert metadata.template_id == "nf-core/ampliseq/2.14.0"
+        assert len(metadata.variables) == 1
+
+    def test_get_required_variable_names(self) -> None:
+        """Required variable names are returned correctly."""
+        metadata = TemplateMetadata(
+            template_id="test",
+            description="Test",
+            version="1.0.0",
+            variables=[
+                TemplateVariable(name="DATA_ROOT", description="Root", required=True),
+                TemplateVariable(name="OPTIONAL_VAR", description="Optional", required=False),
+            ],
+        )
+        assert metadata.get_required_variable_names() == ["DATA_ROOT"]
+
+
+class TestTemplateOriginModel:
+    """Tests for TemplateOrigin Pydantic model."""
+
+    def test_valid_origin(self) -> None:
+        """Valid template origin creates successfully."""
+        origin = TemplateOrigin(
+            template_id="nf-core/ampliseq/2.14.0",
+            template_version="1.0.0",
+            data_root="/my/data",
+            config_snapshot={"name": "test"},
+        )
+        assert origin.template_id == "nf-core/ampliseq/2.14.0"
+        assert origin.data_root == "/my/data"
+        assert origin.applied_at  # auto-generated timestamp
+
+
+class TestValidateDataRoot:
+    """Tests for data root validation."""
+
+    def test_validate_existing_directory(self) -> None:
+        """Valid directory with expected files passes validation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create expected files
+            (Path(tmpdir) / "metadata.tsv").write_text("sample\thabitat\nS1\tsoil")
+
+            metadata = TemplateMetadata(
+                template_id="test",
+                description="Test",
+                version="1.0.0",
+                expected_files=[
+                    ExpectedFile(
+                        relative_path="metadata.tsv",
+                        description="Metadata",
+                        format="TSV",
+                    ),
+                ],
+            )
+
+            result = validate_data_root(metadata, tmpdir)
+            assert result.valid
+            assert len(result.errors) == 0
+
+    def test_validate_missing_file(self) -> None:
+        """Missing expected file produces an error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata = TemplateMetadata(
+                template_id="test",
+                description="Test",
+                version="1.0.0",
+                expected_files=[
+                    ExpectedFile(
+                        relative_path="nonexistent.tsv",
+                        description="Missing file",
+                    ),
+                ],
+            )
+
+            result = validate_data_root(metadata, tmpdir)
+            assert not result.valid
+            assert any("nonexistent.tsv" in e for e in result.errors)
+
+    def test_validate_nonexistent_directory(self) -> None:
+        """Nonexistent data root produces an error."""
+        metadata = TemplateMetadata(
+            template_id="test",
+            description="Test",
+            version="1.0.0",
+        )
+
+        result = validate_data_root(metadata, "/nonexistent/path/12345")
+        assert not result.valid
+        assert any("does not exist" in e for e in result.errors)
+
+    def test_validate_glob_directory_warning(self) -> None:
+        """Missing glob-pattern directories produce warnings (not errors)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata = TemplateMetadata(
+                template_id="test",
+                description="Test",
+                version="1.0.0",
+                expected_directories=[
+                    ExpectedDirectory(
+                        relative_path="run_*",
+                        description="Run directories",
+                        glob_pattern=True,
+                    ),
+                ],
+            )
+
+            result = validate_data_root(metadata, tmpdir)
+            assert result.valid  # Glob patterns produce warnings, not errors
+            assert len(result.warnings) > 0
+
+    def test_deep_validation_checks_columns(self) -> None:
+        """Deep validation checks column names in TSV files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a TSV with correct columns
+            tsv_path = Path(tmpdir) / "data.tsv"
+            tsv_path.write_text("sample\thabitat\nS1\tsoil")
+
+            metadata = TemplateMetadata(
+                template_id="test",
+                description="Test",
+                version="1.0.0",
+                expected_files=[
+                    ExpectedFile(
+                        relative_path="data.tsv",
+                        description="Data",
+                        format="TSV",
+                        columns=["sample", "habitat"],
+                    ),
+                ],
+            )
+
+            result = validate_data_root(metadata, tmpdir, deep=True)
+            assert result.valid
+            assert len(result.errors) == 0
+
+    def test_deep_validation_missing_column(self) -> None:
+        """Deep validation detects missing columns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tsv_path = Path(tmpdir) / "data.tsv"
+            tsv_path.write_text("sample\tvalue\nS1\t42")
+
+            metadata = TemplateMetadata(
+                template_id="test",
+                description="Test",
+                version="1.0.0",
+                expected_files=[
+                    ExpectedFile(
+                        relative_path="data.tsv",
+                        description="Data",
+                        format="TSV",
+                        columns=["sample", "habitat", "missing_col"],
+                    ),
+                ],
+            )
+
+            result = validate_data_root(metadata, tmpdir, deep=True)
+            assert not result.valid
+            assert any("missing_col" in e for e in result.errors)

--- a/depictio/tests/cli/utils/test_templates.py
+++ b/depictio/tests/cli/utils/test_templates.py
@@ -35,7 +35,7 @@ class TestLocateTemplate:
         """Locate the nf-core/ampliseq template that exists in the repo."""
         path = locate_template("nf-core/ampliseq/2.14.0")
         assert path.is_file()
-        assert path.name == "project.yaml"
+        assert path.name == "template.yaml"
 
     def test_locate_unknown_template_raises(self) -> None:
         """Unknown template ID raises FileNotFoundError."""


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive project template system that allows users to reuse predefined project configurations (e.g., nf-core/ampliseq) with their own data by providing a data root directory. Templates use variable substitution to resolve paths like `{DATA_ROOT}` and include validation to ensure user data matches the expected structure.

## Key Changes

### New Template System Components

- **Template Models** (`depictio/models/models/templates.py`):
  - `TemplateMetadata`: Declares template identity, required variables, and expected data structure
  - `TemplateVariable`: Represents a required variable (e.g., DATA_ROOT) with validation
  - `ExpectedFile`/`ExpectedDirectory`: Define expected data structure for validation
  - `TemplateOrigin`: Tracks template usage on Project model for audit/reproducibility

- **Template Resolution** (`depictio/cli/cli/utils/templates.py`):
  - `locate_template()`: Finds template YAML files by template ID in the projects directory
  - `substitute_template_variables()`: Recursively substitutes `{VAR_NAME}` placeholders in config structures
  - `resolve_template()`: Main entry point that loads, validates, and resolves templates
  - `_strip_ids()`: Removes hardcoded IDs so fresh ones are generated for new projects

- **Template Validation** (`depictio/cli/cli/utils/template_validator.py`):
  - `validate_data_root()`: Two-level validation of user data against template expectations
    - Level 1: Checks directory existence and file/directory presence
    - Level 2 (--deep): Validates file schemas (TSV/CSV/Parquet column names)
  - `ValidationResult`: Pydantic model for validation results with errors and warnings

### CLI Integration

- **Updated `run` command** (`depictio/cli/cli/commands/run.py`):
  - Added `--template`, `--data-root`, `--project-name`, and `--deep` options
  - Mutual exclusivity check between `--template` and `--project-config-path`
  - New Step 0 for template resolution and validation before project creation
  - Proper error handling and user feedback for template mode

- **Config Validation** (`depictio/cli/cli/utils/config.py`):
  - `validate_template_project_config()`: Validates template-resolved configs (from dict instead of YAML file)
  - `_resolve_link_tags_to_ids()`: Resolves tag-based link references to data collection IDs
  - `_resolve_link_tags_after_id_assignment()`: Final link resolution after ID assignment

### Model Updates

- **Links** (`depictio/models/models/links.py`):
  - Added `source_dc_tag` and `target_dc_tag` fields to `DCLink` for template-based references
  - Made `source_dc_id` and `target_dc_id` optional (default empty string) to support tag-based resolution

- **Projects** (`depictio/models/models/projects.py`):
  - Added `template_origin` field to track template usage on Project model

### Example Template

- **nf-core/ampliseq 2.14.0 template** (`depictio/projects/nf-core/ampliseq/2.14.0/template.yaml`):
  - Complete template configuration for microbial community analysis
  - Defines 8 data collections (metadata, alpha diversity, taxonomy, ANCOM results, etc.)
  - Specifies expected files and directories with glob pattern support
  - Includes MultiQC integration and comprehensive link definitions

### Tests

- **Template system tests** (`depictio/tests/cli/utils/test_templates.py`):
  - Tests for template location, variable substitution, ID stripping
  - Pydantic model validation tests
  - Data root validation tests (both standard and deep levels)
  - Glob pattern and column validation tests

## Implementation Details

- Templates use `{DATA_ROOT}` placeholder syntax consistent with existing WorkflowDataLocation env var expansion
- Variable substitution is recursive and handles nested dicts

https://claude.ai/code/session_01STHfHCCD1Whiv2LDb7ZUcS