### PR TITLE
feat: add dedicated ingress for MinIO and backend API

### DIFF
--- a/helm-charts/depictio/README.md
+++ b/helm-charts/depictio/README.md
@@ -109,7 +109,6 @@ These credentials are also stored in the Kubernetes Secret named `<release-name>
 | `minio.service.type` | MinIO service type | `ClusterIP` |
 | `minio.service.httpPort` | MinIO HTTP service port | `9000` |
 | `minio.service.consolePort` | MinIO console service port | `9001` |
-| `minio.ingress.enabled` | Force a dedicated MinIO ingress resource | `false` |
 | `minio.ingress.separateRoute` | Split MinIO out of the shared ingress so `/` auth settings do not affect it | `false` |
 | `minio.ingress.inheritDefaultAnnotations` | Reuse `ingress.annotations` on the dedicated MinIO ingress when MinIO annotations are empty | `true` |
 | `minio.ingress.annotations` | MinIO-specific ingress annotations; falls back to `ingress.annotations` | `{}` |
@@ -134,7 +133,6 @@ These credentials are also stored in the Kubernetes Secret named `<release-name>
 | `backend.env` | Backend environment variables | Check `values.yaml` |
 | `backend.command` | Backend container command | `["python", "/app/depictio/api/run.py"]` |
 | `backend.securityContext.fsGroup` | Backend pod fsGroup | `2000` |
-| `backend.ingress.enabled` | Force a dedicated backend API ingress resource | `false` |
 | `backend.ingress.separateRoute` | Split the API out of the shared ingress so `/` auth settings do not affect it | `false` |
 | `backend.ingress.inheritDefaultAnnotations` | Reuse `ingress.annotations` on the dedicated backend ingress when backend annotations are empty | `true` |
 | `backend.ingress.annotations` | Backend-specific ingress annotations; falls back to `ingress.annotations` | `{}` |

--- a/helm-charts/depictio/README.md
+++ b/helm-charts/depictio/README.md
@@ -110,7 +110,6 @@ These credentials are also stored in the Kubernetes Secret named `<release-name>
 | `minio.service.httpPort` | MinIO HTTP service port | `9000` |
 | `minio.service.consolePort` | MinIO console service port | `9001` |
 | `minio.ingress.separateRoute` | Split MinIO out of the shared ingress so `/` auth settings do not affect it | `false` |
-| `minio.ingress.inheritDefaultAnnotations` | Reuse `ingress.annotations` on the dedicated MinIO ingress when MinIO annotations are empty | `true` |
 | `minio.ingress.annotations` | MinIO-specific ingress annotations; falls back to `ingress.annotations` | `{}` |
 | `minio.ingress.labels` | MinIO-specific ingress labels; falls back to `ingress.labels` | `{}` |
 | `minio.ingress.hosts` | Optional explicit host rules for the dedicated MinIO ingress | `[]` |
@@ -134,7 +133,6 @@ These credentials are also stored in the Kubernetes Secret named `<release-name>
 | `backend.command` | Backend container command | `["python", "/app/depictio/api/run.py"]` |
 | `backend.securityContext.fsGroup` | Backend pod fsGroup | `2000` |
 | `backend.ingress.separateRoute` | Split the API out of the shared ingress so `/` auth settings do not affect it | `false` |
-| `backend.ingress.inheritDefaultAnnotations` | Reuse `ingress.annotations` on the dedicated backend ingress when backend annotations are empty | `true` |
 | `backend.ingress.annotations` | Backend-specific ingress annotations; falls back to `ingress.annotations` | `{}` |
 | `backend.ingress.labels` | Backend-specific ingress labels; falls back to `ingress.labels` | `{}` |
 | `backend.ingress.hosts` | Optional explicit host rules for the dedicated backend ingress | `[]` |

--- a/helm-charts/depictio/README.md
+++ b/helm-charts/depictio/README.md
@@ -109,6 +109,13 @@ These credentials are also stored in the Kubernetes Secret named `<release-name>
 | `minio.service.type` | MinIO service type | `ClusterIP` |
 | `minio.service.httpPort` | MinIO HTTP service port | `9000` |
 | `minio.service.consolePort` | MinIO console service port | `9001` |
+| `minio.ingress.enabled` | Force a dedicated MinIO ingress resource | `false` |
+| `minio.ingress.separateRoute` | Split MinIO out of the shared ingress so `/` auth settings do not affect it | `false` |
+| `minio.ingress.inheritDefaultAnnotations` | Reuse `ingress.annotations` on the dedicated MinIO ingress when MinIO annotations are empty | `true` |
+| `minio.ingress.annotations` | MinIO-specific ingress annotations; falls back to `ingress.annotations` | `{}` |
+| `minio.ingress.labels` | MinIO-specific ingress labels; falls back to `ingress.labels` | `{}` |
+| `minio.ingress.hosts` | Optional explicit host rules for the dedicated MinIO ingress | `[]` |
+| `minio.ingress.tls` | Optional TLS entries for the dedicated MinIO ingress; falls back to `ingress.tls` | `[]` |
 | `minio.args` | MinIO container arguments | `["server", "/data", "--console-address", ":9001"]` |
 
 ### Backend parameters
@@ -127,6 +134,13 @@ These credentials are also stored in the Kubernetes Secret named `<release-name>
 | `backend.env` | Backend environment variables | Check `values.yaml` |
 | `backend.command` | Backend container command | `["python", "/app/depictio/api/run.py"]` |
 | `backend.securityContext.fsGroup` | Backend pod fsGroup | `2000` |
+| `backend.ingress.enabled` | Force a dedicated backend API ingress resource | `false` |
+| `backend.ingress.separateRoute` | Split the API out of the shared ingress so `/` auth settings do not affect it | `false` |
+| `backend.ingress.inheritDefaultAnnotations` | Reuse `ingress.annotations` on the dedicated backend ingress when backend annotations are empty | `true` |
+| `backend.ingress.annotations` | Backend-specific ingress annotations; falls back to `ingress.annotations` | `{}` |
+| `backend.ingress.labels` | Backend-specific ingress labels; falls back to `ingress.labels` | `{}` |
+| `backend.ingress.hosts` | Optional explicit host rules for the dedicated backend ingress | `[]` |
+| `backend.ingress.tls` | Optional TLS entries for the dedicated backend ingress; falls back to `ingress.tls` | `[]` |
 
 ### Frontend parameters
 

--- a/helm-charts/depictio/templates/ingress.yaml
+++ b/helm-charts/depictio/templates/ingress.yaml
@@ -1,3 +1,9 @@
+{{- $minioIngress := .Values.minio.ingress | default dict }}
+{{- $useSeparateMinioIngress := and .Values.ingress.enabled .Values.minio.enabled (or $minioIngress.enabled $minioIngress.separateRoute $minioIngress.annotations $minioIngress.labels $minioIngress.hosts $minioIngress.tls $minioIngress.ingressClassName) }}
+{{- $inheritDefaultMinioAnnotations := ne $minioIngress.inheritDefaultAnnotations false }}
+{{- $backendIngress := .Values.backend.ingress | default dict }}
+{{- $useSeparateBackendIngress := and .Values.ingress.enabled (or $backendIngress.enabled $backendIngress.separateRoute $backendIngress.annotations $backendIngress.labels $backendIngress.hosts $backendIngress.tls $backendIngress.ingressClassName) }}
+{{- $inheritDefaultBackendAnnotations := ne $backendIngress.inheritDefaultAnnotations false }}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -52,6 +58,7 @@ spec:
                 name: {{ .Release.Name }}-depictio-frontend
                 port:
                   number: {{ .Values.frontend.service.httpPort }}
+    {{- if not $useSeparateBackendIngress }}
     - host: {{ include "depictio.apiUrl" . | quote }}
       http:
         paths:
@@ -62,7 +69,8 @@ spec:
                 name: {{ .Release.Name }}-depictio-backend
                 port:
                   number: {{ .Values.backend.service.httpPort }}
-    {{- if .Values.minio.enabled }}
+    {{- end }}
+    {{- if and .Values.minio.enabled (not $useSeparateMinioIngress) }}
     - host: {{ include "depictio.minioUrl" . | quote }}
       http:
         paths:
@@ -76,6 +84,140 @@ spec:
     {{- end }}
   {{- end }}
   {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if $useSeparateMinioIngress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-minio-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: depictio
+    component: minio-ingress
+    {{- if $minioIngress.labels }}
+    {{- toYaml $minioIngress.labels | nindent 4 }}
+    {{- else if .Values.ingress.labels }}
+    {{- toYaml .Values.ingress.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if $minioIngress.annotations }}
+    {{- toYaml $minioIngress.annotations | nindent 4 }}
+    {{- else if and $inheritDefaultMinioAnnotations .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if $minioIngress.ingressClassName }}
+  ingressClassName: {{ $minioIngress.ingressClassName }}
+  {{- else if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  rules:
+  {{- if $minioIngress.hosts }}
+  {{- range $minioIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ printf "%s-%s" $.Release.Name .service.name }}
+                port:
+                  {{- if .service.portName }}
+                  name: {{ .service.portName }}
+                  {{- else }}
+                  number: {{ .service.port }}
+                  {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- else }}
+    - host: {{ include "depictio.minioUrl" . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-minio
+                port:
+                  number: {{ .Values.minio.service.httpPort }}
+  {{- end }}
+  {{- if $minioIngress.tls }}
+  tls:
+    {{- toYaml $minioIngress.tls | nindent 4 }}
+  {{- else if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if $useSeparateBackendIngress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-backend-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: depictio
+    component: backend-ingress
+    {{- if $backendIngress.labels }}
+    {{- toYaml $backendIngress.labels | nindent 4 }}
+    {{- else if .Values.ingress.labels }}
+    {{- toYaml .Values.ingress.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if $backendIngress.annotations }}
+    {{- toYaml $backendIngress.annotations | nindent 4 }}
+    {{- else if and $inheritDefaultBackendAnnotations .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if $backendIngress.ingressClassName }}
+  ingressClassName: {{ $backendIngress.ingressClassName }}
+  {{- else if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  rules:
+  {{- if $backendIngress.hosts }}
+  {{- range $backendIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ printf "%s-%s" $.Release.Name .service.name }}
+                port:
+                  {{- if .service.portName }}
+                  name: {{ .service.portName }}
+                  {{- else }}
+                  number: {{ .service.port }}
+                  {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- else }}
+    - host: {{ include "depictio.apiUrl" . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-depictio-backend
+                port:
+                  number: {{ .Values.backend.service.httpPort }}
+  {{- end }}
+  {{- if $backendIngress.tls }}
+  tls:
+    {{- toYaml $backendIngress.tls | nindent 4 }}
+  {{- else if .Values.ingress.tls }}
   tls:
     {{- toYaml .Values.ingress.tls | nindent 4 }}
   {{- end }}

--- a/helm-charts/depictio/templates/ingress.yaml
+++ b/helm-charts/depictio/templates/ingress.yaml
@@ -1,9 +1,7 @@
 {{- $minioIngress := .Values.minio.ingress | default dict }}
 {{- $useSeparateMinioIngress := and .Values.ingress.enabled .Values.minio.enabled (or $minioIngress.separateRoute $minioIngress.annotations $minioIngress.labels $minioIngress.hosts $minioIngress.tls $minioIngress.ingressClassName) }}
-{{- $inheritDefaultMinioAnnotations := $minioIngress.inheritDefaultAnnotations | default true }}
 {{- $backendIngress := .Values.backend.ingress | default dict }}
 {{- $useSeparateBackendIngress := and .Values.ingress.enabled (or $backendIngress.separateRoute $backendIngress.annotations $backendIngress.labels $backendIngress.hosts $backendIngress.tls $backendIngress.ingressClassName) }}
-{{- $inheritDefaultBackendAnnotations := $backendIngress.inheritDefaultAnnotations | default true }}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/helm-charts/depictio/templates/ingress.yaml
+++ b/helm-charts/depictio/templates/ingress.yaml
@@ -17,11 +17,6 @@ metadata:
     {{- toYaml .Values.ingress.labels | nindent 4 }}
     {{- end }}
   annotations:
-    {{- if and (ne (.Values.permission | default "") "public") (ne (.Values.permission | default "") "link") .Values.global.auth_domain }}
-    nginx.ingress.kubernetes.io/auth-url: {{ printf "%s://%s:8080/auth/?release=%s" .Values.global.protocol .Values.global.auth_domain .Values.release | quote }}
-    nginx.ingress.kubernetes.io/auth-signin: {{ printf "https://%s/accounts/login/" .Values.global.domain | quote }}
-    nginx.ingress.kubernetes.io/auth-signin-redirect-param: "next"
-    {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{- end }}

--- a/helm-charts/depictio/templates/ingress.yaml
+++ b/helm-charts/depictio/templates/ingress.yaml
@@ -103,9 +103,6 @@ metadata:
     {{- toYaml .Values.ingress.labels | nindent 4 }}
     {{- end }}
   annotations:
-    nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
-    nginx.ingress.kubernetes.io/default-backend: nginx-errors
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.clientMaxBodySize | default "100m" | quote }}
     {{- if $minioIngress.annotations }}
     {{- toYaml $minioIngress.annotations | nindent 4 }}
     {{- end }}
@@ -171,9 +168,6 @@ metadata:
     {{- toYaml .Values.ingress.labels | nindent 4 }}
     {{- end }}
   annotations:
-    nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
-    nginx.ingress.kubernetes.io/default-backend: nginx-errors
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.clientMaxBodySize | default "100m" | quote }}
     {{- if $backendIngress.annotations }}
     {{- toYaml $backendIngress.annotations | nindent 4 }}
     {{- end }}

--- a/helm-charts/depictio/templates/ingress.yaml
+++ b/helm-charts/depictio/templates/ingress.yaml
@@ -108,10 +108,11 @@ metadata:
     {{- toYaml .Values.ingress.labels | nindent 4 }}
     {{- end }}
   annotations:
+    nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
+    nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.clientMaxBodySize | default "100m" | quote }}
     {{- if $minioIngress.annotations }}
     {{- toYaml $minioIngress.annotations | nindent 4 }}
-    {{- else if and $inheritDefaultMinioAnnotations .Values.ingress.annotations }}
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{- end }}
 spec:
   {{- if $minioIngress.ingressClassName }}
@@ -175,10 +176,11 @@ metadata:
     {{- toYaml .Values.ingress.labels | nindent 4 }}
     {{- end }}
   annotations:
+    nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
+    nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.clientMaxBodySize | default "100m" | quote }}
     {{- if $backendIngress.annotations }}
     {{- toYaml $backendIngress.annotations | nindent 4 }}
-    {{- else if and $inheritDefaultBackendAnnotations .Values.ingress.annotations }}
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{- end }}
 spec:
   {{- if $backendIngress.ingressClassName }}

--- a/helm-charts/depictio/templates/ingress.yaml
+++ b/helm-charts/depictio/templates/ingress.yaml
@@ -17,7 +17,11 @@ metadata:
     {{- toYaml .Values.ingress.labels | nindent 4 }}
     {{- end }}
   annotations:
-
+    {{- if and (ne (.Values.permission | default "") "public") (ne (.Values.permission | default "") "link") .Values.global.auth_domain }}
+    nginx.ingress.kubernetes.io/auth-url: {{ printf "%s://%s:8080/auth/?release=%s" .Values.global.protocol .Values.global.auth_domain .Values.release | quote }}
+    nginx.ingress.kubernetes.io/auth-signin: {{ printf "https://%s/accounts/login/" .Values.global.domain | quote }}
+    nginx.ingress.kubernetes.io/auth-signin-redirect-param: "next"
+    {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{- end }}

--- a/helm-charts/depictio/templates/ingress.yaml
+++ b/helm-charts/depictio/templates/ingress.yaml
@@ -1,9 +1,9 @@
 {{- $minioIngress := .Values.minio.ingress | default dict }}
-{{- $useSeparateMinioIngress := and .Values.ingress.enabled .Values.minio.enabled (or $minioIngress.enabled $minioIngress.separateRoute $minioIngress.annotations $minioIngress.labels $minioIngress.hosts $minioIngress.tls $minioIngress.ingressClassName) }}
-{{- $inheritDefaultMinioAnnotations := ne $minioIngress.inheritDefaultAnnotations false }}
+{{- $useSeparateMinioIngress := and .Values.ingress.enabled .Values.minio.enabled (or $minioIngress.separateRoute $minioIngress.annotations $minioIngress.labels $minioIngress.hosts $minioIngress.tls $minioIngress.ingressClassName) }}
+{{- $inheritDefaultMinioAnnotations := $minioIngress.inheritDefaultAnnotations | default true }}
 {{- $backendIngress := .Values.backend.ingress | default dict }}
-{{- $useSeparateBackendIngress := and .Values.ingress.enabled (or $backendIngress.enabled $backendIngress.separateRoute $backendIngress.annotations $backendIngress.labels $backendIngress.hosts $backendIngress.tls $backendIngress.ingressClassName) }}
-{{- $inheritDefaultBackendAnnotations := ne $backendIngress.inheritDefaultAnnotations false }}
+{{- $useSeparateBackendIngress := and .Values.ingress.enabled (or $backendIngress.separateRoute $backendIngress.annotations $backendIngress.labels $backendIngress.hosts $backendIngress.tls $backendIngress.ingressClassName) }}
+{{- $inheritDefaultBackendAnnotations := $backendIngress.inheritDefaultAnnotations | default true }}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/helm-charts/depictio/values-serve.yaml
+++ b/helm-charts/depictio/values-serve.yaml
@@ -1,13 +1,13 @@
 # Serve-specific values for Depictio deployment.
-# Auth annotations on the shared ingress are rendered automatically by the
-# ingress template based on the `permission` value set by Serve at deploy time.
+# Auth annotations on the shared ingress are rendered by the template based
+# on `permission` set by Serve at deploy time. Base nginx annotations on the
+# dedicated backend/minio ingresses are always rendered by the template.
 ingress:
   enabled: true
   ingressClassName: "nginx"
   annotations:
     nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
-    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
   tls:
     - secretName: "serve-tls-secret"
       hosts: []
@@ -18,19 +18,11 @@ backend:
   ingress:
     separateRoute: true
     inheritDefaultAnnotations: false
-    annotations:
-      nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
-      nginx.ingress.kubernetes.io/default-backend: nginx-errors
-      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 
 minio:
   ingress:
     separateRoute: true
     inheritDefaultAnnotations: false
-    annotations:
-      nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
-      nginx.ingress.kubernetes.io/default-backend: nginx-errors
-      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 
 global:
   domain: ""

--- a/helm-charts/depictio/values-serve.yaml
+++ b/helm-charts/depictio/values-serve.yaml
@@ -1,39 +1,36 @@
-# Serve specific ingress values (values-serve.yaml)
+# Serve-specific values for Depictio deployment.
+# Auth annotations on the shared ingress are rendered automatically by the
+# ingress template based on the `permission` value set by Serve at deploy time.
 ingress:
   enabled: true
   ingressClassName: "nginx"
-
-  # Serve specific annotations
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: # {{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}
-    nginx.ingress.kubernetes.io/auth-signin: # "https://{{ .Values.global.domain }}/accounts/login/?next=$scheme%3A%2F%2F$host"
-    nginx.ingress.kubernetes.io/custom-http-errors: "503"
+    nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
     nginx.ingress.kubernetes.io/default-backend: nginx-errors
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
-
-  # Host configuration for unified service setup
-  hosts:
-    - host: # studio.127.0.0.1.nip.io
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-          service:
-            name: depictio-frontend
-            port: 80
-        - path: /api
-          pathType: ImplementationSpecific
-          service:
-            name: depictio-backend
-            port: 80
-
-  # TLS configuration
   tls:
     - secretName: "serve-tls-secret"
-      hosts:
-        - # studio.127.0.0.1.nip.io
+      hosts: []
 
+# Backend and MinIO get dedicated ingresses so Serve auth annotations
+# on the shared frontend ingress do not affect them.
+backend:
+  ingress:
+    separateRoute: true
+    inheritDefaultAnnotations: false
+    annotations:
+      nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
+      nginx.ingress.kubernetes.io/default-backend: nginx-errors
+      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+
+minio:
+  ingress:
+    separateRoute: true
+    inheritDefaultAnnotations: false
+    annotations:
+      nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
+      nginx.ingress.kubernetes.io/default-backend: nginx-errors
+      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 
 global:
-#   protocol: TCP
-  domain: studio.127.0.0.1.nip.io
-#   auth_domain: studio.127.0.0.1.nip.io
+  domain: ""

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -137,15 +137,10 @@ minio:
     DEPICTIO_MINIO_BUCKET: "depictio-bucket"
     DEPICTIO_MINIO_SERVICE_PORT: "9000"
   ingress:
-    # When any value in this block is set, MinIO is rendered as a dedicated Ingress.
-    # This allows MinIO-specific annotations while optionally falling back to ingress.* defaults.
-    enabled: false
-    # Split MinIO out of the shared ingress even when no other MinIO ingress overrides are set.
-    # Use this to keep auth annotations from the main ingress away from MinIO.
+    # Set separateRoute: true to keep shared-ingress auth annotations away from MinIO.
     separateRoute: false
     ingressClassName: ""
-    # When true and no MinIO-specific annotations are set, reuse ingress.annotations.
-    # Set to false when MinIO must not inherit shared auth annotations.
+    # Set to false to prevent MinIO from inheriting shared ingress auth annotations.
     inheritDefaultAnnotations: true
     annotations: {}
     labels: {}
@@ -240,15 +235,10 @@ backend:
     seccompProfile:
       type: RuntimeDefault
   ingress:
-    # When any value in this block is set, the backend API is rendered as a dedicated Ingress.
-    # This allows API-specific annotations while optionally falling back to ingress.* defaults.
-    enabled: false
-    # Split the backend out of the shared ingress even when no other backend ingress overrides are set.
-    # Use this to keep auth annotations from the main ingress away from the API.
+    # Set separateRoute: true to keep shared-ingress auth annotations away from the API.
     separateRoute: false
     ingressClassName: ""
-    # When true and no backend-specific annotations are set, reuse ingress.annotations.
-    # Set to false when the backend must not inherit shared auth annotations.
+    # Set to false to prevent the backend from inheriting shared ingress auth annotations.
     inheritDefaultAnnotations: true
     annotations: {}
     labels: {}

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -374,10 +374,6 @@ initContainerResources:
     memory: "128Mi"
     cpu: "100m"
 
-# Set by Serve at deploy time; controls auth annotations on the shared ingress
-permission: ""
-release: ""
-
 global:
   domain: "example.com" # Default domain, can be overridden in environment-specific values
 

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -137,11 +137,8 @@ minio:
     DEPICTIO_MINIO_BUCKET: "depictio-bucket"
     DEPICTIO_MINIO_SERVICE_PORT: "9000"
   ingress:
-    # Set separateRoute: true to keep shared-ingress auth annotations away from MinIO.
     separateRoute: false
     ingressClassName: ""
-    # Set to false to prevent MinIO from inheriting shared ingress auth annotations.
-    inheritDefaultAnnotations: true
     annotations: {}
     labels: {}
     hosts: []
@@ -238,8 +235,6 @@ backend:
     # Set separateRoute: true to keep shared-ingress auth annotations away from the API.
     separateRoute: false
     ingressClassName: ""
-    # Set to false to prevent the backend from inheriting shared ingress auth annotations.
-    inheritDefaultAnnotations: true
     annotations: {}
     labels: {}
     hosts: []

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -374,6 +374,10 @@ initContainerResources:
     memory: "128Mi"
     cpu: "100m"
 
+# Set by Serve at deploy time; controls auth annotations on the shared ingress
+permission: ""
+release: ""
+
 global:
   domain: "example.com" # Default domain, can be overridden in environment-specific values
 

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -136,6 +136,21 @@ minio:
     DEPICTIO_MINIO_ROOT_PASSWORD: "minio123"
     DEPICTIO_MINIO_BUCKET: "depictio-bucket"
     DEPICTIO_MINIO_SERVICE_PORT: "9000"
+  ingress:
+    # When any value in this block is set, MinIO is rendered as a dedicated Ingress.
+    # This allows MinIO-specific annotations while optionally falling back to ingress.* defaults.
+    enabled: false
+    # Split MinIO out of the shared ingress even when no other MinIO ingress overrides are set.
+    # Use this to keep auth annotations from the main ingress away from MinIO.
+    separateRoute: false
+    ingressClassName: ""
+    # When true and no MinIO-specific annotations are set, reuse ingress.annotations.
+    # Set to false when MinIO must not inherit shared auth annotations.
+    inheritDefaultAnnotations: true
+    annotations: {}
+    labels: {}
+    hosts: []
+    tls: []
 
 # Backend settings
 backend:
@@ -224,6 +239,21 @@ backend:
       - ALL
     seccompProfile:
       type: RuntimeDefault
+  ingress:
+    # When any value in this block is set, the backend API is rendered as a dedicated Ingress.
+    # This allows API-specific annotations while optionally falling back to ingress.* defaults.
+    enabled: false
+    # Split the backend out of the shared ingress even when no other backend ingress overrides are set.
+    # Use this to keep auth annotations from the main ingress away from the API.
+    separateRoute: false
+    ingressClassName: ""
+    # When true and no backend-specific annotations are set, reuse ingress.annotations.
+    # Set to false when the backend must not inherit shared auth annotations.
+    inheritDefaultAnnotations: true
+    annotations: {}
+    labels: {}
+    hosts: []
+    tls: []
 
 # Celery Worker settings
 celery:


### PR DESCRIPTION
Extends PR #736 (MinIO separate ingress) with an identical `backend.ingress` block, so both MinIO and FastAPI can bypass auth annotations on the shared frontend ingress (e.g. Scilifelab Serve).

- `minio.ingress.*` and `backend.ingress.*` config blocks in `values.yaml`
- Each triggers a dedicated `Ingress` resource; the shared ingress drops the corresponding host rule
- Falls back to `ingress.*` defaults; `inheritDefaultAnnotations: false` suppresses auth annotation inheritance
- Opt-in via `enabled` or `separateRoute` — default behaviour unchanged