### PR TITLE
feat: project migrate command with ZIP export/import and UI

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,37 @@
+# Project Memory
+
+## Multi-Version Clone Setup Pattern
+
+See [multi-version-setup.md](multi-version-setup.md) for full details.
+
+**Quick reference** — to clone & configure a new version/branch:
+1. `GIT_LFS_SKIP_SMUDGE=1 git clone <repo> <dir>`
+2. Checkout tag via local branch (or fetch remote branch)
+3. Copy real SVGs from `depitio-0.7.4/docs/images/` (LFS server returns 404)
+4. `source .devcontainer/scripts/allocate-ports.sh`
+5. Regenerate `docker-compose.override.yaml` cleanly (allocate-ports.sh output is missing SINGLE_USER_MODE and may have issues)
+6. Append `DEPICTIO_AUTH_SINGLE_USER_MODE=true` to `.env.instance` if missing
+7. `rm -f .env && ln -sf .env.instance .env`
+8. Launch: `source .env.instance && docker-compose -p ${COMPOSE_PROJECT_NAME} --env-file .env.instance -f docker-compose.dev.yaml -f docker-compose.override.yaml up -d --force-recreate`
+
+**Key gotchas:**
+- macOS `sed` doesn't support `\n` in replacement strings — use heredoc/cat to regenerate files instead
+- `allocate-ports.sh` needs `git branch --show-current` to work — use local branches, not detached HEAD
+- Port offset 110-149 range is for unknown branch types (hash-based, collisions possible)
+- `docker-compose` (hyphenated) works, not `docker compose` (space) on this machine
+- All 3 services need SINGLE_USER_MODE in override: frontend, backend, celery-worker
+
+## Existing Workspace Versions
+
+Located in `/Users/tweber/Gits/workspaces/depictio-workspace/`:
+
+| Directory | Version/Branch | Dash | API | Offset |
+|-----------|---------------|------|-----|--------|
+| depitio-0.7.4 | v0.7.4 | 5111 | 8111 | 111 |
+| depitio-0.7.5-b1 | v0.7.5-b1 | 5143 | 8143 | 143 |
+| depitio-0.7.5-b2 | v0.7.5-b2 | 5126 | 8126 | 126 |
+| depitio-0.7.5 | v0.7.5 | 5117 | 8117 | 117 |
+| depitio-0.7.6-b1 | v0.7.6-b1 | 5125 | 8125 | 125 |
+| depitio-0.7.6 | v0.7.6 | 5130 | 8130 | 130 |
+| depitio-0.8.0-b1 | v0.8.0-b1 | 5114 | 8114 | 114 |
+| depitio-claude-python-bioinformatics-setup | claude/python-bioinformatics-setup-SVaj0 | 5138 | 8138 | 138 |

--- a/.claude/memory/multi-version-setup.md
+++ b/.claude/memory/multi-version-setup.md
@@ -1,0 +1,84 @@
+# Multi-Version Setup Pattern for Bug Bisection
+
+## Purpose
+Clone and configure multiple Depictio versions to run simultaneously for manual bug bisection.
+
+## Full Setup Steps for a New Version/Branch
+
+### 1. Clone with LFS skip
+```bash
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/depictio/depictio depitio-<name>
+```
+
+### 2. Checkout
+For tags: `git checkout -b local/<version> <tag>` (avoids detached HEAD)
+For branches: `git fetch origin <branch> && git checkout -b <branch> origin/<branch>`
+
+### 3. Fix broken LFS files
+```bash
+cp /path/to/depitio-0.7.4/docs/images/{favicon,logo_hd,logo_hd_white}.svg docs/images/
+```
+LFS server returns 404 for these objects.
+
+### 4. Generate port config
+```bash
+source .devcontainer/scripts/allocate-ports.sh
+```
+This creates `.env.instance` and `docker-compose.override.yaml`.
+
+### 5. Fix single-user mode
+Append to `.env.instance` if missing:
+```
+DEPICTIO_AUTH_SINGLE_USER_MODE=true
+```
+
+### 6. Regenerate docker-compose.override.yaml
+The allocate-ports.sh output is missing SINGLE_USER_MODE (versions before v0.8.0-b1).
+Regenerate cleanly using heredoc reading COMPOSE_PROJECT_NAME, FASTAPI_PORT, DASH_PORT from .env.instance.
+
+Template:
+```yaml
+services:
+  mongo:
+    container_name: ${COMPOSE_PROJECT}-mongo
+  redis:
+    container_name: ${COMPOSE_PROJECT}-redis
+  minio:
+    container_name: ${COMPOSE_PROJECT}-minio
+  depictio-frontend:
+    container_name: ${COMPOSE_PROJECT}-depictio-frontend
+    environment:
+      - DEPICTIO_FASTAPI_EXTERNAL_PORT=${FASTAPI_PORT}
+      - DEPICTIO_DASH_EXTERNAL_PORT=${DASH_PORT}
+      - DEPICTIO_DEV_MODE=true
+      - DEPICTIO_MONGODB_WIPE=false
+      - DEPICTIO_AUTH_SINGLE_USER_MODE=true
+  depictio-backend:
+    container_name: ${COMPOSE_PROJECT}-depictio-backend
+    environment:
+      - DEPICTIO_DEV_MODE=true
+      - DEPICTIO_MONGODB_WIPE=false
+      - DEPICTIO_AUTH_SINGLE_USER_MODE=true
+  depictio-celery-worker:
+    container_name: ${COMPOSE_PROJECT}-depictio-celery-worker
+    environment:
+      - DEPICTIO_DEV_MODE=true
+      - DEPICTIO_MONGODB_WIPE=false
+      - DEPICTIO_AUTH_SINGLE_USER_MODE=true
+```
+
+### 7. Symlink .env
+```bash
+rm -f .env && ln -sf .env.instance .env
+```
+
+### 8. Launch
+```bash
+source .env.instance && docker-compose -p ${COMPOSE_PROJECT_NAME} --env-file .env.instance -f docker-compose.dev.yaml -f docker-compose.override.yaml up -d --force-recreate
+```
+
+## Gotchas
+- macOS sed doesn't support `\n` in replacement — always use cat heredoc
+- `docker-compose` (hyphenated) works on this machine, NOT `docker compose` (space)
+- allocate-ports.sh hash can collide (e.g., v0.7.6-b1 and v0.7.6 both got 125) — manually fix offset if needed
+- v0.7.4 was originally set up with empty branch name causing double-dash container names — fixed by setting COMPOSE_PROJECT_NAME to depictio-v0-7-4

--- a/.devcontainer/scripts/allocate-ports.sh
+++ b/.devcontainer/scripts/allocate-ports.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Save caller's shell options so we can restore them when this script is sourced.
+# Without this, `set -e` leaks into the interactive shell and breaks readline
+# (Esc key, Ctrl+R history search, etc. all return non-zero and abort the shell).
+_ALLOCATE_PORTS_SAVED_OPTS=$(set +o)
 set -e
 
 # Port allocation script for git worktree-based multi-instance setup
@@ -215,3 +219,8 @@ export DASH_PORT
 export MINIO_PORT
 export MINIO_CONSOLE_PORT
 export DATA_DIR="data/${COMPOSE_PROJECT_NAME}"
+
+# Restore caller's shell options (prevents set -e from leaking into the
+# interactive shell when this script is sourced).
+eval "$_ALLOCATE_PORTS_SAVED_OPTS"
+unset _ALLOCATE_PORTS_SAVED_OPTS

--- a/.devcontainer/scripts/allocate-ports.sh
+++ b/.devcontainer/scripts/allocate-ports.sh
@@ -106,6 +106,9 @@ else
 fi
 echo ""
 
+# Development auth settings (default: single-user mode for devcontainers)
+DEPICTIO_AUTH_SINGLE_USER_MODE=${DEPICTIO_AUTH_SINGLE_USER_MODE:-true}
+
 # Save configuration to .env.instance for persistence
 cat > .env.instance <<EOF
 # Auto-generated instance configuration
@@ -146,7 +149,7 @@ DEPICTIO_MINIO_ROOT_PASSWORD=minio123
 
 # Development settings
 DEPICTIO_DEV_MODE=true
-DEPICTIO_AUTH_SINGLE_USER_MODE=true
+DEPICTIO_AUTH_SINGLE_USER_MODE=${DEPICTIO_AUTH_SINGLE_USER_MODE}
 DEPICTIO_MONGODB_WIPE=${MONGODB_WIPE}
 
 # Data directory

--- a/.devcontainer/scripts/allocate-ports.sh
+++ b/.devcontainer/scripts/allocate-ports.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-# Save caller's shell options so we can restore them when this script is sourced.
-# Without this, `set -e` leaks into the interactive shell and breaks readline
-# (Esc key, Ctrl+R history search, etc. all return non-zero and abort the shell).
-_ALLOCATE_PORTS_SAVED_OPTS=$(set +o)
-set -e
+# Note: intentionally no `set -e` — this script is sourced by pre_create_setup.sh
+# and set -e would leak into the interactive shell, breaking readline (Esc, Ctrl+R, etc.).
 
 # Port allocation script for git worktree-based multi-instance setup
 # Uses branch naming convention to assign deterministic port offsets
@@ -219,8 +216,3 @@ export DASH_PORT
 export MINIO_PORT
 export MINIO_CONSOLE_PORT
 export DATA_DIR="data/${COMPOSE_PROJECT_NAME}"
-
-# Restore caller's shell options (prevents set -e from leaking into the
-# interactive shell when this script is sourced).
-eval "$_ALLOCATE_PORTS_SAVED_OPTS"
-unset _ALLOCATE_PORTS_SAVED_OPTS

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -2099,6 +2099,78 @@ jobs:
 
           echo "✅ Migrate (all mode) verified — files=$UPSERTED_FILES deltatables=$UPSERTED_DELTATABLES upserted, S3 copy confirmed"
 
+      - name: Test project cascade delete (S3 + MongoDB cleanup) - ${{ matrix.strategy_name }}
+        run: |
+          echo "🗑️ Testing project cascade delete for ${{ matrix.strategy_name }}..."
+          cd depictio/cli
+          source venv/bin/activate
+
+          IRIS_PROJECT_NAME="Iris Dataset Project Data Analysis"
+
+          # Resolve project ID
+          IRIS_PROJECT_ID=$(python3 -c "
+          import httpx, sys
+          r = httpx.get('http://localhost:8058/depictio/api/v1/projects/get/all',
+                        headers={'Authorization': 'Bearer $(cat admin_config.yaml | python3 -c \"import sys,yaml; print(yaml.safe_load(sys.stdin)[\\\"token\\\"])\")'})
+          r.raise_for_status()
+          projects = r.json()
+          match = [p for p in projects if p.get('name') == '$IRIS_PROJECT_NAME']
+          print(match[0]['id'] if match else '')
+          " 2>/dev/null)
+
+          if [ -z "$IRIS_PROJECT_ID" ]; then
+            echo "⚠️  Iris project not found — skipping cascade delete test"
+            exit 0
+          fi
+          echo "📌 Iris project ID: $IRIS_PROJECT_ID"
+
+          # Snapshot MongoDB counts before deletion
+          FILES_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.files.countDocuments({})" --quiet 2>&1 | tail -1)
+          DELTATABLES_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.deltatables.countDocuments({})" --quiet 2>&1 | tail -1)
+          DASHBOARDS_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          PROJECTS_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 Before delete: projects=$PROJECTS_BEFORE files=$FILES_BEFORE deltatables=$DELTATABLES_BEFORE dashboards=$DASHBOARDS_BEFORE"
+
+          # Delete the project via the API
+          TOKEN=$(cat admin_config.yaml | python3 -c "import sys,yaml; print(yaml.safe_load(sys.stdin)['token'])")
+          DELETE_RESP=$(python3 -c "
+          import httpx
+          r = httpx.delete('http://localhost:8058/depictio/api/v1/projects/delete',
+                           params={'project_id': '$IRIS_PROJECT_ID'},
+                           headers={'Authorization': 'Bearer $TOKEN'})
+          print(r.status_code, r.text[:200])
+          ")
+          echo "🗑️ Delete response: $DELETE_RESP"
+
+          # Verify project is gone
+          PROJECTS_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
+          [ "$PROJECTS_AFTER" -lt "$PROJECTS_BEFORE" ] || \
+            { echo "❌ Project count did not decrease ($PROJECTS_BEFORE → $PROJECTS_AFTER)"; exit 1; }
+          echo "✅ Project document deleted"
+
+          # Verify dependent MongoDB docs were cascade-deleted
+          FILES_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.files.countDocuments({})" --quiet 2>&1 | tail -1)
+          DELTATABLES_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.deltatables.countDocuments({})" --quiet 2>&1 | tail -1)
+          DASHBOARDS_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 After delete: projects=$PROJECTS_AFTER files=$FILES_AFTER deltatables=$DELTATABLES_AFTER dashboards=$DASHBOARDS_AFTER"
+
+          [ "$FILES_AFTER" -lt "$FILES_BEFORE" ] || \
+            { echo "❌ files collection not cleaned up ($FILES_BEFORE → $FILES_AFTER)"; exit 1; }
+          [ "$DELTATABLES_AFTER" -lt "$DELTATABLES_BEFORE" ] || \
+            { echo "❌ deltatables collection not cleaned up ($DELTATABLES_BEFORE → $DELTATABLES_AFTER)"; exit 1; }
+          [ "$DASHBOARDS_AFTER" -lt "$DASHBOARDS_BEFORE" ] || \
+            { echo "❌ dashboards collection not cleaned up ($DASHBOARDS_BEFORE → $DASHBOARDS_AFTER)"; exit 1; }
+
+          echo "✅ Cascade delete verified — files/deltatables/dashboards all cleaned up"
+
       - name: Cleanup and summary - ${{ matrix.strategy_name }}
         run: |
           echo "🧹 Cleanup and summary for ${{ matrix.strategy_name }}..."

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -2160,7 +2160,7 @@ jobs:
           IRIS_PROJECT_NAME="Iris Dataset Project Data Analysis"
 
           # Resolve project ID
-          TOKEN=$(cat admin_config.yaml | python3 -c "import sys,yaml; print(yaml.safe_load(sys.stdin)['token'])")
+          TOKEN=$(grep 'access_token' admin_config.yaml | awk '{print $2}' | tr -d "'\"")
           IRIS_PROJECT_ID=$(python3 -c "
           import httpx
           r = httpx.get('http://localhost:8058/depictio/api/v1/projects/get/all',
@@ -2188,8 +2188,7 @@ jobs:
             --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
           echo "📊 Before delete: projects=$PROJECTS_BEFORE files=$FILES_BEFORE deltatables=$DELTATABLES_BEFORE dashboards=$DASHBOARDS_BEFORE"
 
-          # Delete the project via the API
-          TOKEN=$(cat admin_config.yaml | python3 -c "import sys,yaml; print(yaml.safe_load(sys.stdin)['token'])")
+          # Delete the project via the API (TOKEN already set above)
           DELETE_RESP=$(python3 -c "
           import httpx
           r = httpx.delete('http://localhost:8058/depictio/api/v1/projects/delete',

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -1922,6 +1922,91 @@ jobs:
             exit 1
           fi
 
+      - name: Test migrate (self-migration, metadata mode) - ${{ matrix.strategy_name }}
+        run: |
+          echo "🔄 Testing depictio migrate (self-migration, metadata mode) for ${{ matrix.strategy_name }}..."
+          cd depictio/cli
+          source venv/bin/activate
+
+          # Resolve the Iris project name and capture before-counts
+          IRIS_PROJECT_NAME="Iris Dataset Project Data Analysis"
+
+          PROJECT_COUNT_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
+          WORKFLOW_COUNT_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.workflows.countDocuments({})" --quiet 2>&1 | tail -1)
+          DASHBOARD_COUNT_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 Before migrate: projects=$PROJECT_COUNT_BEFORE  workflows=$WORKFLOW_COUNT_BEFORE  dashboards=$DASHBOARD_COUNT_BEFORE"
+
+          # Dry-run first — must not change anything
+          echo "🏃 Running dry-run migrate..."
+          depictio-cli -v -vl DEBUG migrate \
+            --project "$IRIS_PROJECT_NAME" \
+            --CLI-config-path admin_config.yaml \
+            --target-config admin_config.yaml \
+            --mode metadata \
+            --dry-run
+          echo "✅ Dry-run migrate completed"
+
+          PROJECT_COUNT_DRY=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
+          [ "$PROJECT_COUNT_DRY" -eq "$PROJECT_COUNT_BEFORE" ] || \
+            { echo "❌ Dry-run changed project count ($PROJECT_COUNT_BEFORE → $PROJECT_COUNT_DRY)"; exit 1; }
+          echo "✅ Dry-run did not modify the database"
+
+          # Real migrate (same instance as source and target — idempotent upsert)
+          echo "🚀 Running real migrate (metadata mode)..."
+          depictio-cli -v -vl DEBUG migrate \
+            --project "$IRIS_PROJECT_NAME" \
+            --CLI-config-path admin_config.yaml \
+            --target-config admin_config.yaml \
+            --mode metadata
+          echo "✅ Real migrate completed"
+
+          # Verify counts are preserved (upsert is non-destructive)
+          PROJECT_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
+          WORKFLOW_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.workflows.countDocuments({})" --quiet 2>&1 | tail -1)
+          DASHBOARD_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 After migrate: projects=$PROJECT_COUNT_AFTER  workflows=$WORKFLOW_COUNT_AFTER  dashboards=$DASHBOARD_COUNT_AFTER"
+
+          [ "$PROJECT_COUNT_AFTER" -ge "$PROJECT_COUNT_BEFORE" ] || \
+            { echo "❌ Projects decreased after migrate ($PROJECT_COUNT_BEFORE → $PROJECT_COUNT_AFTER)"; exit 1; }
+          [ "$WORKFLOW_COUNT_AFTER" -ge "$WORKFLOW_COUNT_BEFORE" ] || \
+            { echo "❌ Workflows decreased after migrate ($WORKFLOW_COUNT_BEFORE → $WORKFLOW_COUNT_AFTER)"; exit 1; }
+
+          echo "✅ Migrate (metadata mode) verified — non-destructive upsert confirmed"
+
+      - name: Test migrate (dashboard mode) - ${{ matrix.strategy_name }}
+        run: |
+          echo "📊 Testing depictio migrate --mode dashboard for ${{ matrix.strategy_name }}..."
+          cd depictio/cli
+          source venv/bin/activate
+
+          IRIS_PROJECT_NAME="Iris Dataset Project Data Analysis"
+
+          DASH_COUNT_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 Dashboards before dashboard-mode migrate: $DASH_COUNT_BEFORE"
+
+          depictio-cli -v -vl DEBUG migrate \
+            --project "$IRIS_PROJECT_NAME" \
+            --CLI-config-path admin_config.yaml \
+            --target-config admin_config.yaml \
+            --mode dashboard
+
+          DASH_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 Dashboards after dashboard-mode migrate: $DASH_COUNT_AFTER"
+
+          [ "$DASH_COUNT_AFTER" -ge "$DASH_COUNT_BEFORE" ] || \
+            { echo "❌ Dashboards decreased after dashboard migrate ($DASH_COUNT_BEFORE → $DASH_COUNT_AFTER)"; exit 1; }
+
+          echo "✅ Migrate (dashboard mode) verified"
+
       - name: Cleanup and summary - ${{ matrix.strategy_name }}
         run: |
           echo "🧹 Cleanup and summary for ${{ matrix.strategy_name }}..."

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -1956,13 +1956,27 @@ jobs:
           echo "✅ Dry-run did not modify the database"
 
           # Real migrate (same instance as source and target — idempotent upsert)
+          # --overwrite required because the project already exists on this instance
           echo "🚀 Running real migrate (metadata mode)..."
           depictio-cli -v -vl DEBUG migrate run \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
-            --mode metadata
+            --mode metadata \
+            --overwrite
           echo "✅ Real migrate completed"
+
+          # Verify conflict detection: run WITHOUT --overwrite → must fail with conflict
+          echo "🔒 Testing conflict detection (no --overwrite, should fail)..."
+          if depictio-cli migrate run \
+            --project "$IRIS_PROJECT_NAME" \
+            --CLI-config-path admin_config.yaml \
+            --target-config admin_config.yaml \
+            --mode metadata 2>&1; then
+            echo "❌ Expected conflict exit but command succeeded"
+            exit 1
+          fi
+          echo "✅ Conflict detection works — second import without --overwrite correctly rejected"
 
           # Verify counts are preserved (upsert is non-destructive)
           PROJECT_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
@@ -2002,7 +2016,8 @@ jobs:
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
-            --mode dashboard 2>&1 | tee "$MIGRATE_LOG"
+            --mode dashboard \
+            --overwrite 2>&1 | tee "$MIGRATE_LOG"
 
           # Check that the export found > 0 dashboards (not a no-op due to wrong project_id query)
           UPSERTED_DASHBOARDS=$(python3 -c "
@@ -2045,11 +2060,31 @@ jobs:
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
-            --mode all 2>&1 | tee "$MIGRATE_LOG"
+            --mode all \
+            --overwrite 2>&1 | tee "$MIGRATE_LOG"
 
-          # Verify S3 copy ran (may copy 0 locations if no delta tables, that is ok)
+          # Verify S3 copy ran
           echo "📋 Migrate all-mode output (S3 section):"
           grep -i "s3\|location\|copied\|files" "$MIGRATE_LOG" || echo "(no S3 lines in output)"
+
+          # Verify files and deltatables were included (dc_ids fix)
+          UPSERTED_FILES=$(python3 -c "
+          import re
+          text = open('$MIGRATE_LOG').read()
+          m = re.search(r'\"files\"[^0-9]*([0-9]+)', text)
+          print(m.group(1) if m else '0')
+          " 2>/dev/null || echo "0")
+          UPSERTED_DELTATABLES=$(python3 -c "
+          import re
+          text = open('$MIGRATE_LOG').read()
+          m = re.search(r'\"deltatables\"[^0-9]*([0-9]+)', text)
+          print(m.group(1) if m else '0')
+          " 2>/dev/null || echo "0")
+          echo "📊 All-mode upserted: files=$UPSERTED_FILES  deltatables=$UPSERTED_DELTATABLES"
+          [ "$UPSERTED_FILES" -gt 0 ] || \
+            { echo "❌ All mode upserted 0 files (dc_ids lookup failed)"; exit 1; }
+          [ "$UPSERTED_DELTATABLES" -gt 0 ] || \
+            { echo "❌ All mode upserted 0 deltatables (dc_ids lookup failed)"; exit 1; }
 
           PROJECT_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
             --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
@@ -2062,7 +2097,7 @@ jobs:
           [ "$DASHBOARD_COUNT_AFTER" -ge "$DASHBOARD_COUNT_BEFORE" ] || \
             { echo "❌ Dashboards decreased after all-mode migrate ($DASHBOARD_COUNT_BEFORE → $DASHBOARD_COUNT_AFTER)"; exit 1; }
 
-          echo "✅ Migrate (all mode) verified — non-destructive upsert + S3 copy confirmed"
+          echo "✅ Migrate (all mode) verified — files=$UPSERTED_FILES deltatables=$UPSERTED_DELTATABLES upserted, S3 copy confirmed"
 
       - name: Cleanup and summary - ${{ matrix.strategy_name }}
         run: |

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -1941,7 +1941,7 @@ jobs:
 
           # Dry-run first — must not change anything
           echo "🏃 Running dry-run migrate..."
-          depictio-cli -v -vl DEBUG migrate \
+          depictio-cli -v -vl DEBUG migrate run \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
@@ -1957,7 +1957,7 @@ jobs:
 
           # Real migrate (same instance as source and target — idempotent upsert)
           echo "🚀 Running real migrate (metadata mode)..."
-          depictio-cli -v -vl DEBUG migrate \
+          depictio-cli -v -vl DEBUG migrate run \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
@@ -1992,7 +1992,7 @@ jobs:
             --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
           echo "📊 Dashboards before dashboard-mode migrate: $DASH_COUNT_BEFORE"
 
-          depictio-cli -v -vl DEBUG migrate \
+          depictio-cli -v -vl DEBUG migrate run \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -1992,11 +1992,28 @@ jobs:
             --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
           echo "📊 Dashboards before dashboard-mode migrate: $DASH_COUNT_BEFORE"
 
+          # Verify there are dashboards to work with
+          [ "$DASH_COUNT_BEFORE" -gt 0 ] || \
+            { echo "❌ No dashboards found before dashboard-mode test — environment not set up correctly"; exit 1; }
+
+          # Run migrate and capture output to verify dashboards were actually exported
+          MIGRATE_LOG=$(mktemp)
           depictio-cli -v -vl DEBUG migrate run \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
-            --mode dashboard
+            --mode dashboard 2>&1 | tee "$MIGRATE_LOG"
+
+          # Check that the export found > 0 dashboards (not a no-op due to wrong project_id query)
+          UPSERTED_DASHBOARDS=$(python3 -c "
+          import re, sys
+          text = open('$MIGRATE_LOG').read()
+          m = re.search(r'\"dashboards\"[^0-9]*([0-9]+)', text)
+          print(m.group(1) if m else '0')
+          " 2>/dev/null || echo "0")
+          echo "📊 Dashboards upserted in bundle: $UPSERTED_DASHBOARDS"
+          [ "$UPSERTED_DASHBOARDS" -gt 0 ] || \
+            { echo "❌ Dashboard mode exported 0 dashboards (project_id lookup failed)"; exit 1; }
 
           DASH_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
             --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
@@ -2005,7 +2022,47 @@ jobs:
           [ "$DASH_COUNT_AFTER" -ge "$DASH_COUNT_BEFORE" ] || \
             { echo "❌ Dashboards decreased after dashboard migrate ($DASH_COUNT_BEFORE → $DASH_COUNT_AFTER)"; exit 1; }
 
-          echo "✅ Migrate (dashboard mode) verified"
+          echo "✅ Migrate (dashboard mode) verified — exported $UPSERTED_DASHBOARDS dashboards"
+
+      - name: Test migrate (all mode, S3 + MongoDB) - ${{ matrix.strategy_name }}
+        run: |
+          echo "🔄 Testing depictio migrate --mode all for ${{ matrix.strategy_name }}..."
+          cd depictio/cli
+          source venv/bin/activate
+
+          IRIS_PROJECT_NAME="Iris Dataset Project Data Analysis"
+
+          PROJECT_COUNT_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
+          DASHBOARD_COUNT_BEFORE=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 Before all-mode migrate: projects=$PROJECT_COUNT_BEFORE  dashboards=$DASHBOARD_COUNT_BEFORE"
+
+          # Run mode=all (self-migration: same instance as source and target)
+          # This exercises the S3 copy code path in addition to MongoDB upserts
+          MIGRATE_LOG=$(mktemp)
+          depictio-cli -v -vl DEBUG migrate run \
+            --project "$IRIS_PROJECT_NAME" \
+            --CLI-config-path admin_config.yaml \
+            --target-config admin_config.yaml \
+            --mode all 2>&1 | tee "$MIGRATE_LOG"
+
+          # Verify S3 copy ran (may copy 0 locations if no delta tables, that is ok)
+          echo "📋 Migrate all-mode output (S3 section):"
+          grep -i "s3\|location\|copied\|files" "$MIGRATE_LOG" || echo "(no S3 lines in output)"
+
+          PROJECT_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.projects.countDocuments({})" --quiet 2>&1 | tail -1)
+          DASHBOARD_COUNT_AFTER=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "📊 After all-mode migrate: projects=$PROJECT_COUNT_AFTER  dashboards=$DASHBOARD_COUNT_AFTER"
+
+          [ "$PROJECT_COUNT_AFTER" -ge "$PROJECT_COUNT_BEFORE" ] || \
+            { echo "❌ Projects decreased after all-mode migrate ($PROJECT_COUNT_BEFORE → $PROJECT_COUNT_AFTER)"; exit 1; }
+          [ "$DASHBOARD_COUNT_AFTER" -ge "$DASHBOARD_COUNT_BEFORE" ] || \
+            { echo "❌ Dashboards decreased after all-mode migrate ($DASHBOARD_COUNT_BEFORE → $DASHBOARD_COUNT_AFTER)"; exit 1; }
+
+          echo "✅ Migrate (all mode) verified — non-destructive upsert + S3 copy confirmed"
 
       - name: Cleanup and summary - ${{ matrix.strategy_name }}
         run: |

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -2082,6 +2082,29 @@ jobs:
             --eval "db.dashboards.countDocuments({})" --quiet 2>&1 | tail -1)
           echo "📊 Before all-mode migrate: projects=$PROJECT_COUNT_BEFORE  dashboards=$DASHBOARD_COUNT_BEFORE"
 
+          # === Pre-flight diagnostics: verify MongoDB state before migrate ===
+          echo "Pre-migrate DB diagnostics:"
+          IRIS_DC_ID=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "var p=db.projects.findOne({name:'Iris Dataset Project Data Analysis'}); \
+                    print(p&&p.workflows&&p.workflows[0]&&p.workflows[0].data_collections&&p.workflows[0].data_collections[0] \
+                          ? p.workflows[0].data_collections[0]._id : 'NOT_FOUND')" \
+            --quiet 2>&1 | tail -1)
+          echo "  Iris DC _id from project: $IRIS_DC_ID"
+
+          DT_COUNT=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.deltatables.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "  Total deltatables: $DT_COUNT"
+
+          FILES_COUNT=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.files.countDocuments({})" --quiet 2>&1 | tail -1)
+          echo "  Total files: $FILES_COUNT"
+
+          echo "  DT data_collection_id field sample (first 3):"
+          docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "db.deltatables.find({},{data_collection_id:1,delta_table_location:1}).limit(3).forEach(d=>print(JSON.stringify(d)))" \
+            --quiet 2>&1 | grep -v "^$" || true
+          echo "=== End pre-migrate diagnostics ==="
+
           # Run mode=all (self-migration: same instance as source and target)
           # This exercises the S3 copy code path in addition to MongoDB upserts
           MIGRATE_LOG=$(mktemp)

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -1587,8 +1587,37 @@ jobs:
             sleep 15
           done
 
-          echo "⏳ Additional stabilization period..."
-          sleep 30
+          # Wait for background reference-dataset processing to complete
+          # (iris/penguins/ampliseq scan+process runs async after API startup;
+          #  deltatables are only created once background_processing_complete=true)
+          echo "⏳ Waiting for background reference dataset processing to complete..."
+          for i in {1..20}; do
+            bg_status=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+              --eval "var doc = db.initialization.findOne({_id: 'reference_datasets_metadata'}); \
+                      print(doc ? (doc.background_processing_complete ? 'complete' : (doc.background_processing_failed ? 'failed' : 'pending')) : 'missing')" \
+              --quiet 2>&1 | tail -1)
+            echo "📊 Background processing status (attempt $i/20): $bg_status"
+            if [ "$bg_status" = "complete" ]; then
+              echo "✅ Reference dataset background processing complete"
+              break
+            elif [ "$bg_status" = "failed" ]; then
+              echo "❌ Background processing failed — checking logs:"
+              docker compose logs --tail=30 depictio-backend
+              exit 1
+            fi
+            sleep 15
+          done
+
+          # Verify iris deltatable was created (needed for migrate all-mode test)
+          IRIS_DC_ID=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+            --eval "JSON.stringify(db.projects.find().toArray())" --quiet 2>&1 | \
+            grep '^[\[{]' | jq -r '.[] | select(.name == "Iris Dataset Project Data Analysis") | .workflows[0].data_collections[0]._id' 2>/dev/null || echo "")
+          if [ -n "$IRIS_DC_ID" ]; then
+            IRIS_DT=$(docker compose exec -T mongo mongosh localhost:27018/depictioDB \
+              --eval "JSON.stringify(db.deltatables.find({\"data_collection_id\": ObjectId(\"$IRIS_DC_ID\")}).toArray())" \
+              --quiet 2>&1 | grep '^[\[{]' | jq -r '.[]._id // empty' 2>/dev/null || echo "")
+            echo "📊 Iris deltatable: ${IRIS_DT:-not found yet}"
+          fi
 
           echo "📊 Final container status before backup testing:"
           docker compose ps

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -2160,10 +2160,11 @@ jobs:
           IRIS_PROJECT_NAME="Iris Dataset Project Data Analysis"
 
           # Resolve project ID
+          TOKEN=$(cat admin_config.yaml | python3 -c "import sys,yaml; print(yaml.safe_load(sys.stdin)['token'])")
           IRIS_PROJECT_ID=$(python3 -c "
-          import httpx, sys
+          import httpx
           r = httpx.get('http://localhost:8058/depictio/api/v1/projects/get/all',
-                        headers={'Authorization': 'Bearer $(cat admin_config.yaml | python3 -c \"import sys,yaml; print(yaml.safe_load(sys.stdin)[\\\"token\\\"])\")'})
+                        headers={'Authorization': 'Bearer $TOKEN'})
           r.raise_for_status()
           projects = r.json()
           match = [p for p in projects if p.get('name') == '$IRIS_PROJECT_NAME']

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -91,6 +91,16 @@ def _normalize_s3_path(location: str, bucket: str) -> str | None:
     return parts[1] if len(parts) == 2 else None
 
 
+def _dc_ids_query(dc_ids: list[ObjectId]) -> dict:
+    """Build a $in query matching data_collection_id stored as either ObjectId or string.
+
+    Some documents (e.g. deltatables created by the background processor) store
+    data_collection_id as a plain string; others store it as an ObjectId.  Querying
+    with both forms ensures we find all matching documents regardless of storage format.
+    """
+    return {"$in": dc_ids + [str(dc_id) for dc_id in dc_ids]}
+
+
 def _collect_s3_locations_for_project(dc_ids: list[ObjectId], source_bucket: str) -> list[str]:
     """Collect all S3 paths for a project's data collections across all DC types."""
     locations: list[str] = []
@@ -101,8 +111,10 @@ def _collect_s3_locations_for_project(dc_ids: list[ObjectId], source_bucket: str
             seen.add(loc)
             locations.append(loc)
 
+    dc_query = _dc_ids_query(dc_ids)
+
     # Delta Lake tables
-    for dt in deltatables_collection.find({"data_collection_id": {"$in": dc_ids}}):
+    for dt in deltatables_collection.find({"data_collection_id": dc_query}):
         raw = dt.get("delta_table_location") or dt.get("location")
         add(_normalize_s3_path(raw, source_bucket) if raw else None)
 
@@ -119,13 +131,13 @@ def _collect_s3_locations_for_project(dc_ids: list[ObjectId], source_bucket: str
             add(_normalize_s3_path(image_folder, source_bucket))
 
     # MultiQC reports
-    for report in multiqc_collection.find({"data_collection_id": {"$in": dc_ids}}):
+    for report in multiqc_collection.find({"data_collection_id": dc_query}):
         raw = report.get("s3_location")
         if raw:
             add(_normalize_s3_path(raw, source_bucket))
 
     # JBrowse2 – only include S3 URIs
-    for jb in jbrowse_collection.find({"data_collection_id": {"$in": dc_ids}}):
+    for jb in jbrowse_collection.find({"data_collection_id": dc_query}):
         for track in jb.get("tracks", []):
             uri = track.get("uri", "")
             if uri.startswith("s3://"):
@@ -293,10 +305,9 @@ async def export_project(
 
     if mode in ("all", "metadata"):
         if dc_ids:
-            files_docs = list(files_collection.find({"data_collection_id": {"$in": dc_ids}}))
-            deltatables_docs = list(
-                deltatables_collection.find({"data_collection_id": {"$in": dc_ids}})
-            )
+            dc_query = _dc_ids_query(dc_ids)
+            files_docs = list(files_collection.find({"data_collection_id": dc_query}))
+            deltatables_docs = list(deltatables_collection.find({"data_collection_id": dc_query}))
         if workflow_ids:
             runs_docs = list(runs_collection.find({"workflow_id": {"$in": workflow_ids}}))
 

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -79,18 +79,17 @@ class MigrateImportResponse(BaseModel):
 def _normalize_s3_path(location: str, bucket: str) -> str | None:
     """Strip s3://bucket/ prefix and return the path within the bucket.
 
-    Returns None if the path is not S3 or belongs to a different bucket.
+    Returns None if the path is empty or an S3 URI without a key component.
+    Non-S3 paths are assumed to be bare keys and returned as-is.
     """
     if not location:
         return None
-    if location.startswith("s3://"):
-        rest = location[len("s3://") :]
-        parts = rest.split("/", 1)
-        if len(parts) == 2:
-            return parts[1]
-        return None
-    # Assume it is already a bare path
-    return location
+    prefix = "s3://"
+    if not location.startswith(prefix):
+        return location
+    # Split "bucket/path/to/object" into at most 2 parts
+    parts = location[len(prefix) :].split("/", 1)
+    return parts[1] if len(parts) == 2 else None
 
 
 def _collect_s3_locations_for_project(dc_ids: list[ObjectId], source_bucket: str) -> list[str]:
@@ -173,17 +172,14 @@ def _copy_s3_locations(
             paginator = source_client.get_paginator("list_objects_v2")
             for page in paginator.paginate(Bucket=source_bucket, Prefix=path_key):
                 for obj in page.get("Contents", []):
-                    source_key = obj["Key"]
-                    target_key = source_key  # Preserve path
+                    key = obj["Key"]
                     if not dry_run:
                         try:
-                            get_resp = source_client.get_object(
-                                Bucket=source_bucket, Key=source_key
-                            )
+                            get_resp = source_client.get_object(Bucket=source_bucket, Key=key)
                             target_client.upload_fileobj(
                                 get_resp["Body"],
                                 target_bucket,
-                                target_key,
+                                key,
                                 ExtraArgs={
                                     "ContentType": get_resp.get(
                                         "ContentType", "application/octet-stream"
@@ -191,7 +187,7 @@ def _copy_s3_locations(
                                 },
                             )
                         except ClientError as e:
-                            error_msg = f"Failed to copy {source_key}: {e}"
+                            error_msg = f"Failed to copy {key}: {e}"
                             logger.error(error_msg)
                             errors.append(error_msg)
                             continue
@@ -200,9 +196,9 @@ def _copy_s3_locations(
                     logger.debug(
                         "%s %s -> s3://%s/%s",
                         "DRY RUN:" if dry_run else "Copied:",
-                        source_key,
+                        key,
                         target_bucket,
-                        target_key,
+                        key,
                     )
         except ClientError as e:
             error_msg = f"Error listing {path_key}: {e}"
@@ -495,49 +491,34 @@ async def import_project(
     # Collect existing user IDs on this instance (for owner remapping)
     existing_user_ids = {str(u["_id"]) for u in users_collection.find({}, {"_id": 1})}
 
-    # workflows and data_collections are embedded in the project document,
+    # Import order respects dependencies (project first, then its dependents).
+    # Workflows and data_collections are embedded in the project document,
     # so they are not stored in separate collections and don't appear in the bundle.
-    collection_map: dict[str, Collection[dict[str, Any]]] = {
-        "projects": projects_collection,
-        "files": files_collection,
-        "deltatables": deltatables_collection,
-        "runs": runs_collection,
-        "dashboards": dashboards_collection,
-    }
-
-    # Import order respects dependencies (project first, then its dependents)
-    import_order = [
-        "projects",
-        "files",
-        "deltatables",
-        "runs",
-        "dashboards",
+    ordered_collections: list[tuple[str, Collection[dict[str, Any]]]] = [
+        ("projects", projects_collection),
+        ("files", files_collection),
+        ("deltatables", deltatables_collection),
+        ("runs", runs_collection),
+        ("dashboards", dashboards_collection),
     ]
 
     data_section = bundle["data"]
     upserted: dict[str, int] = {}
-    total_upserted = 0
 
-    for collection_name in import_order:
-        if collection_name not in data_section:
-            continue
-
-        raw_docs: list[dict] = data_section[collection_name]
+    for collection_name, collection in ordered_collections:
+        raw_docs: list[dict] = data_section.get(collection_name, [])
         if not raw_docs:
             upserted[collection_name] = 0
             continue
 
-        collection = collection_map[collection_name]
         ops: list[ReplaceOne] = []
-
         for doc in raw_docs:
             doc = _prepare_doc_for_import(
                 doc, existing_user_ids, admin_id, force_remap=request.force_owner_remap
             )
             ops.append(ReplaceOne({"_id": doc["_id"]}, doc, upsert=True))
 
-        count = len(ops)
-        if not request.dry_run and ops:
+        if not request.dry_run:
             try:
                 collection.bulk_write(ops, ordered=False)
             except Exception as e:
@@ -547,18 +528,18 @@ async def import_project(
                     detail=f"Import failed for {collection_name}: {e}",
                 )
 
-        upserted[collection_name] = count
-        total_upserted += count
+        upserted[collection_name] = len(ops)
         logger.info(
             "migrate import: %s %d docs into %s",
             "DRY RUN would upsert" if request.dry_run else "upserted",
-            count,
+            len(ops),
             collection_name,
         )
 
+    total = sum(upserted.values())
     return MigrateImportResponse(
         success=True,
-        message=f"{'DRY RUN: would upsert' if request.dry_run else 'Upserted'} {total_upserted} documents",
+        message=f"{'DRY RUN: would upsert' if request.dry_run else 'Upserted'} {total} documents",
         upserted=upserted,
         dry_run=request.dry_run,
     )

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -33,6 +33,7 @@ from depictio.api.v1.db import (
     projects_collection,
     runs_collection,
     users_collection,
+    workflows_collection,
 )
 from depictio.api.v1.endpoints.backup_endpoints.routes import _convert_complex_objects_to_strings
 from depictio.api.v1.endpoints.user_endpoints.routes import get_current_user
@@ -59,6 +60,7 @@ class MigrateImportRequest(BaseModel):
     owner_user_id: str | None = None
     dry_run: bool = False
     force_owner_remap: bool = False
+    overwrite: bool = False  # must be True to replace an already-existing project
 
 
 class MigrateImportResponse(BaseModel):
@@ -66,6 +68,7 @@ class MigrateImportResponse(BaseModel):
     message: str
     upserted: dict = {}
     dry_run: bool = False
+    conflict: bool = False  # True when project exists and overwrite=False was rejected
 
 
 # ---------------------------------------------------------------------------
@@ -250,18 +253,39 @@ async def export_project(
     mode = request.mode
 
     # Cascade queries ---------------------------------------------------
-    # Workflows and data_collections are embedded in the project document.
-    # Extract them directly rather than querying separate collections.
+    # Workflows are embedded in the project document (may be ID-only refs after processing).
+    # Fetch full workflow documents from workflows_collection for authoritative DC IDs.
     embedded_workflows: list[dict] = project.get("workflows", [])
     workflow_ids: list[ObjectId] = [
         w["_id"] for w in embedded_workflows if isinstance(w.get("_id"), ObjectId)
     ]
+
+    # Prefer workflows_collection (authoritative) over embedded refs (may be ID-only)
+    if workflow_ids:
+        full_workflows = list(workflows_collection.find({"_id": {"$in": workflow_ids}}))
+    else:
+        full_workflows = []
+
     dc_ids: list[ObjectId] = [
         dc["_id"]
-        for wf in embedded_workflows
+        for wf in full_workflows
         for dc in wf.get("data_collections", [])
         if isinstance(dc.get("_id"), ObjectId)
     ]
+    # Fallback: extract from embedded workflows if workflows_collection returned nothing
+    if not dc_ids:
+        dc_ids = [
+            dc["_id"]
+            for wf in embedded_workflows
+            for dc in wf.get("data_collections", [])
+            if isinstance(dc.get("_id"), ObjectId)
+        ]
+    logger.info(
+        "migrate export: project=%s workflow_ids=%d dc_ids=%d",
+        str(project_id),
+        len(workflow_ids),
+        len(dc_ids),
+    )
 
     files_docs: list[dict] = []
     deltatables_docs: list[dict] = []
@@ -307,25 +331,33 @@ async def export_project(
         doc_counts["workflows_embedded"] = len(embedded_workflows)
         doc_counts["data_collections_embedded"] = len(dc_ids)
 
-    # S3 copy -----------------------------------------------------------
+    # S3 handling -------------------------------------------------------
     s3_metadata: dict[str, Any] = {}
-    if mode in ("all", "files") and request.target_s3_config:
-        source_config = {
-            "bucket": settings.minio.bucket,
-            "endpoint_url": settings.minio.endpoint_url,
-            "aws_access_key_id": settings.minio.aws_access_key_id,
-            "aws_secret_access_key": settings.minio.aws_secret_access_key,
-            "region_name": "us-east-1",
-        }
+    s3_paths: list[str] = []
+    if mode in ("all", "files"):
         s3_paths = _collect_s3_locations_for_project(dc_ids, settings.minio.bucket)
-        logger.info("Migrate: copying %d S3 locations to target", len(s3_paths))
-        s3_metadata = _copy_s3_locations(
-            s3_paths,
-            source_config,
-            request.target_s3_config,
-            dry_run=request.dry_run,
-        )
-        s3_metadata["paths"] = s3_paths
+        logger.info("Migrate: found %d S3 locations for project", len(s3_paths))
+
+        if request.target_s3_config:
+            # CLI path: copy between two S3 instances
+            source_config = {
+                "bucket": settings.minio.bucket,
+                "endpoint_url": settings.minio.endpoint_url,
+                "aws_access_key_id": settings.minio.aws_access_key_id,
+                "aws_secret_access_key": settings.minio.aws_secret_access_key,
+                "region_name": "us-east-1",
+            }
+            logger.info("Migrate: copying %d S3 locations to target", len(s3_paths))
+            s3_metadata = _copy_s3_locations(
+                s3_paths,
+                source_config,
+                request.target_s3_config,
+                dry_run=request.dry_run,
+            )
+            s3_metadata["paths"] = s3_paths
+        else:
+            # UI path: S3 objects will be bundled directly into the ZIP below
+            s3_metadata = {"paths": s3_paths, "bundled_in_zip": True, "dry_run": request.dry_run}
 
     bundle: dict[str, Any] = {
         "migrate_metadata": {
@@ -358,6 +390,43 @@ async def export_project(
             "bundle.json",
             json.dumps(bundle["data"], indent=2, default=_json_default),
         )
+
+        # UI path: bundle S3 objects directly into the ZIP under s3_data/
+        if (
+            mode in ("all", "files")
+            and not request.target_s3_config
+            and s3_paths
+            and not request.dry_run
+        ):
+            s3_client = boto3.client(
+                "s3",
+                endpoint_url=settings.minio.endpoint_url,
+                aws_access_key_id=settings.minio.aws_access_key_id,
+                aws_secret_access_key=settings.minio.aws_secret_access_key,
+                region_name="us-east-1",
+                verify=False,
+            )
+            bundled_files = 0
+            for path in s3_paths:
+                path_key = path.strip("/")
+                try:
+                    paginator = s3_client.get_paginator("list_objects_v2")
+                    for page in paginator.paginate(Bucket=settings.minio.bucket, Prefix=path_key):
+                        for obj in page.get("Contents", []):
+                            key = obj["Key"]
+                            try:
+                                resp = s3_client.get_object(Bucket=settings.minio.bucket, Key=key)
+                                zf.writestr(f"s3_data/{key}", resp["Body"].read())
+                                bundled_files += 1
+                                logger.debug("Bundled S3 object into ZIP: %s", key)
+                            except ClientError as e:
+                                logger.error("Failed to bundle S3 object %s: %s", key, e)
+                except ClientError as e:
+                    logger.error("Error listing S3 path %s: %s", path_key, e)
+            logger.info("Migrate: bundled %d S3 files into ZIP", bundled_files)
+            bundle["s3_migrate_metadata"]["bundled_files"] = bundled_files
+
+        # Write s3_metadata.json last so bundled_files count is included
         if "s3_migrate_metadata" in bundle:
             zf.writestr(
                 "s3_metadata.json",
@@ -397,6 +466,23 @@ async def import_project(
     bundle = request.bundle
     if "data" not in bundle:
         raise HTTPException(status_code=400, detail="Bundle missing 'data' section")
+
+    # Conflict check — refuse to overwrite an existing project unless overwrite=True
+    project_docs = bundle.get("data", {}).get("projects", [])
+    if project_docs:
+        raw_pid = project_docs[0].get("_id") or project_docs[0].get("id")
+        try:
+            existing = projects_collection.find_one({"_id": ObjectId(str(raw_pid))})
+        except Exception:
+            existing = None
+        if existing and not request.overwrite:
+            project_name = existing.get("name", str(raw_pid))
+            return MigrateImportResponse(
+                success=False,
+                message=f"Project '{project_name}' already exists on this instance. "
+                "Set overwrite=true to replace it.",
+                conflict=True,
+            )
 
     # Determine fallback owner ID
     admin_id = current_user.id
@@ -482,6 +568,7 @@ async def import_project(
 async def import_project_zip(
     file: UploadFile = File(...),
     dry_run: bool = False,
+    overwrite: bool = False,
     current_user: User = Depends(get_current_user),
 ) -> MigrateImportResponse:
     """
@@ -499,6 +586,34 @@ async def import_project_zip(
         with zipfile.ZipFile(buf) as zf:
             bundle_data = json.loads(zf.read("bundle.json"))
             migrate_metadata = json.loads(zf.read("migrate_metadata.json"))
+
+            # Restore S3 data files bundled in the ZIP back to MinIO at original paths
+            s3_keys = [n for n in zf.namelist() if n.startswith("s3_data/")]
+            if s3_keys and not dry_run:
+                s3_client = boto3.client(
+                    "s3",
+                    endpoint_url=settings.minio.endpoint_url,
+                    aws_access_key_id=settings.minio.aws_access_key_id,
+                    aws_secret_access_key=settings.minio.aws_secret_access_key,
+                    region_name="us-east-1",
+                    verify=False,
+                )
+                uploaded = 0
+                for zip_path in s3_keys:
+                    s3_key = zip_path[len("s3_data/") :]  # strip prefix to get original path
+                    if not s3_key:
+                        continue
+                    try:
+                        s3_client.put_object(
+                            Bucket=settings.minio.bucket,
+                            Key=s3_key,
+                            Body=zf.read(zip_path),
+                        )
+                        uploaded += 1
+                        logger.debug("Restored S3 object: %s", s3_key)
+                    except ClientError as e:
+                        logger.error("Failed to restore S3 object %s: %s", s3_key, e)
+                logger.info("Migrate import: restored %d S3 objects to MinIO", uploaded)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid ZIP bundle: {e}")
 
@@ -507,6 +622,7 @@ async def import_project_zip(
         bundle=bundle,
         dry_run=dry_run,
         force_owner_remap=True,
+        overwrite=overwrite,
     )
     return await import_project(import_request, current_user)
 
@@ -559,6 +675,7 @@ def _prepare_doc_for_import(
 
 
 _ID_FIELD_NAMES = {
+    "_id",
     "project_id",
     "workflow_id",
     "data_collection_id",

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -1,0 +1,562 @@
+"""
+Project Migration Endpoints
+
+Provides non-destructive project-scoped migration between Depictio instances.
+Exports a project bundle (MongoDB docs + S3 files) from the source instance
+and imports it into the target instance via upsert (never wipes other projects).
+"""
+
+import io
+import json
+import zipfile
+from datetime import datetime
+from typing import Any, Literal, cast
+
+import boto3
+from botocore.exceptions import ClientError
+from bson import ObjectId
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from pymongo.collection import Collection
+from pymongo.operations import ReplaceOne
+
+from depictio.api.v1.configs.config import settings
+from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.db import (
+    dashboards_collection,
+    data_collections_collection,
+    deltatables_collection,
+    files_collection,
+    jbrowse_collection,
+    multiqc_collection,
+    projects_collection,
+    runs_collection,
+    users_collection,
+    workflows_collection,
+)
+from depictio.api.v1.endpoints.backup_endpoints.routes import _convert_complex_objects_to_strings
+from depictio.api.v1.endpoints.user_endpoints.routes import get_current_user
+from depictio.models.models.users import User
+
+migrate_endpoint_router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class MigrateExportRequest(BaseModel):
+    project_id: str | None = None
+    project_name: str | None = None
+    mode: Literal["all", "metadata", "dashboard", "files"] = "all"
+    target_s3_config: dict | None = None
+    dry_run: bool = False
+
+
+class MigrateImportRequest(BaseModel):
+    bundle: dict
+    owner_user_id: str | None = None
+    dry_run: bool = False
+    force_owner_remap: bool = False
+
+
+class MigrateImportResponse(BaseModel):
+    success: bool
+    message: str
+    upserted: dict = {}
+    dry_run: bool = False
+
+
+# ---------------------------------------------------------------------------
+# S3 helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_s3_path(location: str, bucket: str) -> str | None:
+    """Strip s3://bucket/ prefix and return the path within the bucket.
+
+    Returns None if the path is not S3 or belongs to a different bucket.
+    """
+    if not location:
+        return None
+    if location.startswith("s3://"):
+        rest = location[len("s3://") :]
+        parts = rest.split("/", 1)
+        if len(parts) == 2:
+            return parts[1]
+        return None
+    # Assume it is already a bare path
+    return location
+
+
+def _collect_s3_locations_for_project(dc_ids: list[ObjectId], source_bucket: str) -> list[str]:
+    """Collect all S3 paths for a project's data collections across all DC types."""
+    locations: list[str] = []
+    seen: set[str] = set()
+
+    def add(loc: str | None) -> None:
+        if loc and loc not in seen:
+            seen.add(loc)
+            locations.append(loc)
+
+    # Delta Lake tables
+    for dt in deltatables_collection.find({"data_collection_id": {"$in": dc_ids}}):
+        raw = dt.get("delta_table_location") or dt.get("location")
+        add(_normalize_s3_path(raw, source_bucket) if raw else None)
+
+    # GeoJSON and Image (stored in data_collections.config.dc_specific_properties)
+    for dc in data_collections_collection.find({"_id": {"$in": dc_ids}}):
+        props = dc.get("config", {}).get("dc_specific_properties", {}) or {}
+        # GeoJSON
+        geojson_loc = props.get("s3_location")
+        if geojson_loc:
+            add(_normalize_s3_path(geojson_loc, source_bucket))
+        # Image base folder (prefix-based)
+        image_folder = props.get("s3_base_folder")
+        if image_folder:
+            add(_normalize_s3_path(image_folder, source_bucket))
+
+    # MultiQC reports
+    for report in multiqc_collection.find({"data_collection_id": {"$in": dc_ids}}):
+        raw = report.get("s3_location")
+        if raw:
+            add(_normalize_s3_path(raw, source_bucket))
+
+    # JBrowse2 – only include S3 URIs
+    for jb in jbrowse_collection.find({"data_collection_id": {"$in": dc_ids}}):
+        for track in jb.get("tracks", []):
+            uri = track.get("uri", "")
+            if uri.startswith("s3://"):
+                add(_normalize_s3_path(uri, source_bucket))
+
+    return locations
+
+
+def _copy_s3_locations(
+    s3_paths: list[str],
+    source_config: dict,
+    target_config: dict,
+    dry_run: bool = False,
+) -> dict:
+    """Copy S3 objects from source to target MinIO, preserving paths."""
+    source_client = boto3.client(
+        "s3",
+        endpoint_url=source_config["endpoint_url"],
+        aws_access_key_id=source_config["aws_access_key_id"],
+        aws_secret_access_key=source_config["aws_secret_access_key"],
+        region_name=source_config.get("region_name", "us-east-1"),
+        verify=False,
+    )
+    target_client = boto3.client(
+        "s3",
+        endpoint_url=target_config["endpoint_url"],
+        aws_access_key_id=target_config["aws_access_key_id"],
+        aws_secret_access_key=target_config["aws_secret_access_key"],
+        region_name=target_config.get("region_name", "us-east-1"),
+        verify=False,
+    )
+
+    source_bucket = source_config["bucket"]
+    target_bucket = target_config["bucket"]
+
+    total_files = 0
+    total_bytes = 0
+    errors: list[str] = []
+
+    for path in s3_paths:
+        path_key = path.strip("/")
+        try:
+            paginator = source_client.get_paginator("list_objects_v2")
+            for page in paginator.paginate(Bucket=source_bucket, Prefix=path_key):
+                for obj in page.get("Contents", []):
+                    source_key = obj["Key"]
+                    target_key = source_key  # Preserve path
+                    if not dry_run:
+                        try:
+                            get_resp = source_client.get_object(
+                                Bucket=source_bucket, Key=source_key
+                            )
+                            target_client.upload_fileobj(
+                                get_resp["Body"],
+                                target_bucket,
+                                target_key,
+                                ExtraArgs={
+                                    "ContentType": get_resp.get(
+                                        "ContentType", "application/octet-stream"
+                                    )
+                                },
+                            )
+                        except ClientError as e:
+                            error_msg = f"Failed to copy {source_key}: {e}"
+                            logger.error(error_msg)
+                            errors.append(error_msg)
+                            continue
+                    total_files += 1
+                    total_bytes += obj["Size"]
+                    logger.debug(
+                        "%s %s -> s3://%s/%s",
+                        "DRY RUN:" if dry_run else "Copied:",
+                        source_key,
+                        target_bucket,
+                        target_key,
+                    )
+        except ClientError as e:
+            error_msg = f"Error listing {path_key}: {e}"
+            logger.error(error_msg)
+            errors.append(error_msg)
+
+    return {
+        "locations_copied": len(s3_paths),
+        "total_files": total_files,
+        "total_bytes": total_bytes,
+        "errors": errors,
+        "dry_run": dry_run,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Export endpoint
+# ---------------------------------------------------------------------------
+
+
+@migrate_endpoint_router.post("/export-project")
+async def export_project(
+    request: MigrateExportRequest,
+    current_user: User = Depends(get_current_user),
+) -> StreamingResponse:
+    """
+    Export a project bundle from this instance.
+
+    Scoped to one project: cascades through workflows → data_collections →
+    files / deltatables / runs → dashboards.  Optionally copies S3 data to
+    a target MinIO (modes all / files).
+    """
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Only administrators can export projects")
+
+    # Resolve project
+    if request.project_id:
+        project = projects_collection.find_one({"_id": ObjectId(request.project_id)})
+    elif request.project_name:
+        project = projects_collection.find_one({"name": request.project_name})
+    else:
+        raise HTTPException(status_code=400, detail="Provide project_id or project_name")
+
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    project_id = project["_id"]
+    mode = request.mode
+
+    # Cascade queries ---------------------------------------------------
+    dc_ids: list[ObjectId] = []
+
+    workflows = list(workflows_collection.find({"project_id": project_id}))
+    workflow_ids = [w["_id"] for w in workflows]
+
+    if workflow_ids:
+        dcs = list(data_collections_collection.find({"workflow_id": {"$in": workflow_ids}}))
+        dc_ids = [dc["_id"] for dc in dcs]
+    else:
+        dcs = []
+
+    files_docs: list[dict] = []
+    deltatables_docs: list[dict] = []
+    runs_docs: list[dict] = []
+    dashboards_docs: list[dict] = []
+
+    if mode in ("all", "metadata"):
+        if dc_ids:
+            files_docs = list(files_collection.find({"data_collection_id": {"$in": dc_ids}}))
+            deltatables_docs = list(
+                deltatables_collection.find({"data_collection_id": {"$in": dc_ids}})
+            )
+        if workflow_ids:
+            runs_docs = list(runs_collection.find({"workflow_id": {"$in": workflow_ids}}))
+
+    if mode in ("all", "metadata", "dashboard"):
+        dashboards_docs = list(dashboards_collection.find({"project_id": project_id}))
+
+    # Build data dict based on mode
+    data: dict[str, list[dict]] = {}
+    if mode in ("all", "metadata"):
+        data["projects"] = [project]
+        data["workflows"] = workflows
+        data["data_collections"] = dcs
+        data["files"] = files_docs
+        data["deltatables"] = deltatables_docs
+        data["runs"] = runs_docs
+        data["dashboards"] = dashboards_docs
+    elif mode == "dashboard":
+        data["dashboards"] = dashboards_docs
+    # files mode: only S3, no MongoDB docs
+
+    # Serialize all ObjectIds / DBRefs
+    data = cast(dict[str, list[dict]], _convert_complex_objects_to_strings(data))
+
+    # Document counts
+    doc_counts = {k: len(v) for k, v in data.items()}
+
+    # S3 copy -----------------------------------------------------------
+    s3_metadata: dict[str, Any] = {}
+    if mode in ("all", "files") and request.target_s3_config:
+        source_config = {
+            "bucket": settings.minio.bucket,
+            "endpoint_url": settings.minio.endpoint_url,
+            "aws_access_key_id": settings.minio.aws_access_key_id,
+            "aws_secret_access_key": settings.minio.aws_secret_access_key,
+            "region_name": "us-east-1",
+        }
+        s3_paths = _collect_s3_locations_for_project(dc_ids, settings.minio.bucket)
+        logger.info("Migrate: copying %d S3 locations to target", len(s3_paths))
+        s3_metadata = _copy_s3_locations(
+            s3_paths,
+            source_config,
+            request.target_s3_config,
+            dry_run=request.dry_run,
+        )
+        s3_metadata["paths"] = s3_paths
+
+    bundle: dict[str, Any] = {
+        "migrate_metadata": {
+            "timestamp": datetime.now().isoformat(),
+            "project_id": str(project_id),
+            "project_name": project.get("name"),
+            "mode": mode,
+            "depictio_version": settings.version if hasattr(settings, "version") else "unknown",
+            "document_counts": doc_counts,
+            "dry_run": request.dry_run,
+        },
+        "data": data,
+    }
+    if s3_metadata:
+        bundle["s3_migrate_metadata"] = s3_metadata
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("migrate_metadata.json", json.dumps(bundle["migrate_metadata"], indent=2))
+        zf.writestr("bundle.json", json.dumps(bundle["data"], indent=2))
+        if "s3_migrate_metadata" in bundle:
+            zf.writestr("s3_metadata.json", json.dumps(bundle["s3_migrate_metadata"], indent=2))
+    buf.seek(0)
+
+    project_name = (project.get("name") or "export").replace(" ", "_")
+    filename = f"depictio_export_{project_name}.zip"
+    return StreamingResponse(
+        buf,
+        media_type="application/zip",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Import endpoint
+# ---------------------------------------------------------------------------
+
+
+@migrate_endpoint_router.post("/import-project", response_model=MigrateImportResponse)
+async def import_project(
+    request: MigrateImportRequest,
+    current_user: User = Depends(get_current_user),
+) -> MigrateImportResponse:
+    """
+    Import a project bundle into this instance (non-destructive upsert).
+
+    Documents are upserted in dependency order.  Owner IDs that do not exist
+    on this instance are remapped to the calling admin (or the specified
+    owner_user_id).
+    """
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Only administrators can import projects")
+
+    bundle = request.bundle
+    if "data" not in bundle:
+        raise HTTPException(status_code=400, detail="Bundle missing 'data' section")
+
+    # Determine fallback owner ID
+    admin_id = current_user.id
+    if request.owner_user_id:
+        try:
+            admin_id = ObjectId(request.owner_user_id)
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid owner_user_id")
+
+    # Collect existing user IDs on this instance (for owner remapping)
+    existing_user_ids = {str(u["_id"]) for u in users_collection.find({}, {"_id": 1})}
+
+    collection_map: dict[str, Collection[dict[str, Any]]] = {
+        "projects": projects_collection,
+        "workflows": workflows_collection,
+        "data_collections": data_collections_collection,
+        "files": files_collection,
+        "deltatables": deltatables_collection,
+        "runs": runs_collection,
+        "dashboards": dashboards_collection,
+    }
+
+    # Import order respects dependencies
+    import_order = [
+        "projects",
+        "workflows",
+        "data_collections",
+        "files",
+        "deltatables",
+        "runs",
+        "dashboards",
+    ]
+
+    data_section = bundle["data"]
+    upserted: dict[str, int] = {}
+    total_upserted = 0
+
+    for collection_name in import_order:
+        if collection_name not in data_section:
+            continue
+
+        raw_docs: list[dict] = data_section[collection_name]
+        if not raw_docs:
+            upserted[collection_name] = 0
+            continue
+
+        collection = collection_map[collection_name]
+        ops: list[ReplaceOne] = []
+
+        for doc in raw_docs:
+            doc = _prepare_doc_for_import(
+                doc, existing_user_ids, admin_id, force_remap=request.force_owner_remap
+            )
+            ops.append(ReplaceOne({"_id": doc["_id"]}, doc, upsert=True))
+
+        count = len(ops)
+        if not request.dry_run and ops:
+            try:
+                collection.bulk_write(ops, ordered=False)
+            except Exception as e:
+                logger.error("migrate import error for %s: %s", collection_name, e)
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Import failed for {collection_name}: {e}",
+                )
+
+        upserted[collection_name] = count
+        total_upserted += count
+        logger.info(
+            "migrate import: %s %d docs into %s",
+            "DRY RUN would upsert" if request.dry_run else "upserted",
+            count,
+            collection_name,
+        )
+
+    return MigrateImportResponse(
+        success=True,
+        message=f"{'DRY RUN: would upsert' if request.dry_run else 'Upserted'} {total_upserted} documents",
+        upserted=upserted,
+        dry_run=request.dry_run,
+    )
+
+
+@migrate_endpoint_router.post("/import-project-zip", response_model=MigrateImportResponse)
+async def import_project_zip(
+    file: UploadFile = File(...),
+    dry_run: bool = False,
+    current_user: User = Depends(get_current_user),
+) -> MigrateImportResponse:
+    """
+    Import a project bundle from a ZIP file (for UI use).
+
+    Accepts a .zip file containing bundle.json and migrate_metadata.json.
+    Always remaps all owners to the calling user (force_owner_remap=True).
+    """
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Only administrators can import projects")
+
+    contents = await file.read()
+    buf = io.BytesIO(contents)
+    try:
+        with zipfile.ZipFile(buf) as zf:
+            bundle_data = json.loads(zf.read("bundle.json"))
+            migrate_metadata = json.loads(zf.read("migrate_metadata.json"))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid ZIP bundle: {e}")
+
+    bundle = {"data": bundle_data, "migrate_metadata": migrate_metadata}
+    import_request = MigrateImportRequest(
+        bundle=bundle,
+        dry_run=dry_run,
+        force_owner_remap=True,
+    )
+    return await import_project(import_request, current_user)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _prepare_doc_for_import(
+    doc: dict,
+    existing_user_ids: set[str],
+    fallback_owner_id: Any,
+    force_remap: bool = False,
+) -> dict:
+    """Convert string IDs back to ObjectId and remap unknown owners."""
+    doc = dict(doc)
+    # Convert _id
+    if "id" in doc and "_id" not in doc:
+        doc["_id"] = doc.pop("id")
+    if "_id" in doc and isinstance(doc["_id"], str):
+        try:
+            doc["_id"] = ObjectId(doc["_id"])
+        except Exception:
+            pass
+
+    # Remap owner IDs in permissions
+    permissions = doc.get("permissions")
+    if isinstance(permissions, dict):
+        owners = permissions.get("owners")
+        if isinstance(owners, list):
+            new_owners = []
+            for owner in owners:
+                if isinstance(owner, dict):
+                    owner_id = str(owner.get("_id", ""))
+                    if force_remap or owner_id not in existing_user_ids:
+                        owner = dict(owner)
+                        owner["_id"] = str(fallback_owner_id)
+                    new_owners.append(owner)
+                else:
+                    new_owners.append(owner)
+            permissions = dict(permissions)
+            permissions["owners"] = new_owners
+            doc["permissions"] = permissions
+
+    # Recursively convert any remaining string ObjectIds for known ID fields
+    _convert_id_fields(doc)
+
+    return doc
+
+
+_ID_FIELD_NAMES = {
+    "project_id",
+    "workflow_id",
+    "data_collection_id",
+    "run_id",
+    "dashboard_id",
+}
+
+
+def _convert_id_fields(obj: Any) -> None:
+    """Convert known ID fields from string to ObjectId in-place."""
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            if key in _ID_FIELD_NAMES and isinstance(val, str):
+                try:
+                    obj[key] = ObjectId(val)
+                except Exception:
+                    pass
+            else:
+                _convert_id_fields(val)
+    elif isinstance(obj, list):
+        for item in obj:
+            _convert_id_fields(item)

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -252,30 +252,35 @@ async def export_project(
     # Workflows are embedded in the project document (may be ID-only refs after processing).
     # Fetch full workflow documents from workflows_collection for authoritative DC IDs.
     embedded_workflows: list[dict] = project.get("workflows", [])
+
+    def _extract_oid(doc: dict) -> ObjectId | None:
+        """Return the ObjectId from a doc that may use '_id' or 'id' as the key."""
+        for key in ("_id", "id"):
+            val = doc.get(key)
+            if isinstance(val, ObjectId):
+                return val
+            if isinstance(val, str):
+                try:
+                    return ObjectId(val)
+                except Exception:
+                    pass
+        return None
+
     workflow_ids: list[ObjectId] = [
-        w["_id"] for w in embedded_workflows if isinstance(w.get("_id"), ObjectId)
+        oid for w in embedded_workflows if (oid := _extract_oid(w)) is not None
     ]
 
     # Prefer workflows_collection (authoritative) over embedded refs (may be ID-only)
-    if workflow_ids:
-        full_workflows = list(workflows_collection.find({"_id": {"$in": workflow_ids}}))
-    else:
-        full_workflows = []
+    full_workflows = (
+        list(workflows_collection.find({"_id": {"$in": workflow_ids}})) if workflow_ids else []
+    )
 
     dc_ids: list[ObjectId] = [
-        dc["_id"]
-        for wf in full_workflows
+        oid
+        for wf in (full_workflows or embedded_workflows)
         for dc in wf.get("data_collections", [])
-        if isinstance(dc.get("_id"), ObjectId)
+        if (oid := _extract_oid(dc)) is not None
     ]
-    # Fallback: extract from embedded workflows if workflows_collection returned nothing
-    if not dc_ids:
-        dc_ids = [
-            dc["_id"]
-            for wf in embedded_workflows
-            for dc in wf.get("data_collections", [])
-            if isinstance(dc.get("_id"), ObjectId)
-        ]
     logger.info(
         "migrate export: project=%s workflow_ids=%d dc_ids=%d",
         str(project_id),
@@ -471,7 +476,7 @@ async def import_project(
             existing = projects_collection.find_one({"_id": ObjectId(str(raw_pid))})
         except Exception:
             existing = None
-        if existing and not request.overwrite:
+        if existing and not request.overwrite and not request.dry_run:
             project_name = existing.get("name", str(raw_pid))
             return MigrateImportResponse(
                 success=False,

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -277,7 +277,12 @@ async def export_project(
             runs_docs = list(runs_collection.find({"workflow_id": {"$in": workflow_ids}}))
 
     if mode in ("all", "metadata", "dashboard"):
-        dashboards_docs = list(dashboards_collection.find({"project_id": project_id}))
+        # project_id may be stored as ObjectId or string depending on how the dashboard was created
+        dashboards_docs = list(
+            dashboards_collection.find(
+                {"$or": [{"project_id": project_id}, {"project_id": str(project_id)}]}
+            )
+        )
 
     # Build data dict based on mode
     data: dict[str, list[dict]] = {}

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -33,7 +33,6 @@ from depictio.api.v1.db import (
     projects_collection,
     runs_collection,
     users_collection,
-    workflows_collection,
 )
 from depictio.api.v1.endpoints.backup_endpoints.routes import _convert_complex_objects_to_strings
 from depictio.api.v1.endpoints.user_endpoints.routes import get_current_user
@@ -251,16 +250,18 @@ async def export_project(
     mode = request.mode
 
     # Cascade queries ---------------------------------------------------
-    dc_ids: list[ObjectId] = []
-
-    workflows = list(workflows_collection.find({"project_id": project_id}))
-    workflow_ids = [w["_id"] for w in workflows]
-
-    if workflow_ids:
-        dcs = list(data_collections_collection.find({"workflow_id": {"$in": workflow_ids}}))
-        dc_ids = [dc["_id"] for dc in dcs]
-    else:
-        dcs = []
+    # Workflows and data_collections are embedded in the project document.
+    # Extract them directly rather than querying separate collections.
+    embedded_workflows: list[dict] = project.get("workflows", [])
+    workflow_ids: list[ObjectId] = [
+        w["_id"] for w in embedded_workflows if isinstance(w.get("_id"), ObjectId)
+    ]
+    dc_ids: list[ObjectId] = [
+        dc["_id"]
+        for wf in embedded_workflows
+        for dc in wf.get("data_collections", [])
+        if isinstance(dc.get("_id"), ObjectId)
+    ]
 
     files_docs: list[dict] = []
     deltatables_docs: list[dict] = []
@@ -287,9 +288,8 @@ async def export_project(
     # Build data dict based on mode
     data: dict[str, list[dict]] = {}
     if mode in ("all", "metadata"):
+        # The project document already embeds workflows and data_collections — no separate entries needed.
         data["projects"] = [project]
-        data["workflows"] = workflows
-        data["data_collections"] = dcs
         data["files"] = files_docs
         data["deltatables"] = deltatables_docs
         data["runs"] = runs_docs
@@ -301,8 +301,11 @@ async def export_project(
     # Serialize all ObjectIds / DBRefs
     data = cast(dict[str, list[dict]], _convert_complex_objects_to_strings(data))
 
-    # Document counts
+    # Document counts (include embedded workflows/DCs for informational purposes)
     doc_counts = {k: len(v) for k, v in data.items()}
+    if mode in ("all", "metadata"):
+        doc_counts["workflows_embedded"] = len(embedded_workflows)
+        doc_counts["data_collections_embedded"] = len(dc_ids)
 
     # S3 copy -----------------------------------------------------------
     s3_metadata: dict[str, Any] = {}
@@ -391,21 +394,19 @@ async def import_project(
     # Collect existing user IDs on this instance (for owner remapping)
     existing_user_ids = {str(u["_id"]) for u in users_collection.find({}, {"_id": 1})}
 
+    # workflows and data_collections are embedded in the project document,
+    # so they are not stored in separate collections and don't appear in the bundle.
     collection_map: dict[str, Collection[dict[str, Any]]] = {
         "projects": projects_collection,
-        "workflows": workflows_collection,
-        "data_collections": data_collections_collection,
         "files": files_collection,
         "deltatables": deltatables_collection,
         "runs": runs_collection,
         "dashboards": dashboards_collection,
     }
 
-    # Import order respects dependencies
+    # Import order respects dependencies (project first, then its dependents)
     import_order = [
         "projects",
-        "workflows",
-        "data_collections",
         "files",
         "deltatables",
         "runs",

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -33,7 +33,6 @@ from depictio.api.v1.db import (
     projects_collection,
     runs_collection,
     users_collection,
-    workflows_collection,
 )
 from depictio.api.v1.endpoints.backup_endpoints.routes import _convert_complex_objects_to_strings
 from depictio.api.v1.endpoints.user_endpoints.routes import get_current_user
@@ -253,33 +252,32 @@ async def export_project(
     # Fetch full workflow documents from workflows_collection for authoritative DC IDs.
     embedded_workflows: list[dict] = project.get("workflows", [])
 
-    def _extract_oid(doc: dict) -> ObjectId | None:
-        """Return the ObjectId from a doc that may use '_id' or 'id' as the key."""
-        for key in ("_id", "id"):
-            val = doc.get(key)
-            if isinstance(val, ObjectId):
-                return val
-            if isinstance(val, str):
-                try:
-                    return ObjectId(val)
-                except Exception:
-                    pass
-        return None
-
-    workflow_ids: list[ObjectId] = [
-        oid for w in embedded_workflows if (oid := _extract_oid(w)) is not None
-    ]
-
-    # Prefer workflows_collection (authoritative) over embedded refs (may be ID-only)
-    full_workflows = (
-        list(workflows_collection.find({"_id": {"$in": workflow_ids}})) if workflow_ids else []
+    # Use the same aggregation pattern as other endpoints (get_tag_from_id, _build_permission_pipeline)
+    # to extract DC and workflow IDs — proven way to traverse project.workflows.data_collections._id
+    dc_agg = list(
+        projects_collection.aggregate(
+            [
+                {"$match": {"_id": project_id}},
+                {"$unwind": "$workflows"},
+                {"$unwind": "$workflows.data_collections"},
+                {"$project": {"_id": 0, "dc_id": "$workflows.data_collections._id"}},
+            ]
+        )
     )
+    dc_ids: list[ObjectId] = [r["dc_id"] for r in dc_agg if isinstance(r.get("dc_id"), ObjectId)]
 
-    dc_ids: list[ObjectId] = [
-        oid
-        for wf in (full_workflows or embedded_workflows)
-        for dc in wf.get("data_collections", [])
-        if (oid := _extract_oid(dc)) is not None
+    # Also collect workflow IDs (needed for runs_collection query)
+    wf_agg = list(
+        projects_collection.aggregate(
+            [
+                {"$match": {"_id": project_id}},
+                {"$unwind": "$workflows"},
+                {"$project": {"_id": 0, "wf_id": "$workflows._id"}},
+            ]
+        )
+    )
+    workflow_ids: list[ObjectId] = [
+        r["wf_id"] for r in wf_agg if isinstance(r.get("wf_id"), ObjectId)
     ]
     logger.info(
         "migrate export: project=%s workflow_ids=%d dc_ids=%d",

--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -342,12 +342,27 @@ async def export_project(
     if s3_metadata:
         bundle["s3_migrate_metadata"] = s3_metadata
 
+    def _json_default(obj: Any) -> Any:
+        """Fallback serializer for types _convert_complex_objects_to_strings doesn't cover."""
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("migrate_metadata.json", json.dumps(bundle["migrate_metadata"], indent=2))
-        zf.writestr("bundle.json", json.dumps(bundle["data"], indent=2))
+        zf.writestr(
+            "migrate_metadata.json",
+            json.dumps(bundle["migrate_metadata"], indent=2, default=_json_default),
+        )
+        zf.writestr(
+            "bundle.json",
+            json.dumps(bundle["data"], indent=2, default=_json_default),
+        )
         if "s3_migrate_metadata" in bundle:
-            zf.writestr("s3_metadata.json", json.dumps(bundle["s3_migrate_metadata"], indent=2))
+            zf.writestr(
+                "s3_metadata.json",
+                json.dumps(bundle["s3_migrate_metadata"], indent=2, default=_json_default),
+            )
     buf.seek(0)
 
     project_name = (project.get("name") or "export").replace(" ", "_")

--- a/depictio/api/v1/endpoints/projects_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/projects_endpoints/routes.py
@@ -1,7 +1,20 @@
+import boto3
 from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from depictio.api.v1.db import dashboards_collection, deltatables_collection, projects_collection
+from depictio.api.v1.configs.config import settings
+from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.db import (
+    dashboards_collection,
+    data_collections_collection,
+    deltatables_collection,
+    files_collection,
+    jbrowse_collection,
+    multiqc_collection,
+    projects_collection,
+    runs_collection,
+)
+from depictio.api.v1.endpoints.migrate_endpoints.routes import _collect_s3_locations_for_project
 from depictio.api.v1.endpoints.projects_endpoints.utils import (
     _async_get_all_projects,
     _async_get_project_from_id,
@@ -213,7 +226,58 @@ async def delete_project(project_id: PyObjectId, current_user=Depends(get_curren
             detail="User does not have permission to delete this project.",
         )
 
-    # Delete the project
+    # Collect dc_ids and workflow_ids via aggregation (same pattern as migrate endpoint)
+    dc_agg = list(
+        projects_collection.aggregate(
+            [
+                {"$match": {"_id": ObjectId(project_id)}},
+                {"$unwind": "$workflows"},
+                {"$unwind": "$workflows.data_collections"},
+                {"$project": {"_id": 0, "dc_id": "$workflows.data_collections._id"}},
+            ]
+        )
+    )
+    dc_ids: list[ObjectId] = [r["dc_id"] for r in dc_agg if isinstance(r.get("dc_id"), ObjectId)]
+
+    # Delete S3 objects (best-effort: log errors but don't fail the request)
+    if dc_ids:
+        try:
+            s3_paths = _collect_s3_locations_for_project(dc_ids, settings.minio.bucket)
+            if s3_paths:
+                s3_client = boto3.client(
+                    "s3",
+                    endpoint_url=settings.minio.endpoint_url,
+                    aws_access_key_id=settings.minio.root_user,
+                    aws_secret_access_key=settings.minio.root_password,
+                    region_name="us-east-1",
+                    verify=False,
+                )
+                for prefix in s3_paths:
+                    paginator = s3_client.get_paginator("list_objects_v2")
+                    for page in paginator.paginate(
+                        Bucket=settings.minio.bucket, Prefix=prefix.strip("/")
+                    ):
+                        keys = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+                        if keys:
+                            s3_client.delete_objects(
+                                Bucket=settings.minio.bucket, Delete={"Objects": keys}
+                            )
+                logger.info(f"Deleted S3 objects for project {project_id}: {s3_paths}")
+        except Exception as exc:
+            logger.warning(f"S3 cleanup failed for project {project_id} (non-fatal): {exc}")
+
+    # Cascade delete dependent MongoDB documents
+    if dc_ids:
+        files_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
+        deltatables_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
+        runs_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
+        multiqc_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
+        jbrowse_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
+        data_collections_collection.delete_many({"_id": {"$in": dc_ids}})
+
+    dashboards_collection.delete_many({"project_id": ObjectId(project_id)})
+
+    # Delete the project document
     projects_collection.delete_one({"_id": ObjectId(project_id)})
 
     return {

--- a/depictio/api/v1/endpoints/projects_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/projects_endpoints/routes.py
@@ -266,13 +266,16 @@ async def delete_project(project_id: PyObjectId, current_user=Depends(get_curren
         except Exception as exc:
             logger.warning(f"S3 cleanup failed for project {project_id} (non-fatal): {exc}")
 
-    # Cascade delete dependent MongoDB documents
+    # Cascade delete dependent MongoDB documents.
+    # data_collection_id may be stored as ObjectId or plain string depending on code path,
+    # so query with both forms to ensure all documents are found.
     if dc_ids:
-        files_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
-        deltatables_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
-        runs_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
-        multiqc_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
-        jbrowse_collection.delete_many({"data_collection_id": {"$in": dc_ids}})
+        dc_query: dict = {"$in": dc_ids + [str(dc_id) for dc_id in dc_ids]}
+        files_collection.delete_many({"data_collection_id": dc_query})
+        deltatables_collection.delete_many({"data_collection_id": dc_query})
+        runs_collection.delete_many({"data_collection_id": dc_query})
+        multiqc_collection.delete_many({"data_collection_id": dc_query})
+        jbrowse_collection.delete_many({"data_collection_id": dc_query})
         data_collections_collection.delete_many({"_id": {"$in": dc_ids}})
 
     dashboards_collection.delete_many({"project_id": ObjectId(project_id)})

--- a/depictio/api/v1/endpoints/routers.py
+++ b/depictio/api/v1/endpoints/routers.py
@@ -23,6 +23,7 @@ from depictio.api.v1.endpoints.events_endpoints.routes import events_router
 from depictio.api.v1.endpoints.files_endpoints.routes import files_endpoint_router
 from depictio.api.v1.endpoints.jbrowse_endpoints.routes import jbrowse_endpoints_router
 from depictio.api.v1.endpoints.links_endpoints.routes import links_endpoint_router
+from depictio.api.v1.endpoints.migrate_endpoints.routes import migrate_endpoint_router
 from depictio.api.v1.endpoints.multiqc_endpoints.routes import router as multiqc_router
 from depictio.api.v1.endpoints.projects_endpoints.routes import projects_endpoint_router
 from depictio.api.v1.endpoints.runs_endpoints.routes import runs_endpoint_router
@@ -89,6 +90,12 @@ router.include_router(
     backup_endpoint_router,
     prefix="/backup",
     tags=["Backup"],
+)
+
+router.include_router(
+    migrate_endpoint_router,
+    prefix="/migrate",
+    tags=["Migrate"],
 )
 
 router.include_router(

--- a/depictio/cli/README.md
+++ b/depictio/cli/README.md
@@ -1,6 +1,12 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/depictio/depictio/main/docs/images/logo_hd.png" alt="Depictio logo" width="300">
+</p>
+
 # Depictio CLI
 
 A command-line interface for interacting with the Depictio API.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/depictio/depictio)
 
 ## Installation
 

--- a/depictio/cli/cli/commands/migrate.py
+++ b/depictio/cli/cli/commands/migrate.py
@@ -102,9 +102,13 @@ def run(
     if dry_run:
         rich_print_checked_statement("DRY RUN mode — no data will be written", "info")
 
-    # Build target S3 config for S3 copy
+    # Build target S3 config for S3 copy.
+    # Skip S3 copy when source and target point to the same API instance — the S3 data is
+    # already there and the external endpoint URL sent by the CLI would be unreachable from
+    # inside the backend container (e.g. localhost:9000 vs minio:9000 in Docker).
     target_s3_config: dict | None = None
-    if mode in ("all", "files"):
+    same_instance = source_config.api_base_url == remote_config.api_base_url
+    if mode in ("all", "files") and not same_instance:
         s3 = remote_config.s3_storage
         target_s3_config = {
             "endpoint_url": s3.endpoint_url,
@@ -115,6 +119,10 @@ def run(
         }
         rich_print_checked_statement(
             f"S3 target: {target_s3_config['endpoint_url']} / {target_s3_config['bucket']}", "info"
+        )
+    elif mode in ("all", "files") and same_instance:
+        rich_print_checked_statement(
+            "S3 copy skipped — source and target are the same instance", "info"
         )
 
     # Step 1 – Export from source -----------------------------------------

--- a/depictio/cli/cli/commands/migrate.py
+++ b/depictio/cli/cli/commands/migrate.py
@@ -56,6 +56,13 @@ def run(
     dry_run: Annotated[
         bool, typer.Option("--dry-run", help="Preview changes without writing anything")
     ] = False,
+    overwrite: Annotated[
+        bool,
+        typer.Option(
+            "--overwrite",
+            help="Replace the project on the target if it already exists",
+        ),
+    ] = False,
 ):
     """
     Migrate a project from one Depictio instance to another (non-destructive).
@@ -163,7 +170,16 @@ def run(
         remote_config,
         bundle=bundle,
         dry_run=dry_run,
+        overwrite=overwrite,
     )
+
+    if import_result.get("conflict"):
+        rich_print_checked_statement(
+            f"Conflict: {import_result.get('message', 'project already exists')}. "
+            "Use --overwrite to replace it.",
+            "error",
+        )
+        raise typer.Exit(1)
 
     if not import_result.get("success"):
         rich_print_checked_statement(

--- a/depictio/cli/cli/commands/migrate.py
+++ b/depictio/cli/cli/commands/migrate.py
@@ -1,0 +1,181 @@
+"""
+depictio migrate — project-scoped cross-instance migration
+
+Exports one project from a source instance and upserts it into a target
+instance.  Never wipes existing data on the target.
+
+Usage examples:
+    # Dry-run first (no changes anywhere)
+    depictio migrate --project "my-project" \\
+        --CLI-config-path ~/.depictio/CLI_local.yaml \\
+        --target-config ~/.depictio/CLI_remote.yaml --dry-run
+
+    # Full migration (MongoDB docs + S3 files)
+    depictio migrate --project "my-project" \\
+        --CLI-config-path ~/.depictio/CLI_local.yaml \\
+        --target-config ~/.depictio/CLI_remote.yaml
+
+    # Dashboard-only update
+    depictio migrate --project "my-project" \\
+        --CLI-config-path ~/.depictio/CLI_local.yaml \\
+        --target-config ~/.depictio/CLI_remote.yaml --mode dashboard
+"""
+
+from typing import Annotated
+
+import typer
+
+from depictio.cli.cli.utils.api_calls import api_export_project, api_import_project, api_login
+from depictio.cli.cli.utils.common import load_depictio_config
+from depictio.cli.cli.utils.rich_utils import (
+    rich_print_checked_statement,
+    rich_print_json,
+)
+
+app = typer.Typer()
+
+_MODES = ["all", "metadata", "dashboard", "files"]
+
+
+@app.command()
+def run(
+    project: Annotated[str, typer.Option("--project", help="Project name to migrate")],
+    CLI_config_path: Annotated[
+        str, typer.Option("--CLI-config-path", help="Source CLI config (local instance)")
+    ] = "~/.depictio/CLI.yaml",
+    target_config: Annotated[
+        str, typer.Option("--target-config", help="Target CLI config (remote instance)")
+    ] = "~/.depictio/CLI_remote.yaml",
+    mode: Annotated[
+        str,
+        typer.Option(
+            "--mode",
+            help="Migration scope: all | metadata | dashboard | files",
+        ),
+    ] = "all",
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview changes without writing anything")
+    ] = False,
+):
+    """
+    Migrate a project from one Depictio instance to another (non-destructive).
+
+    Mode descriptions:
+      all       – MongoDB docs + S3 files  (default, full first-time migration)
+      metadata  – MongoDB docs only        (both instances share S3 storage)
+      dashboard – Dashboards only          (project already exists on remote)
+      files     – S3 files only            (metadata already migrated)
+    """
+    if mode not in _MODES:
+        rich_print_checked_statement(
+            f"Invalid mode '{mode}'. Choose from: {', '.join(_MODES)}", "error"
+        )
+        raise typer.Exit(1)
+
+    # Load configs --------------------------------------------------------
+    source_config = load_depictio_config(yaml_config_path=CLI_config_path)
+    remote_config = load_depictio_config(yaml_config_path=target_config)
+
+    # Authenticate source
+    rich_print_checked_statement("Authenticating with source instance...", "info")
+    auth_source = api_login(CLI_config_path)
+    if not auth_source.get("is_admin"):
+        rich_print_checked_statement("Source: admin access required", "error")
+        raise typer.Exit(1)
+    rich_print_checked_statement("Source: authenticated as admin", "success")
+
+    # Authenticate target
+    rich_print_checked_statement("Authenticating with target instance...", "info")
+    auth_target = api_login(target_config)
+    if not auth_target.get("is_admin"):
+        rich_print_checked_statement("Target: admin access required", "error")
+        raise typer.Exit(1)
+    rich_print_checked_statement("Target: authenticated as admin", "success")
+
+    if dry_run:
+        rich_print_checked_statement("DRY RUN mode — no data will be written", "info")
+
+    # Build target S3 config for S3 copy
+    target_s3_config: dict | None = None
+    if mode in ("all", "files"):
+        s3 = remote_config.s3_storage
+        target_s3_config = {
+            "endpoint_url": s3.endpoint_url,
+            "aws_access_key_id": s3.aws_access_key_id,
+            "aws_secret_access_key": s3.aws_secret_access_key,
+            "bucket": s3.bucket,
+            "region_name": "us-east-1",
+        }
+        rich_print_checked_statement(
+            f"S3 target: {target_s3_config['endpoint_url']} / {target_s3_config['bucket']}", "info"
+        )
+
+    # Step 1 – Export from source -----------------------------------------
+    rich_print_checked_statement(
+        f"Exporting project '{project}' (mode={mode}) from source...", "info"
+    )
+    bundle = api_export_project(
+        source_config,
+        project_name=project,
+        mode=mode,
+        target_s3_config=target_s3_config,
+        dry_run=dry_run,
+    )
+
+    if "success" in bundle and not bundle["success"]:
+        rich_print_checked_statement(
+            f"Export failed: {bundle.get('message', 'unknown error')}", "error"
+        )
+        raise typer.Exit(1)
+
+    meta = bundle.get("migrate_metadata", {})
+    doc_counts = meta.get("document_counts", {})
+    rich_print_checked_statement(
+        f"Export complete — project '{meta.get('project_name')}' (id={meta.get('project_id')})",
+        "success",
+    )
+    if doc_counts:
+        rich_print_json("Document counts:", doc_counts)
+
+    s3_meta = bundle.get("s3_migrate_metadata", {})
+    if s3_meta:
+        action = "Would copy" if dry_run else "Copied"
+        rich_print_checked_statement(
+            f"S3: {action} {s3_meta.get('total_files', 0)} files "
+            f"({s3_meta.get('total_bytes', 0)} bytes) "
+            f"from {len(s3_meta.get('paths', []))} locations",
+            "success" if not s3_meta.get("errors") else "warning",
+        )
+        if s3_meta.get("errors"):
+            for err in s3_meta["errors"]:
+                rich_print_checked_statement(f"  S3 error: {err}", "warning")
+
+    # For files-only mode there is nothing to import into MongoDB
+    if mode == "files":
+        rich_print_checked_statement(
+            "Files-only mode: S3 sync complete, no MongoDB import.", "success"
+        )
+        raise typer.Exit(0)
+
+    # Step 2 – Import into target -----------------------------------------
+    rich_print_checked_statement(f"Importing bundle into target instance (mode={mode})...", "info")
+    import_result = api_import_project(
+        remote_config,
+        bundle=bundle,
+        dry_run=dry_run,
+    )
+
+    if not import_result.get("success"):
+        rich_print_checked_statement(
+            f"Import failed: {import_result.get('message', 'unknown error')}", "error"
+        )
+        raise typer.Exit(1)
+
+    action_label = "Would upsert" if dry_run else "Upserted"
+    rich_print_checked_statement(f"{action_label} documents into target instance", "success")
+    rich_print_json("Upserted per collection:", import_result.get("upserted", {}))
+
+    rich_print_checked_statement(
+        f"Migration {'dry-run' if dry_run else ''} complete for project '{project}'",
+        "success",
+    )

--- a/depictio/cli/cli/utils/api_calls.py
+++ b/depictio/cli/cli/utils/api_calls.py
@@ -913,24 +913,21 @@ def api_export_project(
             headers=generate_api_headers(CLI_config),
             timeout=600.0,
         )
-        if response.status_code == 200:
-            buf = io.BytesIO(response.content)
-            with zipfile.ZipFile(buf) as zf:
-                bundle_data = json.loads(zf.read("bundle.json"))
-                migrate_metadata = json.loads(zf.read("migrate_metadata.json"))
-                s3_metadata: dict = {}
-                if "s3_metadata.json" in zf.namelist():
-                    s3_metadata = json.loads(zf.read("s3_metadata.json"))
-            result: dict = {"data": bundle_data, "migrate_metadata": migrate_metadata}
-            if s3_metadata:
-                result["s3_migrate_metadata"] = s3_metadata
-            return result
-        else:
+        if response.status_code != 200:
             logger.error(f"Export failed: {response.text}")
             return {
                 "success": False,
                 "message": f"API request failed with status {response.status_code}: {response.text}",
             }
+
+        with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+            result: dict = {
+                "data": json.loads(zf.read("bundle.json")),
+                "migrate_metadata": json.loads(zf.read("migrate_metadata.json")),
+            }
+            if "s3_metadata.json" in zf.namelist():
+                result["s3_migrate_metadata"] = json.loads(zf.read("s3_metadata.json"))
+        return result
     except httpx.TimeoutException:
         return {"success": False, "message": "Export request timed out"}
     except Exception as e:
@@ -942,10 +939,11 @@ def api_import_project(
     bundle: dict,
     owner_user_id: str | None = None,
     dry_run: bool = False,
+    overwrite: bool = False,
 ) -> dict:
     """Import a project bundle into the target instance (non-destructive upsert)."""
     url = f"{CLI_config.api_base_url}/depictio/api/v1/migrate/import-project"
-    payload: dict = {"bundle": bundle, "dry_run": dry_run}
+    payload: dict = {"bundle": bundle, "dry_run": dry_run, "overwrite": overwrite}
     if owner_user_id:
         payload["owner_user_id"] = owner_user_id
     return _post_migrate_endpoint(CLI_config, url, payload, "Import")

--- a/depictio/cli/cli/utils/api_calls.py
+++ b/depictio/cli/cli/utils/api_calls.py
@@ -1,3 +1,7 @@
+import io
+import json
+import zipfile
+
 import httpx
 import typer
 from pydantic import validate_call
@@ -854,3 +858,94 @@ def api_update_multiqc_report(report_id: str, multiqc_report: dict, CLI_config: 
     except httpx.RequestError as e:
         logger.error(f"HTTP request failed: {e}")
         raise
+
+
+def _post_migrate_endpoint(
+    CLI_config: CLIConfig,
+    url: str,
+    payload: dict,
+    operation: str,
+) -> dict:
+    """Shared helper for migrate POST endpoints with consistent error handling."""
+    try:
+        response = httpx.post(
+            url,
+            json=payload,
+            headers=generate_api_headers(CLI_config),
+            timeout=600.0,
+        )
+        if response.status_code == 200:
+            return response.json()
+        else:
+            logger.error(f"{operation} failed: {response.text}")
+            return {
+                "success": False,
+                "message": f"API request failed with status {response.status_code}: {response.text}",
+            }
+    except httpx.TimeoutException:
+        return {"success": False, "message": f"{operation} request timed out"}
+    except Exception as e:
+        return {"success": False, "message": f"{operation} failed: {str(e)}"}
+
+
+def api_export_project(
+    CLI_config: CLIConfig,
+    project_name: str | None = None,
+    project_id: str | None = None,
+    mode: str = "all",
+    target_s3_config: dict | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Export a project bundle from the source instance (returns parsed ZIP content)."""
+    url = f"{CLI_config.api_base_url}/depictio/api/v1/migrate/export-project"
+    payload: dict = {"mode": mode, "dry_run": dry_run}
+    if project_name:
+        payload["project_name"] = project_name
+    if project_id:
+        payload["project_id"] = project_id
+    if target_s3_config:
+        payload["target_s3_config"] = target_s3_config
+
+    try:
+        response = httpx.post(
+            url,
+            json=payload,
+            headers=generate_api_headers(CLI_config),
+            timeout=600.0,
+        )
+        if response.status_code == 200:
+            buf = io.BytesIO(response.content)
+            with zipfile.ZipFile(buf) as zf:
+                bundle_data = json.loads(zf.read("bundle.json"))
+                migrate_metadata = json.loads(zf.read("migrate_metadata.json"))
+                s3_metadata: dict = {}
+                if "s3_metadata.json" in zf.namelist():
+                    s3_metadata = json.loads(zf.read("s3_metadata.json"))
+            result: dict = {"data": bundle_data, "migrate_metadata": migrate_metadata}
+            if s3_metadata:
+                result["s3_migrate_metadata"] = s3_metadata
+            return result
+        else:
+            logger.error(f"Export failed: {response.text}")
+            return {
+                "success": False,
+                "message": f"API request failed with status {response.status_code}: {response.text}",
+            }
+    except httpx.TimeoutException:
+        return {"success": False, "message": "Export request timed out"}
+    except Exception as e:
+        return {"success": False, "message": f"Export failed: {str(e)}"}
+
+
+def api_import_project(
+    CLI_config: CLIConfig,
+    bundle: dict,
+    owner_user_id: str | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Import a project bundle into the target instance (non-destructive upsert)."""
+    url = f"{CLI_config.api_base_url}/depictio/api/v1/migrate/import-project"
+    payload: dict = {"bundle": bundle, "dry_run": dry_run}
+    if owner_user_id:
+        payload["owner_user_id"] = owner_user_id
+    return _post_migrate_endpoint(CLI_config, url, payload, "Import")

--- a/depictio/cli/depictio_cli.py
+++ b/depictio/cli/depictio_cli.py
@@ -10,6 +10,7 @@ from depictio.cli.cli.commands.config import app as config
 from depictio.cli.cli.commands.dashboard import app as dashboard
 from depictio.cli.cli.commands.data import app as data
 from depictio.cli.cli.commands.images import app as images
+from depictio.cli.cli.commands.migrate import app as migrate
 from depictio.cli.cli.commands.run import register_run_command
 from depictio.cli.cli.commands.standalone import register_standalone_commands
 from depictio.cli.cli.utils.rich_utils import add_rich_display_to_polars
@@ -54,6 +55,7 @@ app.add_typer(config, name="config", help="Configuration commands")
 app.add_typer(dashboard, name="dashboard", help="Dashboard validation commands")
 app.add_typer(data, name="data", help="Data management commands")
 app.add_typer(images, name="images", help="Image management commands")
+app.add_typer(migrate, name="migrate", help="Cross-instance project migration")
 depictiocli = get_command(app)
 
 

--- a/depictio/dash/layouts/projects.py
+++ b/depictio/dash/layouts/projects.py
@@ -77,6 +77,51 @@ def fetch_projects(token: str) -> list[Project]:
 # =============================================================================
 
 
+def _create_import_project_tab_content() -> dmc.Stack:
+    """Create the Import tab content for the project modal."""
+    return dmc.Stack(
+        [
+            dmc.Text(
+                "Upload a .zip bundle exported from another Depictio instance.",
+                c="dimmed",
+                size="sm",
+            ),
+            dcc.Upload(
+                id="import-project-upload",
+                children=dmc.Stack(
+                    [
+                        DashIconify(icon="mdi:file-upload", width=40, color="violet"),
+                        dmc.Text("Drop .zip here or click to browse", c="dimmed"),
+                    ],
+                    align="center",
+                ),
+                style={
+                    "borderWidth": "2px",
+                    "borderStyle": "dashed",
+                    "borderRadius": "8px",
+                    "borderColor": "#7c3aed",
+                    "padding": "40px 20px",
+                    "textAlign": "center",
+                    "cursor": "pointer",
+                },
+                accept=".zip",
+                multiple=False,
+            ),
+            html.Div(id="import-project-preview"),
+            dcc.Store(id="import-project-store"),
+            dmc.Button(
+                "Import Project",
+                id="import-project-submit",
+                leftSection=DashIconify(icon="mdi:check", width=16),
+                color="violet",
+                disabled=True,
+            ),
+            html.Div(id="import-project-status"),
+        ],
+        gap="md",
+    )
+
+
 def create_project_modal(opened: bool = False) -> tuple[dmc.Modal, str]:
     """Create the project creation modal with stepper wizard.
 
@@ -114,108 +159,140 @@ def create_project_modal(opened: bool = False) -> tuple[dmc.Modal, str]:
         },
         children=[
             html.Div(id="dummy-hover-output", style={"display": "none"}),
-            dcc.Store(
-                id="project-creation-store",
-                data={
-                    "current_step": 0,
-                    "project_type": None,
-                    "project_name": "",
-                    "is_public": False,
-                    "data_collections": [],
-                },
-            ),
-            dcc.Store(
-                id="project-card-click-memory",
-                data={"basic_clicks": 0},
-                storage_type="memory",
-            ),
-            dmc.Stack(
-                gap="xl",
+            dmc.Tabs(
+                id="project-modal-tabs",
+                value="create",
+                variant="pills",
                 children=[
-                    # Header with icon and title
-                    dmc.Group(
-                        justify="center",
-                        gap="sm",
-                        children=[
-                            DashIconify(
-                                icon="mdi:folder-plus-outline",
-                                width=40,
-                                height=40,
-                                color=colors["teal"],
+                    dmc.TabsList(
+                        [
+                            dmc.TabsTab(
+                                "Create New",
+                                value="create",
+                                leftSection=DashIconify(icon="mdi:plus", width=16),
                             ),
-                            dmc.Title(
-                                "Create New Project",
-                                order=1,
-                                c=colors["teal"],
-                                style={"margin": 0},
+                            dmc.TabsTab(
+                                "Import",
+                                value="import",
+                                leftSection=DashIconify(icon="mdi:import", width=16),
                             ),
-                        ],
+                        ]
                     ),
-                    # Divider
-                    dmc.Divider(style={"marginTop": 5, "marginBottom": 5}),
-                    # Stepper
-                    dmc.Stepper(
-                        id="project-creation-stepper",
-                        active=0,
-                        color=colors["teal"],
+                    dmc.TabsPanel(
+                        value="create",
+                        pt="lg",
                         children=[
-                            dmc.StepperStep(
-                                label="Project Type",
-                                description="Choose basic or advanced",
-                                children=[html.Div(id="step-1-content")],
+                            dcc.Store(
+                                id="project-creation-store",
+                                data={
+                                    "current_step": 0,
+                                    "project_type": None,
+                                    "project_name": "",
+                                    "is_public": False,
+                                    "data_collections": [],
+                                },
                             ),
-                            dmc.StepperStep(
-                                label="Project Details",
-                                description="Configure your project",
-                                children=[html.Div(id="step-2-content")],
+                            dcc.Store(
+                                id="project-card-click-memory",
+                                data={"basic_clicks": 0},
+                                storage_type="memory",
                             ),
-                            dmc.StepperCompleted(
+                            dmc.Stack(
+                                gap="xl",
                                 children=[
-                                    dmc.Center(
-                                        [
-                                            dmc.Stack(
+                                    # Header with icon and title
+                                    dmc.Group(
+                                        justify="center",
+                                        gap="sm",
+                                        children=[
+                                            DashIconify(
+                                                icon="mdi:folder-plus-outline",
+                                                width=40,
+                                                height=40,
+                                                color=colors["teal"],
+                                            ),
+                                            dmc.Title(
+                                                "Create New Project",
+                                                order=1,
+                                                c=colors["teal"],
+                                                style={"margin": 0},
+                                            ),
+                                        ],
+                                    ),
+                                    # Divider
+                                    dmc.Divider(style={"marginTop": 5, "marginBottom": 5}),
+                                    # Stepper
+                                    dmc.Stepper(
+                                        id="project-creation-stepper",
+                                        active=0,
+                                        color=colors["teal"],
+                                        children=[
+                                            dmc.StepperStep(
+                                                label="Project Type",
+                                                description="Choose basic or advanced",
+                                                children=[html.Div(id="step-1-content")],
+                                            ),
+                                            dmc.StepperStep(
+                                                label="Project Details",
+                                                description="Configure your project",
+                                                children=[html.Div(id="step-2-content")],
+                                            ),
+                                            dmc.StepperCompleted(
+                                                children=[
+                                                    dmc.Center(
+                                                        [
+                                                            dmc.Stack(
+                                                                [
+                                                                    DashIconify(
+                                                                        icon="mdi:check-circle",
+                                                                        width=64,
+                                                                        color=colors["teal"],
+                                                                    ),
+                                                                    dmc.Text(
+                                                                        "Project created successfully!",
+                                                                        ta="center",
+                                                                        fw="bold",
+                                                                    ),
+                                                                ],
+                                                                align="center",
+                                                            )
+                                                        ]
+                                                    )
+                                                ]
+                                            ),
+                                        ],
+                                    ),
+                                    # Navigation buttons
+                                    dmc.Group(
+                                        justify="space-between",
+                                        mt="xl",
+                                        children=[
+                                            dmc.Button(
+                                                "Previous",
+                                                id="project-stepper-prev",
+                                                variant="outline",
+                                                disabled=True,
+                                            ),
+                                            dmc.Group(
                                                 [
-                                                    DashIconify(
-                                                        icon="mdi:check-circle",
-                                                        width=64,
+                                                    dmc.Button(
+                                                        "Next",
+                                                        id="project-stepper-next",
                                                         color=colors["teal"],
                                                     ),
-                                                    dmc.Text(
-                                                        "Project created successfully!",
-                                                        ta="center",
-                                                        fw="bold",
-                                                    ),
                                                 ],
-                                                align="center",
-                                            )
-                                        ]
-                                    )
-                                ]
+                                                justify="flex-end",
+                                            ),
+                                        ],
+                                    ),
+                                ],
                             ),
                         ],
                     ),
-                    # Navigation buttons
-                    dmc.Group(
-                        justify="space-between",
-                        mt="xl",
-                        children=[
-                            dmc.Button(
-                                "Previous",
-                                id="project-stepper-prev",
-                                variant="outline",
-                                disabled=True,
-                            ),
-                            dmc.Group(
-                                [
-                                    dmc.Button(
-                                        "Next",
-                                        id="project-stepper-next",
-                                        color=colors["teal"],
-                                    ),
-                                ],
-                                justify="flex-end",
-                            ),
-                        ],
+                    dmc.TabsPanel(
+                        value="import",
+                        pt="lg",
+                        children=_create_import_project_tab_content(),
                     ),
                 ],
             ),
@@ -1055,6 +1132,15 @@ def create_project_management_panel(project: Project, current_user: UserBase) ->
                     size="sm",
                     disabled=not user_can_manage,
                 ),
+                dmc.Button(
+                    "Export Project",
+                    id={"type": "export-project-button", "index": str(project.id)},
+                    leftSection=DashIconify(icon="mdi:export", width=16),
+                    variant="light",
+                    color="violet",
+                    size="sm",
+                ),
+                dcc.Download(id={"type": "export-project-download", "index": str(project.id)}),
             ],
             gap="md",
         ),
@@ -2235,3 +2321,107 @@ def register_workflows_callbacks(app) -> None:
     #     [Input("project-creation-modal", "opened"), Input("project-creation-store", "data")],
     #     prevent_initial_call=True,
     # )
+
+    # Export project to ZIP
+    @app.callback(
+        Output({"type": "export-project-download", "index": MATCH}, "data"),
+        Input({"type": "export-project-button", "index": MATCH}, "n_clicks"),
+        State("local-store", "data"),
+        prevent_initial_call=True,
+    )
+    def export_project_to_zip(n_clicks, local_data):
+        """Download a project bundle as a ZIP file."""
+        if not n_clicks:
+            raise dash.exceptions.PreventUpdate
+        ctx = dash.callback_context
+        project_id = ctx.triggered_id["index"]
+        token = local_data.get("access_token") if local_data else None
+        if not token:
+            raise dash.exceptions.PreventUpdate
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = httpx.post(
+            f"{API_BASE_URL}/depictio/api/v1/migrate/export-project",
+            json={"project_id": project_id, "mode": "all"},
+            headers=headers,
+            timeout=120.0,
+        )
+        if resp.status_code != 200:
+            logger.error(f"Export project failed: {resp.text}")
+            raise dash.exceptions.PreventUpdate
+        return dcc.send_bytes(resp.content, f"depictio_export_{project_id}.zip")
+
+    # Handle import project ZIP upload — parse and show preview
+    @app.callback(
+        [
+            Output("import-project-store", "data"),
+            Output("import-project-preview", "children"),
+            Output("import-project-submit", "disabled"),
+        ],
+        Input("import-project-upload", "contents"),
+        State("import-project-upload", "filename"),
+        prevent_initial_call=True,
+    )
+    def handle_import_project_upload(contents, filename):
+        """Parse uploaded ZIP and show project preview."""
+        import base64
+        import io as _io
+        import json as _json
+        import zipfile as _zipfile
+
+        if not contents:
+            raise dash.exceptions.PreventUpdate
+        _content_type, content_string = contents.split(",")
+        decoded = base64.b64decode(content_string)
+        buf = _io.BytesIO(decoded)
+        try:
+            with _zipfile.ZipFile(buf) as zf:
+                meta = _json.loads(zf.read("migrate_metadata.json"))
+                bundle_data = _json.loads(zf.read("bundle.json"))
+        except Exception as e:
+            preview = dmc.Alert(f"Invalid ZIP file: {e}", color="red")
+            return dash.no_update, preview, True
+        preview = dmc.Paper(
+            [
+                dmc.Text(f"Project: {meta.get('project_name')}", fw=600),
+                dmc.Text(
+                    f"Mode: {meta.get('mode')}  |  Exported: {str(meta.get('timestamp', ''))[:10]}",
+                    size="sm",
+                    c="dimmed",
+                ),
+                dmc.Text(str(meta.get("document_counts", {})), size="xs", c="dimmed"),
+            ],
+            p="sm",
+            withBorder=True,
+            radius="md",
+        )
+        full_bundle = {"migrate_metadata": meta, "data": bundle_data}
+        return full_bundle, preview, False
+
+    # Submit import — POST bundle to API
+    @app.callback(
+        [
+            Output("import-project-status", "children"),
+            Output("project-creation-modal", "opened", allow_duplicate=True),
+        ],
+        Input("import-project-submit", "n_clicks"),
+        [State("import-project-store", "data"), State("local-store", "data")],
+        prevent_initial_call=True,
+    )
+    def submit_project_import(n_clicks, bundle, local_data):
+        """POST the import bundle to the API and close modal on success."""
+        if not n_clicks or not bundle:
+            raise dash.exceptions.PreventUpdate
+        token = local_data.get("access_token") if local_data else None
+        if not token:
+            raise dash.exceptions.PreventUpdate
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = httpx.post(
+            f"{API_BASE_URL}/depictio/api/v1/migrate/import-project",
+            json={"bundle": bundle, "force_owner_remap": True},
+            headers=headers,
+            timeout=120.0,
+        )
+        if resp.status_code == 200:
+            return dmc.Alert("Project imported successfully!", color="green"), False
+        else:
+            return dmc.Alert(f"Import failed: {resp.text}", color="red"), True

--- a/depictio/dash/layouts/projects.py
+++ b/depictio/dash/layouts/projects.py
@@ -2379,22 +2379,21 @@ def register_workflows_callbacks(app) -> None:
     def handle_import_project_upload(contents, filename):
         """Parse uploaded ZIP and show project preview."""
         import base64
-        import io as _io
-        import json as _json
-        import zipfile as _zipfile
+        import io
+        import json
+        import zipfile
 
         if not contents:
             raise dash.exceptions.PreventUpdate
         _content_type, content_string = contents.split(",")
         decoded = base64.b64decode(content_string)
-        buf = _io.BytesIO(decoded)
         try:
-            with _zipfile.ZipFile(buf) as zf:
-                meta = _json.loads(zf.read("migrate_metadata.json"))
-                bundle_data = _json.loads(zf.read("bundle.json"))
+            with zipfile.ZipFile(io.BytesIO(decoded)) as zf:
+                meta = json.loads(zf.read("migrate_metadata.json"))
+                bundle_data = json.loads(zf.read("bundle.json"))
         except Exception as e:
-            preview = dmc.Alert(f"Invalid ZIP file: {e}", color="red")
-            return dash.no_update, preview, True
+            return dash.no_update, dmc.Alert(f"Invalid ZIP file: {e}", color="red"), True
+
         preview = dmc.Paper(
             [
                 dmc.Text(f"Project: {meta.get('project_name')}", fw=600),
@@ -2409,8 +2408,7 @@ def register_workflows_callbacks(app) -> None:
             withBorder=True,
             radius="md",
         )
-        full_bundle = {"migrate_metadata": meta, "data": bundle_data}
-        return full_bundle, preview, False
+        return {"migrate_metadata": meta, "data": bundle_data}, preview, False
 
     # Submit import — POST bundle to API
     @app.callback(
@@ -2434,27 +2432,28 @@ def register_workflows_callbacks(app) -> None:
         token = local_data.get("access_token") if local_data else None
         if not token:
             raise dash.exceptions.PreventUpdate
-        headers = {"Authorization": f"Bearer {token}"}
+
         resp = httpx.post(
             f"{API_BASE_URL}/depictio/api/v1/migrate/import-project",
             json={"bundle": bundle, "force_owner_remap": True, "overwrite": bool(overwrite)},
-            headers=headers,
+            headers={"Authorization": f"Bearer {token}"},
             timeout=120.0,
         )
-        no_refresh = dash.no_update
-        if resp.status_code == 200:
-            result = resp.json()
-            if result.get("conflict"):
-                msg = dmc.Alert(
-                    result.get("message", "Project already exists."),
-                    color="yellow",
-                    title="Conflict",
-                    icon=DashIconify(icon="mdi:alert-outline", width=20),
-                )
-                return msg, True, no_refresh
-            # Success — refresh project list and close modal
-            projects = fetch_projects(token)
-            refreshed = render_projects_list(projects=projects, admin_UI=False, token=token)
-            return dmc.Alert("Project imported successfully!", color="green"), False, refreshed
-        else:
-            return dmc.Alert(f"Import failed: {resp.text}", color="red"), True, no_refresh
+
+        if resp.status_code != 200:
+            return dmc.Alert(f"Import failed: {resp.text}", color="red"), True, dash.no_update
+
+        result = resp.json()
+        if result.get("conflict"):
+            alert = dmc.Alert(
+                result.get("message", "Project already exists."),
+                color="yellow",
+                title="Conflict",
+                icon=DashIconify(icon="mdi:alert-outline", width=20),
+            )
+            return alert, True, dash.no_update
+
+        # Success -- refresh project list and close modal
+        projects = fetch_projects(token)
+        refreshed = render_projects_list(projects=projects, admin_UI=False, token=token)
+        return dmc.Alert("Project imported successfully!", color="green"), False, refreshed

--- a/depictio/dash/layouts/projects.py
+++ b/depictio/dash/layouts/projects.py
@@ -109,6 +109,12 @@ def _create_import_project_tab_content() -> dmc.Stack:
             ),
             html.Div(id="import-project-preview"),
             dcc.Store(id="import-project-store"),
+            dmc.Switch(
+                id="import-project-overwrite",
+                label="Overwrite if project already exists",
+                color=colors["teal"],
+                checked=False,
+            ),
             dmc.Button(
                 "Import Project",
                 id="import-project-submit",
@@ -2411,13 +2417,18 @@ def register_workflows_callbacks(app) -> None:
         [
             Output("import-project-status", "children"),
             Output("project-creation-modal", "opened", allow_duplicate=True),
+            Output("projects-content", "children", allow_duplicate=True),
         ],
         Input("import-project-submit", "n_clicks"),
-        [State("import-project-store", "data"), State("local-store", "data")],
+        [
+            State("import-project-store", "data"),
+            State("local-store", "data"),
+            State("import-project-overwrite", "checked"),
+        ],
         prevent_initial_call=True,
     )
-    def submit_project_import(n_clicks, bundle, local_data):
-        """POST the import bundle to the API and close modal on success."""
+    def submit_project_import(n_clicks, bundle, local_data, overwrite):
+        """POST the import bundle to the API, refresh project list on success."""
         if not n_clicks or not bundle:
             raise dash.exceptions.PreventUpdate
         token = local_data.get("access_token") if local_data else None
@@ -2426,11 +2437,24 @@ def register_workflows_callbacks(app) -> None:
         headers = {"Authorization": f"Bearer {token}"}
         resp = httpx.post(
             f"{API_BASE_URL}/depictio/api/v1/migrate/import-project",
-            json={"bundle": bundle, "force_owner_remap": True},
+            json={"bundle": bundle, "force_owner_remap": True, "overwrite": bool(overwrite)},
             headers=headers,
             timeout=120.0,
         )
+        no_refresh = dash.no_update
         if resp.status_code == 200:
-            return dmc.Alert("Project imported successfully!", color="green"), False
+            result = resp.json()
+            if result.get("conflict"):
+                msg = dmc.Alert(
+                    result.get("message", "Project already exists."),
+                    color="yellow",
+                    title="Conflict",
+                    icon=DashIconify(icon="mdi:alert-outline", width=20),
+                )
+                return msg, True, no_refresh
+            # Success — refresh project list and close modal
+            projects = fetch_projects(token)
+            refreshed = render_projects_list(projects=projects, admin_UI=False, token=token)
+            return dmc.Alert("Project imported successfully!", color="green"), False, refreshed
         else:
-            return dmc.Alert(f"Import failed: {resp.text}", color="red"), True
+            return dmc.Alert(f"Import failed: {resp.text}", color="red"), True, no_refresh

--- a/depictio/dash/layouts/projects.py
+++ b/depictio/dash/layouts/projects.py
@@ -90,7 +90,7 @@ def _create_import_project_tab_content() -> dmc.Stack:
                 id="import-project-upload",
                 children=dmc.Stack(
                     [
-                        DashIconify(icon="mdi:file-upload", width=40, color="violet"),
+                        DashIconify(icon="mdi:file-upload", width=40, color=colors["teal"]),
                         dmc.Text("Drop .zip here or click to browse", c="dimmed"),
                     ],
                     align="center",
@@ -99,7 +99,7 @@ def _create_import_project_tab_content() -> dmc.Stack:
                     "borderWidth": "2px",
                     "borderStyle": "dashed",
                     "borderRadius": "8px",
-                    "borderColor": "#7c3aed",
+                    "borderColor": colors["teal"],
                     "padding": "40px 20px",
                     "textAlign": "center",
                     "cursor": "pointer",
@@ -113,7 +113,7 @@ def _create_import_project_tab_content() -> dmc.Stack:
                 "Import Project",
                 id="import-project-submit",
                 leftSection=DashIconify(icon="mdi:check", width=16),
-                color="violet",
+                color=colors["teal"],
                 disabled=True,
             ),
             html.Div(id="import-project-status"),
@@ -163,6 +163,7 @@ def create_project_modal(opened: bool = False) -> tuple[dmc.Modal, str]:
                 id="project-modal-tabs",
                 value="create",
                 variant="pills",
+                color=colors["teal"],
                 children=[
                     dmc.TabsList(
                         [
@@ -176,7 +177,8 @@ def create_project_modal(opened: bool = False) -> tuple[dmc.Modal, str]:
                                 value="import",
                                 leftSection=DashIconify(icon="mdi:import", width=16),
                             ),
-                        ]
+                        ],
+                        mb="md",
                     ),
                     dmc.TabsPanel(
                         value="create",
@@ -1136,8 +1138,8 @@ def create_project_management_panel(project: Project, current_user: UserBase) ->
                     "Export Project",
                     id={"type": "export-project-button", "index": str(project.id)},
                     leftSection=DashIconify(icon="mdi:export", width=16),
-                    variant="light",
-                    color="violet",
+                    variant="outline",
+                    color=colors["teal"],
                     size="sm",
                 ),
                 dcc.Download(id={"type": "export-project-download", "index": str(project.id)}),

--- a/depictio/dash/layouts/projects.py
+++ b/depictio/dash/layouts/projects.py
@@ -159,142 +159,149 @@ def create_project_modal(opened: bool = False) -> tuple[dmc.Modal, str]:
         },
         children=[
             html.Div(id="dummy-hover-output", style={"display": "none"}),
-            dmc.Tabs(
-                id="project-modal-tabs",
-                value="create",
-                variant="pills",
-                color=colors["teal"],
+            # Shared header — always visible above the tabs
+            dmc.Stack(
+                gap=0,
+                mb="md",
                 children=[
-                    dmc.TabsList(
-                        [
-                            dmc.TabsTab(
-                                "Create New",
-                                value="create",
-                                leftSection=DashIconify(icon="mdi:plus", width=16),
+                    dmc.Group(
+                        justify="center",
+                        gap="sm",
+                        mb="md",
+                        children=[
+                            DashIconify(
+                                icon="mdi:folder-plus-outline",
+                                width=40,
+                                height=40,
+                                color=colors["teal"],
                             ),
-                            dmc.TabsTab(
-                                "Import",
-                                value="import",
-                                leftSection=DashIconify(icon="mdi:import", width=16),
+                            dmc.Title(
+                                "Projects",
+                                order=1,
+                                c=colors["teal"],
+                                style={"margin": 0},
                             ),
                         ],
-                        mb="md",
                     ),
-                    dmc.TabsPanel(
+                    dmc.Tabs(
+                        id="project-modal-tabs",
                         value="create",
-                        pt="lg",
+                        variant="pills",
+                        color=colors["teal"],
                         children=[
-                            dcc.Store(
-                                id="project-creation-store",
-                                data={
-                                    "current_step": 0,
-                                    "project_type": None,
-                                    "project_name": "",
-                                    "is_public": False,
-                                    "data_collections": [],
-                                },
-                            ),
-                            dcc.Store(
-                                id="project-card-click-memory",
-                                data={"basic_clicks": 0},
-                                storage_type="memory",
-                            ),
-                            dmc.Stack(
-                                gap="xl",
-                                children=[
-                                    # Header with icon and title
-                                    dmc.Group(
-                                        justify="center",
-                                        gap="sm",
-                                        children=[
-                                            DashIconify(
-                                                icon="mdi:folder-plus-outline",
-                                                width=40,
-                                                height=40,
-                                                color=colors["teal"],
-                                            ),
-                                            dmc.Title(
-                                                "Create New Project",
-                                                order=1,
-                                                c=colors["teal"],
-                                                style={"margin": 0},
-                                            ),
-                                        ],
+                            dmc.TabsList(
+                                [
+                                    dmc.TabsTab(
+                                        "Create New",
+                                        value="create",
+                                        leftSection=DashIconify(icon="mdi:plus", width=16),
                                     ),
-                                    # Divider
-                                    dmc.Divider(style={"marginTop": 5, "marginBottom": 5}),
-                                    # Stepper
-                                    dmc.Stepper(
-                                        id="project-creation-stepper",
-                                        active=0,
-                                        color=colors["teal"],
+                                    dmc.TabsTab(
+                                        "Import",
+                                        value="import",
+                                        leftSection=DashIconify(icon="mdi:import", width=16),
+                                    ),
+                                ],
+                                justify="center",
+                                mb="md",
+                            ),
+                            dmc.Divider(mb="md"),
+                            dmc.TabsPanel(
+                                value="create",
+                                children=[
+                                    dcc.Store(
+                                        id="project-creation-store",
+                                        data={
+                                            "current_step": 0,
+                                            "project_type": None,
+                                            "project_name": "",
+                                            "is_public": False,
+                                            "data_collections": [],
+                                        },
+                                    ),
+                                    dcc.Store(
+                                        id="project-card-click-memory",
+                                        data={"basic_clicks": 0},
+                                        storage_type="memory",
+                                    ),
+                                    dmc.Stack(
+                                        gap="xl",
                                         children=[
-                                            dmc.StepperStep(
-                                                label="Project Type",
-                                                description="Choose basic or advanced",
-                                                children=[html.Div(id="step-1-content")],
-                                            ),
-                                            dmc.StepperStep(
-                                                label="Project Details",
-                                                description="Configure your project",
-                                                children=[html.Div(id="step-2-content")],
-                                            ),
-                                            dmc.StepperCompleted(
+                                            # Stepper
+                                            dmc.Stepper(
+                                                id="project-creation-stepper",
+                                                active=0,
+                                                color=colors["teal"],
                                                 children=[
-                                                    dmc.Center(
-                                                        [
-                                                            dmc.Stack(
+                                                    dmc.StepperStep(
+                                                        label="Project Type",
+                                                        description="Choose basic or advanced",
+                                                        children=[html.Div(id="step-1-content")],
+                                                    ),
+                                                    dmc.StepperStep(
+                                                        label="Project Details",
+                                                        description="Configure your project",
+                                                        children=[html.Div(id="step-2-content")],
+                                                    ),
+                                                    dmc.StepperCompleted(
+                                                        children=[
+                                                            dmc.Center(
                                                                 [
-                                                                    DashIconify(
-                                                                        icon="mdi:check-circle",
-                                                                        width=64,
-                                                                        color=colors["teal"],
-                                                                    ),
-                                                                    dmc.Text(
-                                                                        "Project created successfully!",
-                                                                        ta="center",
-                                                                        fw="bold",
-                                                                    ),
-                                                                ],
-                                                                align="center",
+                                                                    dmc.Stack(
+                                                                        [
+                                                                            DashIconify(
+                                                                                icon="mdi:check-circle",
+                                                                                width=64,
+                                                                                color=colors[
+                                                                                    "teal"
+                                                                                ],
+                                                                            ),
+                                                                            dmc.Text(
+                                                                                "Project created successfully!",
+                                                                                ta="center",
+                                                                                fw="bold",
+                                                                            ),
+                                                                        ],
+                                                                        align="center",
+                                                                    )
+                                                                ]
                                                             )
                                                         ]
-                                                    )
-                                                ]
-                                            ),
-                                        ],
-                                    ),
-                                    # Navigation buttons
-                                    dmc.Group(
-                                        justify="space-between",
-                                        mt="xl",
-                                        children=[
-                                            dmc.Button(
-                                                "Previous",
-                                                id="project-stepper-prev",
-                                                variant="outline",
-                                                disabled=True,
-                                            ),
-                                            dmc.Group(
-                                                [
-                                                    dmc.Button(
-                                                        "Next",
-                                                        id="project-stepper-next",
-                                                        color=colors["teal"],
                                                     ),
                                                 ],
-                                                justify="flex-end",
+                                            ),
+                                            # Navigation buttons
+                                            dmc.Group(
+                                                justify="space-between",
+                                                mt="xl",
+                                                children=[
+                                                    dmc.Button(
+                                                        "Previous",
+                                                        id="project-stepper-prev",
+                                                        variant="outline",
+                                                        disabled=True,
+                                                    ),
+                                                    dmc.Group(
+                                                        [
+                                                            dmc.Button(
+                                                                "Next",
+                                                                id="project-stepper-next",
+                                                                color=colors["teal"],
+                                                            ),
+                                                        ],
+                                                        justify="flex-end",
+                                                    ),
+                                                ],
                                             ),
                                         ],
                                     ),
                                 ],
                             ),
+                            dmc.TabsPanel(
+                                value="import",
+                                children=_create_import_project_tab_content(),
+                            ),
                         ],
-                    ),
-                    dmc.TabsPanel(
-                        value="import",
-                        pt="lg",
-                        children=_create_import_project_tab_content(),
                     ),
                 ],
             ),

--- a/depictio/tests/cli/commands/test_migrate.py
+++ b/depictio/tests/cli/commands/test_migrate.py
@@ -1,0 +1,574 @@
+import os
+import tempfile
+from unittest.mock import Mock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from depictio.cli.cli.commands.migrate import app
+
+
+@pytest.fixture
+def runner():
+    """Create CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_cli_config():
+    """Mock CLI configuration (same shape used by test_backup.py)."""
+    return {
+        "user": {
+            "email": "admin@example.com",
+            "is_admin": True,
+            "id": "507f1f77bcf86cd799439011",
+            "token": {
+                "user_id": "507f1f77bcf86cd799439011",
+                "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+                "refresh_token": "refresh-token-example",
+                "token_type": "bearer",
+                "token_lifetime": "short-lived",
+                "expire_datetime": "2025-12-31T23:59:59",
+                "refresh_expire_datetime": "2025-12-31T23:59:59",
+                "name": "test-token",
+                "created_at": "2025-06-30T18:00:00",
+                "logged_in": False,
+            },
+        },
+        "api_base_url": "http://localhost:8000",
+        "s3_storage": {
+            "service_name": "minio",
+            "service_port": 9000,
+            "external_host": "localhost",
+            "external_port": 9000,
+            "external_protocol": "http",
+            "root_user": "minio",
+            "root_password": "minio123",
+            "bucket": "depictio-bucket",
+        },
+    }
+
+
+@pytest.fixture
+def config_file(mock_cli_config):
+    """Write mock CLI config to a temp file and return its path."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path = os.path.join(tmp_dir, "config.yaml")
+        with open(path, "w") as f:
+            yaml.dump(mock_cli_config, f)
+        yield path
+
+
+# ---------------------------------------------------------------------------
+# Non-admin access denied
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateCLIAccessControl:
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_source_non_admin_denied(self, mock_login, mock_load, runner, config_file):
+        """Non-admin source credentials must be rejected."""
+        mock_load.return_value = Mock()
+        mock_login.return_value = {"success": True, "is_admin": False}
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "admin" in result.stdout.lower()
+
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_target_non_admin_denied(self, mock_login, mock_load, runner, config_file):
+        """Non-admin target credentials must be rejected."""
+        mock_load.return_value = Mock()
+        # First call (source) succeeds as admin; second call (target) fails
+        mock_login.side_effect = [
+            {"success": True, "is_admin": True},
+            {"success": True, "is_admin": False},
+        ]
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "admin" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Mode validation
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateCLIModeValidation:
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_invalid_mode_rejected(self, mock_login, mock_load, runner, config_file):
+        """Unknown --mode value must exit with error."""
+        mock_load.return_value = Mock()
+        mock_login.return_value = {"success": True, "is_admin": True}
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                "invalid_mode",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "invalid mode" in result.stdout.lower() or "invalid" in result.stdout.lower()
+
+    @pytest.mark.parametrize("mode", ["all", "metadata", "dashboard", "files"])
+    @patch("depictio.cli.cli.commands.migrate.api_import_project")
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_valid_modes_accepted(
+        self, mock_login, mock_load, mock_export, mock_import, mode, runner, config_file
+    ):
+        """All four valid modes must be accepted without mode-rejection error."""
+        mock_load.return_value = Mock()
+        mock_load.return_value.s3_storage.endpoint_url = "http://localhost:9000"
+        mock_load.return_value.s3_storage.aws_access_key_id = "minio"
+        mock_load.return_value.s3_storage.aws_secret_access_key = "minio123"
+        mock_load.return_value.s3_storage.bucket = "depictio-bucket"
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "migrate_metadata": {
+                "project_name": "my-project",
+                "project_id": "507f1f77bcf86cd799439011",
+                "mode": mode,
+                "document_counts": {"projects": 1},
+            },
+            "data": {"projects": [], "dashboards": []},
+        }
+        mock_import.return_value = {
+            "success": True,
+            "message": "Upserted 1 documents",
+            "upserted": {"projects": 1},
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                mode,
+            ],
+        )
+
+        # Should not fail with "invalid mode"
+        assert "invalid mode" not in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Successful migration
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateCLISuccess:
+    @patch("depictio.cli.cli.commands.migrate.api_import_project")
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_full_migration_success(
+        self, mock_login, mock_load, mock_export, mock_import, runner, config_file
+    ):
+        """Successful full migration (mode=all) prints summary and exits 0."""
+        mock_load.return_value = Mock()
+        mock_load.return_value.s3_storage.endpoint_url = "http://localhost:9000"
+        mock_load.return_value.s3_storage.aws_access_key_id = "minio"
+        mock_load.return_value.s3_storage.aws_secret_access_key = "minio123"
+        mock_load.return_value.s3_storage.bucket = "depictio-bucket"
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "migrate_metadata": {
+                "project_name": "my-project",
+                "project_id": "507f1f77bcf86cd799439011",
+                "mode": "all",
+                "document_counts": {
+                    "projects": 1,
+                    "workflows": 2,
+                    "data_collections": 3,
+                    "files": 10,
+                    "deltatables": 3,
+                    "runs": 5,
+                    "dashboards": 2,
+                },
+            },
+            "data": {
+                "projects": [{"_id": "507f1f77bcf86cd799439011", "name": "my-project"}],
+                "dashboards": [{"_id": "507f1f77bcf86cd799439012"}],
+            },
+            "s3_migrate_metadata": {
+                "locations_copied": 3,
+                "total_files": 42,
+                "total_bytes": 1024000,
+                "paths": ["dc1/", "dc2/", "dc3/"],
+                "errors": [],
+            },
+        }
+        mock_import.return_value = {
+            "success": True,
+            "message": "Upserted 25 documents",
+            "upserted": {
+                "projects": 1,
+                "workflows": 2,
+                "data_collections": 3,
+                "files": 10,
+                "deltatables": 3,
+                "runs": 5,
+                "dashboards": 2,
+            },
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                "all",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Export complete" in result.stdout
+        assert "Upserted" in result.stdout or "upserted" in result.stdout.lower()
+
+    @patch("depictio.cli.cli.commands.migrate.api_import_project")
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_dashboard_mode_success(
+        self, mock_login, mock_load, mock_export, mock_import, runner, config_file
+    ):
+        """Dashboard-only migration exits 0 and mentions dashboards."""
+        mock_load.return_value = Mock()
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "migrate_metadata": {
+                "project_name": "my-project",
+                "project_id": "507f1f77bcf86cd799439011",
+                "mode": "dashboard",
+                "document_counts": {"dashboards": 2},
+            },
+            "data": {"dashboards": [{"_id": "abc"}]},
+        }
+        mock_import.return_value = {
+            "success": True,
+            "message": "Upserted 2 documents",
+            "upserted": {"dashboards": 2},
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                "dashboard",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "dashboards" in result.stdout.lower() or "Export complete" in result.stdout
+
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_files_only_mode_skips_import(
+        self, mock_login, mock_load, mock_export, runner, config_file
+    ):
+        """files mode exits after S3 sync without calling import."""
+        mock_load.return_value = Mock()
+        mock_load.return_value.s3_storage.endpoint_url = "http://localhost:9000"
+        mock_load.return_value.s3_storage.aws_access_key_id = "minio"
+        mock_load.return_value.s3_storage.aws_secret_access_key = "minio123"
+        mock_load.return_value.s3_storage.bucket = "depictio-bucket"
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "migrate_metadata": {
+                "project_name": "my-project",
+                "project_id": "507f1f77bcf86cd799439011",
+                "mode": "files",
+                "document_counts": {},
+            },
+            "data": {},
+            "s3_migrate_metadata": {
+                "locations_copied": 2,
+                "total_files": 10,
+                "total_bytes": 5000,
+                "paths": ["dc1/", "dc2/"],
+                "errors": [],
+            },
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                "files",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "S3 sync complete" in result.stdout or "files-only" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateCLIDryRun:
+    @patch("depictio.cli.cli.commands.migrate.api_import_project")
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_dry_run_flag_propagated(
+        self, mock_login, mock_load, mock_export, mock_import, runner, config_file
+    ):
+        """--dry-run flag is passed to both export and import calls."""
+        mock_load.return_value = Mock()
+        mock_load.return_value.s3_storage.endpoint_url = "http://localhost:9000"
+        mock_load.return_value.s3_storage.aws_access_key_id = "minio"
+        mock_load.return_value.s3_storage.aws_secret_access_key = "minio123"
+        mock_load.return_value.s3_storage.bucket = "depictio-bucket"
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "migrate_metadata": {
+                "project_name": "my-project",
+                "project_id": "507f1f77bcf86cd799439011",
+                "mode": "metadata",
+                "document_counts": {"projects": 1},
+                "dry_run": True,
+            },
+            "data": {"projects": []},
+        }
+        mock_import.return_value = {
+            "success": True,
+            "message": "DRY RUN: would upsert 1 documents",
+            "upserted": {"projects": 1},
+            "dry_run": True,
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                "metadata",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Verify dry_run was forwarded to both API calls
+        _, export_kwargs = mock_export.call_args
+        assert export_kwargs.get("dry_run") is True or mock_export.call_args[0][-1] is True
+
+        assert "DRY RUN" in result.stdout or "dry-run" in result.stdout.lower()
+
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_dry_run_mode_noted_in_output(self, mock_login, mock_load, runner, config_file):
+        """Output must mention DRY RUN when --dry-run is passed (even before API calls)."""
+        mock_load.return_value = Mock()
+        mock_login.return_value = {"success": True, "is_admin": False}  # Fail early
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--dry-run",
+            ],
+        )
+
+        # Even if denied, the dry-run note appears before auth check fails
+        # (it appears right after successful source auth)
+        assert result.exit_code == 1  # denied by non-admin
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateCLIErrorHandling:
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_export_failure_exits_nonzero(
+        self, mock_login, mock_load, mock_export, runner, config_file
+    ):
+        """Export API error propagates as non-zero exit."""
+        mock_load.return_value = Mock()
+        mock_load.return_value.s3_storage.endpoint_url = "http://localhost:9000"
+        mock_load.return_value.s3_storage.aws_access_key_id = "minio"
+        mock_load.return_value.s3_storage.aws_secret_access_key = "minio123"
+        mock_load.return_value.s3_storage.bucket = "depictio-bucket"
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "success": False,
+            "message": "Project not found",
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "nonexistent-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Export failed" in result.stdout or "not found" in result.stdout.lower()
+
+    @patch("depictio.cli.cli.commands.migrate.api_import_project")
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_import_failure_exits_nonzero(
+        self, mock_login, mock_load, mock_export, mock_import, runner, config_file
+    ):
+        """Import API error propagates as non-zero exit."""
+        mock_load.return_value = Mock()
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "migrate_metadata": {
+                "project_name": "my-project",
+                "project_id": "507f1f77bcf86cd799439011",
+                "mode": "dashboard",
+                "document_counts": {"dashboards": 1},
+            },
+            "data": {"dashboards": [{"_id": "abc"}]},
+        }
+        mock_import.return_value = {
+            "success": False,
+            "message": "Database error during import",
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                "dashboard",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Import failed" in result.stdout or "failed" in result.stdout.lower()
+
+    @patch("depictio.cli.cli.commands.migrate.api_export_project")
+    @patch("depictio.cli.cli.commands.migrate.load_depictio_config")
+    @patch("depictio.cli.cli.commands.migrate.api_login")
+    def test_s3_errors_shown_as_warnings(
+        self, mock_login, mock_load, mock_export, runner, config_file
+    ):
+        """S3 copy errors surfaced in the bundle are shown as warnings (not hard exit)."""
+        mock_load.return_value = Mock()
+        mock_load.return_value.s3_storage.endpoint_url = "http://localhost:9000"
+        mock_load.return_value.s3_storage.aws_access_key_id = "minio"
+        mock_load.return_value.s3_storage.aws_secret_access_key = "minio123"
+        mock_load.return_value.s3_storage.bucket = "depictio-bucket"
+        mock_login.return_value = {"success": True, "is_admin": True}
+        mock_export.return_value = {
+            "migrate_metadata": {
+                "project_name": "my-project",
+                "project_id": "507f1f77bcf86cd799439011",
+                "mode": "files",
+                "document_counts": {},
+            },
+            "data": {},
+            "s3_migrate_metadata": {
+                "locations_copied": 1,
+                "total_files": 0,
+                "total_bytes": 0,
+                "paths": ["dc1/"],
+                "errors": ["Failed to copy dc1/some_file.parquet: S3 timeout"],
+            },
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                "my-project",
+                "--CLI-config-path",
+                config_file,
+                "--target-config",
+                config_file,
+                "--mode",
+                "files",
+            ],
+        )
+
+        # Should still exit 0 (files mode, S3 warning not fatal at CLI level)
+        assert "S3 error" in result.stdout or "error" in result.stdout.lower()


### PR DESCRIPTION
## Summary

- **New `depictio migrate` CLI command** — non-destructive cross-instance project migration (MongoDB docs + optional S3 files) with `--mode all|metadata|dashboard|files` and `--dry-run`
- **ZIP export format** — `/migrate/export-project` returns a `.zip` bundle (`migrate_metadata.json` + `bundle.json`) instead of raw JSON; avoids RAM buffering via `upload_fileobj`
- **UI Export button** — per-project "Export Project" button in the Management accordion panel downloads a `.zip`
- **UI Import tab** — "Create New Project" modal now has a second "Import" tab with drag-and-drop ZIP upload, bundle preview (project name, mode, document counts), and submit
- **New `/migrate/import-project-zip` endpoint** — accepts `UploadFile` ZIP, always remaps all owners to the calling user (`force_owner_remap=True`)
- **Simplifier fixes**: stream S3 copy via `upload_fileobj`, removed dead `workflow_ids` init and `s3_migrate_prefix` field, `_prepare_doc_for_import` copy-on-entry, deduplicated `_post_migrate_endpoint()` helper in `api_calls.py`
- **CI smoke test** — self-migration dry-run + metadata mode against the Iris project

## Test plan

- [ ] CLI: `depictio migrate --project "iris" --CLI-config-path ~/.depictio/CLI_local.yaml --target-config ~/.depictio/CLI_remote.yaml --dry-run` completes without errors
- [ ] CLI: live `metadata` mode upserts documents; re-running is idempotent
- [ ] UI: `/projects` → expand project → Management → "Export Project" → `.zip` downloads
- [ ] UI: unzip → confirm `bundle.json` + `migrate_metadata.json` present
- [ ] UI: "Create new project" → "Import" tab visible
- [ ] UI: upload downloaded `.zip` → preview shows project name + document counts
- [ ] UI: click "Import Project" → success alert, modal closes, project appears in list
- [ ] UI: imported project owners are remapped to the authenticated user

🤖 Generated with [Claude Code](https://claude.com/claude-code)