### PR TITLE
fix: unblock K8s deploy + seed processing for ampliseq/viralrecon

### DIFF
--- a/depictio/api/v1/db_init_reference_datasets.py
+++ b/depictio/api/v1/db_init_reference_datasets.py
@@ -414,8 +414,12 @@ class ReferenceDatasetRegistry:
         config.pop("template", None)
 
         # 2. Build variables: DATA_ROOT + reference defaults (with DATA_ROOT substituted inside them)
+        # Skip DATA_ROOT in the loop — the caller-resolved path must win over any
+        # placeholder declared in template.reference.vars.DATA_ROOT.
         variables: dict[str, str] = {"DATA_ROOT": data_root}
         for var_name, var_default in reference_defaults.items():
+            if var_name == "DATA_ROOT":
+                continue
             variables[var_name] = var_default.replace("{DATA_ROOT}", data_root)
         provided_vars: set[str] = set(variables.keys())
         config = substitute_template_variables(config, variables)

--- a/depictio/cli/cli/utils/deltatables.py
+++ b/depictio/cli/cli/utils/deltatables.py
@@ -428,8 +428,16 @@ def client_aggregate_data(
             ),
         }
 
-    # Handle transformed (recipe-based) data collections
-    if data_collection.config.source == "transformed":
+    # Handle transformed (recipe-based) data collections.
+    # Init seeding for reference datasets pops the `transform` block while
+    # keeping `source: transformed` so the React viewer can still surface the
+    # recipe-derived lineage — those DCs already have a `scan` block pointing
+    # at the pre-computed seed file, so fall through to the regular file-scan
+    # path instead of erroring.
+    if (
+        data_collection.config.source == "transformed"
+        and data_collection.config.transform is not None
+    ):
         return process_recipe_data_collection(
             data_collection, CLI_config, overwrite, workflow, preview=preview_recipes
         )

--- a/depictio/projects/nf-core/ampliseq/2.16.0/template.yaml
+++ b/depictio/projects/nf-core/ampliseq/2.16.0/template.yaml
@@ -506,6 +506,19 @@ links:
   # Links 2-6 reference the metadata DC and are pruned automatically
   # when METADATA_FILE is absent (conditional block removes metadata DC).
 
+  # Link 1b: Metadata -> MultiQC (secondary sample filter via metadata DC)
+  # Without this, dashboards bound to metadata interactive filters
+  # (habitat, sampling_date, sample) cannot narrow MultiQC plots.
+  - source_dc_tag: "metadata"
+    source_column: "sample"
+    target_dc_tag: "multiqc_data"
+    target_type: "multiqc"
+    link_config:
+      resolver: "sample_mapping"
+      target_field: "sample_name"
+    description: "Filter MultiQC by metadata samples"
+    enabled: true
+
   # Link 2: Metadata -> Alpha Diversity
   - source_dc_tag: "metadata"
     source_column: "sample"

--- a/depictio/projects/nf-core/viralrecon/3.0.0/template.yaml
+++ b/depictio/projects/nf-core/viralrecon/3.0.0/template.yaml
@@ -23,9 +23,8 @@ template:
       required: true
   dashboards:
     - "dashboards/base.yaml"
-  reference:
-    vars:
-      DATA_ROOT: "/path/to/viralrecon/output"
+  # No reference.vars needed — DATA_ROOT is resolved by db_init to the
+  # bundled project directory (/app/depictio/projects/nf-core/viralrecon/3.0.0).
 
 # ============================================================================
 # PROJECT CONFIGURATION

--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -323,7 +323,8 @@ spec:
               mountPath: /iris-config
         {{- if .Values.local_development }}
         - name: fix-permissions
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ["/bin/sh"]
           args:
           - -c
@@ -397,7 +398,8 @@ spec:
             - name: depictio-screenshots
               mountPath: /mounted-screenshots
         - name: wait-for-mongo
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo {{ .Values.mongo.service.port }}; do echo "Waiting for mongo..."; sleep 2; done']
           securityContext:
             {{- toYaml .Values.backend.securityContext | nindent 12 }}
@@ -405,7 +407,8 @@ spec:
             {{- toYaml .Values.initContainerResources | nindent 12 }}
         {{- if .Values.minio.enabled }}
         - name: wait-for-minio
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-minio {{ .Values.minio.service.httpPort }}; do echo "Waiting for minio..."; sleep 2; done']
           securityContext:
             {{- toYaml .Values.backend.securityContext | nindent 12 }}
@@ -414,7 +417,8 @@ spec:
         {{- end }}
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-redis {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 2; done']
           securityContext:
             {{- toYaml .Values.backend.securityContext | nindent 12 }}
@@ -422,7 +426,8 @@ spec:
             {{- toYaml .Values.initContainerResources | nindent 12 }}
         {{- end }}
         - name: verify-config-storage
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c']
           args:
             - |
@@ -570,7 +575,8 @@ spec:
       initContainers:
         # STEP 0: Fix permissions for mounted volumes (always run for frontend)
         - name: fix-permissions-frontend
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ["/bin/sh"]
           args:
           - -c
@@ -610,7 +616,8 @@ spec:
             {{- toYaml .Values.initContainerResources | nindent 12 }}
         # STEP 0.5: Verify config storage is mounted and writable
         - name: verify-config-storage
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c']
           args:
             - |
@@ -672,7 +679,8 @@ spec:
               mountPath: /mounted-screenshots
         # STEP 1: Wait for backend service to be available (network check)
         - name: wait-for-backend
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c']
           args:
             - |
@@ -700,7 +708,8 @@ spec:
 
         # STEP 2: Wait for backend to fully start and generate keys
         - name: wait-for-backend-startup
-          image: curlimages/curl:8.5.0
+          image: "{{ .Values.curlInitContainerImage.repository }}:{{ .Values.curlInitContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.curlInitContainerImage.pullPolicy }}
           securityContext:
             {{- toYaml .Values.frontend.securityContext | nindent 12 }}
           resources:
@@ -736,7 +745,8 @@ spec:
 
         # STEP 3: Verify key files are actually available
         - name: wait-for-api-key
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           securityContext:
             {{- toYaml .Values.frontend.securityContext | nindent 12 }}
           resources:
@@ -772,7 +782,8 @@ spec:
         # STEP 4: Wait for Redis to be available
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           securityContext:
             {{- toYaml .Values.frontend.securityContext | nindent 12 }}
           resources:
@@ -900,7 +911,8 @@ spec:
       initContainers:
         # STEP 0: Fix permissions for mounted volumes
         - name: fix-permissions-celery
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ["/bin/sh"]
           args:
           - -c
@@ -929,7 +941,8 @@ spec:
             {{- toYaml .Values.initContainerResources | nindent 12 }}
         # STEP 1: Wait for MongoDB
         - name: wait-for-mongo
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo {{ .Values.mongo.service.port }}; do echo "Waiting for mongo..."; sleep 2; done']
           securityContext:
             {{- toYaml .Values.celery.securityContext | nindent 12 }}
@@ -938,7 +951,8 @@ spec:
         # STEP 2: Wait for Redis
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-redis {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 2; done']
           securityContext:
             {{- toYaml .Values.celery.securityContext | nindent 12 }}
@@ -947,7 +961,8 @@ spec:
         {{- end }}
         # STEP 3: Wait for backend service to be available
         - name: wait-for-backend
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c']
           args:
             - |
@@ -971,7 +986,8 @@ spec:
             {{- toYaml .Values.initContainerResources | nindent 12 }}
         # STEP 4: Verify API key files are available
         - name: wait-for-api-key
-          image: busybox:1.35
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c']
           args:
             - |
@@ -999,7 +1015,8 @@ spec:
         # STEP 5: Wait for frontend (Dash) service - required for screenshot generation
         # Must wait for app to be FULLY ready (callbacks registered), not just port open
         - name: wait-for-frontend
-          image: curlimages/curl:8.5.0
+          image: "{{ .Values.curlInitContainerImage.repository }}:{{ .Values.curlInitContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.curlInitContainerImage.pullPolicy }}
           command: ['sh', '-c']
           args:
             - |

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -379,6 +379,23 @@ initContainerResources:
     memory: "128Mi"
     cpu: "100m"
 
+# Shared image for the busybox-based init containers
+# (wait-for-mongo, wait-for-redis, fix-permissions-*, etc.).
+# pullPolicy defaults to Always so PSA / Capsule policies that forbid
+# IfNotPresent on tagged images don't reject pod creation.
+initContainerImage:
+  repository: busybox
+  tag: "1.35"
+  pullPolicy: Always
+
+# Curl-based init containers that probe HTTP readiness of dependent
+# services (wait-for-backend-startup on frontend, wait-for-frontend on
+# celery). Same pullPolicy=Always reasoning as initContainerImage.
+curlInitContainerImage:
+  repository: curlimages/curl
+  tag: "8.5.0"
+  pullPolicy: Always
+
 global:
   domain: "example.com" # Default domain, can be overridden in environment-specific values
 


### PR DESCRIPTION
## Summary

Four independent fixes uncovered while deploying v0.13.1 to a Capsule-gated EMBL cluster (`datasci-depictio-project-demo-dev`). All four block the same end-user outcome (data processing on the seeded reference projects), but they're separate root causes — one commit each.

| Commit | Fix | Blast radius |
|---|---|---|
| [`fb89e531e`](../commit/fb89e531e) | `imagePullPolicy: Always` on busybox/curl init containers | Backend / Frontend / Celery deployments never created pods on Capsule-enabled clusters (admission webhook denied `IfNotPresent` for tagged images) |
| [`7063eadab`](../commit/7063eadab) | Preserve resolved `DATA_ROOT` in seed init | viralrecon scan failed: `directory '/path/to/viralrecon/output' does not exist` — all viralrecon DCs blocked |
| [`d3960cc2e`](../commit/d3960cc2e) | Process materialised recipe DCs as file scans | 13 ampliseq transformed-but-materialised DCs failed: `Transformed DC '...' has no transform config` — dashboards 404'd at render time |
| [`5a657853b`](../commit/5a657853b) | Add `metadata → multiqc_data` DCLink to 2.16.0 template | MultiQC habitat/sample filters from metadata tab silently dropped — fix `b9f7d7fc4` only patched 2.14.0 but seeded dataset is 2.16.0 |

### Details

**1. Helm chart — `fb89e531e`**

Capsule's `pods.projectcapsule.dev` webhook denies `imagePullPolicy: IfNotPresent` for tagged images. 15 busybox-based init containers (`wait-for-mongo`, `wait-for-redis`, `fix-permissions-*`, `verify-config-storage`, etc.) and 2 curl-based init containers (`wait-for-backend-startup`, `wait-for-frontend`) had no policy set — k8s defaults to `IfNotPresent` for any non-`:latest` tag. Added two value blocks (`initContainerImage`, `curlInitContainerImage`) defaulting to `pullPolicy: Always` and templated every init container's image+pullPolicy through them.

**2. Reference-init `DATA_ROOT` — `7063eadab`**

In `db_init_reference_datasets.resolve_template_for_init`, the variables dict is seeded with the caller-resolved path, then a loop adds extra vars from `template.reference.vars` with `{DATA_ROOT}` substituted in. The loop didn't skip `DATA_ROOT` itself — so when a template declared `DATA_ROOT` in `reference.vars` (only viralrecon does, as a user-facing example placeholder), the loop overwrote the resolved path with the placeholder. Skipped `DATA_ROOT` in the loop + removed the redundant entry from viralrecon's template.

**3. Materialised recipe DCs — `d3960cc2e`**

The init resolver converts recipe-based DCs into file scans backed by the bundled `.tsv` seed file. To preserve recipe lineage in the React viewer, it keeps `source: transformed` and only drops `transform`. But `deltatables.process_data_collection` treated `source: transformed` as "must have transform" and errored. Added `and transform is not None` to the recipe-branch guard.

**4. ampliseq 2.16.0 metadata→multiqc link — `5a657853b`**

`b9f7d7fc4` added the DCLink to 2.14.0 only; the active seeded dataset is 2.16.0. Mirrored the link.

## Verified live on `datasci-depictio-project-demo-dev`

- v0.13.1 deploy was previously stuck with only `mongo-0` + `redis-0` Running; all 3 Deployments showed 0 Ready
- After applying the helm fix locally and re-deploying: all 5 pods Running (mongo, redis, backend, frontend, celery)
- Logs then exposed the seed-side failures fixed in this PR

## Test plan

- [ ] CI green
- [ ] After merge, bump to v0.13.2 + redeploy `devdemo` — confirm 0 errors in backend logs for ampliseq + viralrecon seeding
- [ ] Open ampliseq dashboard, change habitat filter on MultiQC metadata tab, verify MultiQC plots narrow accordingly
- [ ] Open viralrecon dashboard, verify all DCs load (not 404)