### PR TITLE
fix: rename migrate run → migrate in CLI command and CI workflow

### DIFF
--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -1970,7 +1970,7 @@ jobs:
 
           # Dry-run first — must not change anything
           echo "🏃 Running dry-run migrate..."
-          depictio-cli -v -vl DEBUG migrate run \
+          depictio-cli -v -vl DEBUG migrate \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
@@ -1987,7 +1987,7 @@ jobs:
           # Real migrate (same instance as source and target — idempotent upsert)
           # --overwrite required because the project already exists on this instance
           echo "🚀 Running real migrate (metadata mode)..."
-          depictio-cli -v -vl DEBUG migrate run \
+          depictio-cli -v -vl DEBUG migrate \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
@@ -1997,7 +1997,7 @@ jobs:
 
           # Verify conflict detection: run WITHOUT --overwrite → must fail with conflict
           echo "🔒 Testing conflict detection (no --overwrite, should fail)..."
-          if depictio-cli migrate run \
+          if depictio-cli migrate \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
@@ -2041,7 +2041,7 @@ jobs:
 
           # Run migrate and capture output to verify dashboards were actually exported
           MIGRATE_LOG=$(mktemp)
-          depictio-cli -v -vl DEBUG migrate run \
+          depictio-cli -v -vl DEBUG migrate \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \
@@ -2108,7 +2108,7 @@ jobs:
           # Run mode=all (self-migration: same instance as source and target)
           # This exercises the S3 copy code path in addition to MongoDB upserts
           MIGRATE_LOG=$(mktemp)
-          depictio-cli -v -vl DEBUG migrate run \
+          depictio-cli -v -vl DEBUG migrate \
             --project "$IRIS_PROJECT_NAME" \
             --CLI-config-path admin_config.yaml \
             --target-config admin_config.yaml \

--- a/depictio/cli/cli/commands/migrate.py
+++ b/depictio/cli/cli/commands/migrate.py
@@ -32,12 +32,12 @@ from depictio.cli.cli.utils.rich_utils import (
     rich_print_json,
 )
 
-app = typer.Typer()
+app = typer.Typer(invoke_without_command=True)
 
 _MODES = ["all", "metadata", "dashboard", "files"]
 
 
-@app.command()
+@app.callback()
 def migrate(
     project: Annotated[str, typer.Option("--project", help="Project name to migrate")],
     CLI_config_path: Annotated[

--- a/depictio/cli/cli/commands/migrate.py
+++ b/depictio/cli/cli/commands/migrate.py
@@ -38,7 +38,7 @@ _MODES = ["all", "metadata", "dashboard", "files"]
 
 
 @app.command()
-def run(
+def migrate(
     project: Annotated[str, typer.Option("--project", help="Project name to migrate")],
     CLI_config_path: Annotated[
         str, typer.Option("--CLI-config-path", help="Source CLI config (local instance)")


### PR DESCRIPTION
## Summary

- Renamed `run` function to `migrate` in `depictio/cli/cli/commands/migrate.py` so the command is invoked as `depictio-cli migrate` instead of `depictio-cli migrate run`
- Updated all 5 occurrences in `.github/workflows/depictio-ci.yaml` accordingly

## Test plan

- [ ] `depictio-cli migrate --help` works
- [ ] CI migrate smoke tests pass