### PR TITLE
fix: add logo and Codespaces badge to CLI README for PyPI

### DIFF
--- a/depictio/cli/README.md
+++ b/depictio/cli/README.md
@@ -1,6 +1,12 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/depictio/depictio/main/docs/images/logo_hd.png" alt="Depictio logo" width="300">
+</p>
+
 # Depictio CLI
 
 A command-line interface for interacting with the Depictio API.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/depictio/depictio)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Added depictio logo (absolute GitHub raw URL) to CLI README so it renders on PyPI
- Added GitHub Codespaces badge for quick setup access
- Images were missing on https://pypi.org/project/depictio-cli/ because the CLI README had no image references

## Test plan
- [ ] Build CLI package and inspect README rendering: `cd depictio/cli && pip install build && python -m build && twine check dist/*`
- [ ] After next PyPI publish, verify images appear at https://pypi.org/project/depictio-cli/

🤖 Generated with [Claude Code](https://claude.com/claude-code)