### PR TITLE
feat: add native title & description support to ComplexHeatmap

### DIFF
--- a/packages/plotly-complexheatmap/examples/basic_heatmap.py
+++ b/packages/plotly-complexheatmap/examples/basic_heatmap.py
@@ -28,6 +28,8 @@ hm = ComplexHeatmap(
     colorscale="RdBu_r",
     normalize="row",
     name="z-score",
+    title="Basic Heatmap",
+    description="Sample gene expression data",
     width=800,
     height=600,
 )

--- a/packages/plotly-complexheatmap/examples/tmp_title_showcase.ipynb
+++ b/packages/plotly-complexheatmap/examples/tmp_title_showcase.ipynb
@@ -1,0 +1,13935 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Title & Description Showcase\n",
+    "\n",
+    "Three examples demonstrating the new `title` and `description` parameters across different heatmap configurations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-03T16:51:54.760733Z",
+     "iopub.status.busy": "2026-03-03T16:51:54.760505Z",
+     "iopub.status.idle": "2026-03-03T16:51:57.978084Z",
+     "shell.execute_reply": "2026-03-03T16:51:57.976155Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from plotly_complexheatmap import ComplexHeatmap, HeatmapAnnotation\n",
+    "\n",
+    "rng = np.random.default_rng(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Small heatmap — title only, no annotations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-03T16:51:57.996700Z",
+     "iopub.status.busy": "2026-03-03T16:51:57.996093Z",
+     "iopub.status.idle": "2026-03-03T16:51:59.201923Z",
+     "shell.execute_reply": "2026-03-03T16:51:59.199645Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "colorbar": {
+          "len": 0.3,
+          "outlinewidth": 0,
+          "thickness": 12,
+          "tickfont": {
+           "family": "Arial, Helvetica, sans-serif",
+           "size": 9
+          },
+          "x": 1.088,
+          "xpad": 4,
+          "y": 0.5
+         },
+         "colorscale": [
+          [
+           0.0,
+           "rgb(247,251,255)"
+          ],
+          [
+           0.125,
+           "rgb(222,235,247)"
+          ],
+          [
+           0.25,
+           "rgb(198,219,239)"
+          ],
+          [
+           0.375,
+           "rgb(158,202,225)"
+          ],
+          [
+           0.5,
+           "rgb(107,174,214)"
+          ],
+          [
+           0.625,
+           "rgb(66,146,198)"
+          ],
+          [
+           0.75,
+           "rgb(33,113,181)"
+          ],
+          [
+           0.875,
+           "rgb(8,81,156)"
+          ],
+          [
+           1.0,
+           "rgb(8,48,107)"
+          ]
+         ],
+         "customdata": [
+          [
+           [
+            "gene_0",
+            "S0"
+           ],
+           [
+            "gene_0",
+            "S1"
+           ],
+           [
+            "gene_0",
+            "S2"
+           ],
+           [
+            "gene_0",
+            "S3"
+           ],
+           [
+            "gene_0",
+            "S4"
+           ],
+           [
+            "gene_0",
+            "S5"
+           ]
+          ],
+          [
+           [
+            "gene_1",
+            "S0"
+           ],
+           [
+            "gene_1",
+            "S1"
+           ],
+           [
+            "gene_1",
+            "S2"
+           ],
+           [
+            "gene_1",
+            "S3"
+           ],
+           [
+            "gene_1",
+            "S4"
+           ],
+           [
+            "gene_1",
+            "S5"
+           ]
+          ],
+          [
+           [
+            "gene_2",
+            "S0"
+           ],
+           [
+            "gene_2",
+            "S1"
+           ],
+           [
+            "gene_2",
+            "S2"
+           ],
+           [
+            "gene_2",
+            "S3"
+           ],
+           [
+            "gene_2",
+            "S4"
+           ],
+           [
+            "gene_2",
+            "S5"
+           ]
+          ],
+          [
+           [
+            "gene_3",
+            "S0"
+           ],
+           [
+            "gene_3",
+            "S1"
+           ],
+           [
+            "gene_3",
+            "S2"
+           ],
+           [
+            "gene_3",
+            "S3"
+           ],
+           [
+            "gene_3",
+            "S4"
+           ],
+           [
+            "gene_3",
+            "S5"
+           ]
+          ],
+          [
+           [
+            "gene_4",
+            "S0"
+           ],
+           [
+            "gene_4",
+            "S1"
+           ],
+           [
+            "gene_4",
+            "S2"
+           ],
+           [
+            "gene_4",
+            "S3"
+           ],
+           [
+            "gene_4",
+            "S4"
+           ],
+           [
+            "gene_4",
+            "S5"
+           ]
+          ],
+          [
+           [
+            "gene_5",
+            "S0"
+           ],
+           [
+            "gene_5",
+            "S1"
+           ],
+           [
+            "gene_5",
+            "S2"
+           ],
+           [
+            "gene_5",
+            "S3"
+           ],
+           [
+            "gene_5",
+            "S4"
+           ],
+           [
+            "gene_5",
+            "S5"
+           ]
+          ],
+          [
+           [
+            "gene_6",
+            "S0"
+           ],
+           [
+            "gene_6",
+            "S1"
+           ],
+           [
+            "gene_6",
+            "S2"
+           ],
+           [
+            "gene_6",
+            "S3"
+           ],
+           [
+            "gene_6",
+            "S4"
+           ],
+           [
+            "gene_6",
+            "S5"
+           ]
+          ],
+          [
+           [
+            "gene_7",
+            "S0"
+           ],
+           [
+            "gene_7",
+            "S1"
+           ],
+           [
+            "gene_7",
+            "S2"
+           ],
+           [
+            "gene_7",
+            "S3"
+           ],
+           [
+            "gene_7",
+            "S4"
+           ],
+           [
+            "gene_7",
+            "S5"
+           ]
+          ]
+         ],
+         "hovertemplate": "row: %{customdata[0]}<br>col: %{customdata[1]}<br>value: %{z:.3f}<extra></extra>",
+         "type": "heatmap",
+         "x": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRA",
+          "dtype": "f8"
+         },
+         "xaxis": "x",
+         "xgap": 0.5,
+         "y": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y",
+         "ygap": 0.5,
+         "z": {
+          "bdata": "jZ8ggg9wAkAEy2pAc7juP9TceY7sAAZANn8VLRsZ7j+P0ImscDf/v8jrty261fS/BLB1MNEFAUBMg4Sbq/D6PwS/n7Uuu/8/f1tfxyJM678Xi8Y4ByTsP+lQuOmr4+g/vXU0GjuHAEDWDLUJlwQJQEVgvIl1vQNAtww56FJ/679gjoDjnJnXP3dyaJAqr+6/ajWa8xAHB0DjdFHjgDP/P0/9JMPNCv0/IAuDwSzK5b/uzrmBh4/zP+ls4D+fx8O/pxMKGblp27/C9sooW4nWvyP86UWtCOE/m4E9gG9j1z9ECTMLNmraP1BSlkGSkts/K10qIxgiAUAjav4gtALav7s7H91KZOC/THHGGm0K6r8fEF96GrbjP844NUBFEPI/bAwXHKkrvb/McwLWj+LqvyDtMW4mYuq/0A5X96fR5D9b5r34vMjnP0W3YQ+FYeE/Fzd/A9tL5b8E3PtUdrfNP4euKgYf370/e8h66fz9yz9FlcKavuLrPwVcwmjHnsw/",
+          "dtype": "f8",
+          "shape": "8, 6"
+         }
+        }
+       ],
+       "layout": {
+        "barmode": "stack",
+        "font": {
+         "family": "Arial, Helvetica, sans-serif",
+         "size": 11
+        },
+        "height": 400,
+        "legend": {
+         "bgcolor": "rgba(255,255,255,0.8)",
+         "bordercolor": "#cccccc",
+         "borderwidth": 1,
+         "font": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 10
+         },
+         "itemsizing": "constant",
+         "tracegroupgap": 8,
+         "x": 1.22,
+         "xanchor": "left",
+         "y": 1.0,
+         "yanchor": "top"
+        },
+        "margin": {
+         "b": 5,
+         "l": 5,
+         "r": 102,
+         "t": 50
+        },
+        "paper_bgcolor": "white",
+        "plot_bgcolor": "rgba(0,0,0,0)",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 16
+         },
+         "text": "Small Heatmap",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 500,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": true,
+         "side": "bottom",
+         "tickangle": -45,
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 10
+         },
+         "ticktext": [
+          "S0",
+          "S1",
+          "S2",
+          "S3",
+          "S4",
+          "S5"
+         ],
+         "tickvals": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+         ],
+         "zeroline": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": false,
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "range": [
+          7.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": true,
+         "side": "right",
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 9
+         },
+         "ticktext": [
+          "gene_0",
+          "gene_1",
+          "gene_2",
+          "gene_3",
+          "gene_4",
+          "gene_5",
+          "gene_6",
+          "gene_7"
+         ],
+         "tickvals": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+         ],
+         "zeroline": false
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 8x6 matrix, no clustering, no annotations\n",
+    "small_data = rng.standard_normal((8, 6))\n",
+    "small_data[:4, :3] += 2.0\n",
+    "\n",
+    "df_small = pd.DataFrame(\n",
+    "    small_data,\n",
+    "    index=[f\"gene_{i}\" for i in range(8)],\n",
+    "    columns=[f\"S{j}\" for j in range(6)],\n",
+    ")\n",
+    "\n",
+    "hm1 = ComplexHeatmap(\n",
+    "    df_small,\n",
+    "    cluster_rows=False,\n",
+    "    cluster_cols=False,\n",
+    "    title=\"Small Heatmap\",\n",
+    "    colorscale=\"Blues\",\n",
+    "    width=500,\n",
+    "    height=400,\n",
+    ")\n",
+    "fig1 = hm1.to_plotly()\n",
+    "fig1.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Medium heatmap — title + description, with annotations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-03T16:51:59.300803Z",
+     "iopub.status.busy": "2026-03-03T16:51:59.299844Z",
+     "iopub.status.idle": "2026-03-03T16:51:59.470287Z",
+     "shell.execute_reply": "2026-03-03T16:51:59.467535Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "colorbar": {
+          "len": 0.3,
+          "outlinewidth": 0,
+          "thickness": 12,
+          "tickfont": {
+           "family": "Arial, Helvetica, sans-serif",
+           "size": 9
+          },
+          "title": {
+           "font": {
+            "family": "Arial, Helvetica, sans-serif",
+            "size": 10
+           },
+           "text": "z-score"
+          },
+          "x": 1.0605555555555555,
+          "xpad": 4,
+          "y": 0.5
+         },
+         "colorscale": [
+          [
+           0.0,
+           "rgb(5,48,97)"
+          ],
+          [
+           0.1,
+           "rgb(33,102,172)"
+          ],
+          [
+           0.2,
+           "rgb(67,147,195)"
+          ],
+          [
+           0.3,
+           "rgb(146,197,222)"
+          ],
+          [
+           0.4,
+           "rgb(209,229,240)"
+          ],
+          [
+           0.5,
+           "rgb(247,247,247)"
+          ],
+          [
+           0.6,
+           "rgb(253,219,199)"
+          ],
+          [
+           0.7,
+           "rgb(244,165,130)"
+          ],
+          [
+           0.8,
+           "rgb(214,96,77)"
+          ],
+          [
+           0.9,
+           "rgb(178,24,43)"
+          ],
+          [
+           1.0,
+           "rgb(103,0,31)"
+          ]
+         ],
+         "customdata": [
+          [
+           [
+            "gene_09",
+            "sample_09"
+           ],
+           [
+            "gene_09",
+            "sample_10"
+           ],
+           [
+            "gene_09",
+            "sample_06"
+           ],
+           [
+            "gene_09",
+            "sample_07"
+           ],
+           [
+            "gene_09",
+            "sample_08"
+           ],
+           [
+            "gene_09",
+            "sample_11"
+           ],
+           [
+            "gene_09",
+            "sample_00"
+           ],
+           [
+            "gene_09",
+            "sample_01"
+           ],
+           [
+            "gene_09",
+            "sample_05"
+           ],
+           [
+            "gene_09",
+            "sample_04"
+           ],
+           [
+            "gene_09",
+            "sample_02"
+           ],
+           [
+            "gene_09",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_05",
+            "sample_09"
+           ],
+           [
+            "gene_05",
+            "sample_10"
+           ],
+           [
+            "gene_05",
+            "sample_06"
+           ],
+           [
+            "gene_05",
+            "sample_07"
+           ],
+           [
+            "gene_05",
+            "sample_08"
+           ],
+           [
+            "gene_05",
+            "sample_11"
+           ],
+           [
+            "gene_05",
+            "sample_00"
+           ],
+           [
+            "gene_05",
+            "sample_01"
+           ],
+           [
+            "gene_05",
+            "sample_05"
+           ],
+           [
+            "gene_05",
+            "sample_04"
+           ],
+           [
+            "gene_05",
+            "sample_02"
+           ],
+           [
+            "gene_05",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_00",
+            "sample_09"
+           ],
+           [
+            "gene_00",
+            "sample_10"
+           ],
+           [
+            "gene_00",
+            "sample_06"
+           ],
+           [
+            "gene_00",
+            "sample_07"
+           ],
+           [
+            "gene_00",
+            "sample_08"
+           ],
+           [
+            "gene_00",
+            "sample_11"
+           ],
+           [
+            "gene_00",
+            "sample_00"
+           ],
+           [
+            "gene_00",
+            "sample_01"
+           ],
+           [
+            "gene_00",
+            "sample_05"
+           ],
+           [
+            "gene_00",
+            "sample_04"
+           ],
+           [
+            "gene_00",
+            "sample_02"
+           ],
+           [
+            "gene_00",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_08",
+            "sample_09"
+           ],
+           [
+            "gene_08",
+            "sample_10"
+           ],
+           [
+            "gene_08",
+            "sample_06"
+           ],
+           [
+            "gene_08",
+            "sample_07"
+           ],
+           [
+            "gene_08",
+            "sample_08"
+           ],
+           [
+            "gene_08",
+            "sample_11"
+           ],
+           [
+            "gene_08",
+            "sample_00"
+           ],
+           [
+            "gene_08",
+            "sample_01"
+           ],
+           [
+            "gene_08",
+            "sample_05"
+           ],
+           [
+            "gene_08",
+            "sample_04"
+           ],
+           [
+            "gene_08",
+            "sample_02"
+           ],
+           [
+            "gene_08",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_07",
+            "sample_09"
+           ],
+           [
+            "gene_07",
+            "sample_10"
+           ],
+           [
+            "gene_07",
+            "sample_06"
+           ],
+           [
+            "gene_07",
+            "sample_07"
+           ],
+           [
+            "gene_07",
+            "sample_08"
+           ],
+           [
+            "gene_07",
+            "sample_11"
+           ],
+           [
+            "gene_07",
+            "sample_00"
+           ],
+           [
+            "gene_07",
+            "sample_01"
+           ],
+           [
+            "gene_07",
+            "sample_05"
+           ],
+           [
+            "gene_07",
+            "sample_04"
+           ],
+           [
+            "gene_07",
+            "sample_02"
+           ],
+           [
+            "gene_07",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_04",
+            "sample_09"
+           ],
+           [
+            "gene_04",
+            "sample_10"
+           ],
+           [
+            "gene_04",
+            "sample_06"
+           ],
+           [
+            "gene_04",
+            "sample_07"
+           ],
+           [
+            "gene_04",
+            "sample_08"
+           ],
+           [
+            "gene_04",
+            "sample_11"
+           ],
+           [
+            "gene_04",
+            "sample_00"
+           ],
+           [
+            "gene_04",
+            "sample_01"
+           ],
+           [
+            "gene_04",
+            "sample_05"
+           ],
+           [
+            "gene_04",
+            "sample_04"
+           ],
+           [
+            "gene_04",
+            "sample_02"
+           ],
+           [
+            "gene_04",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_02",
+            "sample_09"
+           ],
+           [
+            "gene_02",
+            "sample_10"
+           ],
+           [
+            "gene_02",
+            "sample_06"
+           ],
+           [
+            "gene_02",
+            "sample_07"
+           ],
+           [
+            "gene_02",
+            "sample_08"
+           ],
+           [
+            "gene_02",
+            "sample_11"
+           ],
+           [
+            "gene_02",
+            "sample_00"
+           ],
+           [
+            "gene_02",
+            "sample_01"
+           ],
+           [
+            "gene_02",
+            "sample_05"
+           ],
+           [
+            "gene_02",
+            "sample_04"
+           ],
+           [
+            "gene_02",
+            "sample_02"
+           ],
+           [
+            "gene_02",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_06",
+            "sample_09"
+           ],
+           [
+            "gene_06",
+            "sample_10"
+           ],
+           [
+            "gene_06",
+            "sample_06"
+           ],
+           [
+            "gene_06",
+            "sample_07"
+           ],
+           [
+            "gene_06",
+            "sample_08"
+           ],
+           [
+            "gene_06",
+            "sample_11"
+           ],
+           [
+            "gene_06",
+            "sample_00"
+           ],
+           [
+            "gene_06",
+            "sample_01"
+           ],
+           [
+            "gene_06",
+            "sample_05"
+           ],
+           [
+            "gene_06",
+            "sample_04"
+           ],
+           [
+            "gene_06",
+            "sample_02"
+           ],
+           [
+            "gene_06",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_01",
+            "sample_09"
+           ],
+           [
+            "gene_01",
+            "sample_10"
+           ],
+           [
+            "gene_01",
+            "sample_06"
+           ],
+           [
+            "gene_01",
+            "sample_07"
+           ],
+           [
+            "gene_01",
+            "sample_08"
+           ],
+           [
+            "gene_01",
+            "sample_11"
+           ],
+           [
+            "gene_01",
+            "sample_00"
+           ],
+           [
+            "gene_01",
+            "sample_01"
+           ],
+           [
+            "gene_01",
+            "sample_05"
+           ],
+           [
+            "gene_01",
+            "sample_04"
+           ],
+           [
+            "gene_01",
+            "sample_02"
+           ],
+           [
+            "gene_01",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_03",
+            "sample_09"
+           ],
+           [
+            "gene_03",
+            "sample_10"
+           ],
+           [
+            "gene_03",
+            "sample_06"
+           ],
+           [
+            "gene_03",
+            "sample_07"
+           ],
+           [
+            "gene_03",
+            "sample_08"
+           ],
+           [
+            "gene_03",
+            "sample_11"
+           ],
+           [
+            "gene_03",
+            "sample_00"
+           ],
+           [
+            "gene_03",
+            "sample_01"
+           ],
+           [
+            "gene_03",
+            "sample_05"
+           ],
+           [
+            "gene_03",
+            "sample_04"
+           ],
+           [
+            "gene_03",
+            "sample_02"
+           ],
+           [
+            "gene_03",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_11",
+            "sample_09"
+           ],
+           [
+            "gene_11",
+            "sample_10"
+           ],
+           [
+            "gene_11",
+            "sample_06"
+           ],
+           [
+            "gene_11",
+            "sample_07"
+           ],
+           [
+            "gene_11",
+            "sample_08"
+           ],
+           [
+            "gene_11",
+            "sample_11"
+           ],
+           [
+            "gene_11",
+            "sample_00"
+           ],
+           [
+            "gene_11",
+            "sample_01"
+           ],
+           [
+            "gene_11",
+            "sample_05"
+           ],
+           [
+            "gene_11",
+            "sample_04"
+           ],
+           [
+            "gene_11",
+            "sample_02"
+           ],
+           [
+            "gene_11",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_17",
+            "sample_09"
+           ],
+           [
+            "gene_17",
+            "sample_10"
+           ],
+           [
+            "gene_17",
+            "sample_06"
+           ],
+           [
+            "gene_17",
+            "sample_07"
+           ],
+           [
+            "gene_17",
+            "sample_08"
+           ],
+           [
+            "gene_17",
+            "sample_11"
+           ],
+           [
+            "gene_17",
+            "sample_00"
+           ],
+           [
+            "gene_17",
+            "sample_01"
+           ],
+           [
+            "gene_17",
+            "sample_05"
+           ],
+           [
+            "gene_17",
+            "sample_04"
+           ],
+           [
+            "gene_17",
+            "sample_02"
+           ],
+           [
+            "gene_17",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_19",
+            "sample_09"
+           ],
+           [
+            "gene_19",
+            "sample_10"
+           ],
+           [
+            "gene_19",
+            "sample_06"
+           ],
+           [
+            "gene_19",
+            "sample_07"
+           ],
+           [
+            "gene_19",
+            "sample_08"
+           ],
+           [
+            "gene_19",
+            "sample_11"
+           ],
+           [
+            "gene_19",
+            "sample_00"
+           ],
+           [
+            "gene_19",
+            "sample_01"
+           ],
+           [
+            "gene_19",
+            "sample_05"
+           ],
+           [
+            "gene_19",
+            "sample_04"
+           ],
+           [
+            "gene_19",
+            "sample_02"
+           ],
+           [
+            "gene_19",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_21",
+            "sample_09"
+           ],
+           [
+            "gene_21",
+            "sample_10"
+           ],
+           [
+            "gene_21",
+            "sample_06"
+           ],
+           [
+            "gene_21",
+            "sample_07"
+           ],
+           [
+            "gene_21",
+            "sample_08"
+           ],
+           [
+            "gene_21",
+            "sample_11"
+           ],
+           [
+            "gene_21",
+            "sample_00"
+           ],
+           [
+            "gene_21",
+            "sample_01"
+           ],
+           [
+            "gene_21",
+            "sample_05"
+           ],
+           [
+            "gene_21",
+            "sample_04"
+           ],
+           [
+            "gene_21",
+            "sample_02"
+           ],
+           [
+            "gene_21",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_10",
+            "sample_09"
+           ],
+           [
+            "gene_10",
+            "sample_10"
+           ],
+           [
+            "gene_10",
+            "sample_06"
+           ],
+           [
+            "gene_10",
+            "sample_07"
+           ],
+           [
+            "gene_10",
+            "sample_08"
+           ],
+           [
+            "gene_10",
+            "sample_11"
+           ],
+           [
+            "gene_10",
+            "sample_00"
+           ],
+           [
+            "gene_10",
+            "sample_01"
+           ],
+           [
+            "gene_10",
+            "sample_05"
+           ],
+           [
+            "gene_10",
+            "sample_04"
+           ],
+           [
+            "gene_10",
+            "sample_02"
+           ],
+           [
+            "gene_10",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_16",
+            "sample_09"
+           ],
+           [
+            "gene_16",
+            "sample_10"
+           ],
+           [
+            "gene_16",
+            "sample_06"
+           ],
+           [
+            "gene_16",
+            "sample_07"
+           ],
+           [
+            "gene_16",
+            "sample_08"
+           ],
+           [
+            "gene_16",
+            "sample_11"
+           ],
+           [
+            "gene_16",
+            "sample_00"
+           ],
+           [
+            "gene_16",
+            "sample_01"
+           ],
+           [
+            "gene_16",
+            "sample_05"
+           ],
+           [
+            "gene_16",
+            "sample_04"
+           ],
+           [
+            "gene_16",
+            "sample_02"
+           ],
+           [
+            "gene_16",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_15",
+            "sample_09"
+           ],
+           [
+            "gene_15",
+            "sample_10"
+           ],
+           [
+            "gene_15",
+            "sample_06"
+           ],
+           [
+            "gene_15",
+            "sample_07"
+           ],
+           [
+            "gene_15",
+            "sample_08"
+           ],
+           [
+            "gene_15",
+            "sample_11"
+           ],
+           [
+            "gene_15",
+            "sample_00"
+           ],
+           [
+            "gene_15",
+            "sample_01"
+           ],
+           [
+            "gene_15",
+            "sample_05"
+           ],
+           [
+            "gene_15",
+            "sample_04"
+           ],
+           [
+            "gene_15",
+            "sample_02"
+           ],
+           [
+            "gene_15",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_12",
+            "sample_09"
+           ],
+           [
+            "gene_12",
+            "sample_10"
+           ],
+           [
+            "gene_12",
+            "sample_06"
+           ],
+           [
+            "gene_12",
+            "sample_07"
+           ],
+           [
+            "gene_12",
+            "sample_08"
+           ],
+           [
+            "gene_12",
+            "sample_11"
+           ],
+           [
+            "gene_12",
+            "sample_00"
+           ],
+           [
+            "gene_12",
+            "sample_01"
+           ],
+           [
+            "gene_12",
+            "sample_05"
+           ],
+           [
+            "gene_12",
+            "sample_04"
+           ],
+           [
+            "gene_12",
+            "sample_02"
+           ],
+           [
+            "gene_12",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_18",
+            "sample_09"
+           ],
+           [
+            "gene_18",
+            "sample_10"
+           ],
+           [
+            "gene_18",
+            "sample_06"
+           ],
+           [
+            "gene_18",
+            "sample_07"
+           ],
+           [
+            "gene_18",
+            "sample_08"
+           ],
+           [
+            "gene_18",
+            "sample_11"
+           ],
+           [
+            "gene_18",
+            "sample_00"
+           ],
+           [
+            "gene_18",
+            "sample_01"
+           ],
+           [
+            "gene_18",
+            "sample_05"
+           ],
+           [
+            "gene_18",
+            "sample_04"
+           ],
+           [
+            "gene_18",
+            "sample_02"
+           ],
+           [
+            "gene_18",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_13",
+            "sample_09"
+           ],
+           [
+            "gene_13",
+            "sample_10"
+           ],
+           [
+            "gene_13",
+            "sample_06"
+           ],
+           [
+            "gene_13",
+            "sample_07"
+           ],
+           [
+            "gene_13",
+            "sample_08"
+           ],
+           [
+            "gene_13",
+            "sample_11"
+           ],
+           [
+            "gene_13",
+            "sample_00"
+           ],
+           [
+            "gene_13",
+            "sample_01"
+           ],
+           [
+            "gene_13",
+            "sample_05"
+           ],
+           [
+            "gene_13",
+            "sample_04"
+           ],
+           [
+            "gene_13",
+            "sample_02"
+           ],
+           [
+            "gene_13",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_14",
+            "sample_09"
+           ],
+           [
+            "gene_14",
+            "sample_10"
+           ],
+           [
+            "gene_14",
+            "sample_06"
+           ],
+           [
+            "gene_14",
+            "sample_07"
+           ],
+           [
+            "gene_14",
+            "sample_08"
+           ],
+           [
+            "gene_14",
+            "sample_11"
+           ],
+           [
+            "gene_14",
+            "sample_00"
+           ],
+           [
+            "gene_14",
+            "sample_01"
+           ],
+           [
+            "gene_14",
+            "sample_05"
+           ],
+           [
+            "gene_14",
+            "sample_04"
+           ],
+           [
+            "gene_14",
+            "sample_02"
+           ],
+           [
+            "gene_14",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_24",
+            "sample_09"
+           ],
+           [
+            "gene_24",
+            "sample_10"
+           ],
+           [
+            "gene_24",
+            "sample_06"
+           ],
+           [
+            "gene_24",
+            "sample_07"
+           ],
+           [
+            "gene_24",
+            "sample_08"
+           ],
+           [
+            "gene_24",
+            "sample_11"
+           ],
+           [
+            "gene_24",
+            "sample_00"
+           ],
+           [
+            "gene_24",
+            "sample_01"
+           ],
+           [
+            "gene_24",
+            "sample_05"
+           ],
+           [
+            "gene_24",
+            "sample_04"
+           ],
+           [
+            "gene_24",
+            "sample_02"
+           ],
+           [
+            "gene_24",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_25",
+            "sample_09"
+           ],
+           [
+            "gene_25",
+            "sample_10"
+           ],
+           [
+            "gene_25",
+            "sample_06"
+           ],
+           [
+            "gene_25",
+            "sample_07"
+           ],
+           [
+            "gene_25",
+            "sample_08"
+           ],
+           [
+            "gene_25",
+            "sample_11"
+           ],
+           [
+            "gene_25",
+            "sample_00"
+           ],
+           [
+            "gene_25",
+            "sample_01"
+           ],
+           [
+            "gene_25",
+            "sample_05"
+           ],
+           [
+            "gene_25",
+            "sample_04"
+           ],
+           [
+            "gene_25",
+            "sample_02"
+           ],
+           [
+            "gene_25",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_26",
+            "sample_09"
+           ],
+           [
+            "gene_26",
+            "sample_10"
+           ],
+           [
+            "gene_26",
+            "sample_06"
+           ],
+           [
+            "gene_26",
+            "sample_07"
+           ],
+           [
+            "gene_26",
+            "sample_08"
+           ],
+           [
+            "gene_26",
+            "sample_11"
+           ],
+           [
+            "gene_26",
+            "sample_00"
+           ],
+           [
+            "gene_26",
+            "sample_01"
+           ],
+           [
+            "gene_26",
+            "sample_05"
+           ],
+           [
+            "gene_26",
+            "sample_04"
+           ],
+           [
+            "gene_26",
+            "sample_02"
+           ],
+           [
+            "gene_26",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_28",
+            "sample_09"
+           ],
+           [
+            "gene_28",
+            "sample_10"
+           ],
+           [
+            "gene_28",
+            "sample_06"
+           ],
+           [
+            "gene_28",
+            "sample_07"
+           ],
+           [
+            "gene_28",
+            "sample_08"
+           ],
+           [
+            "gene_28",
+            "sample_11"
+           ],
+           [
+            "gene_28",
+            "sample_00"
+           ],
+           [
+            "gene_28",
+            "sample_01"
+           ],
+           [
+            "gene_28",
+            "sample_05"
+           ],
+           [
+            "gene_28",
+            "sample_04"
+           ],
+           [
+            "gene_28",
+            "sample_02"
+           ],
+           [
+            "gene_28",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_20",
+            "sample_09"
+           ],
+           [
+            "gene_20",
+            "sample_10"
+           ],
+           [
+            "gene_20",
+            "sample_06"
+           ],
+           [
+            "gene_20",
+            "sample_07"
+           ],
+           [
+            "gene_20",
+            "sample_08"
+           ],
+           [
+            "gene_20",
+            "sample_11"
+           ],
+           [
+            "gene_20",
+            "sample_00"
+           ],
+           [
+            "gene_20",
+            "sample_01"
+           ],
+           [
+            "gene_20",
+            "sample_05"
+           ],
+           [
+            "gene_20",
+            "sample_04"
+           ],
+           [
+            "gene_20",
+            "sample_02"
+           ],
+           [
+            "gene_20",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_27",
+            "sample_09"
+           ],
+           [
+            "gene_27",
+            "sample_10"
+           ],
+           [
+            "gene_27",
+            "sample_06"
+           ],
+           [
+            "gene_27",
+            "sample_07"
+           ],
+           [
+            "gene_27",
+            "sample_08"
+           ],
+           [
+            "gene_27",
+            "sample_11"
+           ],
+           [
+            "gene_27",
+            "sample_00"
+           ],
+           [
+            "gene_27",
+            "sample_01"
+           ],
+           [
+            "gene_27",
+            "sample_05"
+           ],
+           [
+            "gene_27",
+            "sample_04"
+           ],
+           [
+            "gene_27",
+            "sample_02"
+           ],
+           [
+            "gene_27",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_23",
+            "sample_09"
+           ],
+           [
+            "gene_23",
+            "sample_10"
+           ],
+           [
+            "gene_23",
+            "sample_06"
+           ],
+           [
+            "gene_23",
+            "sample_07"
+           ],
+           [
+            "gene_23",
+            "sample_08"
+           ],
+           [
+            "gene_23",
+            "sample_11"
+           ],
+           [
+            "gene_23",
+            "sample_00"
+           ],
+           [
+            "gene_23",
+            "sample_01"
+           ],
+           [
+            "gene_23",
+            "sample_05"
+           ],
+           [
+            "gene_23",
+            "sample_04"
+           ],
+           [
+            "gene_23",
+            "sample_02"
+           ],
+           [
+            "gene_23",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_22",
+            "sample_09"
+           ],
+           [
+            "gene_22",
+            "sample_10"
+           ],
+           [
+            "gene_22",
+            "sample_06"
+           ],
+           [
+            "gene_22",
+            "sample_07"
+           ],
+           [
+            "gene_22",
+            "sample_08"
+           ],
+           [
+            "gene_22",
+            "sample_11"
+           ],
+           [
+            "gene_22",
+            "sample_00"
+           ],
+           [
+            "gene_22",
+            "sample_01"
+           ],
+           [
+            "gene_22",
+            "sample_05"
+           ],
+           [
+            "gene_22",
+            "sample_04"
+           ],
+           [
+            "gene_22",
+            "sample_02"
+           ],
+           [
+            "gene_22",
+            "sample_03"
+           ]
+          ],
+          [
+           [
+            "gene_29",
+            "sample_09"
+           ],
+           [
+            "gene_29",
+            "sample_10"
+           ],
+           [
+            "gene_29",
+            "sample_06"
+           ],
+           [
+            "gene_29",
+            "sample_07"
+           ],
+           [
+            "gene_29",
+            "sample_08"
+           ],
+           [
+            "gene_29",
+            "sample_11"
+           ],
+           [
+            "gene_29",
+            "sample_00"
+           ],
+           [
+            "gene_29",
+            "sample_01"
+           ],
+           [
+            "gene_29",
+            "sample_05"
+           ],
+           [
+            "gene_29",
+            "sample_04"
+           ],
+           [
+            "gene_29",
+            "sample_02"
+           ],
+           [
+            "gene_29",
+            "sample_03"
+           ]
+          ]
+         ],
+         "hovertemplate": "row: %{customdata[0]}<br>col: %{customdata[1]}<br>value: %{z:.3f}<extra></extra>",
+         "type": "heatmap",
+         "x": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZA",
+          "dtype": "f8"
+         },
+         "xaxis": "x4",
+         "xgap": 0.5,
+         "y": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQAAAAAAAADRAAAAAAAAANUAAAAAAAAA2QAAAAAAAADdAAAAAAAAAOEAAAAAAAAA5QAAAAAAAADpAAAAAAAAAO0AAAAAAAAA8QAAAAAAAAD1A",
+          "dtype": "f8"
+         },
+         "yaxis": "y4",
+         "ygap": 0.5,
+         "z": {
+          "bdata": "fHl8aG0L/L8UZKpxI67Rvw7C8sKs/OU/4JG3yZv++r/f762wonnWv18gF2c56+a/5GT03Kl08T/sMLqKB2/8P8wW5vEowdk/kr21K3DLyj+14XHoQLLiPzRukeDdlqA/Ils4QyiS7L8j4bgkGUXWP0l31qKwTuu/XdzKEKk29b9uACegyUXnv1vkxtZWkfG/xfQiJNNp+z+Baru+LmfTv3NzcRRbELW/0nNRqtbG4j8Ouav8KVD2P/f7fMxz1/M/iwDI5danxD+rb98TITX3v8dJktEx4/K/Yh5MLm+69L+f9Z4qN8Hwv+VaXY0JX8m/Ys/RgVv69D/oBNGtaZnsP0nRhhB0I+Q/bfZRP8zawr8Xjit4Q7jwP/9uEEIrdfQ/dxO1D1YG77+SWGA+X0rmv527j21paOi/yW5k7RoP9b89fdaU2oL7v5o++kwl/tw/O+P+4QK62T97yq5sVuTkP8kWSfm1OfA/n0c09Bhn+T8QEmMQSOvgP1rVkVC5b+o/TaolA8Tv9r89mlmq/v8AwML249A37Nc/HGpMMym57T+p+ppE5K7ivzBC3NU0huW/XvB16SQB8T+TBz+5gmfhPxsrEKpP+PI/wkVzVqTH6z95CeiPZRvLv3SXMN3+ULA/2VJlxheA6L8EPcj7hln0v8G6IsgeyOu/GSwPVoriv7+vtP5f2Cv0v91Vgx4naOu/GQzHh0BUxj+AnXXYV1PZP4S80TvxT/8/Fcfh+Kgh6j9vcj9IMIf1P0LrVECLUd0/gCCZibU49b9Iaxy23dTxvwuzkXVzeNq/VwbMKOo48b+86tmjnBDhv6BUk5MeC/K/eXgArErb0D+CLS3pR0j0PxUokocEcfA/no06rBKY4z+6BUonOkLwP6eIP5KkefY/8AkZ+zDb8b8YyTdlsoHqvwCt0qfFGcU/OATJ0sIa9L+jekiUEsvuv42pzTlNt/W/edJxy5UBxj9n86MHNCHqP1lMu8vwLO0/cQgYVlWw8j9xd5B1/dPqP5pld5vRLvc/mWPjCYHR57/qW44ub0H2v5inuwSH0uq/vo8pTZz97L/jB/Zk71y+vzZ56TOd5fS/SMekkZ1Mwr9Zn6DX8iXlP5ByTJnDVvU/S+K6qC2O9D9jDBDC+6TuP05xAKrYXPM/vC+KTzBl5L9gj9uvjMD5v6g50y0y6Me/8h9JwijC5L9+pL3IPAvrv7gK+kWJbfe/jT/Pi2yJyT80JbdnY3nzP+xVTsw3FfM/KP9gpfdp8z+QSLTeBnHkP8HpO51GxO0/Cw7fqIxG/T/loEGKrkX+P1jNK5sLVeI/oZhKsis+5L8TptfZLC7ov73jOu+QyNA/Tf4xI9TpfL/AglPFmADuv2h/CU+2R8g/F3OQ+M9D6L+BS7syJqP3v9A1J9Ray8a/H6Je+ZKr6D+SKK83ruj0P9eHW0nNOu0/aXyVpqLp2r+sGNXb/qPpP0A0zp3udt0/tiUaZUth7z/kU4OWjQL/v5LaRtDygfS/KwShcX0/2r8qlTMuwkHyvxzAgL2QdqW/N1PUnuN52j/Zst/v8aPuP8hth+DKLPc/9+jvx7qT8T+Iyjt2VCWuv6DGWCXuo+k/e3Nj0hAi8r92u46BeUT2vwwrx1S4v/2/EdB77itdy78sRb5FovnTP/kc9ocR+de/lAUhhyJp9T9MuVwFck3pP4cmefvPbea/wHbbK5cs7T8VepAU9BnKP151K64o4q8/FSx32BVV9T86WaJy1iX+v/JaEmg2jva/1ymTX5mc27+WCznc+s3ePzTL343gPea/geWzwUD06z9UQNGC2UflPz7nNDxO8cm/dYbeiHxB7D9dk3ylsPj+P3N2+s/M9+4/8RhQ8Ly95r9vPuNCQffjvz2yULcGLPi/lg6U0wbj7b/PuqurDlbxvyWfExmDnNC/6lg64VRdub/pzjoJ86bTP6Jlkn4SX6+/CFOBeVrA9j8BOMG+XWT/P/qYYcFOT+U/pHYbAjiG679dykztyLndv6t9E+RUFfG/1pHDQ1Qc5T9eHsC0RuP0v4ER58VOifK/4bFYWrn39T8JGhwLINnbP3Rc8vrYCuk/9SutgbuK6z9VG+TjGUPmv9iT+aqYs+8/TBfzJ7SR878c7bAykkPkvxF7u4kRi+0/iqKpjGBZc7+m/CiY7L79v4CErROhYe6/rFv2dGR8+T+ARsJwDg7kP45wO4XYzuE/A9XTSaEu3D+VGlFbf9rpP795OtvkhfA/sv87js+p8L9Hzr8PuvXTP7tbRT0fzPC/gd4OLkR00r8iWLLRDSn5v9q7haYFq/a/o1SnJ4IgAEBJSJe2ep75P03P9hHbYs2/hDa7cCUn4z9BpmDEBi7RP8DrlkVg7OQ/6HMsKPDW5r82RkMUfgzSvwybuvv8b/G/9M9J9ZLC8L+GZr/ixOjuvzBRumi85em/uV2KEOaE4j+Rx7tiotDlP4GyqAihAPg/hPEk2iIEmT8dtcqLZlztP2Ksl+LD6vg/tdtlNEwv+r+fkGwi4m/Uv8uQmjytOuC/wEjQN8Kv679APUa5evPqv5vUVyIzbvG/oPonR8Qn3z/c/BEUrTQAQGdwDWLX7tw/Sqttv1NR2b9ADXuRuDrZP1ED0QJjhfk/F8uf6SF64L/k1OU37++WP3PdceQY1ua/iO01Nidv8L/+7zRaYWDvv84NTLwHg/W/L8piR3aU/L/nbzbF++vevxZdh04Olbo/ln81FxgD2j/es6jC+of3P8xoyvolBeI/hl/nfF264b8t5/g/jT3UP/5bqzG2ztM/lLB5lEzP/79eXRBq6wDxP7c0wTSfhuI/H50bNRdCvD8KAoNN/yP0v0KrPGdPMPE/svZDx8OssD8RJ8JZTCWxP0Ie4Tb9O9m/kMrz6oMCAcB6GgfcBBD5Pz4DRsakiOg/uFkHXRf77L/yIMA43UfNP99Ii7lazek/S4G/slXC6T8w6z66YUvNvwTF/OrBp/K/X7UXV6g39L+5ht0WanyAP4qDRrylgPY/dfO/vJyr27/Q2lC8q8zNP2fq3F7mh/k/2ocr5R582b9pE8Yqxu7vPxbYxvPi6Pi/YyG2pLLd6j/GnFfnjovxP4zQw5AqwgDAoGPKmkVE2j9LWkPqENLCv/pcUyiE9N8/91Hh9yGA9b8JPH0iBUXfv5TOWokETvK/Z5aHoleo5D8QbkriRzLqPy64kDcpEO0/CY8Yqg5cvL9b7EbRo0v4v0rnC4gOJ5s/+Uv4It+W3D/F6iaIZi7iPxlx0FvjOOM/2flyQ5hunr8TGBDuFr/EP5FgZOr5uwLA3y6yVZc1/D8JTLEDHdCGPz71pT3+B9s/4hom9pGD7D/3/6rB0kj2v+BmWR2Q9PE/zwcI1wmv378UpyYlGViqvw5sREtu4vG/LADgdXom4T9cuGxDRMbgPxEWOP3vUfu/j3uij8gB0780m+2VYBvTP8UgbdKVCPs/zNSZqKfJ6r+w329Mf1PDPwXwbwI6wPg/Pp+7q4sa5z+7lkVA0kbhv1vSRtZOdfC/2Zxl2+Bs/T9sGOs+wOvpP7SOfBsHo9e/IxDxQgGS779WtdhQGtT1v9KQAOb4Fq0/C5gTRBIb5r/SLPixH9jvPy0e3Vfapeg/ENJP1n6d/r+vFizMRHDgP2WCLCkGYt4/59PjoulD+z/Onaql5LG2P2jOJF4pF/W/1mxo/5rV17/7KrKXFj/iP/W5FTA4Teq/b1aQtMkv7b/1uo2Kxpjjv4jPLvdeiPQ/zV2J45a68r/jjr/n5LTlP3mD9gnK0vQ/nFh1tnSU8j/t9ptxHp22P9rfqrTUVZc/roK531Cc57/BMQVsMEjmPwpPdChKyPy/",
+          "dtype": "f8",
+          "shape": "30, 12"
+         }
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          0.0,
+          0.0,
+          1.0,
+          1.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          5.467171998710372,
+          5.467171998710372,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          4.0,
+          4.0,
+          5.0,
+          5.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          4.773321849854318,
+          4.773321849854318,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          3.0,
+          3.0,
+          4.5,
+          4.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          6.334195782551486,
+          6.334195782551486,
+          4.773321849854318
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          2.0,
+          2.0,
+          3.75,
+          3.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          6.895748127661789,
+          6.895748127661789,
+          6.334195782551486
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          0.5,
+          0.5,
+          2.875,
+          2.875
+         ],
+         "xaxis": "x",
+         "y": [
+          5.467171998710372,
+          7.836961447773625,
+          7.836961447773625,
+          6.895748127661789
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          7.0,
+          7.0,
+          8.0,
+          8.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          5.644590587177172,
+          5.644590587177172,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          10.0,
+          10.0,
+          11.0,
+          11.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          5.283880407013986,
+          5.283880407013986,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          9.0,
+          9.0,
+          10.5,
+          10.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          5.898754282767351,
+          5.898754282767351,
+          5.283880407013986
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          7.5,
+          7.5,
+          9.75,
+          9.75
+         ],
+         "xaxis": "x",
+         "y": [
+          5.644590587177172,
+          7.471739404216586,
+          7.471739404216586,
+          5.898754282767351
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          6.0,
+          6.0,
+          8.625,
+          8.625
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          8.02697012285795,
+          8.02697012285795,
+          7.471739404216586
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          1.6875,
+          1.6875,
+          7.3125,
+          7.3125
+         ],
+         "xaxis": "x",
+         "y": [
+          7.836961447773625,
+          17.41834806891193,
+          17.41834806891193,
+          8.02697012285795
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.7225403598649467,
+          -2.7225403598649467,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          2.0,
+          2.0,
+          3.0,
+          3.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.128002831785297,
+          -3.128002831785297,
+          -2.7225403598649467
+         ],
+         "xaxis": "x3",
+         "y": [
+          1.0,
+          1.0,
+          2.5,
+          2.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.5814305953969994,
+          -3.5814305953969994,
+          -3.128002831785297
+         ],
+         "xaxis": "x3",
+         "y": [
+          0.0,
+          0.0,
+          1.75,
+          1.75
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -1.1391177036721927,
+          -1.1391177036721927,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          6.0,
+          6.0,
+          7.0,
+          7.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -1.3169267494297434,
+          -1.3169267494297434,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          8.0,
+          8.0,
+          9.0,
+          9.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -1.1391177036721927,
+          -1.6488299999287976,
+          -1.6488299999287976,
+          -1.3169267494297434
+         ],
+         "xaxis": "x3",
+         "y": [
+          6.5,
+          6.5,
+          8.5,
+          8.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.422883305748994,
+          -2.422883305748994,
+          -1.6488299999287976
+         ],
+         "xaxis": "x3",
+         "y": [
+          5.0,
+          5.0,
+          7.5,
+          7.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.750955579526704,
+          -3.750955579526704,
+          -2.422883305748994
+         ],
+         "xaxis": "x3",
+         "y": [
+          4.0,
+          4.0,
+          6.25,
+          6.25
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.5814305953969994,
+          -4.249894499111786,
+          -4.249894499111786,
+          -3.750955579526704
+         ],
+         "xaxis": "x3",
+         "y": [
+          0.875,
+          0.875,
+          5.125,
+          5.125
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.912415058509613,
+          -2.912415058509613,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          10.0,
+          10.0,
+          11.0,
+          11.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.5860446106880173,
+          -3.5860446106880173,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          12.0,
+          12.0,
+          13.0,
+          13.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.912415058509613,
+          -3.9318251499430943,
+          -3.9318251499430943,
+          -3.5860446106880173
+         ],
+         "xaxis": "x3",
+         "y": [
+          10.5,
+          10.5,
+          12.5,
+          12.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.2622346376760625,
+          -2.2622346376760625,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          14.0,
+          14.0,
+          15.0,
+          15.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -1.995254613705312,
+          -1.995254613705312,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          17.0,
+          17.0,
+          18.0,
+          18.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.2119806516635814,
+          -2.2119806516635814,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          19.0,
+          19.0,
+          20.0,
+          20.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -1.995254613705312,
+          -2.7843383962860644,
+          -2.7843383962860644,
+          -2.2119806516635814
+         ],
+         "xaxis": "x3",
+         "y": [
+          17.5,
+          17.5,
+          19.5,
+          19.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.5094550911914517,
+          -3.5094550911914517,
+          -2.7843383962860644
+         ],
+         "xaxis": "x3",
+         "y": [
+          16.0,
+          16.0,
+          18.5,
+          18.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.2622346376760625,
+          -4.233816887026965,
+          -4.233816887026965,
+          -3.5094550911914517
+         ],
+         "xaxis": "x3",
+         "y": [
+          14.5,
+          14.5,
+          17.25,
+          17.25
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.9318251499430943,
+          -5.3374007214179375,
+          -5.3374007214179375,
+          -4.233816887026965
+         ],
+         "xaxis": "x3",
+         "y": [
+          11.5,
+          11.5,
+          15.875,
+          15.875
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.7824466825953422,
+          -3.7824466825953422,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          21.0,
+          21.0,
+          22.0,
+          22.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -4.724967606161236,
+          -4.724967606161236,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          23.0,
+          23.0,
+          24.0,
+          24.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.7824466825953422,
+          -5.7088215298158005,
+          -5.7088215298158005,
+          -4.724967606161236
+         ],
+         "xaxis": "x3",
+         "y": [
+          21.5,
+          21.5,
+          23.5,
+          23.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.6372809929888463,
+          -3.6372809929888463,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          25.0,
+          25.0,
+          26.0,
+          26.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.7121080308711107,
+          -2.7121080308711107,
+          -0.0
+         ],
+         "xaxis": "x3",
+         "y": [
+          28.0,
+          28.0,
+          29.0,
+          29.0
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -4.785006467509484,
+          -4.785006467509484,
+          -2.7121080308711107
+         ],
+         "xaxis": "x3",
+         "y": [
+          27.0,
+          27.0,
+          28.5,
+          28.5
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.6372809929888463,
+          -5.99524130947591,
+          -5.99524130947591,
+          -4.785006467509484
+         ],
+         "xaxis": "x3",
+         "y": [
+          25.5,
+          25.5,
+          27.75,
+          27.75
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -5.7088215298158005,
+          -6.864001694694401,
+          -6.864001694694401,
+          -5.99524130947591
+         ],
+         "xaxis": "x3",
+         "y": [
+          22.5,
+          22.5,
+          26.625,
+          26.625
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -5.3374007214179375,
+          -9.132381849743231,
+          -9.132381849743231,
+          -6.864001694694401
+         ],
+         "xaxis": "x3",
+         "y": [
+          13.6875,
+          13.6875,
+          24.5625,
+          24.5625
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -4.249894499111786,
+          -15.583961337834326,
+          -15.583961337834326,
+          -9.132381849743231
+         ],
+         "xaxis": "x3",
+         "y": [
+          3.0,
+          3.0,
+          19.125,
+          19.125
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "colorscale": [
+          [
+           0.0,
+           "#E41A1C"
+          ],
+          [
+           0.5,
+           "#E41A1C"
+          ],
+          [
+           0.5,
+           "#FF7F00"
+          ],
+          [
+           1.0,
+           "#FF7F00"
+          ]
+         ],
+         "customdata": [
+          [
+           "Treated",
+           "Treated",
+           "Treated",
+           "Treated",
+           "Treated",
+           "Treated",
+           "Control",
+           "Control",
+           "Control",
+           "Control",
+           "Control",
+           "Control"
+          ]
+         ],
+         "hovertemplate": "group: %{customdata}<extra></extra>",
+         "showscale": false,
+         "type": "heatmap",
+         "x": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZA",
+          "dtype": "f8"
+         },
+         "xaxis": "x2",
+         "xgap": 1,
+         "y": [
+          "group"
+         ],
+         "yaxis": "y2",
+         "ygap": 1,
+         "z": {
+          "bdata": "AQEBAQEBAAAAAAAA",
+          "dtype": "i1",
+          "shape": "1, 12"
+         },
+         "zmax": 1.5,
+         "zmin": -0.5
+        },
+        {
+         "colorscale": [
+          [
+           0.0,
+           "#377EB8"
+          ],
+          [
+           0.3333333333333333,
+           "#377EB8"
+          ],
+          [
+           0.3333333333333333,
+           "#4DAF4A"
+          ],
+          [
+           0.6666666666666666,
+           "#4DAF4A"
+          ],
+          [
+           0.6666666666666666,
+           "#984EA3"
+          ],
+          [
+           1.0,
+           "#984EA3"
+          ]
+         ],
+         "customdata": [
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Metabolism"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Signaling"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ],
+          [
+           "Other"
+          ]
+         ],
+         "hovertemplate": "pathway: %{customdata}<extra></extra>",
+         "showscale": false,
+         "type": "heatmap",
+         "x": [
+          "pathway"
+         ],
+         "xaxis": "x5",
+         "xgap": 1,
+         "y": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQAAAAAAAADRAAAAAAAAANUAAAAAAAAA2QAAAAAAAADdAAAAAAAAAOEAAAAAAAAA5QAAAAAAAADpAAAAAAAAAO0AAAAAAAAA8QAAAAAAAAD1A",
+          "dtype": "f8"
+         },
+         "yaxis": "y5",
+         "ygap": 1,
+         "z": {
+          "bdata": "AAAAAAAAAAAAAAICAgECAgICAgICAQEBAQEBAQEB",
+          "dtype": "i1",
+          "shape": "30, 1"
+         },
+         "zmax": 2.5,
+         "zmin": -0.5
+        },
+        {
+         "legendgroup": "group",
+         "legendgrouptitle": {
+          "text": "group"
+         },
+         "marker": {
+          "color": "#E41A1C",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "group: Control",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "group",
+         "legendgrouptitle": {
+          "text": "group"
+         },
+         "marker": {
+          "color": "#FF7F00",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "group: Treated",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "pathway",
+         "legendgrouptitle": {
+          "text": "pathway"
+         },
+         "marker": {
+          "color": "#377EB8",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "pathway: Metabolism",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "pathway",
+         "legendgrouptitle": {
+          "text": "pathway"
+         },
+         "marker": {
+          "color": "#4DAF4A",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "pathway: Other",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "pathway",
+         "legendgrouptitle": {
+          "text": "pathway"
+         },
+         "marker": {
+          "color": "#984EA3",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "pathway: Signaling",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        }
+       ],
+       "layout": {
+        "barmode": "stack",
+        "font": {
+         "family": "Arial, Helvetica, sans-serif",
+         "size": 11
+        },
+        "height": 700,
+        "legend": {
+         "bgcolor": "rgba(255,255,255,0.8)",
+         "bordercolor": "#cccccc",
+         "borderwidth": 1,
+         "font": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 10
+         },
+         "itemsizing": "constant",
+         "tracegroupgap": 8,
+         "x": 1.13,
+         "xanchor": "left",
+         "y": 1.0,
+         "yanchor": "top"
+        },
+        "margin": {
+         "b": 5,
+         "l": 5,
+         "r": 229,
+         "t": 65
+        },
+        "paper_bgcolor": "white",
+        "plot_bgcolor": "rgba(0,0,0,0)",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 16
+         },
+         "subtitle": {
+          "font": {
+           "color": "#666666",
+           "family": "Arial, Helvetica, sans-serif",
+           "size": 12
+          },
+          "text": "Clustered heatmap with treatment groups and pathway annotations"
+         },
+         "text": "Gene Expression Analysis",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0.0926,
+          0.96075
+         ],
+         "matches": "x4",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.0926,
+          0.96075
+         ],
+         "matches": "x4",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "domain": [
+          0.0,
+          0.0776
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "xaxis4": {
+         "anchor": "y4",
+         "domain": [
+          0.0926,
+          0.96075
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": true,
+         "side": "bottom",
+         "tickangle": -45,
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 10
+         },
+         "ticktext": [
+          "sample_09",
+          "sample_10",
+          "sample_06",
+          "sample_07",
+          "sample_08",
+          "sample_11",
+          "sample_00",
+          "sample_01",
+          "sample_05",
+          "sample_04",
+          "sample_02",
+          "sample_03"
+         ],
+         "tickvals": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11
+         ],
+         "zeroline": false
+        },
+        "xaxis5": {
+         "anchor": "y5",
+         "domain": [
+          0.97575,
+          1.0
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": true,
+         "tickangle": -90,
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 9
+         },
+         "ticktext": [
+          "pathway"
+         ],
+         "tickvals": [
+          "pathway"
+         ],
+         "zeroline": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0.92128,
+          1.0
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.88868,
+          0.91328
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "autorange": false,
+         "domain": [
+          0.0,
+          0.88068
+         ],
+         "range": [
+          29.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis4": {
+         "anchor": "x4",
+         "autorange": false,
+         "domain": [
+          0.0,
+          0.88068
+         ],
+         "matches": "y3",
+         "range": [
+          29.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis5": {
+         "anchor": "x5",
+         "autorange": false,
+         "domain": [
+          0.0,
+          0.88068
+         ],
+         "matches": "y3",
+         "range": [
+          29.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": true,
+         "side": "right",
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 9
+         },
+         "ticktext": [
+          "gene_09",
+          "gene_05",
+          "gene_00",
+          "gene_08",
+          "gene_07",
+          "gene_04",
+          "gene_02",
+          "gene_06",
+          "gene_01",
+          "gene_03",
+          "gene_11",
+          "gene_17",
+          "gene_19",
+          "gene_21",
+          "gene_10",
+          "gene_16",
+          "gene_15",
+          "gene_12",
+          "gene_18",
+          "gene_13",
+          "gene_14",
+          "gene_24",
+          "gene_25",
+          "gene_26",
+          "gene_28",
+          "gene_20",
+          "gene_27",
+          "gene_23",
+          "gene_22",
+          "gene_29"
+         ],
+         "tickvals": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29
+         ],
+         "zeroline": false
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 30x12 matrix with row/column annotations\n",
+    "n_genes, n_samples = 30, 12\n",
+    "med_data = rng.standard_normal((n_genes, n_samples))\n",
+    "med_data[:10, :6] += 2.5\n",
+    "med_data[10:20, 6:] += 1.8\n",
+    "\n",
+    "df_med = pd.DataFrame(\n",
+    "    med_data,\n",
+    "    index=[f\"gene_{i:02d}\" for i in range(n_genes)],\n",
+    "    columns=[f\"sample_{j:02d}\" for j in range(n_samples)],\n",
+    ")\n",
+    "\n",
+    "# Column annotation: treatment group\n",
+    "groups = [\"Control\"] * 6 + [\"Treated\"] * 6\n",
+    "top_ha = HeatmapAnnotation(group=groups)\n",
+    "\n",
+    "# Row annotation: pathway\n",
+    "pathways = [\"Metabolism\"] * 10 + [\"Signaling\"] * 10 + [\"Other\"] * 10\n",
+    "right_ha = HeatmapAnnotation(pathway=pathways, which=\"row\")\n",
+    "\n",
+    "hm2 = ComplexHeatmap(\n",
+    "    df_med,\n",
+    "    cluster_rows=True,\n",
+    "    cluster_cols=True,\n",
+    "    top_annotation=top_ha,\n",
+    "    right_annotation=right_ha,\n",
+    "    colorscale=\"RdBu_r\",\n",
+    "    normalize=\"row\",\n",
+    "    name=\"z-score\",\n",
+    "    title=\"Gene Expression Analysis\",\n",
+    "    description=\"Clustered heatmap with treatment groups and pathway annotations\",\n",
+    "    width=900,\n",
+    "    height=700,\n",
+    ")\n",
+    "fig2 = hm2.to_plotly()\n",
+    "fig2.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Large heatmap — title + description, multiple annotation tracks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-03T16:51:59.476557Z",
+     "iopub.status.busy": "2026-03-03T16:51:59.476389Z",
+     "iopub.status.idle": "2026-03-03T16:51:59.626727Z",
+     "shell.execute_reply": "2026-03-03T16:51:59.624445Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "colorbar": {
+          "len": 0.3,
+          "outlinewidth": 0,
+          "thickness": 12,
+          "tickfont": {
+           "family": "Arial, Helvetica, sans-serif",
+           "size": 9
+          },
+          "title": {
+           "font": {
+            "family": "Arial, Helvetica, sans-serif",
+            "size": 10
+           },
+           "text": "expression"
+          },
+          "x": 1.0572727272727274,
+          "xpad": 4,
+          "y": 0.5
+         },
+         "colorscale": [
+          [
+           0.0,
+           "#440154"
+          ],
+          [
+           0.1111111111111111,
+           "#482878"
+          ],
+          [
+           0.2222222222222222,
+           "#3e4989"
+          ],
+          [
+           0.3333333333333333,
+           "#31688e"
+          ],
+          [
+           0.4444444444444444,
+           "#26828e"
+          ],
+          [
+           0.5555555555555556,
+           "#1f9e89"
+          ],
+          [
+           0.6666666666666666,
+           "#35b779"
+          ],
+          [
+           0.7777777777777778,
+           "#6ece58"
+          ],
+          [
+           0.8888888888888888,
+           "#b5de2b"
+          ],
+          [
+           1.0,
+           "#fde725"
+          ]
+         ],
+         "customdata": [
+          [
+           [
+            "gene_015",
+            "sample_00"
+           ],
+           [
+            "gene_015",
+            "sample_01"
+           ],
+           [
+            "gene_015",
+            "sample_04"
+           ],
+           [
+            "gene_015",
+            "sample_05"
+           ],
+           [
+            "gene_015",
+            "sample_06"
+           ],
+           [
+            "gene_015",
+            "sample_02"
+           ],
+           [
+            "gene_015",
+            "sample_03"
+           ],
+           [
+            "gene_015",
+            "sample_08"
+           ],
+           [
+            "gene_015",
+            "sample_11"
+           ],
+           [
+            "gene_015",
+            "sample_13"
+           ],
+           [
+            "gene_015",
+            "sample_10"
+           ],
+           [
+            "gene_015",
+            "sample_07"
+           ],
+           [
+            "gene_015",
+            "sample_09"
+           ],
+           [
+            "gene_015",
+            "sample_12"
+           ],
+           [
+            "gene_015",
+            "sample_17"
+           ],
+           [
+            "gene_015",
+            "sample_14"
+           ],
+           [
+            "gene_015",
+            "sample_15"
+           ],
+           [
+            "gene_015",
+            "sample_16"
+           ],
+           [
+            "gene_015",
+            "sample_18"
+           ],
+           [
+            "gene_015",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_004",
+            "sample_00"
+           ],
+           [
+            "gene_004",
+            "sample_01"
+           ],
+           [
+            "gene_004",
+            "sample_04"
+           ],
+           [
+            "gene_004",
+            "sample_05"
+           ],
+           [
+            "gene_004",
+            "sample_06"
+           ],
+           [
+            "gene_004",
+            "sample_02"
+           ],
+           [
+            "gene_004",
+            "sample_03"
+           ],
+           [
+            "gene_004",
+            "sample_08"
+           ],
+           [
+            "gene_004",
+            "sample_11"
+           ],
+           [
+            "gene_004",
+            "sample_13"
+           ],
+           [
+            "gene_004",
+            "sample_10"
+           ],
+           [
+            "gene_004",
+            "sample_07"
+           ],
+           [
+            "gene_004",
+            "sample_09"
+           ],
+           [
+            "gene_004",
+            "sample_12"
+           ],
+           [
+            "gene_004",
+            "sample_17"
+           ],
+           [
+            "gene_004",
+            "sample_14"
+           ],
+           [
+            "gene_004",
+            "sample_15"
+           ],
+           [
+            "gene_004",
+            "sample_16"
+           ],
+           [
+            "gene_004",
+            "sample_18"
+           ],
+           [
+            "gene_004",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_016",
+            "sample_00"
+           ],
+           [
+            "gene_016",
+            "sample_01"
+           ],
+           [
+            "gene_016",
+            "sample_04"
+           ],
+           [
+            "gene_016",
+            "sample_05"
+           ],
+           [
+            "gene_016",
+            "sample_06"
+           ],
+           [
+            "gene_016",
+            "sample_02"
+           ],
+           [
+            "gene_016",
+            "sample_03"
+           ],
+           [
+            "gene_016",
+            "sample_08"
+           ],
+           [
+            "gene_016",
+            "sample_11"
+           ],
+           [
+            "gene_016",
+            "sample_13"
+           ],
+           [
+            "gene_016",
+            "sample_10"
+           ],
+           [
+            "gene_016",
+            "sample_07"
+           ],
+           [
+            "gene_016",
+            "sample_09"
+           ],
+           [
+            "gene_016",
+            "sample_12"
+           ],
+           [
+            "gene_016",
+            "sample_17"
+           ],
+           [
+            "gene_016",
+            "sample_14"
+           ],
+           [
+            "gene_016",
+            "sample_15"
+           ],
+           [
+            "gene_016",
+            "sample_16"
+           ],
+           [
+            "gene_016",
+            "sample_18"
+           ],
+           [
+            "gene_016",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_012",
+            "sample_00"
+           ],
+           [
+            "gene_012",
+            "sample_01"
+           ],
+           [
+            "gene_012",
+            "sample_04"
+           ],
+           [
+            "gene_012",
+            "sample_05"
+           ],
+           [
+            "gene_012",
+            "sample_06"
+           ],
+           [
+            "gene_012",
+            "sample_02"
+           ],
+           [
+            "gene_012",
+            "sample_03"
+           ],
+           [
+            "gene_012",
+            "sample_08"
+           ],
+           [
+            "gene_012",
+            "sample_11"
+           ],
+           [
+            "gene_012",
+            "sample_13"
+           ],
+           [
+            "gene_012",
+            "sample_10"
+           ],
+           [
+            "gene_012",
+            "sample_07"
+           ],
+           [
+            "gene_012",
+            "sample_09"
+           ],
+           [
+            "gene_012",
+            "sample_12"
+           ],
+           [
+            "gene_012",
+            "sample_17"
+           ],
+           [
+            "gene_012",
+            "sample_14"
+           ],
+           [
+            "gene_012",
+            "sample_15"
+           ],
+           [
+            "gene_012",
+            "sample_16"
+           ],
+           [
+            "gene_012",
+            "sample_18"
+           ],
+           [
+            "gene_012",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_014",
+            "sample_00"
+           ],
+           [
+            "gene_014",
+            "sample_01"
+           ],
+           [
+            "gene_014",
+            "sample_04"
+           ],
+           [
+            "gene_014",
+            "sample_05"
+           ],
+           [
+            "gene_014",
+            "sample_06"
+           ],
+           [
+            "gene_014",
+            "sample_02"
+           ],
+           [
+            "gene_014",
+            "sample_03"
+           ],
+           [
+            "gene_014",
+            "sample_08"
+           ],
+           [
+            "gene_014",
+            "sample_11"
+           ],
+           [
+            "gene_014",
+            "sample_13"
+           ],
+           [
+            "gene_014",
+            "sample_10"
+           ],
+           [
+            "gene_014",
+            "sample_07"
+           ],
+           [
+            "gene_014",
+            "sample_09"
+           ],
+           [
+            "gene_014",
+            "sample_12"
+           ],
+           [
+            "gene_014",
+            "sample_17"
+           ],
+           [
+            "gene_014",
+            "sample_14"
+           ],
+           [
+            "gene_014",
+            "sample_15"
+           ],
+           [
+            "gene_014",
+            "sample_16"
+           ],
+           [
+            "gene_014",
+            "sample_18"
+           ],
+           [
+            "gene_014",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_009",
+            "sample_00"
+           ],
+           [
+            "gene_009",
+            "sample_01"
+           ],
+           [
+            "gene_009",
+            "sample_04"
+           ],
+           [
+            "gene_009",
+            "sample_05"
+           ],
+           [
+            "gene_009",
+            "sample_06"
+           ],
+           [
+            "gene_009",
+            "sample_02"
+           ],
+           [
+            "gene_009",
+            "sample_03"
+           ],
+           [
+            "gene_009",
+            "sample_08"
+           ],
+           [
+            "gene_009",
+            "sample_11"
+           ],
+           [
+            "gene_009",
+            "sample_13"
+           ],
+           [
+            "gene_009",
+            "sample_10"
+           ],
+           [
+            "gene_009",
+            "sample_07"
+           ],
+           [
+            "gene_009",
+            "sample_09"
+           ],
+           [
+            "gene_009",
+            "sample_12"
+           ],
+           [
+            "gene_009",
+            "sample_17"
+           ],
+           [
+            "gene_009",
+            "sample_14"
+           ],
+           [
+            "gene_009",
+            "sample_15"
+           ],
+           [
+            "gene_009",
+            "sample_16"
+           ],
+           [
+            "gene_009",
+            "sample_18"
+           ],
+           [
+            "gene_009",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_006",
+            "sample_00"
+           ],
+           [
+            "gene_006",
+            "sample_01"
+           ],
+           [
+            "gene_006",
+            "sample_04"
+           ],
+           [
+            "gene_006",
+            "sample_05"
+           ],
+           [
+            "gene_006",
+            "sample_06"
+           ],
+           [
+            "gene_006",
+            "sample_02"
+           ],
+           [
+            "gene_006",
+            "sample_03"
+           ],
+           [
+            "gene_006",
+            "sample_08"
+           ],
+           [
+            "gene_006",
+            "sample_11"
+           ],
+           [
+            "gene_006",
+            "sample_13"
+           ],
+           [
+            "gene_006",
+            "sample_10"
+           ],
+           [
+            "gene_006",
+            "sample_07"
+           ],
+           [
+            "gene_006",
+            "sample_09"
+           ],
+           [
+            "gene_006",
+            "sample_12"
+           ],
+           [
+            "gene_006",
+            "sample_17"
+           ],
+           [
+            "gene_006",
+            "sample_14"
+           ],
+           [
+            "gene_006",
+            "sample_15"
+           ],
+           [
+            "gene_006",
+            "sample_16"
+           ],
+           [
+            "gene_006",
+            "sample_18"
+           ],
+           [
+            "gene_006",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_007",
+            "sample_00"
+           ],
+           [
+            "gene_007",
+            "sample_01"
+           ],
+           [
+            "gene_007",
+            "sample_04"
+           ],
+           [
+            "gene_007",
+            "sample_05"
+           ],
+           [
+            "gene_007",
+            "sample_06"
+           ],
+           [
+            "gene_007",
+            "sample_02"
+           ],
+           [
+            "gene_007",
+            "sample_03"
+           ],
+           [
+            "gene_007",
+            "sample_08"
+           ],
+           [
+            "gene_007",
+            "sample_11"
+           ],
+           [
+            "gene_007",
+            "sample_13"
+           ],
+           [
+            "gene_007",
+            "sample_10"
+           ],
+           [
+            "gene_007",
+            "sample_07"
+           ],
+           [
+            "gene_007",
+            "sample_09"
+           ],
+           [
+            "gene_007",
+            "sample_12"
+           ],
+           [
+            "gene_007",
+            "sample_17"
+           ],
+           [
+            "gene_007",
+            "sample_14"
+           ],
+           [
+            "gene_007",
+            "sample_15"
+           ],
+           [
+            "gene_007",
+            "sample_16"
+           ],
+           [
+            "gene_007",
+            "sample_18"
+           ],
+           [
+            "gene_007",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_018",
+            "sample_00"
+           ],
+           [
+            "gene_018",
+            "sample_01"
+           ],
+           [
+            "gene_018",
+            "sample_04"
+           ],
+           [
+            "gene_018",
+            "sample_05"
+           ],
+           [
+            "gene_018",
+            "sample_06"
+           ],
+           [
+            "gene_018",
+            "sample_02"
+           ],
+           [
+            "gene_018",
+            "sample_03"
+           ],
+           [
+            "gene_018",
+            "sample_08"
+           ],
+           [
+            "gene_018",
+            "sample_11"
+           ],
+           [
+            "gene_018",
+            "sample_13"
+           ],
+           [
+            "gene_018",
+            "sample_10"
+           ],
+           [
+            "gene_018",
+            "sample_07"
+           ],
+           [
+            "gene_018",
+            "sample_09"
+           ],
+           [
+            "gene_018",
+            "sample_12"
+           ],
+           [
+            "gene_018",
+            "sample_17"
+           ],
+           [
+            "gene_018",
+            "sample_14"
+           ],
+           [
+            "gene_018",
+            "sample_15"
+           ],
+           [
+            "gene_018",
+            "sample_16"
+           ],
+           [
+            "gene_018",
+            "sample_18"
+           ],
+           [
+            "gene_018",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_011",
+            "sample_00"
+           ],
+           [
+            "gene_011",
+            "sample_01"
+           ],
+           [
+            "gene_011",
+            "sample_04"
+           ],
+           [
+            "gene_011",
+            "sample_05"
+           ],
+           [
+            "gene_011",
+            "sample_06"
+           ],
+           [
+            "gene_011",
+            "sample_02"
+           ],
+           [
+            "gene_011",
+            "sample_03"
+           ],
+           [
+            "gene_011",
+            "sample_08"
+           ],
+           [
+            "gene_011",
+            "sample_11"
+           ],
+           [
+            "gene_011",
+            "sample_13"
+           ],
+           [
+            "gene_011",
+            "sample_10"
+           ],
+           [
+            "gene_011",
+            "sample_07"
+           ],
+           [
+            "gene_011",
+            "sample_09"
+           ],
+           [
+            "gene_011",
+            "sample_12"
+           ],
+           [
+            "gene_011",
+            "sample_17"
+           ],
+           [
+            "gene_011",
+            "sample_14"
+           ],
+           [
+            "gene_011",
+            "sample_15"
+           ],
+           [
+            "gene_011",
+            "sample_16"
+           ],
+           [
+            "gene_011",
+            "sample_18"
+           ],
+           [
+            "gene_011",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_013",
+            "sample_00"
+           ],
+           [
+            "gene_013",
+            "sample_01"
+           ],
+           [
+            "gene_013",
+            "sample_04"
+           ],
+           [
+            "gene_013",
+            "sample_05"
+           ],
+           [
+            "gene_013",
+            "sample_06"
+           ],
+           [
+            "gene_013",
+            "sample_02"
+           ],
+           [
+            "gene_013",
+            "sample_03"
+           ],
+           [
+            "gene_013",
+            "sample_08"
+           ],
+           [
+            "gene_013",
+            "sample_11"
+           ],
+           [
+            "gene_013",
+            "sample_13"
+           ],
+           [
+            "gene_013",
+            "sample_10"
+           ],
+           [
+            "gene_013",
+            "sample_07"
+           ],
+           [
+            "gene_013",
+            "sample_09"
+           ],
+           [
+            "gene_013",
+            "sample_12"
+           ],
+           [
+            "gene_013",
+            "sample_17"
+           ],
+           [
+            "gene_013",
+            "sample_14"
+           ],
+           [
+            "gene_013",
+            "sample_15"
+           ],
+           [
+            "gene_013",
+            "sample_16"
+           ],
+           [
+            "gene_013",
+            "sample_18"
+           ],
+           [
+            "gene_013",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_008",
+            "sample_00"
+           ],
+           [
+            "gene_008",
+            "sample_01"
+           ],
+           [
+            "gene_008",
+            "sample_04"
+           ],
+           [
+            "gene_008",
+            "sample_05"
+           ],
+           [
+            "gene_008",
+            "sample_06"
+           ],
+           [
+            "gene_008",
+            "sample_02"
+           ],
+           [
+            "gene_008",
+            "sample_03"
+           ],
+           [
+            "gene_008",
+            "sample_08"
+           ],
+           [
+            "gene_008",
+            "sample_11"
+           ],
+           [
+            "gene_008",
+            "sample_13"
+           ],
+           [
+            "gene_008",
+            "sample_10"
+           ],
+           [
+            "gene_008",
+            "sample_07"
+           ],
+           [
+            "gene_008",
+            "sample_09"
+           ],
+           [
+            "gene_008",
+            "sample_12"
+           ],
+           [
+            "gene_008",
+            "sample_17"
+           ],
+           [
+            "gene_008",
+            "sample_14"
+           ],
+           [
+            "gene_008",
+            "sample_15"
+           ],
+           [
+            "gene_008",
+            "sample_16"
+           ],
+           [
+            "gene_008",
+            "sample_18"
+           ],
+           [
+            "gene_008",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_019",
+            "sample_00"
+           ],
+           [
+            "gene_019",
+            "sample_01"
+           ],
+           [
+            "gene_019",
+            "sample_04"
+           ],
+           [
+            "gene_019",
+            "sample_05"
+           ],
+           [
+            "gene_019",
+            "sample_06"
+           ],
+           [
+            "gene_019",
+            "sample_02"
+           ],
+           [
+            "gene_019",
+            "sample_03"
+           ],
+           [
+            "gene_019",
+            "sample_08"
+           ],
+           [
+            "gene_019",
+            "sample_11"
+           ],
+           [
+            "gene_019",
+            "sample_13"
+           ],
+           [
+            "gene_019",
+            "sample_10"
+           ],
+           [
+            "gene_019",
+            "sample_07"
+           ],
+           [
+            "gene_019",
+            "sample_09"
+           ],
+           [
+            "gene_019",
+            "sample_12"
+           ],
+           [
+            "gene_019",
+            "sample_17"
+           ],
+           [
+            "gene_019",
+            "sample_14"
+           ],
+           [
+            "gene_019",
+            "sample_15"
+           ],
+           [
+            "gene_019",
+            "sample_16"
+           ],
+           [
+            "gene_019",
+            "sample_18"
+           ],
+           [
+            "gene_019",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_000",
+            "sample_00"
+           ],
+           [
+            "gene_000",
+            "sample_01"
+           ],
+           [
+            "gene_000",
+            "sample_04"
+           ],
+           [
+            "gene_000",
+            "sample_05"
+           ],
+           [
+            "gene_000",
+            "sample_06"
+           ],
+           [
+            "gene_000",
+            "sample_02"
+           ],
+           [
+            "gene_000",
+            "sample_03"
+           ],
+           [
+            "gene_000",
+            "sample_08"
+           ],
+           [
+            "gene_000",
+            "sample_11"
+           ],
+           [
+            "gene_000",
+            "sample_13"
+           ],
+           [
+            "gene_000",
+            "sample_10"
+           ],
+           [
+            "gene_000",
+            "sample_07"
+           ],
+           [
+            "gene_000",
+            "sample_09"
+           ],
+           [
+            "gene_000",
+            "sample_12"
+           ],
+           [
+            "gene_000",
+            "sample_17"
+           ],
+           [
+            "gene_000",
+            "sample_14"
+           ],
+           [
+            "gene_000",
+            "sample_15"
+           ],
+           [
+            "gene_000",
+            "sample_16"
+           ],
+           [
+            "gene_000",
+            "sample_18"
+           ],
+           [
+            "gene_000",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_002",
+            "sample_00"
+           ],
+           [
+            "gene_002",
+            "sample_01"
+           ],
+           [
+            "gene_002",
+            "sample_04"
+           ],
+           [
+            "gene_002",
+            "sample_05"
+           ],
+           [
+            "gene_002",
+            "sample_06"
+           ],
+           [
+            "gene_002",
+            "sample_02"
+           ],
+           [
+            "gene_002",
+            "sample_03"
+           ],
+           [
+            "gene_002",
+            "sample_08"
+           ],
+           [
+            "gene_002",
+            "sample_11"
+           ],
+           [
+            "gene_002",
+            "sample_13"
+           ],
+           [
+            "gene_002",
+            "sample_10"
+           ],
+           [
+            "gene_002",
+            "sample_07"
+           ],
+           [
+            "gene_002",
+            "sample_09"
+           ],
+           [
+            "gene_002",
+            "sample_12"
+           ],
+           [
+            "gene_002",
+            "sample_17"
+           ],
+           [
+            "gene_002",
+            "sample_14"
+           ],
+           [
+            "gene_002",
+            "sample_15"
+           ],
+           [
+            "gene_002",
+            "sample_16"
+           ],
+           [
+            "gene_002",
+            "sample_18"
+           ],
+           [
+            "gene_002",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_017",
+            "sample_00"
+           ],
+           [
+            "gene_017",
+            "sample_01"
+           ],
+           [
+            "gene_017",
+            "sample_04"
+           ],
+           [
+            "gene_017",
+            "sample_05"
+           ],
+           [
+            "gene_017",
+            "sample_06"
+           ],
+           [
+            "gene_017",
+            "sample_02"
+           ],
+           [
+            "gene_017",
+            "sample_03"
+           ],
+           [
+            "gene_017",
+            "sample_08"
+           ],
+           [
+            "gene_017",
+            "sample_11"
+           ],
+           [
+            "gene_017",
+            "sample_13"
+           ],
+           [
+            "gene_017",
+            "sample_10"
+           ],
+           [
+            "gene_017",
+            "sample_07"
+           ],
+           [
+            "gene_017",
+            "sample_09"
+           ],
+           [
+            "gene_017",
+            "sample_12"
+           ],
+           [
+            "gene_017",
+            "sample_17"
+           ],
+           [
+            "gene_017",
+            "sample_14"
+           ],
+           [
+            "gene_017",
+            "sample_15"
+           ],
+           [
+            "gene_017",
+            "sample_16"
+           ],
+           [
+            "gene_017",
+            "sample_18"
+           ],
+           [
+            "gene_017",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_001",
+            "sample_00"
+           ],
+           [
+            "gene_001",
+            "sample_01"
+           ],
+           [
+            "gene_001",
+            "sample_04"
+           ],
+           [
+            "gene_001",
+            "sample_05"
+           ],
+           [
+            "gene_001",
+            "sample_06"
+           ],
+           [
+            "gene_001",
+            "sample_02"
+           ],
+           [
+            "gene_001",
+            "sample_03"
+           ],
+           [
+            "gene_001",
+            "sample_08"
+           ],
+           [
+            "gene_001",
+            "sample_11"
+           ],
+           [
+            "gene_001",
+            "sample_13"
+           ],
+           [
+            "gene_001",
+            "sample_10"
+           ],
+           [
+            "gene_001",
+            "sample_07"
+           ],
+           [
+            "gene_001",
+            "sample_09"
+           ],
+           [
+            "gene_001",
+            "sample_12"
+           ],
+           [
+            "gene_001",
+            "sample_17"
+           ],
+           [
+            "gene_001",
+            "sample_14"
+           ],
+           [
+            "gene_001",
+            "sample_15"
+           ],
+           [
+            "gene_001",
+            "sample_16"
+           ],
+           [
+            "gene_001",
+            "sample_18"
+           ],
+           [
+            "gene_001",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_005",
+            "sample_00"
+           ],
+           [
+            "gene_005",
+            "sample_01"
+           ],
+           [
+            "gene_005",
+            "sample_04"
+           ],
+           [
+            "gene_005",
+            "sample_05"
+           ],
+           [
+            "gene_005",
+            "sample_06"
+           ],
+           [
+            "gene_005",
+            "sample_02"
+           ],
+           [
+            "gene_005",
+            "sample_03"
+           ],
+           [
+            "gene_005",
+            "sample_08"
+           ],
+           [
+            "gene_005",
+            "sample_11"
+           ],
+           [
+            "gene_005",
+            "sample_13"
+           ],
+           [
+            "gene_005",
+            "sample_10"
+           ],
+           [
+            "gene_005",
+            "sample_07"
+           ],
+           [
+            "gene_005",
+            "sample_09"
+           ],
+           [
+            "gene_005",
+            "sample_12"
+           ],
+           [
+            "gene_005",
+            "sample_17"
+           ],
+           [
+            "gene_005",
+            "sample_14"
+           ],
+           [
+            "gene_005",
+            "sample_15"
+           ],
+           [
+            "gene_005",
+            "sample_16"
+           ],
+           [
+            "gene_005",
+            "sample_18"
+           ],
+           [
+            "gene_005",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_003",
+            "sample_00"
+           ],
+           [
+            "gene_003",
+            "sample_01"
+           ],
+           [
+            "gene_003",
+            "sample_04"
+           ],
+           [
+            "gene_003",
+            "sample_05"
+           ],
+           [
+            "gene_003",
+            "sample_06"
+           ],
+           [
+            "gene_003",
+            "sample_02"
+           ],
+           [
+            "gene_003",
+            "sample_03"
+           ],
+           [
+            "gene_003",
+            "sample_08"
+           ],
+           [
+            "gene_003",
+            "sample_11"
+           ],
+           [
+            "gene_003",
+            "sample_13"
+           ],
+           [
+            "gene_003",
+            "sample_10"
+           ],
+           [
+            "gene_003",
+            "sample_07"
+           ],
+           [
+            "gene_003",
+            "sample_09"
+           ],
+           [
+            "gene_003",
+            "sample_12"
+           ],
+           [
+            "gene_003",
+            "sample_17"
+           ],
+           [
+            "gene_003",
+            "sample_14"
+           ],
+           [
+            "gene_003",
+            "sample_15"
+           ],
+           [
+            "gene_003",
+            "sample_16"
+           ],
+           [
+            "gene_003",
+            "sample_18"
+           ],
+           [
+            "gene_003",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_010",
+            "sample_00"
+           ],
+           [
+            "gene_010",
+            "sample_01"
+           ],
+           [
+            "gene_010",
+            "sample_04"
+           ],
+           [
+            "gene_010",
+            "sample_05"
+           ],
+           [
+            "gene_010",
+            "sample_06"
+           ],
+           [
+            "gene_010",
+            "sample_02"
+           ],
+           [
+            "gene_010",
+            "sample_03"
+           ],
+           [
+            "gene_010",
+            "sample_08"
+           ],
+           [
+            "gene_010",
+            "sample_11"
+           ],
+           [
+            "gene_010",
+            "sample_13"
+           ],
+           [
+            "gene_010",
+            "sample_10"
+           ],
+           [
+            "gene_010",
+            "sample_07"
+           ],
+           [
+            "gene_010",
+            "sample_09"
+           ],
+           [
+            "gene_010",
+            "sample_12"
+           ],
+           [
+            "gene_010",
+            "sample_17"
+           ],
+           [
+            "gene_010",
+            "sample_14"
+           ],
+           [
+            "gene_010",
+            "sample_15"
+           ],
+           [
+            "gene_010",
+            "sample_16"
+           ],
+           [
+            "gene_010",
+            "sample_18"
+           ],
+           [
+            "gene_010",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_041",
+            "sample_00"
+           ],
+           [
+            "gene_041",
+            "sample_01"
+           ],
+           [
+            "gene_041",
+            "sample_04"
+           ],
+           [
+            "gene_041",
+            "sample_05"
+           ],
+           [
+            "gene_041",
+            "sample_06"
+           ],
+           [
+            "gene_041",
+            "sample_02"
+           ],
+           [
+            "gene_041",
+            "sample_03"
+           ],
+           [
+            "gene_041",
+            "sample_08"
+           ],
+           [
+            "gene_041",
+            "sample_11"
+           ],
+           [
+            "gene_041",
+            "sample_13"
+           ],
+           [
+            "gene_041",
+            "sample_10"
+           ],
+           [
+            "gene_041",
+            "sample_07"
+           ],
+           [
+            "gene_041",
+            "sample_09"
+           ],
+           [
+            "gene_041",
+            "sample_12"
+           ],
+           [
+            "gene_041",
+            "sample_17"
+           ],
+           [
+            "gene_041",
+            "sample_14"
+           ],
+           [
+            "gene_041",
+            "sample_15"
+           ],
+           [
+            "gene_041",
+            "sample_16"
+           ],
+           [
+            "gene_041",
+            "sample_18"
+           ],
+           [
+            "gene_041",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_050",
+            "sample_00"
+           ],
+           [
+            "gene_050",
+            "sample_01"
+           ],
+           [
+            "gene_050",
+            "sample_04"
+           ],
+           [
+            "gene_050",
+            "sample_05"
+           ],
+           [
+            "gene_050",
+            "sample_06"
+           ],
+           [
+            "gene_050",
+            "sample_02"
+           ],
+           [
+            "gene_050",
+            "sample_03"
+           ],
+           [
+            "gene_050",
+            "sample_08"
+           ],
+           [
+            "gene_050",
+            "sample_11"
+           ],
+           [
+            "gene_050",
+            "sample_13"
+           ],
+           [
+            "gene_050",
+            "sample_10"
+           ],
+           [
+            "gene_050",
+            "sample_07"
+           ],
+           [
+            "gene_050",
+            "sample_09"
+           ],
+           [
+            "gene_050",
+            "sample_12"
+           ],
+           [
+            "gene_050",
+            "sample_17"
+           ],
+           [
+            "gene_050",
+            "sample_14"
+           ],
+           [
+            "gene_050",
+            "sample_15"
+           ],
+           [
+            "gene_050",
+            "sample_16"
+           ],
+           [
+            "gene_050",
+            "sample_18"
+           ],
+           [
+            "gene_050",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_052",
+            "sample_00"
+           ],
+           [
+            "gene_052",
+            "sample_01"
+           ],
+           [
+            "gene_052",
+            "sample_04"
+           ],
+           [
+            "gene_052",
+            "sample_05"
+           ],
+           [
+            "gene_052",
+            "sample_06"
+           ],
+           [
+            "gene_052",
+            "sample_02"
+           ],
+           [
+            "gene_052",
+            "sample_03"
+           ],
+           [
+            "gene_052",
+            "sample_08"
+           ],
+           [
+            "gene_052",
+            "sample_11"
+           ],
+           [
+            "gene_052",
+            "sample_13"
+           ],
+           [
+            "gene_052",
+            "sample_10"
+           ],
+           [
+            "gene_052",
+            "sample_07"
+           ],
+           [
+            "gene_052",
+            "sample_09"
+           ],
+           [
+            "gene_052",
+            "sample_12"
+           ],
+           [
+            "gene_052",
+            "sample_17"
+           ],
+           [
+            "gene_052",
+            "sample_14"
+           ],
+           [
+            "gene_052",
+            "sample_15"
+           ],
+           [
+            "gene_052",
+            "sample_16"
+           ],
+           [
+            "gene_052",
+            "sample_18"
+           ],
+           [
+            "gene_052",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_045",
+            "sample_00"
+           ],
+           [
+            "gene_045",
+            "sample_01"
+           ],
+           [
+            "gene_045",
+            "sample_04"
+           ],
+           [
+            "gene_045",
+            "sample_05"
+           ],
+           [
+            "gene_045",
+            "sample_06"
+           ],
+           [
+            "gene_045",
+            "sample_02"
+           ],
+           [
+            "gene_045",
+            "sample_03"
+           ],
+           [
+            "gene_045",
+            "sample_08"
+           ],
+           [
+            "gene_045",
+            "sample_11"
+           ],
+           [
+            "gene_045",
+            "sample_13"
+           ],
+           [
+            "gene_045",
+            "sample_10"
+           ],
+           [
+            "gene_045",
+            "sample_07"
+           ],
+           [
+            "gene_045",
+            "sample_09"
+           ],
+           [
+            "gene_045",
+            "sample_12"
+           ],
+           [
+            "gene_045",
+            "sample_17"
+           ],
+           [
+            "gene_045",
+            "sample_14"
+           ],
+           [
+            "gene_045",
+            "sample_15"
+           ],
+           [
+            "gene_045",
+            "sample_16"
+           ],
+           [
+            "gene_045",
+            "sample_18"
+           ],
+           [
+            "gene_045",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_053",
+            "sample_00"
+           ],
+           [
+            "gene_053",
+            "sample_01"
+           ],
+           [
+            "gene_053",
+            "sample_04"
+           ],
+           [
+            "gene_053",
+            "sample_05"
+           ],
+           [
+            "gene_053",
+            "sample_06"
+           ],
+           [
+            "gene_053",
+            "sample_02"
+           ],
+           [
+            "gene_053",
+            "sample_03"
+           ],
+           [
+            "gene_053",
+            "sample_08"
+           ],
+           [
+            "gene_053",
+            "sample_11"
+           ],
+           [
+            "gene_053",
+            "sample_13"
+           ],
+           [
+            "gene_053",
+            "sample_10"
+           ],
+           [
+            "gene_053",
+            "sample_07"
+           ],
+           [
+            "gene_053",
+            "sample_09"
+           ],
+           [
+            "gene_053",
+            "sample_12"
+           ],
+           [
+            "gene_053",
+            "sample_17"
+           ],
+           [
+            "gene_053",
+            "sample_14"
+           ],
+           [
+            "gene_053",
+            "sample_15"
+           ],
+           [
+            "gene_053",
+            "sample_16"
+           ],
+           [
+            "gene_053",
+            "sample_18"
+           ],
+           [
+            "gene_053",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_056",
+            "sample_00"
+           ],
+           [
+            "gene_056",
+            "sample_01"
+           ],
+           [
+            "gene_056",
+            "sample_04"
+           ],
+           [
+            "gene_056",
+            "sample_05"
+           ],
+           [
+            "gene_056",
+            "sample_06"
+           ],
+           [
+            "gene_056",
+            "sample_02"
+           ],
+           [
+            "gene_056",
+            "sample_03"
+           ],
+           [
+            "gene_056",
+            "sample_08"
+           ],
+           [
+            "gene_056",
+            "sample_11"
+           ],
+           [
+            "gene_056",
+            "sample_13"
+           ],
+           [
+            "gene_056",
+            "sample_10"
+           ],
+           [
+            "gene_056",
+            "sample_07"
+           ],
+           [
+            "gene_056",
+            "sample_09"
+           ],
+           [
+            "gene_056",
+            "sample_12"
+           ],
+           [
+            "gene_056",
+            "sample_17"
+           ],
+           [
+            "gene_056",
+            "sample_14"
+           ],
+           [
+            "gene_056",
+            "sample_15"
+           ],
+           [
+            "gene_056",
+            "sample_16"
+           ],
+           [
+            "gene_056",
+            "sample_18"
+           ],
+           [
+            "gene_056",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_057",
+            "sample_00"
+           ],
+           [
+            "gene_057",
+            "sample_01"
+           ],
+           [
+            "gene_057",
+            "sample_04"
+           ],
+           [
+            "gene_057",
+            "sample_05"
+           ],
+           [
+            "gene_057",
+            "sample_06"
+           ],
+           [
+            "gene_057",
+            "sample_02"
+           ],
+           [
+            "gene_057",
+            "sample_03"
+           ],
+           [
+            "gene_057",
+            "sample_08"
+           ],
+           [
+            "gene_057",
+            "sample_11"
+           ],
+           [
+            "gene_057",
+            "sample_13"
+           ],
+           [
+            "gene_057",
+            "sample_10"
+           ],
+           [
+            "gene_057",
+            "sample_07"
+           ],
+           [
+            "gene_057",
+            "sample_09"
+           ],
+           [
+            "gene_057",
+            "sample_12"
+           ],
+           [
+            "gene_057",
+            "sample_17"
+           ],
+           [
+            "gene_057",
+            "sample_14"
+           ],
+           [
+            "gene_057",
+            "sample_15"
+           ],
+           [
+            "gene_057",
+            "sample_16"
+           ],
+           [
+            "gene_057",
+            "sample_18"
+           ],
+           [
+            "gene_057",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_046",
+            "sample_00"
+           ],
+           [
+            "gene_046",
+            "sample_01"
+           ],
+           [
+            "gene_046",
+            "sample_04"
+           ],
+           [
+            "gene_046",
+            "sample_05"
+           ],
+           [
+            "gene_046",
+            "sample_06"
+           ],
+           [
+            "gene_046",
+            "sample_02"
+           ],
+           [
+            "gene_046",
+            "sample_03"
+           ],
+           [
+            "gene_046",
+            "sample_08"
+           ],
+           [
+            "gene_046",
+            "sample_11"
+           ],
+           [
+            "gene_046",
+            "sample_13"
+           ],
+           [
+            "gene_046",
+            "sample_10"
+           ],
+           [
+            "gene_046",
+            "sample_07"
+           ],
+           [
+            "gene_046",
+            "sample_09"
+           ],
+           [
+            "gene_046",
+            "sample_12"
+           ],
+           [
+            "gene_046",
+            "sample_17"
+           ],
+           [
+            "gene_046",
+            "sample_14"
+           ],
+           [
+            "gene_046",
+            "sample_15"
+           ],
+           [
+            "gene_046",
+            "sample_16"
+           ],
+           [
+            "gene_046",
+            "sample_18"
+           ],
+           [
+            "gene_046",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_059",
+            "sample_00"
+           ],
+           [
+            "gene_059",
+            "sample_01"
+           ],
+           [
+            "gene_059",
+            "sample_04"
+           ],
+           [
+            "gene_059",
+            "sample_05"
+           ],
+           [
+            "gene_059",
+            "sample_06"
+           ],
+           [
+            "gene_059",
+            "sample_02"
+           ],
+           [
+            "gene_059",
+            "sample_03"
+           ],
+           [
+            "gene_059",
+            "sample_08"
+           ],
+           [
+            "gene_059",
+            "sample_11"
+           ],
+           [
+            "gene_059",
+            "sample_13"
+           ],
+           [
+            "gene_059",
+            "sample_10"
+           ],
+           [
+            "gene_059",
+            "sample_07"
+           ],
+           [
+            "gene_059",
+            "sample_09"
+           ],
+           [
+            "gene_059",
+            "sample_12"
+           ],
+           [
+            "gene_059",
+            "sample_17"
+           ],
+           [
+            "gene_059",
+            "sample_14"
+           ],
+           [
+            "gene_059",
+            "sample_15"
+           ],
+           [
+            "gene_059",
+            "sample_16"
+           ],
+           [
+            "gene_059",
+            "sample_18"
+           ],
+           [
+            "gene_059",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_058",
+            "sample_00"
+           ],
+           [
+            "gene_058",
+            "sample_01"
+           ],
+           [
+            "gene_058",
+            "sample_04"
+           ],
+           [
+            "gene_058",
+            "sample_05"
+           ],
+           [
+            "gene_058",
+            "sample_06"
+           ],
+           [
+            "gene_058",
+            "sample_02"
+           ],
+           [
+            "gene_058",
+            "sample_03"
+           ],
+           [
+            "gene_058",
+            "sample_08"
+           ],
+           [
+            "gene_058",
+            "sample_11"
+           ],
+           [
+            "gene_058",
+            "sample_13"
+           ],
+           [
+            "gene_058",
+            "sample_10"
+           ],
+           [
+            "gene_058",
+            "sample_07"
+           ],
+           [
+            "gene_058",
+            "sample_09"
+           ],
+           [
+            "gene_058",
+            "sample_12"
+           ],
+           [
+            "gene_058",
+            "sample_17"
+           ],
+           [
+            "gene_058",
+            "sample_14"
+           ],
+           [
+            "gene_058",
+            "sample_15"
+           ],
+           [
+            "gene_058",
+            "sample_16"
+           ],
+           [
+            "gene_058",
+            "sample_18"
+           ],
+           [
+            "gene_058",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_049",
+            "sample_00"
+           ],
+           [
+            "gene_049",
+            "sample_01"
+           ],
+           [
+            "gene_049",
+            "sample_04"
+           ],
+           [
+            "gene_049",
+            "sample_05"
+           ],
+           [
+            "gene_049",
+            "sample_06"
+           ],
+           [
+            "gene_049",
+            "sample_02"
+           ],
+           [
+            "gene_049",
+            "sample_03"
+           ],
+           [
+            "gene_049",
+            "sample_08"
+           ],
+           [
+            "gene_049",
+            "sample_11"
+           ],
+           [
+            "gene_049",
+            "sample_13"
+           ],
+           [
+            "gene_049",
+            "sample_10"
+           ],
+           [
+            "gene_049",
+            "sample_07"
+           ],
+           [
+            "gene_049",
+            "sample_09"
+           ],
+           [
+            "gene_049",
+            "sample_12"
+           ],
+           [
+            "gene_049",
+            "sample_17"
+           ],
+           [
+            "gene_049",
+            "sample_14"
+           ],
+           [
+            "gene_049",
+            "sample_15"
+           ],
+           [
+            "gene_049",
+            "sample_16"
+           ],
+           [
+            "gene_049",
+            "sample_18"
+           ],
+           [
+            "gene_049",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_042",
+            "sample_00"
+           ],
+           [
+            "gene_042",
+            "sample_01"
+           ],
+           [
+            "gene_042",
+            "sample_04"
+           ],
+           [
+            "gene_042",
+            "sample_05"
+           ],
+           [
+            "gene_042",
+            "sample_06"
+           ],
+           [
+            "gene_042",
+            "sample_02"
+           ],
+           [
+            "gene_042",
+            "sample_03"
+           ],
+           [
+            "gene_042",
+            "sample_08"
+           ],
+           [
+            "gene_042",
+            "sample_11"
+           ],
+           [
+            "gene_042",
+            "sample_13"
+           ],
+           [
+            "gene_042",
+            "sample_10"
+           ],
+           [
+            "gene_042",
+            "sample_07"
+           ],
+           [
+            "gene_042",
+            "sample_09"
+           ],
+           [
+            "gene_042",
+            "sample_12"
+           ],
+           [
+            "gene_042",
+            "sample_17"
+           ],
+           [
+            "gene_042",
+            "sample_14"
+           ],
+           [
+            "gene_042",
+            "sample_15"
+           ],
+           [
+            "gene_042",
+            "sample_16"
+           ],
+           [
+            "gene_042",
+            "sample_18"
+           ],
+           [
+            "gene_042",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_054",
+            "sample_00"
+           ],
+           [
+            "gene_054",
+            "sample_01"
+           ],
+           [
+            "gene_054",
+            "sample_04"
+           ],
+           [
+            "gene_054",
+            "sample_05"
+           ],
+           [
+            "gene_054",
+            "sample_06"
+           ],
+           [
+            "gene_054",
+            "sample_02"
+           ],
+           [
+            "gene_054",
+            "sample_03"
+           ],
+           [
+            "gene_054",
+            "sample_08"
+           ],
+           [
+            "gene_054",
+            "sample_11"
+           ],
+           [
+            "gene_054",
+            "sample_13"
+           ],
+           [
+            "gene_054",
+            "sample_10"
+           ],
+           [
+            "gene_054",
+            "sample_07"
+           ],
+           [
+            "gene_054",
+            "sample_09"
+           ],
+           [
+            "gene_054",
+            "sample_12"
+           ],
+           [
+            "gene_054",
+            "sample_17"
+           ],
+           [
+            "gene_054",
+            "sample_14"
+           ],
+           [
+            "gene_054",
+            "sample_15"
+           ],
+           [
+            "gene_054",
+            "sample_16"
+           ],
+           [
+            "gene_054",
+            "sample_18"
+           ],
+           [
+            "gene_054",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_040",
+            "sample_00"
+           ],
+           [
+            "gene_040",
+            "sample_01"
+           ],
+           [
+            "gene_040",
+            "sample_04"
+           ],
+           [
+            "gene_040",
+            "sample_05"
+           ],
+           [
+            "gene_040",
+            "sample_06"
+           ],
+           [
+            "gene_040",
+            "sample_02"
+           ],
+           [
+            "gene_040",
+            "sample_03"
+           ],
+           [
+            "gene_040",
+            "sample_08"
+           ],
+           [
+            "gene_040",
+            "sample_11"
+           ],
+           [
+            "gene_040",
+            "sample_13"
+           ],
+           [
+            "gene_040",
+            "sample_10"
+           ],
+           [
+            "gene_040",
+            "sample_07"
+           ],
+           [
+            "gene_040",
+            "sample_09"
+           ],
+           [
+            "gene_040",
+            "sample_12"
+           ],
+           [
+            "gene_040",
+            "sample_17"
+           ],
+           [
+            "gene_040",
+            "sample_14"
+           ],
+           [
+            "gene_040",
+            "sample_15"
+           ],
+           [
+            "gene_040",
+            "sample_16"
+           ],
+           [
+            "gene_040",
+            "sample_18"
+           ],
+           [
+            "gene_040",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_051",
+            "sample_00"
+           ],
+           [
+            "gene_051",
+            "sample_01"
+           ],
+           [
+            "gene_051",
+            "sample_04"
+           ],
+           [
+            "gene_051",
+            "sample_05"
+           ],
+           [
+            "gene_051",
+            "sample_06"
+           ],
+           [
+            "gene_051",
+            "sample_02"
+           ],
+           [
+            "gene_051",
+            "sample_03"
+           ],
+           [
+            "gene_051",
+            "sample_08"
+           ],
+           [
+            "gene_051",
+            "sample_11"
+           ],
+           [
+            "gene_051",
+            "sample_13"
+           ],
+           [
+            "gene_051",
+            "sample_10"
+           ],
+           [
+            "gene_051",
+            "sample_07"
+           ],
+           [
+            "gene_051",
+            "sample_09"
+           ],
+           [
+            "gene_051",
+            "sample_12"
+           ],
+           [
+            "gene_051",
+            "sample_17"
+           ],
+           [
+            "gene_051",
+            "sample_14"
+           ],
+           [
+            "gene_051",
+            "sample_15"
+           ],
+           [
+            "gene_051",
+            "sample_16"
+           ],
+           [
+            "gene_051",
+            "sample_18"
+           ],
+           [
+            "gene_051",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_044",
+            "sample_00"
+           ],
+           [
+            "gene_044",
+            "sample_01"
+           ],
+           [
+            "gene_044",
+            "sample_04"
+           ],
+           [
+            "gene_044",
+            "sample_05"
+           ],
+           [
+            "gene_044",
+            "sample_06"
+           ],
+           [
+            "gene_044",
+            "sample_02"
+           ],
+           [
+            "gene_044",
+            "sample_03"
+           ],
+           [
+            "gene_044",
+            "sample_08"
+           ],
+           [
+            "gene_044",
+            "sample_11"
+           ],
+           [
+            "gene_044",
+            "sample_13"
+           ],
+           [
+            "gene_044",
+            "sample_10"
+           ],
+           [
+            "gene_044",
+            "sample_07"
+           ],
+           [
+            "gene_044",
+            "sample_09"
+           ],
+           [
+            "gene_044",
+            "sample_12"
+           ],
+           [
+            "gene_044",
+            "sample_17"
+           ],
+           [
+            "gene_044",
+            "sample_14"
+           ],
+           [
+            "gene_044",
+            "sample_15"
+           ],
+           [
+            "gene_044",
+            "sample_16"
+           ],
+           [
+            "gene_044",
+            "sample_18"
+           ],
+           [
+            "gene_044",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_047",
+            "sample_00"
+           ],
+           [
+            "gene_047",
+            "sample_01"
+           ],
+           [
+            "gene_047",
+            "sample_04"
+           ],
+           [
+            "gene_047",
+            "sample_05"
+           ],
+           [
+            "gene_047",
+            "sample_06"
+           ],
+           [
+            "gene_047",
+            "sample_02"
+           ],
+           [
+            "gene_047",
+            "sample_03"
+           ],
+           [
+            "gene_047",
+            "sample_08"
+           ],
+           [
+            "gene_047",
+            "sample_11"
+           ],
+           [
+            "gene_047",
+            "sample_13"
+           ],
+           [
+            "gene_047",
+            "sample_10"
+           ],
+           [
+            "gene_047",
+            "sample_07"
+           ],
+           [
+            "gene_047",
+            "sample_09"
+           ],
+           [
+            "gene_047",
+            "sample_12"
+           ],
+           [
+            "gene_047",
+            "sample_17"
+           ],
+           [
+            "gene_047",
+            "sample_14"
+           ],
+           [
+            "gene_047",
+            "sample_15"
+           ],
+           [
+            "gene_047",
+            "sample_16"
+           ],
+           [
+            "gene_047",
+            "sample_18"
+           ],
+           [
+            "gene_047",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_043",
+            "sample_00"
+           ],
+           [
+            "gene_043",
+            "sample_01"
+           ],
+           [
+            "gene_043",
+            "sample_04"
+           ],
+           [
+            "gene_043",
+            "sample_05"
+           ],
+           [
+            "gene_043",
+            "sample_06"
+           ],
+           [
+            "gene_043",
+            "sample_02"
+           ],
+           [
+            "gene_043",
+            "sample_03"
+           ],
+           [
+            "gene_043",
+            "sample_08"
+           ],
+           [
+            "gene_043",
+            "sample_11"
+           ],
+           [
+            "gene_043",
+            "sample_13"
+           ],
+           [
+            "gene_043",
+            "sample_10"
+           ],
+           [
+            "gene_043",
+            "sample_07"
+           ],
+           [
+            "gene_043",
+            "sample_09"
+           ],
+           [
+            "gene_043",
+            "sample_12"
+           ],
+           [
+            "gene_043",
+            "sample_17"
+           ],
+           [
+            "gene_043",
+            "sample_14"
+           ],
+           [
+            "gene_043",
+            "sample_15"
+           ],
+           [
+            "gene_043",
+            "sample_16"
+           ],
+           [
+            "gene_043",
+            "sample_18"
+           ],
+           [
+            "gene_043",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_048",
+            "sample_00"
+           ],
+           [
+            "gene_048",
+            "sample_01"
+           ],
+           [
+            "gene_048",
+            "sample_04"
+           ],
+           [
+            "gene_048",
+            "sample_05"
+           ],
+           [
+            "gene_048",
+            "sample_06"
+           ],
+           [
+            "gene_048",
+            "sample_02"
+           ],
+           [
+            "gene_048",
+            "sample_03"
+           ],
+           [
+            "gene_048",
+            "sample_08"
+           ],
+           [
+            "gene_048",
+            "sample_11"
+           ],
+           [
+            "gene_048",
+            "sample_13"
+           ],
+           [
+            "gene_048",
+            "sample_10"
+           ],
+           [
+            "gene_048",
+            "sample_07"
+           ],
+           [
+            "gene_048",
+            "sample_09"
+           ],
+           [
+            "gene_048",
+            "sample_12"
+           ],
+           [
+            "gene_048",
+            "sample_17"
+           ],
+           [
+            "gene_048",
+            "sample_14"
+           ],
+           [
+            "gene_048",
+            "sample_15"
+           ],
+           [
+            "gene_048",
+            "sample_16"
+           ],
+           [
+            "gene_048",
+            "sample_18"
+           ],
+           [
+            "gene_048",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_055",
+            "sample_00"
+           ],
+           [
+            "gene_055",
+            "sample_01"
+           ],
+           [
+            "gene_055",
+            "sample_04"
+           ],
+           [
+            "gene_055",
+            "sample_05"
+           ],
+           [
+            "gene_055",
+            "sample_06"
+           ],
+           [
+            "gene_055",
+            "sample_02"
+           ],
+           [
+            "gene_055",
+            "sample_03"
+           ],
+           [
+            "gene_055",
+            "sample_08"
+           ],
+           [
+            "gene_055",
+            "sample_11"
+           ],
+           [
+            "gene_055",
+            "sample_13"
+           ],
+           [
+            "gene_055",
+            "sample_10"
+           ],
+           [
+            "gene_055",
+            "sample_07"
+           ],
+           [
+            "gene_055",
+            "sample_09"
+           ],
+           [
+            "gene_055",
+            "sample_12"
+           ],
+           [
+            "gene_055",
+            "sample_17"
+           ],
+           [
+            "gene_055",
+            "sample_14"
+           ],
+           [
+            "gene_055",
+            "sample_15"
+           ],
+           [
+            "gene_055",
+            "sample_16"
+           ],
+           [
+            "gene_055",
+            "sample_18"
+           ],
+           [
+            "gene_055",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_026",
+            "sample_00"
+           ],
+           [
+            "gene_026",
+            "sample_01"
+           ],
+           [
+            "gene_026",
+            "sample_04"
+           ],
+           [
+            "gene_026",
+            "sample_05"
+           ],
+           [
+            "gene_026",
+            "sample_06"
+           ],
+           [
+            "gene_026",
+            "sample_02"
+           ],
+           [
+            "gene_026",
+            "sample_03"
+           ],
+           [
+            "gene_026",
+            "sample_08"
+           ],
+           [
+            "gene_026",
+            "sample_11"
+           ],
+           [
+            "gene_026",
+            "sample_13"
+           ],
+           [
+            "gene_026",
+            "sample_10"
+           ],
+           [
+            "gene_026",
+            "sample_07"
+           ],
+           [
+            "gene_026",
+            "sample_09"
+           ],
+           [
+            "gene_026",
+            "sample_12"
+           ],
+           [
+            "gene_026",
+            "sample_17"
+           ],
+           [
+            "gene_026",
+            "sample_14"
+           ],
+           [
+            "gene_026",
+            "sample_15"
+           ],
+           [
+            "gene_026",
+            "sample_16"
+           ],
+           [
+            "gene_026",
+            "sample_18"
+           ],
+           [
+            "gene_026",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_039",
+            "sample_00"
+           ],
+           [
+            "gene_039",
+            "sample_01"
+           ],
+           [
+            "gene_039",
+            "sample_04"
+           ],
+           [
+            "gene_039",
+            "sample_05"
+           ],
+           [
+            "gene_039",
+            "sample_06"
+           ],
+           [
+            "gene_039",
+            "sample_02"
+           ],
+           [
+            "gene_039",
+            "sample_03"
+           ],
+           [
+            "gene_039",
+            "sample_08"
+           ],
+           [
+            "gene_039",
+            "sample_11"
+           ],
+           [
+            "gene_039",
+            "sample_13"
+           ],
+           [
+            "gene_039",
+            "sample_10"
+           ],
+           [
+            "gene_039",
+            "sample_07"
+           ],
+           [
+            "gene_039",
+            "sample_09"
+           ],
+           [
+            "gene_039",
+            "sample_12"
+           ],
+           [
+            "gene_039",
+            "sample_17"
+           ],
+           [
+            "gene_039",
+            "sample_14"
+           ],
+           [
+            "gene_039",
+            "sample_15"
+           ],
+           [
+            "gene_039",
+            "sample_16"
+           ],
+           [
+            "gene_039",
+            "sample_18"
+           ],
+           [
+            "gene_039",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_021",
+            "sample_00"
+           ],
+           [
+            "gene_021",
+            "sample_01"
+           ],
+           [
+            "gene_021",
+            "sample_04"
+           ],
+           [
+            "gene_021",
+            "sample_05"
+           ],
+           [
+            "gene_021",
+            "sample_06"
+           ],
+           [
+            "gene_021",
+            "sample_02"
+           ],
+           [
+            "gene_021",
+            "sample_03"
+           ],
+           [
+            "gene_021",
+            "sample_08"
+           ],
+           [
+            "gene_021",
+            "sample_11"
+           ],
+           [
+            "gene_021",
+            "sample_13"
+           ],
+           [
+            "gene_021",
+            "sample_10"
+           ],
+           [
+            "gene_021",
+            "sample_07"
+           ],
+           [
+            "gene_021",
+            "sample_09"
+           ],
+           [
+            "gene_021",
+            "sample_12"
+           ],
+           [
+            "gene_021",
+            "sample_17"
+           ],
+           [
+            "gene_021",
+            "sample_14"
+           ],
+           [
+            "gene_021",
+            "sample_15"
+           ],
+           [
+            "gene_021",
+            "sample_16"
+           ],
+           [
+            "gene_021",
+            "sample_18"
+           ],
+           [
+            "gene_021",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_029",
+            "sample_00"
+           ],
+           [
+            "gene_029",
+            "sample_01"
+           ],
+           [
+            "gene_029",
+            "sample_04"
+           ],
+           [
+            "gene_029",
+            "sample_05"
+           ],
+           [
+            "gene_029",
+            "sample_06"
+           ],
+           [
+            "gene_029",
+            "sample_02"
+           ],
+           [
+            "gene_029",
+            "sample_03"
+           ],
+           [
+            "gene_029",
+            "sample_08"
+           ],
+           [
+            "gene_029",
+            "sample_11"
+           ],
+           [
+            "gene_029",
+            "sample_13"
+           ],
+           [
+            "gene_029",
+            "sample_10"
+           ],
+           [
+            "gene_029",
+            "sample_07"
+           ],
+           [
+            "gene_029",
+            "sample_09"
+           ],
+           [
+            "gene_029",
+            "sample_12"
+           ],
+           [
+            "gene_029",
+            "sample_17"
+           ],
+           [
+            "gene_029",
+            "sample_14"
+           ],
+           [
+            "gene_029",
+            "sample_15"
+           ],
+           [
+            "gene_029",
+            "sample_16"
+           ],
+           [
+            "gene_029",
+            "sample_18"
+           ],
+           [
+            "gene_029",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_027",
+            "sample_00"
+           ],
+           [
+            "gene_027",
+            "sample_01"
+           ],
+           [
+            "gene_027",
+            "sample_04"
+           ],
+           [
+            "gene_027",
+            "sample_05"
+           ],
+           [
+            "gene_027",
+            "sample_06"
+           ],
+           [
+            "gene_027",
+            "sample_02"
+           ],
+           [
+            "gene_027",
+            "sample_03"
+           ],
+           [
+            "gene_027",
+            "sample_08"
+           ],
+           [
+            "gene_027",
+            "sample_11"
+           ],
+           [
+            "gene_027",
+            "sample_13"
+           ],
+           [
+            "gene_027",
+            "sample_10"
+           ],
+           [
+            "gene_027",
+            "sample_07"
+           ],
+           [
+            "gene_027",
+            "sample_09"
+           ],
+           [
+            "gene_027",
+            "sample_12"
+           ],
+           [
+            "gene_027",
+            "sample_17"
+           ],
+           [
+            "gene_027",
+            "sample_14"
+           ],
+           [
+            "gene_027",
+            "sample_15"
+           ],
+           [
+            "gene_027",
+            "sample_16"
+           ],
+           [
+            "gene_027",
+            "sample_18"
+           ],
+           [
+            "gene_027",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_036",
+            "sample_00"
+           ],
+           [
+            "gene_036",
+            "sample_01"
+           ],
+           [
+            "gene_036",
+            "sample_04"
+           ],
+           [
+            "gene_036",
+            "sample_05"
+           ],
+           [
+            "gene_036",
+            "sample_06"
+           ],
+           [
+            "gene_036",
+            "sample_02"
+           ],
+           [
+            "gene_036",
+            "sample_03"
+           ],
+           [
+            "gene_036",
+            "sample_08"
+           ],
+           [
+            "gene_036",
+            "sample_11"
+           ],
+           [
+            "gene_036",
+            "sample_13"
+           ],
+           [
+            "gene_036",
+            "sample_10"
+           ],
+           [
+            "gene_036",
+            "sample_07"
+           ],
+           [
+            "gene_036",
+            "sample_09"
+           ],
+           [
+            "gene_036",
+            "sample_12"
+           ],
+           [
+            "gene_036",
+            "sample_17"
+           ],
+           [
+            "gene_036",
+            "sample_14"
+           ],
+           [
+            "gene_036",
+            "sample_15"
+           ],
+           [
+            "gene_036",
+            "sample_16"
+           ],
+           [
+            "gene_036",
+            "sample_18"
+           ],
+           [
+            "gene_036",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_024",
+            "sample_00"
+           ],
+           [
+            "gene_024",
+            "sample_01"
+           ],
+           [
+            "gene_024",
+            "sample_04"
+           ],
+           [
+            "gene_024",
+            "sample_05"
+           ],
+           [
+            "gene_024",
+            "sample_06"
+           ],
+           [
+            "gene_024",
+            "sample_02"
+           ],
+           [
+            "gene_024",
+            "sample_03"
+           ],
+           [
+            "gene_024",
+            "sample_08"
+           ],
+           [
+            "gene_024",
+            "sample_11"
+           ],
+           [
+            "gene_024",
+            "sample_13"
+           ],
+           [
+            "gene_024",
+            "sample_10"
+           ],
+           [
+            "gene_024",
+            "sample_07"
+           ],
+           [
+            "gene_024",
+            "sample_09"
+           ],
+           [
+            "gene_024",
+            "sample_12"
+           ],
+           [
+            "gene_024",
+            "sample_17"
+           ],
+           [
+            "gene_024",
+            "sample_14"
+           ],
+           [
+            "gene_024",
+            "sample_15"
+           ],
+           [
+            "gene_024",
+            "sample_16"
+           ],
+           [
+            "gene_024",
+            "sample_18"
+           ],
+           [
+            "gene_024",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_025",
+            "sample_00"
+           ],
+           [
+            "gene_025",
+            "sample_01"
+           ],
+           [
+            "gene_025",
+            "sample_04"
+           ],
+           [
+            "gene_025",
+            "sample_05"
+           ],
+           [
+            "gene_025",
+            "sample_06"
+           ],
+           [
+            "gene_025",
+            "sample_02"
+           ],
+           [
+            "gene_025",
+            "sample_03"
+           ],
+           [
+            "gene_025",
+            "sample_08"
+           ],
+           [
+            "gene_025",
+            "sample_11"
+           ],
+           [
+            "gene_025",
+            "sample_13"
+           ],
+           [
+            "gene_025",
+            "sample_10"
+           ],
+           [
+            "gene_025",
+            "sample_07"
+           ],
+           [
+            "gene_025",
+            "sample_09"
+           ],
+           [
+            "gene_025",
+            "sample_12"
+           ],
+           [
+            "gene_025",
+            "sample_17"
+           ],
+           [
+            "gene_025",
+            "sample_14"
+           ],
+           [
+            "gene_025",
+            "sample_15"
+           ],
+           [
+            "gene_025",
+            "sample_16"
+           ],
+           [
+            "gene_025",
+            "sample_18"
+           ],
+           [
+            "gene_025",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_022",
+            "sample_00"
+           ],
+           [
+            "gene_022",
+            "sample_01"
+           ],
+           [
+            "gene_022",
+            "sample_04"
+           ],
+           [
+            "gene_022",
+            "sample_05"
+           ],
+           [
+            "gene_022",
+            "sample_06"
+           ],
+           [
+            "gene_022",
+            "sample_02"
+           ],
+           [
+            "gene_022",
+            "sample_03"
+           ],
+           [
+            "gene_022",
+            "sample_08"
+           ],
+           [
+            "gene_022",
+            "sample_11"
+           ],
+           [
+            "gene_022",
+            "sample_13"
+           ],
+           [
+            "gene_022",
+            "sample_10"
+           ],
+           [
+            "gene_022",
+            "sample_07"
+           ],
+           [
+            "gene_022",
+            "sample_09"
+           ],
+           [
+            "gene_022",
+            "sample_12"
+           ],
+           [
+            "gene_022",
+            "sample_17"
+           ],
+           [
+            "gene_022",
+            "sample_14"
+           ],
+           [
+            "gene_022",
+            "sample_15"
+           ],
+           [
+            "gene_022",
+            "sample_16"
+           ],
+           [
+            "gene_022",
+            "sample_18"
+           ],
+           [
+            "gene_022",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_028",
+            "sample_00"
+           ],
+           [
+            "gene_028",
+            "sample_01"
+           ],
+           [
+            "gene_028",
+            "sample_04"
+           ],
+           [
+            "gene_028",
+            "sample_05"
+           ],
+           [
+            "gene_028",
+            "sample_06"
+           ],
+           [
+            "gene_028",
+            "sample_02"
+           ],
+           [
+            "gene_028",
+            "sample_03"
+           ],
+           [
+            "gene_028",
+            "sample_08"
+           ],
+           [
+            "gene_028",
+            "sample_11"
+           ],
+           [
+            "gene_028",
+            "sample_13"
+           ],
+           [
+            "gene_028",
+            "sample_10"
+           ],
+           [
+            "gene_028",
+            "sample_07"
+           ],
+           [
+            "gene_028",
+            "sample_09"
+           ],
+           [
+            "gene_028",
+            "sample_12"
+           ],
+           [
+            "gene_028",
+            "sample_17"
+           ],
+           [
+            "gene_028",
+            "sample_14"
+           ],
+           [
+            "gene_028",
+            "sample_15"
+           ],
+           [
+            "gene_028",
+            "sample_16"
+           ],
+           [
+            "gene_028",
+            "sample_18"
+           ],
+           [
+            "gene_028",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_030",
+            "sample_00"
+           ],
+           [
+            "gene_030",
+            "sample_01"
+           ],
+           [
+            "gene_030",
+            "sample_04"
+           ],
+           [
+            "gene_030",
+            "sample_05"
+           ],
+           [
+            "gene_030",
+            "sample_06"
+           ],
+           [
+            "gene_030",
+            "sample_02"
+           ],
+           [
+            "gene_030",
+            "sample_03"
+           ],
+           [
+            "gene_030",
+            "sample_08"
+           ],
+           [
+            "gene_030",
+            "sample_11"
+           ],
+           [
+            "gene_030",
+            "sample_13"
+           ],
+           [
+            "gene_030",
+            "sample_10"
+           ],
+           [
+            "gene_030",
+            "sample_07"
+           ],
+           [
+            "gene_030",
+            "sample_09"
+           ],
+           [
+            "gene_030",
+            "sample_12"
+           ],
+           [
+            "gene_030",
+            "sample_17"
+           ],
+           [
+            "gene_030",
+            "sample_14"
+           ],
+           [
+            "gene_030",
+            "sample_15"
+           ],
+           [
+            "gene_030",
+            "sample_16"
+           ],
+           [
+            "gene_030",
+            "sample_18"
+           ],
+           [
+            "gene_030",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_033",
+            "sample_00"
+           ],
+           [
+            "gene_033",
+            "sample_01"
+           ],
+           [
+            "gene_033",
+            "sample_04"
+           ],
+           [
+            "gene_033",
+            "sample_05"
+           ],
+           [
+            "gene_033",
+            "sample_06"
+           ],
+           [
+            "gene_033",
+            "sample_02"
+           ],
+           [
+            "gene_033",
+            "sample_03"
+           ],
+           [
+            "gene_033",
+            "sample_08"
+           ],
+           [
+            "gene_033",
+            "sample_11"
+           ],
+           [
+            "gene_033",
+            "sample_13"
+           ],
+           [
+            "gene_033",
+            "sample_10"
+           ],
+           [
+            "gene_033",
+            "sample_07"
+           ],
+           [
+            "gene_033",
+            "sample_09"
+           ],
+           [
+            "gene_033",
+            "sample_12"
+           ],
+           [
+            "gene_033",
+            "sample_17"
+           ],
+           [
+            "gene_033",
+            "sample_14"
+           ],
+           [
+            "gene_033",
+            "sample_15"
+           ],
+           [
+            "gene_033",
+            "sample_16"
+           ],
+           [
+            "gene_033",
+            "sample_18"
+           ],
+           [
+            "gene_033",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_034",
+            "sample_00"
+           ],
+           [
+            "gene_034",
+            "sample_01"
+           ],
+           [
+            "gene_034",
+            "sample_04"
+           ],
+           [
+            "gene_034",
+            "sample_05"
+           ],
+           [
+            "gene_034",
+            "sample_06"
+           ],
+           [
+            "gene_034",
+            "sample_02"
+           ],
+           [
+            "gene_034",
+            "sample_03"
+           ],
+           [
+            "gene_034",
+            "sample_08"
+           ],
+           [
+            "gene_034",
+            "sample_11"
+           ],
+           [
+            "gene_034",
+            "sample_13"
+           ],
+           [
+            "gene_034",
+            "sample_10"
+           ],
+           [
+            "gene_034",
+            "sample_07"
+           ],
+           [
+            "gene_034",
+            "sample_09"
+           ],
+           [
+            "gene_034",
+            "sample_12"
+           ],
+           [
+            "gene_034",
+            "sample_17"
+           ],
+           [
+            "gene_034",
+            "sample_14"
+           ],
+           [
+            "gene_034",
+            "sample_15"
+           ],
+           [
+            "gene_034",
+            "sample_16"
+           ],
+           [
+            "gene_034",
+            "sample_18"
+           ],
+           [
+            "gene_034",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_037",
+            "sample_00"
+           ],
+           [
+            "gene_037",
+            "sample_01"
+           ],
+           [
+            "gene_037",
+            "sample_04"
+           ],
+           [
+            "gene_037",
+            "sample_05"
+           ],
+           [
+            "gene_037",
+            "sample_06"
+           ],
+           [
+            "gene_037",
+            "sample_02"
+           ],
+           [
+            "gene_037",
+            "sample_03"
+           ],
+           [
+            "gene_037",
+            "sample_08"
+           ],
+           [
+            "gene_037",
+            "sample_11"
+           ],
+           [
+            "gene_037",
+            "sample_13"
+           ],
+           [
+            "gene_037",
+            "sample_10"
+           ],
+           [
+            "gene_037",
+            "sample_07"
+           ],
+           [
+            "gene_037",
+            "sample_09"
+           ],
+           [
+            "gene_037",
+            "sample_12"
+           ],
+           [
+            "gene_037",
+            "sample_17"
+           ],
+           [
+            "gene_037",
+            "sample_14"
+           ],
+           [
+            "gene_037",
+            "sample_15"
+           ],
+           [
+            "gene_037",
+            "sample_16"
+           ],
+           [
+            "gene_037",
+            "sample_18"
+           ],
+           [
+            "gene_037",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_038",
+            "sample_00"
+           ],
+           [
+            "gene_038",
+            "sample_01"
+           ],
+           [
+            "gene_038",
+            "sample_04"
+           ],
+           [
+            "gene_038",
+            "sample_05"
+           ],
+           [
+            "gene_038",
+            "sample_06"
+           ],
+           [
+            "gene_038",
+            "sample_02"
+           ],
+           [
+            "gene_038",
+            "sample_03"
+           ],
+           [
+            "gene_038",
+            "sample_08"
+           ],
+           [
+            "gene_038",
+            "sample_11"
+           ],
+           [
+            "gene_038",
+            "sample_13"
+           ],
+           [
+            "gene_038",
+            "sample_10"
+           ],
+           [
+            "gene_038",
+            "sample_07"
+           ],
+           [
+            "gene_038",
+            "sample_09"
+           ],
+           [
+            "gene_038",
+            "sample_12"
+           ],
+           [
+            "gene_038",
+            "sample_17"
+           ],
+           [
+            "gene_038",
+            "sample_14"
+           ],
+           [
+            "gene_038",
+            "sample_15"
+           ],
+           [
+            "gene_038",
+            "sample_16"
+           ],
+           [
+            "gene_038",
+            "sample_18"
+           ],
+           [
+            "gene_038",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_031",
+            "sample_00"
+           ],
+           [
+            "gene_031",
+            "sample_01"
+           ],
+           [
+            "gene_031",
+            "sample_04"
+           ],
+           [
+            "gene_031",
+            "sample_05"
+           ],
+           [
+            "gene_031",
+            "sample_06"
+           ],
+           [
+            "gene_031",
+            "sample_02"
+           ],
+           [
+            "gene_031",
+            "sample_03"
+           ],
+           [
+            "gene_031",
+            "sample_08"
+           ],
+           [
+            "gene_031",
+            "sample_11"
+           ],
+           [
+            "gene_031",
+            "sample_13"
+           ],
+           [
+            "gene_031",
+            "sample_10"
+           ],
+           [
+            "gene_031",
+            "sample_07"
+           ],
+           [
+            "gene_031",
+            "sample_09"
+           ],
+           [
+            "gene_031",
+            "sample_12"
+           ],
+           [
+            "gene_031",
+            "sample_17"
+           ],
+           [
+            "gene_031",
+            "sample_14"
+           ],
+           [
+            "gene_031",
+            "sample_15"
+           ],
+           [
+            "gene_031",
+            "sample_16"
+           ],
+           [
+            "gene_031",
+            "sample_18"
+           ],
+           [
+            "gene_031",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_032",
+            "sample_00"
+           ],
+           [
+            "gene_032",
+            "sample_01"
+           ],
+           [
+            "gene_032",
+            "sample_04"
+           ],
+           [
+            "gene_032",
+            "sample_05"
+           ],
+           [
+            "gene_032",
+            "sample_06"
+           ],
+           [
+            "gene_032",
+            "sample_02"
+           ],
+           [
+            "gene_032",
+            "sample_03"
+           ],
+           [
+            "gene_032",
+            "sample_08"
+           ],
+           [
+            "gene_032",
+            "sample_11"
+           ],
+           [
+            "gene_032",
+            "sample_13"
+           ],
+           [
+            "gene_032",
+            "sample_10"
+           ],
+           [
+            "gene_032",
+            "sample_07"
+           ],
+           [
+            "gene_032",
+            "sample_09"
+           ],
+           [
+            "gene_032",
+            "sample_12"
+           ],
+           [
+            "gene_032",
+            "sample_17"
+           ],
+           [
+            "gene_032",
+            "sample_14"
+           ],
+           [
+            "gene_032",
+            "sample_15"
+           ],
+           [
+            "gene_032",
+            "sample_16"
+           ],
+           [
+            "gene_032",
+            "sample_18"
+           ],
+           [
+            "gene_032",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_035",
+            "sample_00"
+           ],
+           [
+            "gene_035",
+            "sample_01"
+           ],
+           [
+            "gene_035",
+            "sample_04"
+           ],
+           [
+            "gene_035",
+            "sample_05"
+           ],
+           [
+            "gene_035",
+            "sample_06"
+           ],
+           [
+            "gene_035",
+            "sample_02"
+           ],
+           [
+            "gene_035",
+            "sample_03"
+           ],
+           [
+            "gene_035",
+            "sample_08"
+           ],
+           [
+            "gene_035",
+            "sample_11"
+           ],
+           [
+            "gene_035",
+            "sample_13"
+           ],
+           [
+            "gene_035",
+            "sample_10"
+           ],
+           [
+            "gene_035",
+            "sample_07"
+           ],
+           [
+            "gene_035",
+            "sample_09"
+           ],
+           [
+            "gene_035",
+            "sample_12"
+           ],
+           [
+            "gene_035",
+            "sample_17"
+           ],
+           [
+            "gene_035",
+            "sample_14"
+           ],
+           [
+            "gene_035",
+            "sample_15"
+           ],
+           [
+            "gene_035",
+            "sample_16"
+           ],
+           [
+            "gene_035",
+            "sample_18"
+           ],
+           [
+            "gene_035",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_020",
+            "sample_00"
+           ],
+           [
+            "gene_020",
+            "sample_01"
+           ],
+           [
+            "gene_020",
+            "sample_04"
+           ],
+           [
+            "gene_020",
+            "sample_05"
+           ],
+           [
+            "gene_020",
+            "sample_06"
+           ],
+           [
+            "gene_020",
+            "sample_02"
+           ],
+           [
+            "gene_020",
+            "sample_03"
+           ],
+           [
+            "gene_020",
+            "sample_08"
+           ],
+           [
+            "gene_020",
+            "sample_11"
+           ],
+           [
+            "gene_020",
+            "sample_13"
+           ],
+           [
+            "gene_020",
+            "sample_10"
+           ],
+           [
+            "gene_020",
+            "sample_07"
+           ],
+           [
+            "gene_020",
+            "sample_09"
+           ],
+           [
+            "gene_020",
+            "sample_12"
+           ],
+           [
+            "gene_020",
+            "sample_17"
+           ],
+           [
+            "gene_020",
+            "sample_14"
+           ],
+           [
+            "gene_020",
+            "sample_15"
+           ],
+           [
+            "gene_020",
+            "sample_16"
+           ],
+           [
+            "gene_020",
+            "sample_18"
+           ],
+           [
+            "gene_020",
+            "sample_19"
+           ]
+          ],
+          [
+           [
+            "gene_023",
+            "sample_00"
+           ],
+           [
+            "gene_023",
+            "sample_01"
+           ],
+           [
+            "gene_023",
+            "sample_04"
+           ],
+           [
+            "gene_023",
+            "sample_05"
+           ],
+           [
+            "gene_023",
+            "sample_06"
+           ],
+           [
+            "gene_023",
+            "sample_02"
+           ],
+           [
+            "gene_023",
+            "sample_03"
+           ],
+           [
+            "gene_023",
+            "sample_08"
+           ],
+           [
+            "gene_023",
+            "sample_11"
+           ],
+           [
+            "gene_023",
+            "sample_13"
+           ],
+           [
+            "gene_023",
+            "sample_10"
+           ],
+           [
+            "gene_023",
+            "sample_07"
+           ],
+           [
+            "gene_023",
+            "sample_09"
+           ],
+           [
+            "gene_023",
+            "sample_12"
+           ],
+           [
+            "gene_023",
+            "sample_17"
+           ],
+           [
+            "gene_023",
+            "sample_14"
+           ],
+           [
+            "gene_023",
+            "sample_15"
+           ],
+           [
+            "gene_023",
+            "sample_16"
+           ],
+           [
+            "gene_023",
+            "sample_18"
+           ],
+           [
+            "gene_023",
+            "sample_19"
+           ]
+          ]
+         ],
+         "hovertemplate": "row: %{customdata[0]}<br>col: %{customdata[1]}<br>value: %{z:.3f}<extra></extra>",
+         "type": "heatmap",
+         "x": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQA==",
+          "dtype": "f8"
+         },
+         "xaxis": "x5",
+         "xgap": 0.5,
+         "y": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQAAAAAAAADRAAAAAAAAANUAAAAAAAAA2QAAAAAAAADdAAAAAAAAAOEAAAAAAAAA5QAAAAAAAADpAAAAAAAAAO0AAAAAAAAA8QAAAAAAAAD1AAAAAAAAAPkAAAAAAAAA/QAAAAAAAAEBAAAAAAACAQEAAAAAAAABBQAAAAAAAgEFAAAAAAAAAQkAAAAAAAIBCQAAAAAAAAENAAAAAAACAQ0AAAAAAAABEQAAAAAAAgERAAAAAAAAARUAAAAAAAIBFQAAAAAAAAEZAAAAAAACARkAAAAAAAABHQAAAAAAAgEdAAAAAAAAASEAAAAAAAIBIQAAAAAAAAElAAAAAAACASUAAAAAAAABKQAAAAAAAgEpAAAAAAAAAS0AAAAAAAIBLQAAAAAAAAExAAAAAAACATEAAAAAAAABNQAAAAAAAgE1A",
+          "dtype": "f8"
+         },
+         "yaxis": "y5",
+         "ygap": 0.5,
+         "z": {
+          "bdata": "3VIxUf/x8D8z11hcp274PwKWiR5n3+M/NC9eNPO/8j+5pT826wnxPxKhZjGBvPI/xcyQuiXm+D/2FeV3T3b0v7Uoavpbme+/BRuhHA7PxT+w0MV/FQjkv0HbZ+Cxd/G/GqU7vfVYsb96Hj8uhUjfv3Hn5Ha2YtY/OiiKs0Ck+r9vjajg5OLzv7EO/Qvt4u2///DFQf460r8Z/ZpRI2qYvxDvhQshyeM/xaoUeBZc9T+4tLTktlTsPydFoW+ewvM/habPfe/96z98AME9Loj4P+Dx1KVwGfM/0CqlWzIw9L86KU2KZKXxvy+nmgnz45o/c/1Dv6Jk9b/2ii4pGzWnPzShwt3dw+G/9pJkUlmzzz9Z/i4uXejkvwYNUlBmkee/niXSLsuz8b9pp6VEtcD8v5Zdko6L5ec/ApY1lLJ4yL+r41os7EvfP3Yp9IBsCOA/A8unyVOS9z+wcKG8irTwP8bzwQptDPU/5PvrJ2yh9j8oFDbpmv/yPwZGu4oaH8K/JUVE8It4/r/IiL0Dreq4P1FHt+P4nvi/ydPGYe8V4L9aDyF5dOG/v1hMHytIoYa/srTB0GrQqr9gSIfMlQjzv+s04rzB2/q/Gozb1v8v4b+HnqKynvncP/Y2msQH0NK/TY5bFMzN8T+HM1n4CdbqP1rBD+AzsP0/NqRsRKoe3z9yH0pufiX1P1exSMNQHP8/T6GDcWRB7j8DcIjEJyjsv9EgjdJyieO/b1U4PTdk3b9GD82FpgDDP3sMNurDvNK/MmT8SC06178hGKVcSpX0v74wNvb9sPS/ayLDHTuv7L8SC77shNTjvwTM4ntyat+/apnmeeL687/zfgUhNzDLvzV8cTE7BfI/IptHXPxW8j9OC/9dJD//P/lbX/+0Z7M/Tx0mz9Uk7T9gNozdGkT5P6WVItaVBPQ/zj8WjJiN+7+2012v+77evyHgiTh3MuC/1dDHWrPC7L8QSD8JmEXqv36vp01mq+2/niuJ2jeH0j9zdmOGiObtv4dFCI3R7e6/PN3x9jxX2b9+KSPb2iLQP5MC5FO2rOy/QRmVvYQWor+Z35TXJz30P/IqtLu5dQBArL+8PLhtAUDog76e2L3GP1rMdwnvCdk/6DB2Nfcz2z8UbWdPOF30P/vQ5HumxOy/HNmgImTy+b/bEUjvbtHtvxQICdNMbt2/emrije/66r80U+emJ8LAvxMdaCRRVtO/2ogjnYdj0r8qLk8kvkzBP+pYDn6kve6/vwHk9D/o7r+X1Nkl72vEv4lncaKt0dW/is/OZkNh9j/cnFPsBPIAQCg59gAZJ/A/NNUY1BAX+D8TrQnTGD3ZP9A8HDXc6vA/MvohcUag5z+owhcHrSXmv1mScPF4g+q/26+8CGU267+ial+f4Gv7v/8ofMOtuqa/2rB05uZJzj+reGBTdS/1v9uAYGO86t6/RWNzZiSU0L+FyOFJjZ/fv6oUswNFHuG/G/zVHJ0j0r+5LpHIxmzuv8dx7NUrG/U/CV4ZUxvA9D84gCnlQM3xP2ZYZ+iyzP8/SCRozaJt7T+1OJUx54PyP4Obredc5fM/h3L99bmb7b+4C2f4Ucnvv2XSwg9AL9i/DpjAjLjB8r/wpjJ9cWvmv85VojlZDPG/YQwyTvic4r94K29/x0bGv9PcFp3OpuC/5dx7IznN7b/TfR7B1Ne3v3Y/kR60C+S/TROHR//8678un33qIkTIP4AVcM2Pavs/6ERwCadX7z/7/7FOibD4P9e+hKWsVus/eStgGf/N+z8eP18Ap8L4P2RXZvaKIfS/jUvogmra9b+Ex8hk7JHnv6bJoKlNQ+W/av6ueAHr4r9d8iAb3XDfv1Lb7gCnGee/gCDOlyUp4r+J83KsNV3NP0W/sJkXIs6/Qt54YZkR5r9kJn2Neoflv7GpDsssmem/EICfddQw4j/C/p+a7k/Hv1BuSHKwT+0/PnV1cL4FtD/gX1M/bPjuP5QzcMiUJgBAhQTMv9BBBECG77tzXm7jv7fbazX9s8u/VoUDHrTxvr/WDEcmNNnHv6koGdDiHeW/Hv9UojXM8b+vyCd+4SH1v9NzKeKil+K/DRSIM8fS4z9UVQzHhjHav2jwXBngAua/Ls0A7mRZxb97LolUPDP3v9XAPoXypO0/hKF+l+ES47/VGKVUchXpP4hDolKzZdU/gtp8XyAH/z8mPF1dfmv+P+kh6G2BTvg/apNYHbBi6z8wdvTCYbjwvzAoySP3Ft2/n8qs1k815L/44+2FjR/lvwkNeYnnbuO/ZjaTN2/x07+1RNvysnH0v3mTQlQo8Yk/6LvuEqHy9L/2pVD4Quzzv30nxW62LtW/jz15NcsoyT8PehNJGvP3P+3E22h3w/Q/6Btp8g1r9T+SU+xylEzmPxGjcIuyx/Q/hMDLzS812T+KEnBBS4DyPzQsCaL2lNE/KLMXmm3P0L+QzMee3aLxv+U5fyVbS+O/08OJMkFG9L88eGUbpOzMP+zYR0h0t/y/MWMTWGd65D8AK0jqFgbkv2RHDwZO5PC/eadhdOubsb9TQB7cudDxv8hWSKmWou2/OXSl+fNf5j+7/3HDklr2PySLxtg8S/4/X78HChDb/D/6TzF9E/PFP2zSRSF9cO4/7yVpUWFZ4j/INT3kT0aBPzGeER4XrOa/IOj29ZbL+L93zPsaq8KfP3if1KAMjOq/EM6qQW6wrD8Y2mf9G+/1v8m6okajKbY/gIdILT2v3r/S2npSiQXdv9SAEtwADc0/xGk0fqLG6r/V92GoOLj6v5bLe5J+XMQ/r3/meV1i5j8VmbL8ud3yPxb20CVWSwJAcVE9AdC/9z9OX7yfC8bhP0dM5pmG6rq/I1TSyTKIzD+WM8ovi2TbP3fSqTtiWfS/+sysTgGg5b9uezWfB//dv0DFyYJTG9o/AtSjARKf4b9fUFxxAczsvyZDuhYvVfG/hYfjzyZV/L/Za+OUnPr0v5FkHTu9XFU/FesYF/PP5j/PX3jHx5v1P9FoqnwsPvA/0cMUUQS/+z8Xoz2hpqv8PyEiBRCm4Os/pmKTM0rv6D+NTOlYWfrvPzKqDVDv+qW/mncXLFeM4b9lChJ3Lmbtvw38M8qej9i/hDejEqii3b9vmtIwXZTtvzHj3FCbH9m/LxkAWnDm578Dxl8VoT/0v34dvga9y/e/ZQF86J7I8L/qu0pMtXjlv+Xh0gs1htY/2DhJefRu6T9ZZ08M/RLfP8GzRDcLcto/Nbi5VOfXAUDJXULruJcAQLx7uulZWvA/1AjmnPzO6j9MuyiS1vb0v4mS9EwrDeC/DnX3robI2L93U2nFLJ/Yv9Cycmp0HLe/SQAOfQ9y0L8fuC2JbXCXvzjso1/XJv2/7Ab/9KPP1L9UFP6um7nYv1JxCk6T++G/CS9fNB/d5r9DswyK7oDxvxW1jc1V9N8/NIqjHGwe+j+f2kp3esT0P1lKFhL8Pcs/B24c5JSW/z/Ss8IS0PTmPypkGUB/9Po/22ni35H6679RBU4he6nQv0apPVRXt9S/QnGkjSFw7r+ErUSFZm7tv/07PdxxdvO/KIp9zSPw5L8ZZJhN9J73v1UqV2B3W9O/YP1ERUjQ0z+r3/8hHBPov6ND+ET46sI/YX9SgQbY57/2NQzUGMjqP/a1Aq5zsvg/b/kKsrWp9D8ChSy4fp3yPwdpiiKNSvw/D4fvR/C6wj8Lka0d10jwP+xRRz3lpti/vz9WvBu/0T826QDqHlX3v022r7XCC82/es+Vthd4479eq7cyFCL1v/k3J5sIPvi/qFIf7aVr8r/11lWZCDuzP/9PO0EuTO+/2579uQ0+vz+VCJTwmCTEP9wQyO1XLOi/Jf+FFjLE/D/YUWvrlPHeP0wj17JqQe0/7E2f5nBn8z/uJ2eW3ND3P1TIVDArDvU//xcpS3/C6j8dGAFCx1rBv9FsbBU92+o/68Y5vlFjuT91VVSjsdjpv0YYip4IcPC/G/rm+aGZ+L9EBEubOHDlv9cMeHjvcO2/svmCizEd6L+1Jy7dslPcvzitufJXIeu/ppcdJw/q9L8XSSNVTznhvxZ28XinDtM/bbHBDAEN/j9NMggj8/feP/ILBOcDAv0/jIdyoiGF7T8E9K1cVlfoP1giTI2gm/o/32LRnM+FwL+ALgGTXEfZP8zuI62YouO/7mzLvyYq8b8cKuQauMT4v6GxwOA2vd2/5CFKYydj7r/Byhpouz/wv71nrIqtf9y/fi82nLY68b+MTDhJ3kzTv+5EeYQ5uu2/Drtb92NA1T/Rc0z+hfjEv5FT8I10Y8S/I/vUJs229b/jXKk6LjTfv+edhIuEq9S/Tg8ZhQCI7b/PvfInzQr1vxi099cE6uC/rmXXxDB94D+NpiIASbbzvxfEzS6Sqr+/2IU5WxZt8b/ejKsl7AHEv22RIUMQ8NQ//d/ul+Be8z/E+CIpz4cCQN0JPbvOn+k/FfCRNzgR/j/kBMju+znsP606u2merrK/18yTfCyl6b/D7YuAPULdv7sNgoIrRv2/F1WwRQNooj9FkglGOEO7P9uAzKU8JvG/LSfNfl+Y5T8f8qK/5ZXlP9KRFKpF3ui/JyUgvPvg7b+u992JfdzDv8f5SOy0uPW/bSWUakPOwb/rImlVNwvuv41zvfflINA/f0sKzCfF8T+preEMK2/8P7KPnzEHIO8/5IpRlDVZ9j+ByZ5te173Pzi905jjW++/B95hX65r87+h6PftfRrqv7X1TBA61vC/JntKhinh3T8++elkttrvv6FJ4uFIGNS/hM7dHG9V8j/cRXgMZg/cv2QAGD2rIvW/e/78F20+5z+URXRGiVbqv0fknI8C/eS/GZuorbh0rD8KBlEVhnn1P361fyQWneM/vk6CaPDy+j99pVpK7uwAQBsU1LhOpNA/QFw5M02SyT8tbhf2iPgAwFop4fQA7+G/GkD88IOq6L+DZn5Uyeqzv+ZnmhWxi5o/DXfvNGiF8b/MhGhrdfnGPzLDSpOr7N2/1Cf7VrVY2z8MmlYu2VDmv8nLIGDhp/S/4D5jKRby6j/4atC8fIG4vx6KOAPLa+q/95IRTCo8/j8RryiQohD0Px5PDxhr79A/l1NKpfWk9j8elA+Cv033P98ViWhlu88/eaZxZwtf9L8XbsBj0q/3v41i9zxya9q/ejTxvUZ8/L/Y5hFo6Kngv0qcERH0odW/kUoVp47s0T/R1WdcJ9/rP1WDbR0CRuQ/6BBqY1qlr7/uekK8oY7kvxyJOzOAHuC/5vo/ZtWp9L88J4Ygi73Av5pzH2iI+eM/xuLMUVT88j93LzWLLxX1P4yTBYYlcfk/+e7V3Ixr+j/tAvEsCADSP2OQdFq1v/2/bzvfrJGorb/3vdEmmRnHPx5vfw9cl/O/ohFHSPJK6z9JSbfjmjS5v5kvKnQPm9C/Yya9EhkfnT+sRZ6boPrgP7NTUtuierY/x649IXYi8b9LYwbdpnDxv/WRQEVPEPm/IufBqZg/5L82UkLjDVDwP1QxVMbhRfU/rgYSoymx8T9zZjLfn4kAQIMePiH6E4I/vYHT5e/B5D/kLMzSyQDJP55GC1DDVK0/RknuZm/l6b//tPmvjcLjv9uJcOZGN/i/Rmzg84bt+r+oivtVdPHtv6E9hh91EO6/vej7FtcN27/zw7TIN63Fv0ER9AmqI9s/IixjJU44678tFW8vkwHZP8oOuh6Qg+S/HsHM4Z3E9T/uWXL3cTDzP0xcewfcAe0/otcisVpv8T/mk37J+IjsP606rLV0iQBAlwnkB0KE57/Ldcf1R/vFv+vl4NaxkLW/ML2TiNai3r8+GpRc7LrYv3kd1qGEA/6/0H2ArJ2n9b8HyV8O9l/Wv/dBqmPHY+m/eNaX60gS2L8ttfGCib3xPxtcuOtcw+E/K1J385b8zL+QDzts9cXyv7g6FL/rygNArKxXyZ0d9D8J1HUJqyHkP/wu261/NtM/hJKbxdby8j9nIG2yqbTfPxMhOVad7/C/i+65K8xc579/qE0ja8Xhv4n7nsVZzey/t9CMUddFy7/QaWYnkuv0vwPRbthYJ/W/WDJtpd3Oz7+cylkpecHxv0zZkA0hU9A/LFE2ES//4D8pNfQAN1rFv4hIkJJPK9O/qB0sznPS3r+mc/GFRyH/P9gK+IKEM/4/2mLNsnVTzD/efcfxNBrtPxcOnGGUsfY/kvkl+86W8z8nddhLEg3LP/Trck9VS/a/9oxSSZZ3rb+e5zDTUWXTv9AFBEOW0PS/lbffp1G10b9pBO2VYZLcvyztv2GUhNG/5jjH+qj4q7/tG795EZvZvxMoiQpuPv2/yBD0TByy8r87EEzwacjaP1A6/57X9OA/iw/LcaMl1D+4FCxwBRn9P7KeUM/Mau4/XcqPKmit9T+Y84GgGdjHvyLgry9guQBAyMY211nz079DwDBdkZjyv+6AQrlCFO2/ZSX4P5v2zL9recrwgfr8v4jYmv3+4++/RAkPnMSl3T9kDZrx78DAv2CvB4zh9ve/rEoZCxtU6L/RNOPXNhzDv2tBkVygMOc/U2alwN9A5b8frOyQftTQPxpqu732Evo/uqziiaNO8D9kd2YgIV3qP7iFN27zbeg/Daso9E5O9T90/q9VjZv5P1Tma3Tw8ee/Jb84fPo7/L9g0zm4zkzzv7lu/uoQstm/nEupq0V28r/K+fFnEvS1P5xMvQM7Pt8/IO7MPBpjrL9zUn8uvznvvxkXycE+pOG/BCMlmRrY5D9r50tAlVPxvx3oihfe0+S/yfI886/1uz/GNw9AZ/rxP1OIyrPwp/w/Rd6+WhEv7D9nHsvCM8DyP33uyPjrEeM/WsyP1+QW+z892epcCJy0vz99RTfU38a/lJea//SL5r/dH7Ca0vrvv7WNJfAb5uC/lP+U0F5q5r9T2dl3zuXTv47NgWGgi7W/0Otx64Mk8b+pLLTFDJfmv4yX4Au268U/G40HtzRU8L+onS2OH9Dwv643sImPXeW/+2DtZazA+j8SL5C0IrcBQESLLfDm+/g/IHKIKdZK8z/cG4vZ0ZCjv+9kLhsREPU/Yx52c8jX7T9+gUobTbrCv77kTlNoMNq/gMyGxmhG5r8B6AV0AAD8vwOjTAkGScY/hidt/nde4r8SOd2Oqq70vxbVtbtxZNo/Q7wALAsy2T/AKyiEoajuv3rbV5wg6/C/1E0/cc6A+L8Jmcy6lkPVvzwl32A8YfU/8FWv4Z9l9D83Kf7XOaH3P5BFnGts9+E/JfslpUwp9z9V/0rjzpvnP+nWumCiO0s/EZbxak7fpz8Tf2PcRIrovzq9vz54dfK/1ta8JgTZyr+98P/AXc/dv0fq3tpXhem/GXJngN2h4b8PWOXHKzDOP3KFyC+I3sK/vemcp/mn7r8A3auu3MLXv1dO2GN1G/2/i7bPipNB5b/ba0pdwDzxPx3Pn/fEcc0/jLsgLqGA+j8tDr6L43jrP5pHua4s1ABAvuEN0CQh+z9U9TmMDJ3tP9UpOIOhns0/99hoUvYX379ooMxZQhv4v8ED5N+OHbq/x3GeR3quw7/y0UAGbGLgv9buTVff5PK/nWM6gqxL6r/+gwW9R6/3v0+D6r/X6e2/oytBqg45zz8KhCggbJLkv9GzFB+8b8y/8UKo4wwDz79Oif0x/EP5P/wa3kRzlPo/AyF4ogYe8T+Sw6gB7DLkP9LIViguF/8/jOVNITr2tj+b+zRV/DTlv0zwBy9ifvi/LOWEz7W41L/knpBb30nqP0boOhxFlei/Mayl5gi/xb/MAVb+2nrrvwQuAnrFm+i/2E8ss48Itz9Hs5faEEjsv2Zq3a5Pxs6/503tC+qN7r+etTpWcYTrvwIEfZssd/g/T4xi1dQ/lL+495P8ein+PxSIBJq3KO8/AO7Vxmg22z/oJi2dM9IBQJ0CbLpaZMG/Xh/J1HPwxr+ceBDw72ztv0rya7rVQda/shmfXQXB8b8jj6XumlfhP6FCqQrVZd4/+JGXe1d28b8q6o+iUZbpv28KT/VkVgLAKw1K8Py21r85XNPSv67jv79eDHUDYOM/hj7n+RLj0T+IXwHhQoP3P1PIgEyLvNC/T3vXUugu/j/MVfXBbjD1P564QDBo6NA/LIBnkVsq9D+bTdNCUnnWP/YDM4QbKcQ/OI4Ht//oy78hhi/DI0P5v+fYNyZNRuC/u0bp9SNI+L+RR2A9nbWxP1FNDEi9nL2/eN1iywAt4D+LktwsA3cDwF8ybmPM4NK/YNK85XVnz7+KbiF48NDXv4+pp7bon9U/wLoPbs859D+/5CE9y4jvPyp2k2ASbPE/G9mCw9MQjT8jZndEtF0AQCNDUnuBvt0/tFm5x5dN6T92IFGtfyPMv5Jkv3BEy8g/mHsX6Pr69b+iweKjnD/zv7hyjfi3TdC/R4c8QhtHdj/j3hADPbnlvzVTpJFPb/W/vJGCAE6A/L9K5Wa5Wpbdv/udcyWuu8a/mf4ZqijW2j/3DX6kUFDvv8XjRfU0XPo/26xs2bL07T/8bthNuL/uPwEckCnlp+o/irVpmLdl+z8hd83Vlw/vP8xURERq3Oq/SrVeUHvG479CwyLVuCvFP8rt67ZJYuA/zEs/VavJ3L9tJqHE+WDlv3r1huvPZ9a/jomIRMizr7/y95MArjX2P6padFjUcfY/F3XPW4sQ9z+XDv7JpwfzP0YuO414eeY/IxZ9Rl1d7T8K7+rJYLPtvxBzmW7cc9S/23v47UBkyD8RAHf2VLjdv7PlqFTMlNu/Uc4X9TM8BsC1wNpkGWK+vwFb6bA73Oa/HiF1T+LI6b+aq1WiBCGFvwBzXtTPmO0/sZhVnMRu4z8W4PNnv7XIP8jqjOa7i3w/5kTKAWUOwj+sVsD7b/riP2Fb1C0fNAFAqr1W5KU1BEB5Phq8WmHPPxaAHvKeVrG//fcKecQr8r8s2pX0h1fRv312O4Zz4uW/8FMS2Tvf8b/YWCD/Jafyv6WozVopxPS/k3kGJhH4sD9AuwqRliACwOViz5IUbPW/tIQLqL577L9RiSKkwtLxv6bOmRW1Ldu/4xYJ/5ST0T+W+iyZhuPVPzbPjkFlhNU/GWLdH0Lk4T8rz3ysOT76P5t1jFPTElM/tBti6ttO9j+0XoveieT6P7WhSh0iWdy/OgNggn312D9ISED9gvvmv9qH9EnDrOK/KUdkltPr8z/q4djk5mLDv583EgYg4fO/B7eQQFSL9r81Sh40/kXmP2/wUQioLNA/t2WQncYG8b/8srF/wTfEvyOnRZCg59k/I6JY7iCF+T9pS/oHsVz6P+YZ9mCdIcs/fQ00Yrsc8D/+YF+LJ2XzP2Gutlje8O8/F+OUTEOa6j9ojLs1Lr7kv0RHQpOmiPW/hN2DOgwc2L+wIXNr4bfuv5xPZD4++NW/s76ijJby9L8KulbL846svx3uDS8J8QDA5ucgfygwfr9U2NES1BPrv0NxAajztOO/L1/mVkkh8r+NGhaQDQqVvxit+AS1wuA/7zN64Hpc7z9gtYeuztPqP/8V097Bpug/C13qGLKO9z8LnL11VrL+P/EA4inEkvk/+CaH04Vj7r+BwN0FEnXov6O19fL7sdO//5WUM+JE0b//AIaHWHrYv/1zaJQHM+S/5AfK+Dp43r9VTqSHrJ76v/dt+EntS+i/WDAuhZwY4j/Dai4RVTvbv/bBf22Skey/QekbXo1B37+edoGh8QTwPxgyadXt2e4/5o3pvonJ4L+/Nxzu6fPsP/J8KCJ/mPw/6naW+GiJ7z9E//C8+IAAQDpcD+VRU78/dWSlAvmi+b/McEPt/l7lvzvqbRFR39O/afn982EWkb/FOWo0zhziv8UqyqQ/A/+/bCjhZFt+9r+TJetIelDhv8iT8OT2Ec+/cx/MHxiA3r+6wM5gaWLqv3gAxjUOgeS/iSIqRPWv4z/A/cAh1TmlP4lbqmqNKPI/Qk2AMWYt9j/XLDYWBUX8P/cKD6ORat8/Dc86MpM59T/m5yR/B7XxPxdBo79Me9e/ahKrohZV6T9TTGgvnuHlv+E5J/Qr0Nq/88tZRgbv8b/fBmUGiJbhvzMJfeAhJ/a/XZmJrV4Ryb8eINuSR9zwv3LzBFl6ZL4/M3GXHPBe8r8pD0ic9uzTv87kZHYrcf4/YBrY93Bw4L+mECHLdcXMP3fWMSi8l/0/JgtfnFEx+z/7oaxfPt/zP3pKZvIb/uM/b3ywHhio6D/bvbjcS3Dgvyj5KMzyRPC/HZCXhFIX578ZoWEKlCznv16pO9HxJNO/16DECreB8b+Nnzq72bXaP/us3AeROdc/2PDwsaVq279dNVvGkETKvxJ4E5vDC+m/pNvpRa287L8jEWgnj2j6P0V03DpbK/8/AWx+4o3Lpz/K0nOhqZLZvyr15gYQwfU/dI3Q7f6u+z9j2515gondP/fgEKCSv9I/sHkzIm1K4L+30rDELl3YvzI/nTfmTvG/Si+kcriq+r+xdqTP/ljqv0x/mPOapNA/wH1ri41F4r9/pd6VWUbZv4etUT9a25u/0sYKTtKX+L//yb1QL8Lrv9vIn8bUeua/KqCWkDxfAkBILGMYLd76PwQ4RK+uHsW/riDLMv4Frr+aZOyDva3SP/sPkLqOJew/miyCD/8o+z+DrUmOYrOKvxZNCSsH5di/8xYftDRvtT8hkWPvjzvQvzfiYAaMo/6/4vwHIOPS0r+7uJ90/NjNPwzaFyLNRZe/JUARJybQ479MZ3wDMW72v/3k/6akn++/ZbMtFOTe8b+GvwWTLlnmP64OVchzyvE/zgeoyrfy9z8wxebEV6f0P2oMWsYKJOs/WUpWgLGW2D/4bf7i5IHsP7HXKpWF6fQ/joJT+Pza4L+n/eWInh5cv9+cSOPAr8E/k3nR8PdX+79A1ZbjpyD8v1ddhKuRVNC/JpQK41oM2z/8Di3Wub/bv1GjVbHUm+C/58b2zrmS9L9j6zHGF+nsv57T72CIBuC/5Ucp9z9F8L+AAZMPkZ/3P3wWA61uq/g//NtM1KzJ5D/dCT3CK+jZP3ZB7YhEl+s/I3PWJxyEAkBjPz6DbuXrPy9abpeq1OO/MFy6zSDKwr8bVjdVebzWv7dwv9bJ/dS/paCkpUXS8r+CRdkndyH0v4egGdQRNcu/yhKTHH806b/67D99rfu/v2DaLIHyKOC/rtf2Hy5b8L93BdZskIbvv2Dk8uqaj+O/ZmEdnvmM+T98Qgd6wjb2PwDlAlVYAPA/RxREbyWP8z9owHvwEg/2Pxk3xDwSo+0/24JVrGgb9T/hkT+c8XLHv1C7JLKMjc+/rav3Owzk0r+zSSDN+rj0vwBw4sm3R/e/rFe/eh+68b+sTpB7J3/OP1V92Gtgo88/Rziw+dXz1r+0XAegLGnwv6WAFj/jEpO/UiiCNIV827/Vba3bmLnIP8WLlz9wYfA/yC9jDvZpvL8z54rAWm7nP7z/Qau6/e2/FK/E5F3H8T9aGuYi4ZoBQGNKPh0rzLI/EAt70rs99L9dVwuh/ffov+5QzFBQg/y/xq+wo+/U9b8Zs/+YWzf2PyLu4TFMp+s/rnZoHjHf4L8DeokldGPfvzjn6ChLU9O/XK7bg4Yz7780pRf6WsLRv68J1oBoc/G/vi8ARGq6+r9flEGJhHbnP0XvoOdAJvo/eBXyuXt+/z/Bu1Di1IX5P9K4hX4pwbc/7XE5JOzc9j/Qda0ltZ3TPxJJ1u5cOvS/09v8zYVe6r/R6WCat1XRPxYyf9PIQsy/Rj5dVEsS3b8GpcyMMwWxP3G82Ctt4+W/zFA/2A0GxD/C9DMruUrxv9N+5buesNK/0woz8Q2l8b80bHkLSUrRPw2xKPalk+C/KGYL7xta+z/gynxQEWb3P7b8o5j6Mfs/A0FOYZAK+T/F1h3S7GntPy6W+3+NVN4/uTAWFo79wz/sgh/WBuP1v9tSn+W1Cb+/2c9sIdIo479owGBscaX0vys5oKb/xPG/ONr6dBh/z7/FUILF7ELyv0ntRZsprc+/fbXGVzNN3b+ANqIYiqbwPxBwhoEpl/a/JYzNI+Yy9b/UnYZ+ixflv37rCoD/POs/I7gJvnql8D8CHMZtEAL7Pzdu7zB1l+o/TA+Eq0Yx+z8Q4aNfS03wPz5S6YebAeU/qwfO2J4j4r/3aUjXNkbqv9oc0NsiYck/DiM1i9Mh7r8nObBJq3TzvzNR3mX9PM6/5WtLDAg02D+4U59Aci98vwFbypRomvq/bDy9K1X17L+yUW4T29njvx5UP7aG/eA/XA9vtP3J7b8yxO9Gl2L+Pw0qtAxAU8E/4R/8lGi07j+lENxg7P3zP1l0FLZ+XPA/2OMTpcQD5T98VxKXeEz1P495Ou6lv+2/EtWQ7otA9b9vPBSV9tXsv5FnpA5Qduu/D7cCz5GK6D/itsRBrS7pvwUTT+bUmN6/J1nJ0S9Uur/dTaAAd/Gzv+EUWp/Yb+O/zzx1xCQ35r9Ql7TZclvZv/ACAEqYF+W/++U3LxGf6z+7ddhbQDnWP+DY6C7RMwFAm90i3mVe9T9w/1BBAcz1P4MPx1QCC/U/mvCked/Y6T+/Ze45yALOvzxYt3bbFfG/TEsyHlHF+7/GOY+fIOv4v3Z0RlZZ2c2/a/yJiy6T1b/6AQqCBZXnv3L0F6Tfh9W/pX7Nultbzj/3xos+4k/Qv1OwlXcWWvu/DVhq0WEhuL/aYavfv9Pwv9sCZA3k1fI/kCuRbyem8j8sCVYLmUP+P64TKu89wPE/sNMpZSFX0b+WkIn7/VnwPyi5waLgqvU/sMolsjE3tr8JU1xDTw7yv1PV7EvQx/K/3pRzPx7Y8b/qT2+CgvzjP+9sRbop7eO/",
+          "dtype": "f8",
+          "shape": "60, 20"
+         }
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          1.0,
+          1.0,
+          2.0,
+          2.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          6.474398190026787,
+          6.474398190026787,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          0.0,
+          0.0,
+          1.5,
+          1.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          7.0509069286390185,
+          7.0509069286390185,
+          6.474398190026787
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          5.0,
+          5.0,
+          6.0,
+          6.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          5.594324042073697,
+          5.594324042073697,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          4.0,
+          4.0,
+          5.5,
+          5.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          7.1359406433981265,
+          7.1359406433981265,
+          5.594324042073697
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          3.0,
+          3.0,
+          4.75,
+          4.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          7.8094789017943675,
+          7.8094789017943675,
+          7.1359406433981265
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          0.75,
+          0.75,
+          3.875,
+          3.875
+         ],
+         "xaxis": "x",
+         "y": [
+          7.0509069286390185,
+          8.39433665980331,
+          8.39433665980331,
+          7.8094789017943675
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          7.0,
+          7.0,
+          8.0,
+          8.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          6.634842965313602,
+          6.634842965313602,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          12.0,
+          12.0,
+          13.0,
+          13.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          6.491381582522518,
+          6.491381582522518,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          11.0,
+          11.0,
+          12.5,
+          12.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          6.701792196343055,
+          6.701792196343055,
+          6.491381582522518
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          10.0,
+          10.0,
+          11.75,
+          11.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          7.469060107668646,
+          7.469060107668646,
+          6.701792196343055
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          9.0,
+          9.0,
+          10.875,
+          10.875
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          8.19975566464174,
+          8.19975566464174,
+          7.469060107668646
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          7.5,
+          7.5,
+          9.9375,
+          9.9375
+         ],
+         "xaxis": "x",
+         "y": [
+          6.634842965313602,
+          8.502617718273054,
+          8.502617718273054,
+          8.19975566464174
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          16.0,
+          16.0,
+          17.0,
+          17.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          5.324536610056513,
+          5.324536610056513,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          15.0,
+          15.0,
+          16.5,
+          16.5
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          6.2145099024636306,
+          6.2145099024636306,
+          5.324536610056513
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          14.0,
+          14.0,
+          15.75,
+          15.75
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          7.371846488226396,
+          7.371846488226396,
+          6.2145099024636306
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          18.0,
+          18.0,
+          19.0,
+          19.0
+         ],
+         "xaxis": "x",
+         "y": [
+          0.0,
+          7.614995363909469,
+          7.614995363909469,
+          0.0
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          14.875,
+          14.875,
+          18.5,
+          18.5
+         ],
+         "xaxis": "x",
+         "y": [
+          7.371846488226396,
+          9.341723666294932,
+          9.341723666294932,
+          7.614995363909469
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          8.71875,
+          8.71875,
+          16.6875,
+          16.6875
+         ],
+         "xaxis": "x",
+         "y": [
+          8.502617718273054,
+          26.18250573607112,
+          26.18250573607112,
+          9.341723666294932
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          2.3125,
+          2.3125,
+          12.703125,
+          12.703125
+         ],
+         "xaxis": "x",
+         "y": [
+          8.39433665980331,
+          28.569404260400702,
+          28.569404260400702,
+          26.18250573607112
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.5252503062886014,
+          -2.5252503062886014,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          1.0,
+          1.0,
+          2.0,
+          2.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.7122356694070855,
+          -2.7122356694070855,
+          -2.5252503062886014
+         ],
+         "xaxis": "x4",
+         "y": [
+          0.0,
+          0.0,
+          1.5,
+          1.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.5428405570345367,
+          -2.5428405570345367,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          3.0,
+          3.0,
+          4.0,
+          4.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.1588836971246246,
+          -2.1588836971246246,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          7.0,
+          7.0,
+          8.0,
+          8.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.5121782789243023,
+          -2.5121782789243023,
+          -2.1588836971246246
+         ],
+         "xaxis": "x4",
+         "y": [
+          6.0,
+          6.0,
+          7.5,
+          7.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.278782720377295,
+          -3.278782720377295,
+          -2.5121782789243023
+         ],
+         "xaxis": "x4",
+         "y": [
+          5.0,
+          5.0,
+          6.75,
+          6.75
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.5428405570345367,
+          -4.035501772341797,
+          -4.035501772341797,
+          -3.278782720377295
+         ],
+         "xaxis": "x4",
+         "y": [
+          3.5,
+          3.5,
+          5.875,
+          5.875
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.7122356694070855,
+          -4.4105556377607344,
+          -4.4105556377607344,
+          -4.035501772341797
+         ],
+         "xaxis": "x4",
+         "y": [
+          0.75,
+          0.75,
+          4.6875,
+          4.6875
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.3894606423409344,
+          -3.3894606423409344,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          9.0,
+          9.0,
+          10.0,
+          10.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.6036967473213912,
+          -2.6036967473213912,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          11.0,
+          11.0,
+          12.0,
+          12.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.74590651555451,
+          -2.74590651555451,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          13.0,
+          13.0,
+          14.0,
+          14.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.774692524517872,
+          -2.774692524517872,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          16.0,
+          16.0,
+          17.0,
+          17.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.167723970790714,
+          -3.167723970790714,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          18.0,
+          18.0,
+          19.0,
+          19.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.774692524517872,
+          -3.56874053488601,
+          -3.56874053488601,
+          -3.167723970790714
+         ],
+         "xaxis": "x4",
+         "y": [
+          16.5,
+          16.5,
+          18.5,
+          18.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.627168358378926,
+          -3.627168358378926,
+          -3.56874053488601
+         ],
+         "xaxis": "x4",
+         "y": [
+          15.0,
+          15.0,
+          17.5,
+          17.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.74590651555451,
+          -4.527661330989433,
+          -4.527661330989433,
+          -3.627168358378926
+         ],
+         "xaxis": "x4",
+         "y": [
+          13.5,
+          13.5,
+          16.25,
+          16.25
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.6036967473213912,
+          -5.059161994003742,
+          -5.059161994003742,
+          -4.527661330989433
+         ],
+         "xaxis": "x4",
+         "y": [
+          11.5,
+          11.5,
+          14.875,
+          14.875
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.3894606423409344,
+          -5.382259173844895,
+          -5.382259173844895,
+          -5.059161994003742
+         ],
+         "xaxis": "x4",
+         "y": [
+          9.5,
+          9.5,
+          13.1875,
+          13.1875
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -4.4105556377607344,
+          -5.527952470550665,
+          -5.527952470550665,
+          -5.382259173844895
+         ],
+         "xaxis": "x4",
+         "y": [
+          2.71875,
+          2.71875,
+          11.34375,
+          11.34375
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.5169367621368264,
+          -3.5169367621368264,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          21.0,
+          21.0,
+          22.0,
+          22.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.974795410125942,
+          -3.974795410125942,
+          -3.5169367621368264
+         ],
+         "xaxis": "x4",
+         "y": [
+          20.0,
+          20.0,
+          21.5,
+          21.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.1848091813687844,
+          -3.1848091813687844,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          24.0,
+          24.0,
+          25.0,
+          25.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -4.08146582260192,
+          -4.08146582260192,
+          -3.1848091813687844
+         ],
+         "xaxis": "x4",
+         "y": [
+          23.0,
+          23.0,
+          24.5,
+          24.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.974795410125942,
+          -4.719585110909341,
+          -4.719585110909341,
+          -4.08146582260192
+         ],
+         "xaxis": "x4",
+         "y": [
+          20.75,
+          20.75,
+          23.75,
+          23.75
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.1948898177214486,
+          -2.1948898177214486,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          27.0,
+          27.0,
+          28.0,
+          28.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.40653031328266,
+          -3.40653031328266,
+          -2.1948898177214486
+         ],
+         "xaxis": "x4",
+         "y": [
+          26.0,
+          26.0,
+          27.5,
+          27.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.7819029016700125,
+          -2.7819029016700125,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          31.0,
+          31.0,
+          32.0,
+          32.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.3371457488225555,
+          -3.3371457488225555,
+          -2.7819029016700125
+         ],
+         "xaxis": "x4",
+         "y": [
+          30.0,
+          30.0,
+          31.5,
+          31.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -4.283709287430891,
+          -4.283709287430891,
+          -3.3371457488225555
+         ],
+         "xaxis": "x4",
+         "y": [
+          29.0,
+          29.0,
+          30.75,
+          30.75
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.40653031328266,
+          -5.297299515169979,
+          -5.297299515169979,
+          -4.283709287430891
+         ],
+         "xaxis": "x4",
+         "y": [
+          26.75,
+          26.75,
+          29.875,
+          29.875
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.8703883063064874,
+          -2.8703883063064874,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          33.0,
+          33.0,
+          34.0,
+          34.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.811445282772557,
+          -3.811445282772557,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          35.0,
+          35.0,
+          36.0,
+          36.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -2.8703883063064874,
+          -4.050938930265649,
+          -4.050938930265649,
+          -3.811445282772557
+         ],
+         "xaxis": "x4",
+         "y": [
+          33.5,
+          33.5,
+          35.5,
+          35.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.2203063330062482,
+          -3.2203063330062482,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          38.0,
+          38.0,
+          39.0,
+          39.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -4.06417816679395,
+          -4.06417816679395,
+          -3.2203063330062482
+         ],
+         "xaxis": "x4",
+         "y": [
+          37.0,
+          37.0,
+          38.5,
+          38.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -4.050938930265649,
+          -5.435727405686973,
+          -5.435727405686973,
+          -4.06417816679395
+         ],
+         "xaxis": "x4",
+         "y": [
+          34.5,
+          34.5,
+          37.75,
+          37.75
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -5.297299515169979,
+          -6.1199059293090565,
+          -6.1199059293090565,
+          -5.435727405686973
+         ],
+         "xaxis": "x4",
+         "y": [
+          28.3125,
+          28.3125,
+          36.125,
+          36.125
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -4.719585110909341,
+          -6.807660565621052,
+          -6.807660565621052,
+          -6.1199059293090565
+         ],
+         "xaxis": "x4",
+         "y": [
+          22.25,
+          22.25,
+          32.21875,
+          32.21875
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.900268999389516,
+          -3.900268999389516,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          40.0,
+          40.0,
+          41.0,
+          41.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.943484953894304,
+          -2.943484953894304,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          44.0,
+          44.0,
+          45.0,
+          45.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.182112286793227,
+          -3.182112286793227,
+          -2.943484953894304
+         ],
+         "xaxis": "x4",
+         "y": [
+          43.0,
+          43.0,
+          44.5,
+          44.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.3938774449627656,
+          -3.3938774449627656,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          46.0,
+          46.0,
+          47.0,
+          47.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.182112286793227,
+          -4.369058913611246,
+          -4.369058913611246,
+          -3.3938774449627656
+         ],
+         "xaxis": "x4",
+         "y": [
+          43.75,
+          43.75,
+          46.5,
+          46.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -4.604773662688782,
+          -4.604773662688782,
+          -4.369058913611246
+         ],
+         "xaxis": "x4",
+         "y": [
+          42.0,
+          42.0,
+          45.125,
+          45.125
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.900268999389516,
+          -5.397488424565543,
+          -5.397488424565543,
+          -4.604773662688782
+         ],
+         "xaxis": "x4",
+         "y": [
+          40.5,
+          40.5,
+          43.5625,
+          43.5625
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.4840981878514063,
+          -2.4840981878514063,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          51.0,
+          51.0,
+          52.0,
+          52.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.007554580525297,
+          -3.007554580525297,
+          -2.4840981878514063
+         ],
+         "xaxis": "x4",
+         "y": [
+          50.0,
+          50.0,
+          51.5,
+          51.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.239152900169107,
+          -3.239152900169107,
+          -3.007554580525297
+         ],
+         "xaxis": "x4",
+         "y": [
+          49.0,
+          49.0,
+          50.75,
+          50.75
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.519098376170015,
+          -3.519098376170015,
+          -3.239152900169107
+         ],
+         "xaxis": "x4",
+         "y": [
+          48.0,
+          48.0,
+          49.875,
+          49.875
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.115393193804137,
+          -3.115393193804137,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          55.0,
+          55.0,
+          56.0,
+          56.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.5217431556113885,
+          -3.5217431556113885,
+          -3.115393193804137
+         ],
+         "xaxis": "x4",
+         "y": [
+          54.0,
+          54.0,
+          55.5,
+          55.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -2.629389838688307,
+          -2.629389838688307,
+          -0.0
+         ],
+         "xaxis": "x4",
+         "y": [
+          58.0,
+          58.0,
+          59.0,
+          59.0
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -3.5890214830329663,
+          -3.5890214830329663,
+          -2.629389838688307
+         ],
+         "xaxis": "x4",
+         "y": [
+          57.0,
+          57.0,
+          58.5,
+          58.5
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.5217431556113885,
+          -4.523579377669903,
+          -4.523579377669903,
+          -3.5890214830329663
+         ],
+         "xaxis": "x4",
+         "y": [
+          54.75,
+          54.75,
+          57.75,
+          57.75
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -0.0,
+          -5.6336449418452235,
+          -5.6336449418452235,
+          -4.523579377669903
+         ],
+         "xaxis": "x4",
+         "y": [
+          53.0,
+          53.0,
+          56.25,
+          56.25
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -3.519098376170015,
+          -6.388452477536813,
+          -6.388452477536813,
+          -5.6336449418452235
+         ],
+         "xaxis": "x4",
+         "y": [
+          48.9375,
+          48.9375,
+          54.625,
+          54.625
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -5.397488424565543,
+          -7.013238443443776,
+          -7.013238443443776,
+          -6.388452477536813
+         ],
+         "xaxis": "x4",
+         "y": [
+          42.03125,
+          42.03125,
+          51.78125,
+          51.78125
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -6.807660565621052,
+          -25.89447187091294,
+          -25.89447187091294,
+          -7.013238443443776
+         ],
+         "xaxis": "x4",
+         "y": [
+          27.234375,
+          27.234375,
+          46.90625,
+          46.90625
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "#444444",
+          "width": 1.0
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          -5.527952470550665,
+          -28.146573264080356,
+          -28.146573264080356,
+          -25.89447187091294
+         ],
+         "xaxis": "x4",
+         "y": [
+          7.03125,
+          7.03125,
+          37.0703125,
+          37.0703125
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "colorscale": [
+          [
+           0.0,
+           "#E41A1C"
+          ],
+          [
+           0.3333333333333333,
+           "#E41A1C"
+          ],
+          [
+           0.3333333333333333,
+           "#FF7F00"
+          ],
+          [
+           0.6666666666666666,
+           "#FF7F00"
+          ],
+          [
+           0.6666666666666666,
+           "#FFD92F"
+          ],
+          [
+           1.0,
+           "#FFD92F"
+          ]
+         ],
+         "customdata": [
+          [
+           "Batch_A",
+           "Batch_A",
+           "Batch_A",
+           "Batch_A",
+           "Batch_A",
+           "Batch_A",
+           "Batch_A",
+           "Batch_B",
+           "Batch_B",
+           "Batch_B",
+           "Batch_B",
+           "Batch_B",
+           "Batch_B",
+           "Batch_B",
+           "Batch_C",
+           "Batch_C",
+           "Batch_C",
+           "Batch_C",
+           "Batch_C",
+           "Batch_C"
+          ]
+         ],
+         "hovertemplate": "batch: %{customdata}<extra></extra>",
+         "showscale": false,
+         "type": "heatmap",
+         "x": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQA==",
+          "dtype": "f8"
+         },
+         "xaxis": "x2",
+         "xgap": 1,
+         "y": [
+          "batch"
+         ],
+         "yaxis": "y2",
+         "ygap": 1,
+         "z": {
+          "bdata": "AAAAAAAAAAEBAQEBAQECAgICAgI=",
+          "dtype": "i1",
+          "shape": "1, 20"
+         },
+         "zmax": 2.5,
+         "zmin": -0.5
+        },
+        {
+         "hovertemplate": "quality: %{y:.2f}<extra></extra>",
+         "marker": {
+          "color": "#4C78A8",
+          "line": {
+           "color": "#333333",
+           "width": 0.5
+          }
+         },
+         "name": "quality",
+         "showlegend": false,
+         "type": "bar",
+         "x": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQA==",
+          "dtype": "f8"
+         },
+         "xaxis": "x3",
+         "y": {
+          "bdata": "4LWCXT3R7j+FspMMjnntPxke29PkdeY/OIeDXbHt5D+QgHOn1kfvPyPyFBLumuY/vuX6y3u15j+rTXJkdhPmP3959lBFpuM/y0R9QOVh6z9xfa59SE/oP8j4bFahWOg/7fTRWpIJ7j9NsJqi2UXlPx5DLlO/F+4//SWfvp847T8MQjXKY+blP3+g3mVS8e4/x8bcjiwP7j+zIDQ2Mx3mPw==",
+          "dtype": "f8"
+         },
+         "yaxis": "y3"
+        },
+        {
+         "colorscale": [
+          [
+           0.0,
+           "#377EB8"
+          ],
+          [
+           0.3333333333333333,
+           "#377EB8"
+          ],
+          [
+           0.3333333333333333,
+           "#4DAF4A"
+          ],
+          [
+           0.6666666666666666,
+           "#4DAF4A"
+          ],
+          [
+           0.6666666666666666,
+           "#984EA3"
+          ],
+          [
+           1.0,
+           "#984EA3"
+          ]
+         ],
+         "customdata": [
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Apoptosis"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Growth"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ],
+          [
+           "Repair"
+          ]
+         ],
+         "hovertemplate": "category: %{customdata}<extra></extra>",
+         "showscale": false,
+         "type": "heatmap",
+         "x": [
+          "category"
+         ],
+         "xaxis": "x6",
+         "xgap": 1,
+         "y": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQAAAAAAAADRAAAAAAAAANUAAAAAAAAA2QAAAAAAAADdAAAAAAAAAOEAAAAAAAAA5QAAAAAAAADpAAAAAAAAAO0AAAAAAAAA8QAAAAAAAAD1AAAAAAAAAPkAAAAAAAAA/QAAAAAAAAEBAAAAAAACAQEAAAAAAAABBQAAAAAAAgEFAAAAAAAAAQkAAAAAAAIBCQAAAAAAAAENAAAAAAACAQ0AAAAAAAABEQAAAAAAAgERAAAAAAAAARUAAAAAAAIBFQAAAAAAAAEZAAAAAAACARkAAAAAAAABHQAAAAAAAgEdAAAAAAAAASEAAAAAAAIBIQAAAAAAAAElAAAAAAACASUAAAAAAAABKQAAAAAAAgEpAAAAAAAAAS0AAAAAAAIBLQAAAAAAAAExAAAAAAACATEAAAAAAAABNQAAAAAAAgE1A",
+          "dtype": "f8"
+         },
+         "yaxis": "y6",
+         "ygap": 1,
+         "z": {
+          "bdata": "AAAAAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEBAQICAgICAgICAgICAgICAgICAgIC",
+          "dtype": "i1",
+          "shape": "60, 1"
+         },
+         "zmax": 2.5,
+         "zmin": -0.5
+        },
+        {
+         "hovertemplate": "score: %{x:.2f}<extra></extra>",
+         "marker": {
+          "color": "#4C78A8",
+          "line": {
+           "color": "#333333",
+           "width": 0.5
+          }
+         },
+         "name": "score",
+         "orientation": "h",
+         "showlegend": false,
+         "type": "bar",
+         "x": {
+          "bdata": "KK2RkkQHB0DAgW2WD2YeQAnHw9zi2vI/pWEPTXTKHUAdc9aQX/kdQF0CN/YephFA395k5cg7H0A0Lk+9LcUiQN1YjHlwHRRABn6fhyoZFUAk7fyM/WggQOY8LEWPIh1ALOWaIgk2FEA2Xid/6CvgPzpRO+fJdghAVvEOTywRA0BNKrVhNVkhQNNngFHkhvQ/ZPWDKLTBGEBgIu2Rl4ghQDTJV+9euQZA/cNT09dWGkB4Yb0xDUzPP+CZKTqsqyFAt2+EZ9WcAUCgN+j5/tITQOjKF7bMquE/f2UOegobCEBxXQwtUE0hQGoy9Kmw3AtAd2rJzSdBGECwqbyw/4IfQPi2TNMJehxAtE9UicKCIUBnsmpLh5cgQIMzyHh9mSNA6PoZCcfOHkAqDUAwZp8OQC6ZwG/S8gpAEM+0WnqKFkB+lHuIbh4bQDLlZxi4fhBAnp2kha+bD0BleuWmLc8fQGgewlty7BRAKl9aPBL1EkC62i/Z7bwDQM74fmz/dR1AA0kBi8R5H0Ddev/IMir+P2kTyRVoNiNAlSJ7TwevI0DZYV9w/ykMQLRr9QeKuyNAnBJHqLwE7j+EUYCimt8cQLJIbHRxWyJAwDgmwGiHGUCfNPwzR04XQFo4N+JYQyJA",
+          "dtype": "f8"
+         },
+         "xaxis": "x7",
+         "y": {
+          "bdata": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxAAAAAAAAALkAAAAAAAAAwQAAAAAAAADFAAAAAAAAAMkAAAAAAAAAzQAAAAAAAADRAAAAAAAAANUAAAAAAAAA2QAAAAAAAADdAAAAAAAAAOEAAAAAAAAA5QAAAAAAAADpAAAAAAAAAO0AAAAAAAAA8QAAAAAAAAD1AAAAAAAAAPkAAAAAAAAA/QAAAAAAAAEBAAAAAAACAQEAAAAAAAABBQAAAAAAAgEFAAAAAAAAAQkAAAAAAAIBCQAAAAAAAAENAAAAAAACAQ0AAAAAAAABEQAAAAAAAgERAAAAAAAAARUAAAAAAAIBFQAAAAAAAAEZAAAAAAACARkAAAAAAAABHQAAAAAAAgEdAAAAAAAAASEAAAAAAAIBIQAAAAAAAAElAAAAAAACASUAAAAAAAABKQAAAAAAAgEpAAAAAAAAAS0AAAAAAAIBLQAAAAAAAAExAAAAAAACATEAAAAAAAABNQAAAAAAAgE1A",
+          "dtype": "f8"
+         },
+         "yaxis": "y7"
+        },
+        {
+         "legendgroup": "batch",
+         "legendgrouptitle": {
+          "text": "batch"
+         },
+         "marker": {
+          "color": "#E41A1C",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "batch: Batch_A",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "batch",
+         "legendgrouptitle": {
+          "text": "batch"
+         },
+         "marker": {
+          "color": "#FF7F00",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "batch: Batch_B",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "batch",
+         "legendgrouptitle": {
+          "text": "batch"
+         },
+         "marker": {
+          "color": "#FFD92F",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "batch: Batch_C",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "category",
+         "legendgrouptitle": {
+          "text": "category"
+         },
+         "marker": {
+          "color": "#377EB8",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "category: Apoptosis",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "category",
+         "legendgrouptitle": {
+          "text": "category"
+         },
+         "marker": {
+          "color": "#4DAF4A",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "category: Growth",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "legendgroup": "category",
+         "legendgrouptitle": {
+          "text": "category"
+         },
+         "marker": {
+          "color": "#984EA3",
+          "size": 10,
+          "symbol": "square"
+         },
+         "mode": "markers",
+         "name": "category: Repair",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        }
+       ],
+       "layout": {
+        "barmode": "stack",
+        "font": {
+         "family": "Arial, Helvetica, sans-serif",
+         "size": 11
+        },
+        "height": 900,
+        "legend": {
+         "bgcolor": "rgba(255,255,255,0.8)",
+         "bordercolor": "#cccccc",
+         "borderwidth": 1,
+         "font": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 10
+         },
+         "itemsizing": "constant",
+         "tracegroupgap": 8,
+         "x": 1.1127272727272728,
+         "xanchor": "left",
+         "y": 1.0,
+         "yanchor": "top"
+        },
+        "margin": {
+         "b": 5,
+         "l": 5,
+         "r": 236,
+         "t": 65
+        },
+        "paper_bgcolor": "white",
+        "plot_bgcolor": "rgba(0,0,0,0)",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0.0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1.0,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0.0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1.0,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 16
+         },
+         "subtitle": {
+          "font": {
+           "color": "#666666",
+           "family": "Arial, Helvetica, sans-serif",
+           "size": 12
+          },
+          "text": "60 genes across 20 samples with batch and pathway annotations"
+         },
+         "text": "Multi-Batch Expression Profiling",
+         "x": 0.5,
+         "xanchor": "center"
+        },
+        "width": 1100,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0.09178391959798993,
+          0.8884170854271356
+         ],
+         "matches": "x5",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.09178391959798993,
+          0.8884170854271356
+         ],
+         "matches": "x5",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "domain": [
+          0.09178391959798993,
+          0.8884170854271356
+         ],
+         "linecolor": "#666666",
+         "linewidth": 1.2,
+         "matches": "x5",
+         "mirror": true,
+         "showgrid": false,
+         "showline": true,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "xaxis4": {
+         "anchor": "y4",
+         "domain": [
+          0.0,
+          0.07678391959798993
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "xaxis5": {
+         "anchor": "y5",
+         "domain": [
+          0.09178391959798993,
+          0.8884170854271356
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": true,
+         "side": "bottom",
+         "tickangle": -45,
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 10
+         },
+         "ticktext": [
+          "sample_00",
+          "sample_01",
+          "sample_04",
+          "sample_05",
+          "sample_06",
+          "sample_02",
+          "sample_03",
+          "sample_08",
+          "sample_11",
+          "sample_13",
+          "sample_10",
+          "sample_07",
+          "sample_09",
+          "sample_12",
+          "sample_17",
+          "sample_14",
+          "sample_15",
+          "sample_16",
+          "sample_18",
+          "sample_19"
+         ],
+         "tickvals": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19
+         ],
+         "zeroline": false
+        },
+        "xaxis6": {
+         "anchor": "y6",
+         "domain": [
+          0.9034170854271356,
+          0.9274120603015075
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": true,
+         "tickangle": -90,
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 9
+         },
+         "ticktext": [
+          "category"
+         ],
+         "tickvals": [
+          "category"
+         ],
+         "zeroline": false
+        },
+        "xaxis7": {
+         "anchor": "y7",
+         "domain": [
+          0.9424120603015075,
+          0.9999999999999999
+         ],
+         "linecolor": "#666666",
+         "linewidth": 1.2,
+         "mirror": true,
+         "showgrid": false,
+         "showline": true,
+         "showticklabels": true,
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 7
+         },
+         "ticklen": 3,
+         "ticks": "outside",
+         "title": {
+          "font": {
+           "family": "Arial, Helvetica, sans-serif",
+           "size": 9
+          },
+          "text": "score"
+         },
+         "zeroline": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0.92192,
+          1.0
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.8895199999999999,
+          0.9139199999999998
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "domain": [
+          0.8229599999999999,
+          0.8815199999999999
+         ],
+         "linecolor": "#666666",
+         "linewidth": 1.2,
+         "mirror": true,
+         "showgrid": false,
+         "showline": true,
+         "showticklabels": true,
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 7
+         },
+         "ticklen": 3,
+         "ticks": "outside",
+         "title": {
+          "font": {
+           "family": "Arial, Helvetica, sans-serif",
+           "size": 9
+          },
+          "text": "quality"
+         },
+         "zeroline": false
+        },
+        "yaxis4": {
+         "anchor": "x4",
+         "autorange": false,
+         "domain": [
+          0.0,
+          0.8149599999999999
+         ],
+         "range": [
+          59.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis5": {
+         "anchor": "x5",
+         "autorange": false,
+         "domain": [
+          0.0,
+          0.8149599999999999
+         ],
+         "matches": "y4",
+         "range": [
+          59.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis6": {
+         "anchor": "x6",
+         "autorange": false,
+         "domain": [
+          0.0,
+          0.8149599999999999
+         ],
+         "matches": "y4",
+         "range": [
+          59.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "zeroline": false
+        },
+        "yaxis7": {
+         "anchor": "x7",
+         "autorange": false,
+         "domain": [
+          0.0,
+          0.8149599999999999
+         ],
+         "linecolor": "#666666",
+         "linewidth": 1.2,
+         "matches": "y4",
+         "mirror": true,
+         "range": [
+          59.5,
+          -0.5
+         ],
+         "showgrid": false,
+         "showline": true,
+         "showticklabels": true,
+         "side": "right",
+         "tickfont": {
+          "family": "Arial, Helvetica, sans-serif",
+          "size": 9
+         },
+         "ticktext": [
+          "gene_015",
+          "gene_004",
+          "gene_016",
+          "gene_012",
+          "gene_014",
+          "gene_009",
+          "gene_006",
+          "gene_007",
+          "gene_018",
+          "gene_011",
+          "gene_013",
+          "gene_008",
+          "gene_019",
+          "gene_000",
+          "gene_002",
+          "gene_017",
+          "gene_001",
+          "gene_005",
+          "gene_003",
+          "gene_010",
+          "gene_041",
+          "gene_050",
+          "gene_052",
+          "gene_045",
+          "gene_053",
+          "gene_056",
+          "gene_057",
+          "gene_046",
+          "gene_059",
+          "gene_058",
+          "gene_049",
+          "gene_042",
+          "gene_054",
+          "gene_040",
+          "gene_051",
+          "gene_044",
+          "gene_047",
+          "gene_043",
+          "gene_048",
+          "gene_055",
+          "gene_026",
+          "gene_039",
+          "gene_021",
+          "gene_029",
+          "gene_027",
+          "gene_036",
+          "gene_024",
+          "gene_025",
+          "gene_022",
+          "gene_028",
+          "gene_030",
+          "gene_033",
+          "gene_034",
+          "gene_037",
+          "gene_038",
+          "gene_031",
+          "gene_032",
+          "gene_035",
+          "gene_020",
+          "gene_023"
+         ],
+         "tickvals": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30,
+          31,
+          32,
+          33,
+          34,
+          35,
+          36,
+          37,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          46,
+          47,
+          48,
+          49,
+          50,
+          51,
+          52,
+          53,
+          54,
+          55,
+          56,
+          57,
+          58,
+          59
+         ],
+         "zeroline": false
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 60x20 matrix with multiple annotation tracks\n",
+    "n_genes, n_samples = 60, 20\n",
+    "big_data = rng.standard_normal((n_genes, n_samples))\n",
+    "big_data[:20, :7] += 3.0\n",
+    "big_data[20:40, 7:14] += 2.0\n",
+    "big_data[40:, 14:] += 2.5\n",
+    "\n",
+    "df_big = pd.DataFrame(\n",
+    "    big_data,\n",
+    "    index=[f\"gene_{i:03d}\" for i in range(n_genes)],\n",
+    "    columns=[f\"sample_{j:02d}\" for j in range(n_samples)],\n",
+    ")\n",
+    "\n",
+    "# Column annotations: batch + quality score\n",
+    "batch = [\"Batch_A\"] * 7 + [\"Batch_B\"] * 7 + [\"Batch_C\"] * 6\n",
+    "quality = rng.uniform(0.6, 1.0, size=n_samples)\n",
+    "top_ha = HeatmapAnnotation(batch=batch, quality=quality)\n",
+    "\n",
+    "# Row annotations: category + numeric score\n",
+    "category = [\"Apoptosis\"] * 20 + [\"Repair\"] * 20 + [\"Growth\"] * 20\n",
+    "score = rng.uniform(0, 10, size=n_genes)\n",
+    "right_ha = HeatmapAnnotation(category=category, score=score, which=\"row\")\n",
+    "\n",
+    "hm3 = ComplexHeatmap(\n",
+    "    df_big,\n",
+    "    cluster_rows=True,\n",
+    "    cluster_cols=True,\n",
+    "    top_annotation=top_ha,\n",
+    "    right_annotation=right_ha,\n",
+    "    colorscale=\"Viridis\",\n",
+    "    normalize=\"row\",\n",
+    "    name=\"expression\",\n",
+    "    title=\"Multi-Batch Expression Profiling\",\n",
+    "    description=\"60 genes across 20 samples with batch and pathway annotations\",\n",
+    "    width=1100,\n",
+    "    height=900,\n",
+    ")\n",
+    "fig3 = hm3.to_plotly()\n",
+    "fig3.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/packages/plotly-complexheatmap/plotly_complexheatmap/heatmap.py
+++ b/packages/plotly-complexheatmap/plotly_complexheatmap/heatmap.py
@@ -50,6 +50,10 @@ class ComplexHeatmap:
         Fraction of figure allocated to each dendrogram axis.
     name:
         Name for the heatmap colourbar title.
+    title:
+        Figure title displayed at the top-centre of the figure.
+    description:
+        Subtitle text displayed below the title.
     width / height:
         Figure size in pixels.
     """
@@ -72,6 +76,8 @@ class ComplexHeatmap:
         cluster_metric: str = "euclidean",
         dendro_ratio: float = 0.08,
         name: str = "",
+        title: str = "",
+        description: str = "",
         width: int = 900,
         height: int = 700,
     ) -> None:
@@ -94,6 +100,8 @@ class ComplexHeatmap:
         self.cluster_metric = cluster_metric
         self.dendro_ratio = dendro_ratio
         self.name = name
+        self.title = title
+        self.description = description
         self.width = width
         self.height = height
 
@@ -930,12 +938,19 @@ class ComplexHeatmap:
 
         legend_x_frac = 1.0 + (label_px + colorbar_px + 8) / self.width
 
+        # Dynamic top margin based on title / description presence
+        top_margin = 30
+        if self.title and self.description:
+            top_margin = 65
+        elif self.title:
+            top_margin = 50
+
         fig.update_layout(
             width=self.width,
             height=self.height,
             plot_bgcolor="rgba(0,0,0,0)",
             paper_bgcolor="white",
-            margin={"l": left_margin, "r": right_margin, "t": 30, "b": 5},
+            margin={"l": left_margin, "r": right_margin, "t": top_margin, "b": 5},
             font={"family": FONT_FAMILY, "size": 11},
             legend={
                 "x": legend_x_frac,
@@ -950,6 +965,21 @@ class ComplexHeatmap:
                 "borderwidth": 1,
             },
         )
+
+        # Title (and optional subtitle via Plotly's native title.subtitle)
+        if self.title:
+            title_cfg: dict[str, object] = {
+                "text": self.title,
+                "x": 0.5,
+                "xanchor": "center",
+                "font": {"size": 16, "family": FONT_FAMILY},
+            }
+            if self.description:
+                title_cfg["subtitle"] = {
+                    "text": self.description,
+                    "font": {"size": 12, "family": FONT_FAMILY, "color": "#666666"},
+                }
+            fig.update_layout(title=title_cfg)
 
     @staticmethod
     def _axis_name(fig: go.Figure, cell: tuple[int, int], axis: str) -> str:

--- a/packages/plotly-complexheatmap/plotly_complexheatmap/layout.py
+++ b/packages/plotly-complexheatmap/plotly_complexheatmap/layout.py
@@ -203,7 +203,7 @@ def create_figure(layout: GridLayout, **kwargs: object) -> object:
         shared_xaxes="columns",
         shared_yaxes="rows",
         horizontal_spacing=0.015,
-        vertical_spacing=0.015,
+        vertical_spacing=0.008,
         specs=layout.specs,
         **kwargs,  # type: ignore[arg-type]
     )


### PR DESCRIPTION
## Summary
- Add `title` and `description` parameters to `ComplexHeatmap` for first-class figure title rendering
- Use Plotly 6's native `title.subtitle` API for proper centering and tight title/description spacing
- Dynamic top margin adjusts based on content (30px base → 50px title-only → 65px title+description)
- Reduce vertical subplot spacing (0.015 → 0.008) for tighter dendrogram-to-annotation gaps
- Add showcase notebook (`tmp_title_showcase.ipynb`) demonstrating various size/annotation configurations

## Test plan
- [ ] Run `python -c "from plotly_complexheatmap import ComplexHeatmap; ..."` verification script
- [ ] Run existing example scripts (`basic_heatmap.py`, `annotated_heatmap.py`) for regression
- [ ] Visual inspection of title/description rendering in notebook
- [ ] Backward compatibility: heatmaps without title/description unchanged (30px margin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)