### PR TITLE
feat(deployment): add config checksum annotations (cherry-pick of #741)

### DIFF
--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -262,6 +262,8 @@ spec:
         app: depictio-backend
         project: {{ .Values.project.slug }}
         type: app
+      annotations:
+        checksum/config: {{ .Values.backend.env | toJson | sha256sum }}
     spec:
       {{- if gt (.Values.backend.replicas | int) 1 }}
       affinity:
@@ -542,6 +544,8 @@ spec:
         app: depictio-frontend
         project: {{ .Values.project.slug }}
         type: app
+      annotations:
+        checksum/config: {{ .Values.frontend.env | toJson | sha256sum }}
     spec:
       {{- if gt (.Values.frontend.replicas | int) 1 }}
       affinity:


### PR DESCRIPTION
Re-applies the single commit from #741 onto an upstream branch so CI can run with secrets (the original PR is from a fork and `GHCR_PAT` isn't exposed to fork-PR workflows).

Authorship of the commit is preserved (`Nikita Churikov <nikita@chur.ru>`); only the committer differs. Once this merges, #741 can be closed as superseded.

## Summary
- Adds `checksum/config` annotations on backend and frontend deployment templates so any change to `*.env` values produces a different pod template hash, triggering a rolling restart automatically.
- Standard Helm pattern, scoped per deployment (a backend-only change does not restart frontend pods).

## Test plan
- [ ] CI green on `cherry-pick/741-config-checksum`
- [ ] `helm template` output shows `checksum/config` annotation under both deployments
- [ ] Annotation hash changes when `backend.env` or `frontend.env` is modified

Refs #741

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jec2sq5EtS51Eh3Ag3AUEm)_