### PR TITLE
fix: shared volume for internal API keys

### DIFF
--- a/depictio/api/v1/key_utils_base.py
+++ b/depictio/api/v1/key_utils_base.py
@@ -1,7 +1,7 @@
 """Base cryptographic key management utilities without logger dependencies."""
 
-import hashlib
 import os
+import secrets
 from pathlib import Path
 from typing import Literal
 
@@ -39,24 +39,15 @@ def _load_or_generate_api_internal_key(
 
 @validate_call(validate_return=True)
 def _generate_api_internal_key() -> str:
-    """Generate a consistent API internal key.
+    """Generate a cryptographically random API internal key.
 
     Returns:
-        Consistently generated API internal key
+        Random 256-bit hex key, persisted via the shared keys volume
     """
-    # Use a combination of environment variables and a salt to generate a consistent key
-    salt = "DEPICTIO_INTERNAL_KEY_SALT"
     base_key = os.getenv("DEPICTIO_INTERNAL_API_KEY", "")
 
-    # If no base key exists, generate a persistent key
     if not base_key:
-        # Generate a hash based on a combination of system information
-        # NOTE: os.getpid() was intentionally removed — it differs across containers,
-        # causing API/Dash key mismatch and permanent 403 on internal calls.
-        system_info = f"{os.getuid()}:{salt}"
-        base_key = hashlib.sha256(system_info.encode()).hexdigest()
-
-        # Set the environment variable to persist the key
+        base_key = secrets.token_hex(32)
         os.environ["DEPICTIO_INTERNAL_API_KEY"] = base_key
 
     return base_key

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,8 @@ services:
     container_name: depictio-frontend
     ports:
       - 5080:5080
+    volumes:
+      - depictio_keys:/app/depictio/keys
     env_file:
       - path: .env
         required: false
@@ -115,6 +117,8 @@ services:
     container_name: depictio-backend
     ports:
       - 8058:8058
+    volumes:
+      - depictio_keys:/app/depictio/keys
     env_file:
       - path: .env
         required: false
@@ -143,6 +147,8 @@ services:
     # Always enabled - required for design mode (stepper) to work
     # Dashboard editor will fail without Celery worker running
     image: ghcr.io/depictio/depictio:${DEPICTIO_VERSION:-latest}
+    volumes:
+      - depictio_keys:/app/depictio/keys
     env_file:
       - path: .env
         required: false
@@ -167,4 +173,6 @@ volumes:
   redis_data:
     driver: local
   minio_data:
+    driver: local
+  depictio_keys:
     driver: local

--- a/docker-compose/docker-compose.no-minio.yaml
+++ b/docker-compose/docker-compose.no-minio.yaml
@@ -58,6 +58,8 @@ services:
     container_name: depictio-frontend
     ports:
       - 5080:5080
+    volumes:
+      - depictio_keys:/app/depictio/keys
     env_file:
       - path: .env
         required: false
@@ -84,6 +86,8 @@ services:
     container_name: depictio-backend
     ports:
       - 8058:8058
+    volumes:
+      - depictio_keys:/app/depictio/keys
     env_file:
       - path: .env
         required: false
@@ -108,6 +112,8 @@ services:
     # Always enabled - required for design mode (stepper) to work
     # Dashboard editor will fail without Celery worker running
     image: ghcr.io/depictio/depictio:${DEPICTIO_VERSION:-latest}
+    volumes:
+      - depictio_keys:/app/depictio/keys
     env_file:
       - path: .env
         required: false
@@ -128,4 +134,6 @@ volumes:
   mongo_data:
     driver: local
   redis_data:
+    driver: local
+  depictio_keys:
     driver: local


### PR DESCRIPTION
## Summary

- Add shared `depictio_keys` named volume to `docker-compose.yaml` and `docker-compose.no-minio.yaml`, mounted on backend, frontend, and celery-worker containers
- Upgrade key generation from deterministic `hashlib.sha256(uid+salt)` to `secrets.token_hex(32)` — the shared volume makes determinism unnecessary and random is more secure
- Fixes blank `/auth` page on fresh Docker install caused by each container generating a different internal API key (different PIDs/UIDs → different hashes → 403 on every internal call)

**This fix works with existing v0.8.0 images** — the shared volume alone ensures all containers read the same key file without requiring an image rebuild.

## Test plan

- [ ] `docker compose down -v` then `docker compose up -d` — fresh install
- [ ] Verify `http://localhost:5080` redirects to `/dashboards` (not blank `/auth`)
- [ ] Verify backend logs show no "Invalid API key" errors
- [ ] Verify `docker exec depictio-backend cat /app/depictio/keys/api_internal_key.pem` matches `docker exec depictio-frontend cat /app/depictio/keys/api_internal_key.pem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)