### PR TITLE
Allow CLI config access in single-user mode

### DIFF
--- a/depictio/dash/layouts/profile.py
+++ b/depictio/dash/layouts/profile.py
@@ -207,8 +207,7 @@ layout = dmc.Container(
                                                 variant="filled",
                                                 # color=colors["green"],
                                                 radius=BUTTON_RADIUS,
-                                                disabled=settings.auth.is_public_mode
-                                                or settings.auth.is_single_user_mode,
+                                                disabled=settings.auth.is_public_mode,
                                                 leftSection=DashIconify(
                                                     icon="mdi:console", width=ICON_SIZE
                                                 ),
@@ -226,10 +225,7 @@ layout = dmc.Container(
                                                 },
                                             ),
                                             href="/cli_configs"
-                                            if not (
-                                                settings.auth.is_public_mode
-                                                or settings.auth.is_single_user_mode
-                                            )
+                                            if not settings.auth.is_public_mode
                                             else "#",
                                         ),
                                     ],


### PR DESCRIPTION
## Summary
Updated the CLI configuration button accessibility logic to allow access in single-user mode while maintaining the restriction for public mode.

## Key Changes
- Removed `settings.auth.is_single_user_mode` condition from the CLI config button's disabled state
- Removed `settings.auth.is_single_user_mode` condition from the CLI config button's href routing logic
- The button now only disables and redirects to "#" when in public mode, allowing single-user mode deployments to access CLI configurations

## Implementation Details
The changes simplify the conditional logic by removing the OR condition that previously blocked CLI config access in both public and single-user modes. Now only public mode restricts access, enabling single-user deployments to manage CLI configurations while maintaining security in public deployments.

https://claude.ai/code/session_014sYPnLqZSh33zQsNriz3gA