### PR TITLE
fix(seeds): force format=tsv on recipe DC conversion

### DIFF
--- a/depictio/api/v1/db_init_reference_datasets.py
+++ b/depictio/api/v1/db_init_reference_datasets.py
@@ -486,6 +486,18 @@ class ReferenceDatasetRegistry:
                         "mode": "single",
                         "scan_parameters": {"filename": pre_computed_path},
                     }
+                    # Bundled recipe seeds are tab-separated by convention
+                    # ({data_root}/{dc_tag}.tsv). The template's original
+                    # `dc_specific_properties.format` describes the recipe's
+                    # *input* source (e.g. summary_metrics consumes a real
+                    # CSV from multiqc), which is irrelevant once we've
+                    # replaced the recipe with a file_scan. Force the seed
+                    # format to TSV so polars uses the right separator —
+                    # otherwise a CSV-declared, TSV-bundled DC parses the
+                    # whole tab-row as one column.
+                    dc_specific = dc_config.get("dc_specific_properties") or {}
+                    dc_specific["format"] = "tsv"
+                    dc_config["dc_specific_properties"] = dc_specific
                     logger.debug(
                         f"Init resolver: converted recipe DC '{dc_tag}' → file scan: {pre_computed_path}"
                     )

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -35,6 +35,35 @@ from depictio.models.models.users import TokenBeanie, User, UserBeanie
 dashboards_endpoint_router = APIRouter()
 
 
+# Screenshots PVC mount inside the backend container; bundled image ships
+# default PNGs here for the seeded reference dashboards.
+_SCREENSHOTS_DIR = "/app/depictio/dash/static/screenshots"
+# Mirrors the Dash auto-screenshot callback's 1h heuristic so the two
+# trigger sites agree on "stale".
+_SCREENSHOT_STALE_AFTER_S = 3600
+
+
+def _should_enqueue_screenshot(dashboard_id: str, now_s: float | None = None) -> bool:
+    """Return True iff dual-theme PNGs are missing or older than 1h.
+
+    Called by the dashboard save endpoint to avoid saturating the celery
+    queue on every React viewer interaction. Without this guard, every
+    tab-open / duplicate / rename / no-op edit triggers a fresh Playwright
+    render — blocking advanced-viz `compute_*` tasks behind a wall of
+    screenshot work at boot and after each user click.
+    """
+    import os
+    import time
+
+    light = os.path.join(_SCREENSHOTS_DIR, f"{dashboard_id}_light.png")
+    dark = os.path.join(_SCREENSHOTS_DIR, f"{dashboard_id}_dark.png")
+    if not (os.path.exists(light) and os.path.exists(dark)):
+        return True  # missing → must (re)generate
+    now = now_s if now_s is not None else time.time()
+    newest = max(os.path.getmtime(light), os.path.getmtime(dark))
+    return (now - newest) >= _SCREENSHOT_STALE_AFTER_S
+
+
 @dashboards_endpoint_router.post("/sync_with_projects")
 async def sync_dashboard_permissions_with_projects(
     current_user: User = Depends(get_current_user),
@@ -635,21 +664,23 @@ async def save_dashboard(
         dashboard_id_str = str(dashboard_id)
 
         # Auto-queue screenshot regeneration so /dashboards-beta and any
-        # other listing surface picks up the latest dashboard state without
-        # the user needing to navigate to the viewer first. Mirrors the
-        # explicit `.delay(...)` call the Dash editor's save callback makes
-        # at depictio/dash/layouts/save.py:367 — moving the dispatch here
-        # means every client (Dash editor, React editor, the React component
-        # builder's upsertComponent flow) gets screenshots queued by default.
-        # Lazy import to keep API startup independent of the Dash worker
-        # module, and a broad except so a Celery/broker outage never breaks
-        # the save response itself.
+        # other listing surface picks up the latest dashboard state.
+        # Guarded by `_should_enqueue_screenshot` to avoid the celery
+        # queue storm every React viewer interaction otherwise creates.
         try:
-            from depictio.dash.celery_app import generate_dashboard_screenshot_dual
+            if _should_enqueue_screenshot(dashboard_id_str):
+                # Lazy import keeps API startup independent of the Dash
+                # worker module; broad except so a Celery/broker outage
+                # never breaks the save response itself.
+                from depictio.dash.celery_app import generate_dashboard_screenshot_dual
 
-            user_id = str(getattr(current_user, "id", "") or "")
-            generate_dashboard_screenshot_dual.delay(dashboard_id_str, user_id)
-            logger.debug(f"Queued screenshot regeneration for dashboard {dashboard_id_str}")
+                user_id = str(getattr(current_user, "id", "") or "")
+                generate_dashboard_screenshot_dual.delay(dashboard_id_str, user_id)
+                logger.debug(f"Queued screenshot regeneration for dashboard {dashboard_id_str}")
+            else:
+                logger.debug(
+                    f"Skipping screenshot enqueue for {dashboard_id_str} — recent PNG exists"
+                )
         except Exception as exc:  # noqa: BLE001 — non-fatal best-effort dispatch
             logger.warning(f"Could not queue screenshot for {dashboard_id_str}: {exc}")
 

--- a/depictio/tests/api/v1/test_dashboard_save_screenshot_guard.py
+++ b/depictio/tests/api/v1/test_dashboard_save_screenshot_guard.py
@@ -1,0 +1,70 @@
+"""Invariants on the screenshot-enqueue idempotency guard.
+
+Every React viewer interaction (open tab, duplicate, rename, no-op edit)
+hits ``POST /dashboards/save/{id}``. Without this guard each one would
+fire ``generate_dashboard_screenshot_dual.delay(...)`` and saturate the
+celery worker pool — blocking advanced-viz ``compute_*`` tasks behind a
+wall of Playwright renders at boot and after every click.
+
+The guard returns True only when there's actual work to do: dual-theme
+PNGs missing on disk, or older than the 1-hour staleness threshold
+shared with the Dash auto-screenshot callback (``save.py:140``).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from depictio.api.v1.endpoints.dashboards_endpoints import routes
+
+
+def _touch(path: Path, mtime: float | None = None) -> None:
+    path.write_bytes(b"")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
+def test_enqueue_when_pngs_missing() -> None:
+    with tempfile.TemporaryDirectory() as td, patch.object(routes, "_SCREENSHOTS_DIR", td):
+        assert routes._should_enqueue_screenshot("abc123") is True, "no PNGs on disk → must enqueue"
+
+
+def test_enqueue_when_only_one_theme_missing() -> None:
+    with tempfile.TemporaryDirectory() as td, patch.object(routes, "_SCREENSHOTS_DIR", td):
+        _touch(Path(td) / "abc123_light.png")
+        # dark missing → must enqueue
+        assert routes._should_enqueue_screenshot("abc123") is True
+
+
+def test_skip_when_both_pngs_fresh() -> None:
+    with tempfile.TemporaryDirectory() as td, patch.object(routes, "_SCREENSHOTS_DIR", td):
+        now = time.time()
+        _touch(Path(td) / "abc123_light.png", mtime=now - 10)
+        _touch(Path(td) / "abc123_dark.png", mtime=now - 10)
+        assert routes._should_enqueue_screenshot("abc123", now_s=now) is False, (
+            "both PNGs present and <1h old → skip — saves a Playwright run"
+        )
+
+
+def test_enqueue_when_pngs_stale() -> None:
+    with tempfile.TemporaryDirectory() as td, patch.object(routes, "_SCREENSHOTS_DIR", td):
+        now = time.time()
+        # 2 hours past the 1h threshold
+        old = now - (routes._SCREENSHOT_STALE_AFTER_S + 60 * 60)
+        _touch(Path(td) / "abc123_light.png", mtime=old)
+        _touch(Path(td) / "abc123_dark.png", mtime=old)
+        assert routes._should_enqueue_screenshot("abc123", now_s=now) is True
+
+
+def test_boundary_at_exactly_stale_threshold() -> None:
+    """Equal-to-threshold counts as stale (>=) so the guard never drifts."""
+    with tempfile.TemporaryDirectory() as td, patch.object(routes, "_SCREENSHOTS_DIR", td):
+        now = time.time()
+        old = now - routes._SCREENSHOT_STALE_AFTER_S
+        _touch(Path(td) / "abc123_light.png", mtime=old)
+        _touch(Path(td) / "abc123_dark.png", mtime=old)
+        assert routes._should_enqueue_screenshot("abc123", now_s=now) is True

--- a/depictio/tests/api/v1/test_db_init_resolver.py
+++ b/depictio/tests/api/v1/test_db_init_resolver.py
@@ -1,0 +1,107 @@
+"""Invariants on `ReferenceDatasetRegistry.resolve_template_for_init`.
+
+The init resolver converts recipe-based DCs (`source: "transformed"` with a
+`transform.recipe` block) into file_scan DCs pointing at a bundled
+`{data_root}/{dc_tag}.tsv` seed. Two things must be true after conversion:
+
+1. The DC keeps `source: "transformed"` so the viewer's data-source info
+   card / admin panel still surfaces the recipe lineage (see also
+   ``deltatables.py:process_data_collection`` which falls through to
+   file-scan when ``source == "transformed"`` *and* ``transform is None``).
+2. ``dc_specific_properties.format`` must be ``"tsv"`` regardless of what
+   the template declared — the template's original format hint described
+   the recipe's *input* source (e.g. summary_metrics' input is a real CSV
+   from multiqc) which is irrelevant once we replace the recipe with a
+   file_scan reading the tab-separated seed.
+
+This test exists because viralrecon's template declared
+``format: "CSV"`` on 12 of 13 recipe DCs (matching the *input* CSVs the
+recipes consumed) — after PRs #765 + #767 turned on the file-scan code
+path for bundled seeds, the CSV-hint caused polars to parse the
+tab-delimited seeds with a comma separator and collapse the whole header
+row into a single column name, breaking every dashboard tile bound to
+those DCs.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from depictio.api.v1.db_init_reference_datasets import ReferenceDatasetRegistry
+
+
+def _make_template_with_recipe_dc(declared_format: str) -> dict:
+    """Build a minimal template config exercising the recipe-DC branch."""
+    return {
+        "name": "test-project",
+        "workflows": [
+            {
+                "name": "test-wf",
+                "data_collections": [
+                    {
+                        "data_collection_tag": "demo",
+                        "config": {
+                            "type": "Table",
+                            "source": "transformed",
+                            "transform": {"recipe": "test/demo.py"},
+                            "dc_specific_properties": {"format": declared_format},
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def _write_seed_tsv(data_root: Path, dc_tag: str) -> None:
+    seed = data_root / f"{dc_tag}.tsv"
+    seed.write_text("col_a\tcol_b\nv1\tv2\n")
+
+
+def test_recipe_dc_conversion_forces_tsv_format() -> None:
+    """A CSV-declared recipe DC keeps a TSV seed → format must be coerced to tsv."""
+    with tempfile.TemporaryDirectory() as td:
+        data_root = Path(td)
+        _write_seed_tsv(data_root, "demo")
+        cfg = _make_template_with_recipe_dc(declared_format="CSV")
+        resolved = ReferenceDatasetRegistry.resolve_template_for_init(cfg, str(data_root))
+
+        dcs = resolved["workflows"][0]["data_collections"]
+        assert len(dcs) == 1
+        dc_cfg = dcs[0]["config"]
+
+        assert dc_cfg["source"] == "transformed", (
+            "recipe lineage must survive conversion (viewer reads source=transformed)"
+        )
+        assert "transform" not in dc_cfg, "transform block must be popped after conversion"
+        assert dc_cfg["scan"]["mode"] == "single"
+        assert dc_cfg["scan"]["scan_parameters"]["filename"] == str(data_root / "demo.tsv")
+        assert dc_cfg["dc_specific_properties"]["format"] == "tsv", (
+            "format must be coerced to tsv so polars uses tab separator on the bundled seed; "
+            f"got {dc_cfg['dc_specific_properties']['format']!r}"
+        )
+
+
+def test_recipe_dc_conversion_drops_when_seed_missing() -> None:
+    """If `{data_root}/{dc_tag}.tsv` is absent, the DC must be pruned entirely."""
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _make_template_with_recipe_dc(declared_format="TSV")
+        resolved = ReferenceDatasetRegistry.resolve_template_for_init(cfg, td)
+        assert resolved["workflows"][0]["data_collections"] == [], (
+            "missing seed → DC dropped so workflow scan doesn't abort downstream"
+        )
+
+
+def test_recipe_dc_conversion_handles_null_dc_specific_properties() -> None:
+    """Resolver must tolerate missing dc_specific_properties block."""
+    with tempfile.TemporaryDirectory() as td:
+        data_root = Path(td)
+        _write_seed_tsv(data_root, "demo")
+        cfg = _make_template_with_recipe_dc(declared_format="CSV")
+        # Strip dc_specific_properties to simulate older template format
+        del cfg["workflows"][0]["data_collections"][0]["config"]["dc_specific_properties"]
+
+        resolved = ReferenceDatasetRegistry.resolve_template_for_init(cfg, str(data_root))
+        dc_cfg = resolved["workflows"][0]["data_collections"][0]["config"]
+        assert dc_cfg["dc_specific_properties"]["format"] == "tsv"

--- a/helm-charts/depictio/values-embl-demo-dev.yaml
+++ b/helm-charts/depictio/values-embl-demo-dev.yaml
@@ -6,35 +6,49 @@
 #   - values-embl-demo-base.yaml (EMBL infrastructure + demo mode)
 #   - values-embl-secrets.yaml (S3 credentials)
 #
-# Resource budget per namespace: ~8 CPU / 16Gi (shared 32 CPU / 64Gi across 4 namespaces)
+# Tenant quota: 32 CPU / 64 GiB / 30 pods, shared between this env and
+# values-embl-demo.yaml. Per-env target: ~6 CPU / 12 GiB requests,
+# ~14 CPU / 28 GiB limits — two envs sum to ~28 / 56 limits with margin
+# for mongo-init / wipe-job hooks.
+#
+# Celery gets the largest share because it's the advanced-viz compute
+# bottleneck — concurrency bumped to 8 (`replicas: 1` kept; multi-replica
+# celery isn't supported yet on this chart). Dash frontend slimmed because
+# the React viewer (served as static assets by the backend at
+# /dashboard-beta) is taking over.
 
 # Demo environment configuration - auto-wipe on upgrades
 demo:
   autoWipeOnUpgrade: true  # Delete PVCs before each upgrade for fresh demo state
 
-# Celery worker - handles background tasks (screenshots, figure rendering)
+# Celery worker — biggest share of the budget because it's the
+# advanced-viz compute bottleneck (volcano / heatmap / coverage_track /
+# sankey / upset / etc.). Threads pool, so the GIL doesn't bottleneck
+# polars (most compute is in C extensions).
 celery:
   enabled: true
-  replicas: 1
+  replicas: 1   # multi-replica celery not validated yet on this chart
   resources:
     requests:
-      memory: "1Gi"
-      cpu: "500m"
+      memory: "6Gi"
+      cpu: "3"
     limits:
-      memory: "3Gi"
-      cpu: "2"
+      memory: "16Gi"
+      cpu: "8"
   env:
-    DEPICTIO_CELERY_WORKERS: "2"  # Celery concurrency (parallel tasks)
+    DEPICTIO_CELERY_WORKERS: "8"  # parallel tasks per worker (was 2)
 
-# Backend API - can use multiple workers
+# Backend API — serves both Dash AJAX *and* the React viewer SPA + its
+# data-fetching endpoints (render_figure, bulk_compute_cards, …), so React
+# adoption raises backend load.
 backend:
   resources:
     requests:
-      memory: "2Gi"
-      cpu: "1"
-    limits:
       memory: "4Gi"
       cpu: "2"
+    limits:
+      memory: "8Gi"
+      cpu: "4"
   env:
     # Demo mode with guided tour tooltips
     DEPICTIO_AUTH_DEMO_MODE: "true"
@@ -51,15 +65,17 @@ backend:
     # Explicit API URL to match ingress host (for browser-based requests)
     DEPICTIO_FASTAPI_PUBLIC_URL: "https://dev.api.demo.depictio.embl.org"
 
-# Frontend Dash - LIMITED TO 1 WORKER (state_manager limitation)
+# Frontend Dash — being phased out in favour of the React viewer (served
+# from the backend container at /dashboard-beta). Halved to free budget
+# for backend + celery. Still single-worker (state_manager limitation).
 frontend:
   resources:
     requests:
-      memory: "2Gi"
-      cpu: "500m"
+      memory: "512Mi"
+      cpu: "250m"
     limits:
-      memory: "4Gi"
-      cpu: "1"  # Single worker doesn't benefit from more CPU
+      memory: "1Gi"
+      cpu: "500m"
   env:
     # Demo mode with guided tour tooltips
     DEPICTIO_AUTH_DEMO_MODE: "true"

--- a/helm-charts/depictio/values-embl-demo.yaml
+++ b/helm-charts/depictio/values-embl-demo.yaml
@@ -5,25 +5,44 @@
 #   - values.yaml (base configuration)
 #   - values-embl-demo-base.yaml (EMBL infrastructure + demo mode)
 #   - values-embl-secrets.yaml (S3 credentials)
+#
+# Tenant quota: 32 CPU / 64 GiB / 30 pods, shared with values-embl-demo-dev.yaml
+# Per-env target: ~6 CPU / 12 GiB requests, ~14 CPU / 28 GiB limits — two
+# envs sum to ~28 / 56 limits with margin for mongo-init / wipe-job hooks.
+# Same rebalance rationale as the dev env values file — see header there
+# for details.
 
 # Demo environment configuration - auto-wipe on upgrades
 demo:
   autoWipeOnUpgrade: true  # Delete PVCs before each upgrade for fresh demo state
 
-# Celery worker (enabled for background tasks)
+# Celery worker — biggest share of the budget because it's the
+# advanced-viz compute bottleneck. Threads pool so polars C-extension
+# compute scales past the GIL.
 celery:
   enabled: true
-  replicas: 1
+  replicas: 1   # multi-replica celery not validated yet on this chart
   resources:
     requests:
-      memory: "512Mi"
-      cpu: "250m"
+      memory: "6Gi"
+      cpu: "3"
     limits:
-      memory: "2Gi"
-      cpu: "1"
+      memory: "16Gi"
+      cpu: "8"
+  env:
+    DEPICTIO_CELERY_WORKERS: "8"  # parallel tasks per worker
 
-# Google Analytics - Production Tracking ID
+# Backend API — handles both Dash AJAX and the React viewer's data-fetching
+# endpoints + serves the SPA static assets. React adoption raises backend
+# load.
 backend:
+  resources:
+    requests:
+      memory: "4Gi"
+      cpu: "2"
+    limits:
+      memory: "8Gi"
+      cpu: "4"
   env:
     # Demo mode with guided tour tooltips
     DEPICTIO_AUTH_DEMO_MODE: "true"
@@ -39,7 +58,17 @@ backend:
     # Explicit API URL to match ingress host (overrides computed URL)
     DEPICTIO_FASTAPI_PUBLIC_URL: "https://api.demo.depictio.embl.org"
 
+# Frontend Dash — being phased out in favour of the React viewer (served
+# from the backend container at /dashboard-beta). Slimmed to free budget
+# for backend + celery. Still single-worker (state_manager limitation).
 frontend:
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
   env:
     # Demo mode with guided tour tooltips
     DEPICTIO_AUTH_DEMO_MODE: "true"


### PR DESCRIPTION
## Why this PR exists

After [#765](../pull/765) (fall-through to file-scan when `transform=None`) and [#767](../pull/767) (bundle viralrecon canonical seed TSVs), the file-scan code path turned on for recipe DCs on K8s. Viralrecon's template declared `dc_specific_properties.format: "CSV"` on 12 of 13 recipe DCs — those declarations described the **recipe's *input* source** (e.g. `summary_metrics` consumes a real comma-separated multiqc CSV) but the **bundled materialised seeds are tab-separated** by convention (`{data_root}/{dc_tag}.tsv`).

Result: `pl.scan_csv(summary_metrics.tsv, separator=',')` collapsed the 10-column header into one field. The deltatable landed with 3 columns instead of 12 (`['sample\tnum_reads_mapped\t...\tlineage', 'depictio_run_id', 'aggregation_time']`), and every dashboard tile bound to that DC fired:

```
polars.exceptions.ColumnNotFoundError: "pct_genome_covered_10x" not found
```

Same bug class hit `variants_long`, `manhattan_variants_canonical`, `pangolin_lineages`, `nextclade_results`, `lollipop_canonical`, `oncoplot_canonical`, `sankey_canonical`, `upset_canonical`, `variant_feature_matrix_canonical` — 4 of 5 viralrecon dashboards mostly broken.

## Why it worked locally but not on K8s

Two different code paths:

| | Code path used | Format read |
|---|---|---|
| **Local (`depictio.cli run`)** | Executes the recipe in Python, writes resulting polars DataFrame directly via `write_delta()`. | `dc_specific_properties.format` **never consulted** — schema comes from the DataFrame itself. |
| **K8s (reference init)** | Init resolver Step 5 drops the recipe, converts the DC to file_scan pointing at the bundled seed. | `pl.scan_csv(path, separator=',')` because template declared CSV — but the seed is tab-separated. |

## Fix

`depictio/api/v1/db_init_reference_datasets.py:484` — when popping `transform` and adding the `scan` block, also force `dc_specific_properties.format = "tsv"` to match the bundled seed's actual delimiter. Ampliseq already declares format=TSV everywhere → no-op for it. Single-line semantic change, ~10 lines incl. doc comment.

## Tests

`depictio/tests/api/v1/test_db_init_resolver.py` — 3 new unit tests on `ReferenceDatasetRegistry.resolve_template_for_init`:
- Format coercion: CSV-declared recipe DC → resolves with `format: "tsv"`
- DC drop when seed file missing (existing behavior preserved)
- Tolerance for missing `dc_specific_properties` block (older template shape)

Verified end-to-end against the real viralrecon template — all 12 recipe DCs now resolve with `fmt=tsv`, native scan DCs (mosdepth, multiqc) untouched.

## Test plan

- [x] `pytest depictio/tests/api/v1/test_db_init_resolver.py` — 3 passed
- [x] `pytest depictio/tests/api/v1/test_reference_seed_dashboards.py` — 34 passed (existing seed invariants still green)
- [ ] CI green
- [ ] After merge + v0.13.6 bump + devdemo redeploy (clean S3 bucket): `mongosh db.deltatables.find({data_collection_id: ObjectId("746b0f3c1e4a2d7f8e5b9c11")})` returns rows with the full 12-column schema
- [ ] Variants / Lineage / Sample QC viralrecon dashboards render without `ColumnNotFoundError`