### PR TITLE
fix: prevent infinite React re-render loop on heavy dashboards

### DIFF
--- a/depictio/dash/modules/figure_component/utils.py
+++ b/depictio/dash/modules/figure_component/utils.py
@@ -945,7 +945,9 @@ def _finalize_figure(
     """
     # Heatmap figures have precisely computed margins/layout from ComplexHeatmap;
     # skip the generic margin/autosize override so dendrograms render correctly.
+    # Still apply uirevision to prevent selectedData/clickData reset loops.
     if visu_type.lower() == "heatmap":
+        figure.update_layout(uirevision="persistent")
         return figure
 
     # Fix marginal plot axis constraints

--- a/depictio/dash/modules/map_component/callbacks/selection.py
+++ b/depictio/dash/modules/map_component/callbacks/selection.py
@@ -75,14 +75,15 @@ def register_map_selection_callback(app):
         triggered_prop = ctx.triggered[0]["prop_id"] if ctx.triggered else ""
         triggered_value = ctx.triggered[0]["value"] if ctx.triggered else None
 
-        # Ignore clearing triggers from map re-render
-        if "selectedData" in triggered_prop and not triggered_value:
-            has_existing = any(
-                v.get("source") == SOURCE_TYPE
-                for v in current_store.get("interactive_components_values", [])
-            )
-            if has_existing:
-                raise dash.exceptions.PreventUpdate
+        # Ignore clearing triggers from map re-render (unconditional guard).
+        # When Plotly re-renders a figure, it resets selectedData/clickData to None.
+        # Without this guard, the None value would propagate back to the store,
+        # triggering another re-render and creating an infinite loop.
+        is_clearing_trigger = (
+            "selectedData" in triggered_prop or "clickData" in triggered_prop
+        ) and not triggered_value
+        if is_clearing_trigger:
+            raise dash.exceptions.PreventUpdate
 
         metadata_by_index = build_metadata_lookup(metadata_list, metadata_ids)
         existing_values = filter_existing_values(current_store, SOURCE_TYPE)
@@ -137,4 +138,20 @@ def register_map_selection_callback(app):
         if should_prevent_update(has_any_selection, current_store, SOURCE_TYPE):
             raise dash.exceptions.PreventUpdate
 
-        return merge_selection_values(existing_values, selection_values)
+        new_store = merge_selection_values(existing_values, selection_values)
+
+        # Final safety: prevent writing identical data to the store.
+        # Without this deep equality check, no-op writes can trigger downstream
+        # callbacks (render_maps_batch, etc.) and cause infinite re-render loops.
+        current_values = sorted(
+            current_store.get("interactive_components_values", []),
+            key=lambda x: (x.get("index", ""), x.get("source", "")),
+        )
+        new_values = sorted(
+            new_store.get("interactive_components_values", []),
+            key=lambda x: (x.get("index", ""), x.get("source", "")),
+        )
+        if current_values == new_values:
+            raise dash.exceptions.PreventUpdate
+
+        return new_store

--- a/depictio/dash/modules/map_component/utils.py
+++ b/depictio/dash/modules/map_component/utils.py
@@ -382,12 +382,13 @@ def render_map(
             )
 
         # Common layout updates
-        # map.uirevision preserves the user's current pan/zoom/bearing/pitch
-        # across re-renders.  This is map-viewport-specific and does NOT
-        # preserve trace selection state (we clear that with selectedpoints=None).
+        # Top-level uirevision preserves selectedData/clickData across re-renders,
+        # preventing infinite loops where figure updates reset selection state.
+        # map.uirevision preserves the user's current pan/zoom/bearing/pitch.
         layout_kwargs: dict[str, Any] = {
             "margin": {"l": 0, "r": 0, "t": 30 if title else 0, "b": 0},
             "paper_bgcolor": "rgba(0,0,0,0)",
+            "uirevision": "persistent",
             "map": {"uirevision": "preserve"},
         }
         if title:

--- a/depictio/dash/modules/multiqc_component/callbacks/core.py
+++ b/depictio/dash/modules/multiqc_component/callbacks/core.py
@@ -583,6 +583,13 @@ def register_core_callbacks(app):
 
             trace_metadata = analyze_multiqc_plot_structure(fig)
 
+            # Set uirevision to prevent Plotly from resetting selectedData/clickData
+            # on figure updates, which can trigger infinite re-render loops.
+            if isinstance(fig, dict):
+                fig.setdefault("layout", {})["uirevision"] = "persistent"
+            elif hasattr(fig, "update_layout"):
+                fig.update_layout(uirevision="persistent")
+
             return (
                 fig,
                 trace_metadata,
@@ -943,6 +950,7 @@ def register_core_callbacks(app):
                 if "layout" not in patched_fig:
                     patched_fig["layout"] = {}
                 patched_fig["layout"]["_depictio_filter_applied"] = has_active_filters
+                patched_fig["layout"]["uirevision"] = "persistent"
                 return patched_fig
 
             return dash.no_update

--- a/depictio/dash/modules/multiqc_component/callbacks/general_stats_callbacks.py
+++ b/depictio/dash/modules/multiqc_component/callbacks/general_stats_callbacks.py
@@ -74,10 +74,13 @@ def register_general_stats_callbacks(app):
             return dash.no_update, dash.no_update, dash.no_update
 
         mode_data = store_data[read_mode]
+        violin_fig = mode_data["violin_figure"]
+        if isinstance(violin_fig, dict):
+            violin_fig.setdefault("layout", {})["uirevision"] = "persistent"
         return (
             mode_data["table_data"],
             mode_data["table_styles"],
-            mode_data["violin_figure"],
+            violin_fig,
         )
 
     # ------------------------------------------------------------------
@@ -138,6 +141,10 @@ def register_general_stats_callbacks(app):
         mode_data = store_data[mode]
         full_data = mode_data["table_data"]
         full_violin = mode_data["violin_figure"]
+        # Ensure uirevision is set to prevent Plotly from treating the figure
+        # as entirely new on each update, which contributes to React update depth.
+        if isinstance(full_violin, dict):
+            full_violin.setdefault("layout", {})["uirevision"] = "persistent"
 
         # No interactive values or empty -> reset to full data + violin
         if not interactive_values:
@@ -287,11 +294,16 @@ def _rebuild_violin_from_filtered(filtered_data: list[dict], mode_data: dict) ->
     """
     if not filtered_data:
         # Return an empty figure rather than the full violin
-        return {"data": [], "layout": {"height": 100, "title": {"text": "No data"}}}
+        return {
+            "data": [],
+            "layout": {"height": 100, "title": {"text": "No data"}, "uirevision": "persistent"},
+        }
 
     original_to_tool = mode_data.get("original_to_tool", {})
     display_to_original = mode_data.get("display_to_original")
 
     df_filtered = pd.DataFrame(filtered_data)
     fig = _create_violin_plot(df_filtered, original_to_tool, display_to_original)
-    return fig.to_dict()
+    fig_dict = fig.to_dict()
+    fig_dict.setdefault("layout", {})["uirevision"] = "persistent"
+    return fig_dict


### PR DESCRIPTION
Apply PR #701's three-layer fix pattern to new components added in
v0.7.4-v0.7.6 that were missing these protections:

Map component:
- Add unconditional clearing guard for selectedData/clickData=None
- Add deep equality check before writing to interactive-values-store
- Add top-level layout.uirevision="persistent" (was only map.uirevision)

MultiQC component:
- Add uirevision="persistent" to rendered and patched figures
- Add uirevision to general stats violin figures (rebuild + mode switch)

Heatmap:
- Add uirevision in _finalize_figure early return for heatmaps

These changes reduce the React update depth on heavy dashboards by:
1. Preventing no-op store writes (deep equality check)
2. Preventing selection state resets (uirevision)
3. Preventing clearing trigger cascades (unconditional guard)

https://claude.ai/code/session_01Ue8fcuoW6GKdV2zdDPwoDM