### PR TITLE
fix(viewer): enable dashboard pinning in public/demo mode

### DIFF
--- a/depictio/viewer/src/dashboards/DashboardsApp.tsx
+++ b/depictio/viewer/src/dashboards/DashboardsApp.tsx
@@ -341,7 +341,6 @@ const DashboardsApp: React.FC = () => {
               dashboards={dashboards}
               projects={projects}
               currentUserEmail={currentUserEmail}
-              pinDisabled={isPublicMode || isDemoMode}
               onView={handleView}
               onEdit={(d) => setEditTarget(d)}
               onDelete={(d) => setDeleteTarget(d)}

--- a/depictio/viewer/src/dashboards/DashboardsList.tsx
+++ b/depictio/viewer/src/dashboards/DashboardsList.tsx
@@ -414,17 +414,6 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
         clearFilters={clearFilters}
       />
 
-      {pinDisabled && (
-        <Paper p="xs" radius="md" withBorder>
-          <Group gap="xs">
-            <Icon icon="mdi:information-outline" width={16} />
-            <Text size="sm" c="dimmed">
-              Pinning and recently-opened tracking are disabled in public mode.
-            </Text>
-          </Group>
-        </Paper>
-      )}
-
       {noResults ? (
         <Paper p="xl" radius="md" withBorder>
           <Stack align="center" gap="sm">


### PR DESCRIPTION
## Summary

Pinning lives in browser localStorage (`depictio.projects.pinned.v1` etc.) — it's a purely client-side preference that never hits the server. There's no privacy or security reason to gate it on auth mode, and short-lived public/demo sessions still benefit from pinning within a single browsing session.

## Changes

- `DashboardsApp.tsx`: drop `pinDisabled={isPublicMode || isDemoMode}` (defaults to `false` on the receiver)
- `DashboardsList.tsx`: remove the "Pinning and recently-opened tracking are disabled in public mode." banner — also note that recently-opened tracking was never actually implemented, the banner was misleading

## Test plan

- [ ] Open `/dashboards-beta` as anonymous user — pin icon is enabled, clicking pins the dashboard
- [ ] Refresh page — pin survives (localStorage)
- [ ] No banner shown about pinning being disabled