### PR TITLE
fix: disable CLI config and logout in public/demo mode

### DIFF
--- a/depictio/api/v1/endpoints/user_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/user_endpoints/routes.py
@@ -733,6 +733,11 @@ async def check_token_validity_endpoint(token: TokenBase):
 async def generate_agent_config_endpoint(
     token: TokenBeanie, current_user: UserBase = Depends(get_current_user)
 ) -> CLIConfig:
+    if settings.auth.is_public_mode or settings.auth.is_demo_mode:
+        raise HTTPException(
+            status_code=403,
+            detail="CLI config generation is disabled in public/demo mode",
+        )
     depictio_agent_config = await _generate_agent_config(user=current_user, token=token)
 
     return depictio_agent_config

--- a/depictio/dash/layouts/profile.py
+++ b/depictio/dash/layouts/profile.py
@@ -130,7 +130,8 @@ layout = dmc.Container(
                                             variant="filled",
                                             # color=colors["pink"],
                                             radius=BUTTON_RADIUS,
-                                            disabled=settings.auth.is_single_user_mode,  # Disable in single-user mode
+                                            disabled=settings.auth.is_public_mode
+                                            or settings.auth.is_single_user_mode,
                                             leftSection=DashIconify(
                                                 icon="mdi:logout", width=ICON_SIZE
                                             ),
@@ -206,7 +207,8 @@ layout = dmc.Container(
                                                 variant="filled",
                                                 # color=colors["green"],
                                                 radius=BUTTON_RADIUS,
-                                                disabled=settings.auth.unauthenticated_mode,
+                                                disabled=settings.auth.is_public_mode
+                                                or settings.auth.is_single_user_mode,
                                                 leftSection=DashIconify(
                                                     icon="mdi:console", width=ICON_SIZE
                                                 ),
@@ -224,7 +226,10 @@ layout = dmc.Container(
                                                 },
                                             ),
                                             href="/cli_configs"
-                                            if not settings.auth.unauthenticated_mode
+                                            if not (
+                                                settings.auth.is_public_mode
+                                                or settings.auth.is_single_user_mode
+                                            )
                                             else "#",
                                         ),
                                     ],

--- a/depictio/dash/layouts/tokens_management.py
+++ b/depictio/dash/layouts/tokens_management.py
@@ -258,7 +258,8 @@ layout = dmc.Container(
                                         },
                                     }
                                 },
-                                disabled=settings.auth.unauthenticated_mode,
+                                disabled=settings.auth.is_public_mode
+                                or settings.auth.is_single_user_mode,
                             ),
                         ],
                         align="center",


### PR DESCRIPTION
## Summary
- Disables "Add New Configuration" button on `/cli_configs` page in public/demo/single-user modes to prevent S3 credential exposure
- Disables "CLI Agents" navigation button and link on `/profile` page in the same modes
- Disables "Logout" button in public/demo mode (no user session to log out of)
- Adds server-side 403 guard on `POST /generate_agent_config` API endpoint for public/demo mode

## Test plan
- [ ] Start in public mode (`DEPICTIO_AUTH_PUBLIC_MODE=true`) — verify "CLI Agents" and "Logout" buttons are disabled on `/profile`
- [ ] Navigate to `/cli_configs` — verify "Add New Configuration" button is disabled
- [ ] Call `POST /generate_agent_config` directly — verify 403 response
- [ ] Start in normal multi-user mode — verify all buttons work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)