### PR TITLE
helm: roll Pods on ConfigMap/Secret change via include-based checksum

### DIFF
--- a/docker-images/Dockerfile_depictio_uv.dockerfile
+++ b/docker-images/Dockerfile_depictio_uv.dockerfile
@@ -171,7 +171,7 @@ USER depictio
 # initialize from these populated dirs on first mount, so the runtime
 # `pnpm install --frozen-lockfile --prefer-offline` is a fast integrity
 # check rather than a full extract.
-RUN corepack prepare pnpm@latest --activate && \
+RUN corepack prepare pnpm@10 --activate && \
     pnpm install --frozen-lockfile --child-concurrency=2 --network-concurrency=4
 
 # -----------------------------
@@ -183,7 +183,10 @@ RUN corepack prepare pnpm@latest --activate && \
 # but no runtime image size impact (intermediate stages are dropped).
 FROM node:20-slim AS viewer-builder
 WORKDIR /build
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Pinned: pnpm 11+ requires Node 22.13+ (uses node:sqlite builtin). Stay on
+# pnpm 10's tip until we bump the base image; `@latest` rolled forward and
+# broke the build mid-day on 2026-05-07.
+RUN corepack enable && corepack prepare pnpm@10 --activate
 COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY packages ./packages/
 COPY depictio/viewer ./depictio/viewer/

--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -263,7 +263,8 @@ spec:
         project: {{ .Values.project.slug }}
         type: app
       annotations:
-        checksum/config: {{ .Values.backend.env | toJson | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       {{- if gt (.Values.backend.replicas | int) 1 }}
       affinity:
@@ -545,7 +546,8 @@ spec:
         project: {{ .Values.project.slug }}
         type: app
       annotations:
-        checksum/config: {{ .Values.frontend.env | toJson | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       {{- if gt (.Values.frontend.replicas | int) 1 }}
       affinity:
@@ -889,6 +891,9 @@ spec:
         app: celery-worker
         project: {{ .Values.project.slug }}
         type: app
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       securityContext:
         {{- toYaml .Values.celery.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
## Summary

- Replace the existing `.Values.{backend,frontend}.env | toJson | sha256sum` checksum on the backend and frontend Deployments with the standard `include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum` form, so the rolling restart fires on **any** change to the rendered ConfigMap (helpers, `| default ...` fallbacks, settings interpolation), not only on edits to the one `.env` map.
- Add a matching `checksum/secrets` annotation so Secret rotations (S3 keys, JWT signing key, etc.) also roll the Pods.
- Add both annotations to the celery-worker Deployment, which had no checksum coverage at all.

## Why

Previously, a `helm upgrade` that changed only the rendered ConfigMap (e.g. flipping `DEPICTIO_FASTAPI_PUBLIC_URL` via `urlPattern` helpers, or any value that flows into `templates/configmaps.yaml` via a helper rather than `.Values.{backend,frontend}.env`) would not change the Pod template — Kubernetes would not restart the running Pods, and they would keep the old env until something else triggered a restart. This caused real "deployed but not actually applied" surprises in the EMBL demo deploys.

The include-based hash captures the **rendered** ConfigMap/Secret manifests, so any upstream change anywhere in the chart triggers a rollout. Standard Helm idiom (Helm Best Practices, "Automatically Roll Deployments").

## Test plan

- [x] `helm lint helm-charts/depictio` with the demo-dev values — passed.
- [x] `helm template` against the demo-dev values; verified all three Deployments (`devdemo-depictio-backend`, `devdemo-depictio-frontend`, `devdemo-celery-worker`) carry both `checksum/config` and `checksum/secrets` in `spec.template.metadata.annotations`.
- [x] Pre-commit hooks (incl. `Helm Lint`) — passed locally.
- [ ] Post-merge: deploy to devdemo with `helm upgrade --install ...`. First rollout will rotate all three Deployments once (annotations changing from absent → present); subsequent upgrades only roll when the ConfigMap or Secret content actually changes.
- [ ] Post-merge: change a ConfigMap-affecting value (e.g. flip `DEPICTIO_DASH_DEBUG_UI`) and confirm `kubectl rollout status deployment/...` rolls automatically without a manual `kubectl rollout restart`.

## Notes

- Out of scope: same annotations on `mongo` / `redis` StatefulSets and the `minio` Deployment. Easy follow-up if desired; today they don't read most app env from the ConfigMap so the gap is less impactful.
- Pre-existing on this chart: the wipe-job race in `templates/wipe-job.yaml` (`--wait=false` on PVC delete then immediate helm-applied PVC re-create). Unrelated to this PR; separately fileable.