### PR TITLE
feat(deployment): add annotations for config checksum in backend and frontend

### DIFF
--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -262,6 +262,8 @@ spec:
         app: depictio-backend
         project: {{ .Values.project.slug }}
         type: app
+      annotations:
+        checksum/config: {{ .Values.backend.env | toJson | sha256sum }}
     spec:
       {{- if gt (.Values.backend.replicas | int) 1 }}
       affinity:
@@ -542,6 +544,8 @@ spec:
         app: depictio-frontend
         project: {{ .Values.project.slug }}
         type: app
+      annotations:
+        checksum/config: {{ .Values.frontend.env | toJson | sha256sum }}
     spec:
       {{- if gt (.Values.frontend.replicas | int) 1 }}
       affinity:


### PR DESCRIPTION
This is the standard Helm pattern for ConfigMap-triggered rollouts. The annotation is derived from the rendered env values, so any change to backend.env or frontend.env produces a different pod template hash — Kubernetes
  detects the diff and performs a rolling restart automatically.

Checksums are scoped per deployment — a backend-only config change does not unnecessarily restart frontend pods.

No external workarounds

This is fully chart-native. No kubectl rollout restart hook or post-upgrade job is required.
