### PR TITLE
fix(seeds): viralrecon dashboards use static DC IDs + invariant test

### DIFF
--- a/depictio/api/v1/db_init_reference_datasets.py
+++ b/depictio/api/v1/db_init_reference_datasets.py
@@ -144,6 +144,11 @@ STATIC_IDS = {
             "dotplot_demo": "646b0f3c1e4a2d7f8e5b8d30",
             "lollipop_demo": "646b0f3c1e4a2d7f8e5b8d31",
             "oncoplot_demo": "646b0f3c1e4a2d7f8e5b8d32",
+            # Coverage-track + categorical-flow demos added later — IDs were
+            # already baked into the seed dashboards (`8d50` / `8d51`) but
+            # never registered here, so seeded deploys 404'd on these tiles.
+            "coverage_track_demo": "646b0f3c1e4a2d7f8e5b8d50",
+            "categorical_flow_demo": "646b0f3c1e4a2d7f8e5b8d51",
         },
         "dashboards": {
             # Main tab reuses the project_id so get_child_tabs(main_id) finds

--- a/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_coverage_depth.json
+++ b/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_coverage_depth.json
@@ -22,18 +22,14 @@
       "wf_id": {
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
-      "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
-      },
+      "dc_id": null,
       "dc_config": {
         "type": null,
         "metatype": null,
         "description": "Per-sample alignment, coverage, and variant calling summary metrics",
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
-        "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
-        }
+        "_id": null
       },
       "cols_json": {},
       "parent_index": null,
@@ -226,7 +222,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd92a2"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1c"
       },
       "dc_config": {
         "type": null,
@@ -235,7 +231,7 @@
         "data_collection_tag": "coverage_track_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd92a2"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1c"
         }
       },
       "cols_json": {},
@@ -273,7 +269,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd92a0"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1b"
       },
       "dc_config": {
         "type": null,
@@ -282,7 +278,7 @@
         "data_collection_tag": "complex_heatmap_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd92a0"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1b"
         }
       },
       "cols_json": {},

--- a/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_lineage_clustering.json
+++ b/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_lineage_clustering.json
@@ -22,18 +22,14 @@
       "wf_id": {
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
-      "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
-      },
+      "dc_id": null,
       "dc_config": {
         "type": null,
         "metatype": null,
         "description": "Per-sample alignment, coverage, and variant calling summary metrics",
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
-        "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
-        }
+        "_id": null
       },
       "cols_json": {},
       "parent_index": null,
@@ -55,7 +51,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9292"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c14"
       },
       "dc_config": {
         "type": null,
@@ -64,7 +60,7 @@
         "data_collection_tag": "pangolin_lineages",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9292"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c14"
         }
       },
       "cols_json": {},
@@ -99,7 +95,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9294"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c15"
       },
       "dc_config": {
         "type": null,
@@ -108,7 +104,7 @@
         "data_collection_tag": "nextclade_results",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9294"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c15"
         }
       },
       "cols_json": {},
@@ -143,7 +139,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -152,7 +148,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -184,7 +180,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9292"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c14"
       },
       "dc_config": {
         "type": null,
@@ -193,7 +189,7 @@
         "data_collection_tag": "pangolin_lineages",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9292"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c14"
         }
       },
       "cols_json": {},
@@ -225,7 +221,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9294"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c15"
       },
       "dc_config": {
         "type": null,
@@ -234,7 +230,7 @@
         "data_collection_tag": "nextclade_results",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9294"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c15"
         }
       },
       "cols_json": {},
@@ -266,7 +262,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9292"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c14"
       },
       "dc_config": {
         "type": null,
@@ -275,7 +271,7 @@
         "data_collection_tag": "pangolin_lineages",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9292"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c14"
         }
       },
       "cols_json": {},
@@ -306,7 +302,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9294"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c15"
       },
       "dc_config": {
         "type": null,
@@ -315,7 +311,7 @@
         "data_collection_tag": "nextclade_results",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9294"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c15"
         }
       },
       "cols_json": {},
@@ -346,7 +342,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd92a4"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1d"
       },
       "dc_config": {
         "type": null,
@@ -355,7 +351,7 @@
         "data_collection_tag": "sankey_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd92a4"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1d"
         }
       },
       "cols_json": {},
@@ -394,7 +390,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd92a8"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1f"
       },
       "dc_config": {
         "type": null,
@@ -403,7 +399,7 @@
         "data_collection_tag": "variant_feature_matrix_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd92a8"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1f"
         }
       },
       "cols_json": {},
@@ -443,7 +439,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9292"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c14"
       },
       "dc_config": {
         "type": null,
@@ -452,7 +448,7 @@
         "data_collection_tag": "pangolin_lineages",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9292"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c14"
         }
       },
       "cols_json": {},
@@ -479,7 +475,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9294"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c15"
       },
       "dc_config": {
         "type": null,
@@ -488,7 +484,7 @@
         "data_collection_tag": "nextclade_results",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9294"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c15"
         }
       },
       "cols_json": {},

--- a/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_multiqc.json
+++ b/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_multiqc.json
@@ -22,18 +22,14 @@
       "wf_id": {
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
-      "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
-      },
+      "dc_id": null,
       "dc_config": {
         "type": null,
         "metatype": null,
         "description": "Per-sample alignment, coverage, and variant calling summary metrics",
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
-        "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
-        }
+        "_id": null
       },
       "cols_json": {},
       "parent_index": null,
@@ -55,7 +51,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -64,7 +60,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -96,7 +92,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -105,7 +101,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},

--- a/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_sample_qc.json
+++ b/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_sample_qc.json
@@ -22,18 +22,14 @@
       "wf_id": {
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
-      "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
-      },
+      "dc_id": null,
       "dc_config": {
         "type": null,
         "metatype": null,
         "description": "Per-sample alignment, coverage, and variant calling summary metrics",
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
-        "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
-        }
+        "_id": null
       },
       "cols_json": {},
       "parent_index": null,
@@ -55,7 +51,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -64,7 +60,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -101,7 +97,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -110,7 +106,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -147,7 +143,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -156,7 +152,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -188,7 +184,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -197,7 +193,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -229,7 +225,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -238,7 +234,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -269,7 +265,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9294"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c15"
       },
       "dc_config": {
         "type": null,
@@ -278,7 +274,7 @@
         "data_collection_tag": "nextclade_results",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9294"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c15"
         }
       },
       "cols_json": {},
@@ -309,7 +305,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -318,7 +314,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},
@@ -349,7 +345,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c11"
       },
       "dc_config": {
         "type": null,
@@ -358,7 +354,7 @@
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c11"
         }
       },
       "cols_json": {},

--- a/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_variants.json
+++ b/depictio/projects/nf-core/viralrecon/3.0.0/.db_seeds/dashboard_variants.json
@@ -22,18 +22,14 @@
       "wf_id": {
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
-      "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
-      },
+      "dc_id": null,
       "dc_config": {
         "type": null,
         "metatype": null,
         "description": "Per-sample alignment, coverage, and variant calling summary metrics",
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
-        "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
-        }
+        "_id": null
       },
       "cols_json": {},
       "parent_index": null,
@@ -55,7 +51,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -64,7 +60,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -99,7 +95,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -108,7 +104,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -143,7 +139,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -152,7 +148,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -187,7 +183,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -196,7 +192,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -231,7 +227,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd9290"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c13"
       },
       "dc_config": {
         "type": null,
@@ -240,7 +236,7 @@
         "data_collection_tag": "manhattan_variants_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd9290"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c13"
         }
       },
       "cols_json": {},
@@ -282,7 +278,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -291,7 +287,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -323,7 +319,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -332,7 +328,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -364,7 +360,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -373,7 +369,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -405,7 +401,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -414,7 +410,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -446,7 +442,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -455,7 +451,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -486,7 +482,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -495,7 +491,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -526,7 +522,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd929c"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c19"
       },
       "dc_config": {
         "type": null,
@@ -535,7 +531,7 @@
         "data_collection_tag": "lollipop_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd929c"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c19"
         }
       },
       "cols_json": {},
@@ -565,7 +561,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c12"
       },
       "dc_config": {
         "type": null,
@@ -574,7 +570,7 @@
         "data_collection_tag": "variants_long",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd928e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c12"
         }
       },
       "cols_json": {},
@@ -600,18 +596,14 @@
       "wf_id": {
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
-      "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd928c"
-      },
+      "dc_id": null,
       "dc_config": {
         "type": null,
         "metatype": null,
         "description": "Per-sample alignment, coverage, and variant calling summary metrics",
         "data_collection_tag": "summary_metrics",
         "dc_specific_properties": null,
-        "_id": {
-          "$oid": "6a0e273941cd17ba0abd928c"
-        }
+        "_id": null
       },
       "cols_json": {},
       "parent_index": null,
@@ -633,7 +625,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd929e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
       },
       "dc_config": {
         "type": null,
@@ -642,7 +634,7 @@
         "data_collection_tag": "oncoplot_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd929e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
         }
       },
       "cols_json": {},
@@ -677,7 +669,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd929e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
       },
       "dc_config": {
         "type": null,
@@ -686,7 +678,7 @@
         "data_collection_tag": "oncoplot_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd929e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
         }
       },
       "cols_json": {},
@@ -721,7 +713,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd929e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
       },
       "dc_config": {
         "type": null,
@@ -730,7 +722,7 @@
         "data_collection_tag": "oncoplot_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd929e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
         }
       },
       "cols_json": {},
@@ -762,7 +754,7 @@
         "$oid": "746b0f3c1e4a2d7f8e5b9c01"
       },
       "dc_id": {
-        "$oid": "6a0e273941cd17ba0abd929e"
+        "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
       },
       "dc_config": {
         "type": null,
@@ -771,7 +763,7 @@
         "data_collection_tag": "oncoplot_canonical",
         "dc_specific_properties": null,
         "_id": {
-          "$oid": "6a0e273941cd17ba0abd929e"
+          "$oid": "746b0f3c1e4a2d7f8e5b9c1a"
         }
       },
       "cols_json": {},

--- a/depictio/projects/nf-core/viralrecon/3.0.0/remap_seeds_to_static_ids.py
+++ b/depictio/projects/nf-core/viralrecon/3.0.0/remap_seeds_to_static_ids.py
@@ -1,0 +1,112 @@
+"""Remap auto-generated DC IDs in viralrecon seed dashboards to static IDs.
+
+When `generate_seeds.sh` exports the dashboards via `python -m depictio.cli run`,
+the CLI ingest path creates DCs with fresh auto-generated ObjectIds — not the
+static IDs from `db_init_reference_datasets.STATIC_IDS`. The reference-init
+flow on a fresh deploy uses static IDs, so dashboards baked with auto-IDs
+404 at render time.
+
+This script walks every `.db_seeds/dashboard_*.json`, looks up each component's
+`data_collection_tag`, and rewrites `dc_id` / `dc_config._id` with the static
+ID from STATIC_IDS. Text components (no DC backing) get `dc_id: null`.
+
+Run via:
+    python -m depictio.projects.nf-core.viralrecon.3_0_0.remap_seeds_to_static_ids
+
+Idempotent — running on already-static seeds is a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Import STATIC_IDS directly to keep this script self-validating.
+sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
+from depictio.api.v1.db_init_reference_datasets import STATIC_IDS  # noqa: E402
+
+PROJECT_KEY = "viralrecon"
+SEEDS_DIR = Path(__file__).resolve().parent / ".db_seeds"
+
+
+def _tag_to_static_id() -> dict[str, str]:
+    return STATIC_IDS[PROJECT_KEY]["data_collections"]
+
+
+def _is_oid_field(value: Any) -> bool:
+    return isinstance(value, dict) and set(value.keys()) == {"$oid"}
+
+
+def _remap_dc_id(component: dict[str, Any], dc_tag_to_id: dict[str, str]) -> bool:
+    """Mutate component in place. Return True iff anything changed."""
+    tag = component.get("data_collection_tag")
+    comp_type = component.get("component_type")
+    changed = False
+
+    if comp_type == "text" or not tag:
+        # Text tiles aren't bound to a DC; null the field to match ampliseq.
+        if component.get("dc_id") is not None:
+            component["dc_id"] = None
+            changed = True
+        if isinstance(component.get("dc_config"), dict) and component["dc_config"].get("_id"):
+            component["dc_config"]["_id"] = None
+            changed = True
+        return changed
+
+    static_id = dc_tag_to_id.get(tag)
+    if not static_id:
+        print(
+            f"  ⚠️  tag '{tag}' has no STATIC_IDS entry — left untouched "
+            f"(component: {component.get('title') or component.get('index')})"
+        )
+        return False
+
+    current = component.get("dc_id")
+    current_oid = current.get("$oid") if _is_oid_field(current) else current
+    if current_oid != static_id:
+        component["dc_id"] = {"$oid": static_id}
+        changed = True
+
+    dc_config = component.get("dc_config")
+    if isinstance(dc_config, dict):
+        current_cfg = dc_config.get("_id")
+        current_cfg_oid = current_cfg.get("$oid") if _is_oid_field(current_cfg) else current_cfg
+        if current_cfg_oid != static_id:
+            dc_config["_id"] = {"$oid": static_id}
+            changed = True
+
+    return changed
+
+
+def remap_file(path: Path, dc_tag_to_id: dict[str, str]) -> int:
+    """Remap one dashboard JSON. Return number of components changed."""
+    doc = json.loads(path.read_text())
+    n = 0
+    for sm in doc.get("stored_metadata", []) or []:
+        if _remap_dc_id(sm, dc_tag_to_id):
+            n += 1
+    if n:
+        # Preserve original 2-space indentation used by the rest of the seeds.
+        path.write_text(json.dumps(doc, indent=2) + "\n")
+    return n
+
+
+def main() -> int:
+    if not SEEDS_DIR.is_dir():
+        print(f"ERROR: seeds directory not found: {SEEDS_DIR}", file=sys.stderr)
+        return 1
+
+    dc_tag_to_id = _tag_to_static_id()
+    total = 0
+    for path in sorted(SEEDS_DIR.glob("dashboard_*.json")):
+        n = remap_file(path, dc_tag_to_id)
+        print(f"{path.name}: {n} component(s) remapped")
+        total += n
+    print(f"\nTotal: {total} component(s) updated across {PROJECT_KEY} dashboards")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Viralrecon dashboards on `devdemo` 404'd at every tile render because the 5 bundled seed JSONs baked auto-generated DC ObjectIds (`6a0e2739...`) — fresh deploys assign static IDs (`746b0f3c...`) from `STATIC_IDS[viralrecon]`, so the dashboard's `dc_id` references never resolved.

Three commits, smallest first:

| Commit | What |
|---|---|
| `fix(seeds): register coverage_track_demo + categorical_flow_demo static IDs` | Two advanced_viz_showcase DCs (`8d50`, `8d51`) were referenced in seeds but missing from `STATIC_IDS` — surfaced by the new test |
| `fix(viralrecon): remap seed dashboards to static DC IDs` | New `remap_seeds_to_static_ids.py` rewrites every `dc_id` / `dc_config._id` by looking up the component's `data_collection_tag` in `STATIC_IDS`; ran it once, 46 references fixed across the 5 dashboards |
| `test(seeds): assert all reference-dashboard dc_ids match STATIC_IDS` | Pytest invariant catches the bug class for every reference project, parameterized over `ReferenceDatasetRegistry.DATASET_PATHS` |

## Why this happened

`generate_seeds.sh` runs the depictio CLI ingest (`python -m depictio.cli run --template …`) to populate Mongo, then exports each dashboard back out. The CLI path assigns *fresh* ObjectIds — it doesn't consult `STATIC_IDS`, which only the reference-init path uses. So every export bakes auto-IDs that don't reproduce.

Ampliseq's 2.16.0 seeds happen to be compliant because they were re-exported manually after the static IDs landed. Viralrecon was the first project where the static IDs and the export drifted.

## CI coverage

User asked specifically:
> how to make sure this works ? add a depictio-ci test maybe ? alongside the ampliseq one

The new pytest is picked up automatically by the existing `python -m pytest -xvs -n auto` step in the `quality` job (`depictio/tests/api/` is already in `pyproject.toml` `testpaths`) — **no workflow edit needed**. It's faster than a viralrecon E2E (the latter would need the nf-core nextflow pipeline to generate test data) and catches every reference project at once.

## Follow-up (not in this PR)

`generate_seeds.sh` should call `remap_seeds_to_static_ids.py` as its final step so future re-exports of viralrecon stay clean. Left out here to keep this PR scoped.

## Test plan

- [x] `pytest depictio/tests/api/v1/test_reference_seed_dashboards.py` — 34 passed
- [ ] CI green
- [ ] After merge + v0.13.3 bump + devdemo redeploy: open each of the 5 viralrecon dashboards, confirm tiles render against the bundled test data (Coverage & Depth / MultiQC dashboards have data; the other 3 still need data for the variant/lineage/sample_qc DCs)