### PR TITLE
fix(dev): unblock side-by-side worktree dev stacks

### DIFF
--- a/.devcontainer/scripts/allocate-ports.sh
+++ b/.devcontainer/scripts/allocate-ports.sh
@@ -2,8 +2,13 @@
 # Note: intentionally no `set -e` — this script is sourced by pre_create_setup.sh
 # and set -e would leak into the interactive shell, breaking readline (Esc, Ctrl+R, etc.).
 
-# Port allocation script for git worktree-based multi-instance setup
-# Uses branch naming convention to assign deterministic port offsets
+# Port allocation for git worktree-based multi-instance dev setups.
+#
+# Strategy: scan offsets 100..250 and pick the first one whose 8-port window
+# (mongo, redis, fastapi, dash, minio-api, minio-console, viewer, flower) is
+# entirely free on the host. No persistence — every `source` re-allocates,
+# so ports may shift between runs if neighbours boot first. Acceptable for
+# pure dev worktrees; if you need stable URLs, pin them by hand.
 
 # Parse command-line arguments
 MONGODB_WIPE="false"
@@ -29,49 +34,52 @@ echo "🔍 Detecting instance configuration..."
 BRANCH_NAME=$(git branch --show-current 2>/dev/null || echo "unknown")
 
 # Sanitize branch name for use in container/project names
-# Replace / with - and remove other special characters
 SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
 
 # Create unique project name
 COMPOSE_PROJECT_NAME="depictio-${SANITIZED_BRANCH}"
 
-# Assign port offset based on branch type
-# This ensures deterministic port allocation
-case "$BRANCH_NAME" in
-  "main")
-    PORT_OFFSET=0
-    echo "📌 Branch: main (production baseline)"
-    ;;
-  feat/*)
-    # Extract feature name and create hash for deterministic offset
-    FEATURE_NAME=$(echo "$BRANCH_NAME" | sed 's/feat\///')
-    # Use first characters of md5 hash to generate number between 10-99
-    HASH_NUM=$(echo -n "$FEATURE_NAME" | md5sum | tr -cd '0-9' | head -c 2)
-    # Ensure it's between 10-89 (allows up to 90 feature branches)
-    PORT_OFFSET=$((10 + (HASH_NUM % 80)))
-    echo "🚀 Branch: $BRANCH_NAME (feature branch, offset: $PORT_OFFSET)"
-    ;;
-  hotfix/*)
-    # Hotfixes get 90-99 range for quick identification
-    HOTFIX_NAME=$(echo "$BRANCH_NAME" | sed 's/hotfix\///')
-    HASH_NUM=$(echo -n "$HOTFIX_NAME" | md5sum | tr -cd '0-9' | head -c 2)
-    PORT_OFFSET=$((90 + (HASH_NUM % 10)))
-    echo "🔥 Branch: $BRANCH_NAME (hotfix branch, offset: $PORT_OFFSET)"
-    ;;
-  release/*)
-    # Releases get 100-109 range
-    RELEASE_NAME=$(echo "$BRANCH_NAME" | sed 's/release\///')
-    HASH_NUM=$(echo -n "$RELEASE_NAME" | md5sum | tr -cd '0-9' | head -c 2)
-    PORT_OFFSET=$((100 + (HASH_NUM % 10)))
-    echo "📦 Branch: $BRANCH_NAME (release branch, offset: $PORT_OFFSET)"
-    ;;
-  *)
-    # Unknown branch types get 110+ range
-    HASH_NUM=$(echo -n "$BRANCH_NAME" | md5sum | tr -cd '0-9' | head -c 2)
-    PORT_OFFSET=$((110 + (HASH_NUM % 40)))
-    echo "❓ Branch: $BRANCH_NAME (unknown type, offset: $PORT_OFFSET)"
-    ;;
-esac
+# Returns 0 if something is LISTENing on the TCP port, 1 otherwise.
+# lsof is present on macOS by default and in most Linux dev images; the
+# /dev/tcp probe is a fallback that catches anything accepting connections.
+port_in_use() {
+  local port=$1
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+  (exec 3<>/dev/tcp/127.0.0.1/"$port") >/dev/null 2>&1 && { exec 3<&-; exec 3>&-; return 0; }
+  return 1
+}
+
+# Host-side port bases. Each instance binds (base + offset) for each entry.
+PORT_BASES=(27000 6000 8000 5000 9000 9500 5500 7000)
+
+PORT_OFFSET=""
+for candidate in $(seq 100 250); do
+  collision=0
+  for base in "${PORT_BASES[@]}"; do
+    if port_in_use $((base + candidate)); then
+      collision=1
+      break
+    fi
+  done
+  if [ "$collision" -eq 0 ]; then
+    PORT_OFFSET=$candidate
+    break
+  fi
+done
+
+if [ -z "$PORT_OFFSET" ]; then
+  echo "❌ No free 8-port window found in offsets 100-250."
+  echo "   Stop some containers or other listeners and re-source this script."
+  # Dual-mode bail: `return` works when this script is sourced, `exit` runs
+  # when it's executed directly. shellcheck can't tell `return` may fail.
+  # shellcheck disable=SC2317
+  return 1 2>/dev/null || exit 1
+fi
+
+echo "🎯 Branch: $BRANCH_NAME (allocated offset: $PORT_OFFSET)"
 
 # Calculate actual ports with offset
 MONGO_PORT=$((27000 + PORT_OFFSET))
@@ -79,12 +87,12 @@ REDIS_PORT=$((6000 + PORT_OFFSET))
 FASTAPI_PORT=$((8000 + PORT_OFFSET))
 DASH_PORT=$((5000 + PORT_OFFSET))
 MINIO_PORT=$((9000 + PORT_OFFSET))
-MINIO_CONSOLE_PORT=$((9001 + PORT_OFFSET))
+MINIO_CONSOLE_PORT=$((9500 + PORT_OFFSET))
+VIEWER_DEV_PORT=$((5500 + PORT_OFFSET))
+FLOWER_PORT=$((7000 + PORT_OFFSET))
 
-# Generate instance ID for display
 INSTANCE_ID="${SANITIZED_BRANCH}-${PORT_OFFSET}"
 
-# Display configuration
 echo ""
 echo "📋 Instance Configuration:"
 echo "   Project Name: ${COMPOSE_PROJECT_NAME}"
@@ -97,6 +105,8 @@ echo "   FastAPI:      ${FASTAPI_PORT}"
 echo "   Dash:         ${DASH_PORT}"
 echo "   MinIO API:    ${MINIO_PORT}"
 echo "   MinIO Console: ${MINIO_CONSOLE_PORT}"
+echo "   Viewer (Vite): ${VIEWER_DEV_PORT}"
+echo "   Flower:       ${FLOWER_PORT}"
 echo ""
 echo "⚙️  Development Settings:"
 echo "   Dev Mode:     ✅ enabled"
@@ -128,6 +138,8 @@ FASTAPI_PORT=${FASTAPI_PORT}
 DASH_PORT=${DASH_PORT}
 MINIO_PORT=${MINIO_PORT}
 MINIO_CONSOLE_PORT=${MINIO_CONSOLE_PORT}
+VIEWER_DEV_PORT=${VIEWER_DEV_PORT}
+FLOWER_PORT=${FLOWER_PORT}
 
 # Internal service URLs (for container-to-container communication)
 DEPICTIO_MONGODB_PORT=${MONGO_PORT}
@@ -199,6 +211,12 @@ services:
     environment:
       - DEPICTIO_DEV_MODE=true
       - DEPICTIO_MONGODB_WIPE=${MONGODB_WIPE}
+
+  depictio-viewer-dev:
+    container_name: ${COMPOSE_PROJECT_NAME}-depictio-viewer-dev
+
+  flower:
+    container_name: ${COMPOSE_PROJECT_NAME}-flower
 EOF
 
 echo "✅ Generated docker-compose.override.yaml for multi-instance setup"
@@ -215,4 +233,6 @@ export FASTAPI_PORT
 export DASH_PORT
 export MINIO_PORT
 export MINIO_CONSOLE_PORT
+export VIEWER_DEV_PORT
+export FLOWER_PORT
 export DATA_DIR="data/${COMPOSE_PROJECT_NAME}"

--- a/depictio/viewer/index.html
+++ b/depictio/viewer/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/dashboard-beta/favicon.svg" />
+    <!-- href is relative to Vite's `base` ('/dashboard-beta/'). Don't hardcode
+         the prefix here — Vite already prepends base for `/`-prefixed URLs and
+         doing it twice yields a 404 in `vite dev` (the user sees a missing
+         favicon and "did you mean /dashboard-beta/dashboard-beta/favicon.svg?"
+         in the network tab). -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Depictio — Dashboard (Beta)</title>

--- a/depictio/viewer/vite.config.ts
+++ b/depictio/viewer/vite.config.ts
@@ -19,7 +19,8 @@ const authDevFallback = (): Plugin => ({
           /^\/dashboards-beta(\/|$|\?)/.test(req.url) ||
           /^\/projects-beta(\/|$|\?)/.test(req.url) ||
           /^\/about-beta(\/|$|\?)/.test(req.url) ||
-          /^\/admin-beta(\/|$|\?)/.test(req.url))
+          /^\/admin-beta(\/|$|\?)/.test(req.url) ||
+          /^\/dashboard-beta-edit(\/|$|\?)/.test(req.url))
       ) {
         req.url = '/dashboard-beta/';
       }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -204,8 +204,10 @@ services:
     command:
       - sh
       - -c
+      # The dev-viewer Dockerfile stage already runs `corepack prepare pnpm@10 --activate`,
+      # so do NOT re-prepare here. `pnpm@latest` at runtime pulls pnpm 11, which requires
+      # `node:sqlite` and crashes on Node 20 with ERR_UNKNOWN_BUILTIN_MODULE.
       - |
-        corepack prepare pnpm@latest --activate &&
         pnpm install --frozen-lockfile --prefer-offline --child-concurrency=2 --network-concurrency=4 &&
         pnpm --filter depictio-viewer dev --host 0.0.0.0 --port 5173
     user: "${UID:-1000}:${GID:-1000}"


### PR DESCRIPTION
## Summary

- **Port allocator** rewritten to probe for the first free 8-port window instead of using a deterministic md5 branch-hash. External squatters and stale containers no longer block `up`.
- **Container names** for `depictio-viewer-dev` and `flower` are now scoped with the compose project prefix in the override.yaml template, so a second worktree's `up` doesn't collide on the global Docker name.
- **MinIO console** moved to its own `9500 + offset` band — fixes the adjacent-offset collision where one branch's console (`9001+N`) clashed with another branch's API (`9000+N+1`).
- **`VIEWER_DEV_PORT`** and **`FLOWER_PORT`** added (`5500+offset` / `7000+offset`) so multi-worktree Vite / Flower don't fight over `5173` / `5555`.
- **pnpm pin** preserved: dropped the runtime `corepack prepare pnpm@latest --activate` in the dev-viewer compose command. The Dockerfile already activates `pnpm@10`; re-preparing pulled pnpm 11, which needs `node:sqlite` and crashes on Node 20 (`ERR_UNKNOWN_BUILTIN_MODULE`).
- **Vite dev fallback** now serves `index.html` for `/dashboard-beta-edit/*` alongside the other `-beta` siblings, so edit-mode URLs work with HMR instead of 404ing with Vite's "did you mean /dashboard-beta/..." suggestion.

## Test plan

- [ ] Bring up worktree A (`docker compose ... up`) — stack starts, ports bound.
- [ ] Bring up worktree B in a separate shell — port allocator walks past A's window, `up` succeeds, no `container name already in use` for `depictio-viewer-dev`.
- [ ] Open `http://localhost:${VIEWER_DEV_PORT}/dashboard-beta-edit/<id>` in dev — editor SPA loads (not a Vite 404).
- [ ] Check `docker logs ${COMPOSE_PROJECT_NAME}-depictio-viewer-dev` — no `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`, pnpm reports `10.x`.