### PR TITLE
fix(deltatables): use positional indexing in precompute_columns_specs

### DIFF
--- a/depictio/api/v1/endpoints/deltatables_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/deltatables_endpoints/utils.py
@@ -173,9 +173,27 @@ def precompute_columns_specs(aggregated_df: pl.DataFrame, agg_functions: dict, d
                 else:
                     continue
 
-                result = result.values if isinstance(result, np.ndarray) else result
-                if method_name == "mode" and isinstance(result.values, np.ndarray):
-                    result = result[0]
+                # Normalize the pandas method's return:
+                # - .mode() returns a pd.Series (possibly empty, possibly with
+                #   a non-RangeIndex when the aggregated df was reindexed); we
+                #   want the first tied mode by position.
+                # - .mean() / .median() / .min() / .max() etc. return scalars.
+                # - .unique() returns an ndarray.
+                # Previous code did ``result[0]`` for the mode branch, which is
+                # LABEL-based indexing on a pd.Series and raised KeyError(0)
+                # any time the Series index didn't contain 0 — e.g. viralrecon
+                # pangolin_lineages, which has sparse string columns whose
+                # aggregated-df modes carry a non-default index. The whole
+                # deltatable upsert aborted, leaving every dashboard tile
+                # bound to that DC stuck on 404.
+                if hasattr(result, "iloc"):  # pd.Series
+                    if len(result) == 0:
+                        continue  # nothing to record for this method
+                    result = result.iloc[0]
+                elif isinstance(result, np.ndarray):
+                    if result.size == 0:
+                        continue
+                    result = result.flat[0]
                 tmp_dict["specs"][str(method_name)] = numpy_to_python(result)
 
         results.append(tmp_dict)

--- a/depictio/tests/api/v1/test_precompute_columns_specs.py
+++ b/depictio/tests/api/v1/test_precompute_columns_specs.py
@@ -1,0 +1,126 @@
+"""Invariants on ``precompute_columns_specs`` — the per-column spec
+builder run during Delta-table upsert.
+
+The previous code used ``result[0]`` after computing ``.mode()`` on each
+column, which is *label-based* pandas indexing. For viralrecon's
+``pangolin_lineages`` DC several columns are sparse strings whose mode,
+computed on the already-aggregated dataframe, comes back with a
+non-default index — so ``result[0]`` raised ``KeyError(0)`` and aborted
+the whole upsert. That left the dashboard tiles bound to that DC stuck
+on 404 because the deltatables collection never got a record written.
+
+These tests pin the positional-indexing behaviour and cover empty /
+non-default-index edge cases so the regression doesn't come back.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import polars as pl
+
+from depictio.api.v1.endpoints.deltatables_endpoints.utils import precompute_columns_specs
+
+_AGG_FUNCTIONS = {
+    "object": {
+        "card_methods": {
+            "mode": {"pandas": "mode"},
+            "count": {"pandas": "count"},
+            "nunique": {"pandas": "nunique"},
+        }
+    },
+    "str": {
+        # polars→pandas conversion can produce ``str``/``string`` dtypes; alias.
+        "card_methods": {
+            "mode": {"pandas": "mode"},
+            "count": {"pandas": "count"},
+            "nunique": {"pandas": "nunique"},
+        }
+    },
+}
+
+
+def _dc_data() -> dict:
+    return {"config": {"dc_specific_properties": {}}}
+
+
+def test_mode_with_default_index() -> None:
+    """The original happy path: mode returns a Series with RangeIndex starting at 0."""
+    df = pl.DataFrame({"lineage": ["A", "A", "B", "A"]})
+    [spec] = precompute_columns_specs(df, _AGG_FUNCTIONS, _dc_data())
+    assert spec["specs"]["mode"] == "A"
+    assert spec["specs"]["count"] == 4
+    assert spec["specs"]["nunique"] == 2
+
+
+def test_mode_with_non_default_index_does_not_raise(monkeypatch) -> None:
+    """The bug reproducer: aggregated df has a non-default index after to_pandas().
+
+    Before the fix this raised ``KeyError(0)`` and the entire upsert
+    aborted, taking the whole dashboard with it. We patch ``to_pandas``
+    to inject the non-default index that the live aggregation pipeline
+    actually produces for sparse string columns.
+    """
+    df = pl.DataFrame({"lineage": ["B.1.1.7", "B.1.1.7", "Unassigned"]})
+    real_to_pandas = pl.DataFrame.to_pandas
+
+    def to_pandas_with_offset_index(self, *a, **kw):  # type: ignore[no-untyped-def]
+        out = real_to_pandas(self, *a, **kw)
+        out.index = pd.RangeIndex(start=10, stop=10 + len(out))
+        return out
+
+    monkeypatch.setattr(pl.DataFrame, "to_pandas", to_pandas_with_offset_index)
+    [spec] = precompute_columns_specs(df, _AGG_FUNCTIONS, _dc_data())
+    assert spec["specs"]["mode"] == "B.1.1.7"
+
+
+def test_empty_column_does_not_crash() -> None:
+    """An empty column emits count=0 without raising, mode entry skipped."""
+    df = pl.DataFrame({"empty_col": pl.Series([], dtype=pl.Utf8)})
+    [spec] = precompute_columns_specs(df, _AGG_FUNCTIONS, _dc_data())
+    assert spec["specs"]["count"] == 0
+    # Mode on an empty series returns an empty Series → guard skips it.
+    assert "mode" not in spec["specs"]
+
+
+def test_pangolin_lineages_shape_does_not_raise() -> None:
+    """Smoke test matching the bundled pangolin_lineages.tsv shape:
+    44 rows, sparse string columns (many empty), non-trivial mode targets.
+    """
+    rows = [
+        {
+            "sample": f"SAMPLE_{i:02d}",
+            "lineage": "B.1.1.7" if i % 2 else "Unassigned",
+            "scorpio_call": "Alpha (B.1.1.7-like)" if i % 2 else "",
+            "scorpio_notes": "",
+            "note": "",
+            "qc_status": "pass" if i % 2 else "fail",
+        }
+        for i in range(44)
+    ]
+    df = pl.from_dicts(rows)
+    specs = precompute_columns_specs(df, _AGG_FUNCTIONS, _dc_data())
+    assert len(specs) == len(df.columns)
+    by_name = {s["name"]: s for s in specs}
+    assert by_name["lineage"]["specs"]["mode"] in ("B.1.1.7", "Unassigned")
+    assert by_name["qc_status"]["specs"]["mode"] in ("pass", "fail")
+
+
+def test_ndarray_result_uses_positional_indexing() -> None:
+    """When pandas_method is callable and returns ndarray, positional
+    indexing must still work — protects the symmetric branch in the fix."""
+    agg_with_callable = {
+        "object": {
+            "card_methods": {
+                "first_unique": {"pandas": lambda s: np.array([s.iloc[0]])},
+            }
+        },
+        "str": {
+            "card_methods": {
+                "first_unique": {"pandas": lambda s: np.array([s.iloc[0]])},
+            }
+        },
+    }
+    df = pl.DataFrame({"col": ["x", "y"]})
+    [spec] = precompute_columns_specs(df, agg_with_callable, _dc_data())
+    assert spec["specs"]["first_unique"] == "x"


### PR DESCRIPTION
## Symptom

On devdemo (v0.13.6) the viralrecon **Lineage & Clustering** dashboard showed:
- **Unique Lineages** card → empty
- **Pangolin lineage distribution** figure → \`Failed to render figure: 500\`

## Root cause

\`deltatables_endpoints/utils.py:178\` (mode branch in \`precompute_columns_specs\`) did:

\`\`\`python
if method_name == "mode" and isinstance(result.values, np.ndarray):
    result = result[0]
\`\`\`

\`result[0]\` is **label-based** pandas indexing on a \`pd.Series\`. For columns whose post-aggregation dataframe carries a non-default \`RangeIndex\` (viralrecon's \`pangolin_lineages\` is the live offender — sparse string columns like \`scorpio_notes\`, \`note\`, \`conflict\` end up indexed offset from 0), \`result[0]\` raised \`KeyError(0)\` and aborted the entire Delta-table upsert.

Knock-on: the \`deltatables\` mongo collection never got a record for pangolin_lineages (DC \`746b0f3c1e4a2d7f8e5b9c14\`), so every render endpoint querying it returned \`404 Not Found\`, surfacing as the empty card + 500 figure.

\`\`\`
File "/app/depictio/api/v1/endpoints/deltatables_endpoints/utils.py", line 178
    result = result[0]
File "/app/.venv/.../pandas/core/series.py", line 1121, in __getitem__
    return self._get_value(key)
...
KeyError: 0
\`\`\`

## Fix

Switch to positional indexing — \`result.iloc[0]\` for \`pd.Series\`, \`result.flat[0]\` for ndarray — and skip silently when the result is empty (fully-null columns). Single-block change in \`precompute_columns_specs\`, ~10 lines.

## Tests

5 new unit tests in \`test_precompute_columns_specs.py\`:
- \`test_mode_with_default_index\` — happy path
- \`test_mode_with_non_default_index_does_not_raise\` — bug reproducer via monkeypatched \`to_pandas\`
- \`test_empty_column_does_not_crash\` — empty Series → mode skipped, count still emitted
- \`test_pangolin_lineages_shape_does_not_raise\` — 44-row sparse-string smoke test mirroring the live DC
- \`test_ndarray_result_uses_positional_indexing\` — symmetric ndarray branch in the fix

All 5 passed locally.

## Test plan

- [ ] CI green
- [ ] After merge + v0.13.7 bump + devdemo redeploy: \`mongosh db.deltatables.countDocuments({data_collection_id: ObjectId("746b0f3c1e4a2d7f8e5b9c14")})\` returns 1 (was 0)
- [ ] Pangolin lineage distribution renders, Unique Lineages card shows count