### PR TITLE
Skip Docker build jobs in fork pull requests

### DIFF
--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -201,9 +201,16 @@ jobs:
 
   docker-build:
     needs: [check-quality-cache, quality]
-    # Run if quality passed OR if it was skipped due to cache hit
+    # Skip for pull requests from forks — repository secrets (GHCR_PAT) are not
+    # exposed to fork PRs, so docker login + push to ghcr.io would fail. The
+    # downstream jobs that depend on the pushed image (docker-system-init,
+    # e2e-tests*, cli-comprehensive-test, backup-s3-strategies-comprehensive-tests)
+    # auto-skip via their `needs.docker-build.result == 'success'` guard.
+    # Run if quality passed OR if it was skipped due to cache hit.
     if: |
       always() &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
       (needs.quality.result == 'success' ||
        (needs.quality.result == 'skipped' && needs.check-quality-cache.outputs.cache-hit == 'true'))
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-and-package-helm-chart.yaml
+++ b/.github/workflows/test-and-package-helm-chart.yaml
@@ -21,6 +21,11 @@ env:
 
 jobs:
   test-build-push:
+    # Skip for pull requests from forks — repository secrets (GHCR_PAT) are not
+    # exposed to fork PRs, so docker login to ghcr.io would fail with
+    # "Password required". Maintainers can still test fork PRs by pushing the
+    # branch to the upstream repo or via workflow_dispatch.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Updated CI workflows to skip Docker build and push operations when pull requests originate from forked repositories, preventing authentication failures due to unavailable repository secrets.

## Key Changes
- **depictio-ci.yaml**: Added conditional check to `docker-build` job to skip execution for fork PRs while allowing it for PRs from the upstream repository. Expanded existing comments to explain the skip behavior and how downstream jobs handle the skipped state.
- **test-and-package-helm-chart.yaml**: Added conditional check to `test-build-push` job with the same fork PR detection logic to prevent Docker login failures.

## Implementation Details
Both workflows now use the same condition pattern:
```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

This allows jobs to run on:
- Non-pull-request events (pushes, scheduled runs, manual triggers)
- Pull requests from the upstream repository

The jobs are skipped for pull requests from forks, where the `GHCR_PAT` secret is not available. Downstream jobs that depend on the Docker image already have guards in place (`needs.docker-build.result == 'success'`) to handle skipped states gracefully.

https://claude.ai/code/session_01Jec2sq5EtS51Eh3Ag3AUEm