### PR TITLE
fix(screenshots): honour dashboard-level owners after duplication

### DIFF
--- a/depictio/api/v1/services/screenshot_service.py
+++ b/depictio/api/v1/services/screenshot_service.py
@@ -16,7 +16,7 @@ without dragging the MongoDB-backed token loader along.
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from bson import ObjectId
 from playwright.async_api import Page, async_playwright
@@ -59,29 +59,31 @@ class ScreenshotResult(TypedDict):
 
 def check_dashboard_owner_permission_sync(dashboard_id: str, user_id: str) -> bool:
     """
-    Check if user is the owner of a dashboard (via project ownership).
+    Check if user is the owner of a dashboard.
+
+    Looks at dashboard-level ``permissions.owners`` first — duplication
+    assigns the new owner there while keeping ``project_id`` pointing at
+    the original project, so a project-only check denies legitimate
+    copies. Falls back to the parent project's owners when the dashboard
+    has no per-dashboard owners (e.g. seeded dashboards).
 
     Uses synchronous MongoDB operations (pymongo). Safe to call from both
     sync contexts (Dash callbacks) and async contexts (via the async wrapper).
-
-    Args:
-        dashboard_id: Dashboard ObjectId as string
-        user_id: User ObjectId as string
-
-    Returns:
-        True if user owns dashboard, False otherwise
     """
     try:
-        # Convert dashboard_id string to ObjectId for MongoDB query
         dashboard_oid = ObjectId(dashboard_id)
         dashboard = dashboards_collection.find_one({"dashboard_id": dashboard_oid})
         if not dashboard:
             logger.warning(f"Dashboard not found: {dashboard_id}")
             return False
 
+        user_obj_id = ObjectId(user_id)
+
+        if _any_owner_matches(dashboard.get("permissions", {}).get("owners"), user_obj_id):
+            return True
+
         project_id = dashboard.get("project_id")
         if not project_id:
-            logger.warning(f"Dashboard {dashboard_id} has no project_id")
             return False
 
         project = projects_collection.find_one({"_id": ObjectId(project_id)})
@@ -89,13 +91,35 @@ def check_dashboard_owner_permission_sync(dashboard_id: str, user_id: str) -> bo
             logger.warning(f"Project not found: {project_id}")
             return False
 
-        owners = project.get("permissions", {}).get("owners", [])
-        user_obj_id = ObjectId(user_id)
-        return any(owner.get("_id") == user_obj_id for owner in owners)
+        return _any_owner_matches(project.get("permissions", {}).get("owners"), user_obj_id)
 
     except Exception as e:
         logger.error(f"Error checking dashboard ownership: {e}")
         return False
+
+
+def _any_owner_matches(owners: object, user_obj_id: ObjectId) -> bool:
+    """Return True if any owner record matches ``user_obj_id``.
+
+    Tolerates both ``ObjectId`` and string forms of the owner's ``_id``.
+    """
+    if not isinstance(owners, list):
+        return False
+    for owner_obj in owners:
+        if not isinstance(owner_obj, dict):
+            continue
+        owner = cast(dict[str, object], owner_obj)
+        raw = owner.get("_id")
+        if isinstance(raw, ObjectId):
+            if raw == user_obj_id:
+                return True
+        elif isinstance(raw, str):
+            try:
+                if ObjectId(raw) == user_obj_id:
+                    return True
+            except Exception:
+                continue
+    return False
 
 
 async def check_dashboard_owner_permission(dashboard_id: str, user_id: str) -> bool:

--- a/depictio/tests/api/v1/test_screenshot_owner_check.py
+++ b/depictio/tests/api/v1/test_screenshot_owner_check.py
@@ -1,0 +1,154 @@
+"""Regression tests for ``check_dashboard_owner_permission_sync``.
+
+Dashboard duplication assigns the new owner at the **dashboard** level
+(``dashboard.permissions.owners``) while keeping ``project_id`` pointing
+at the original project. The screenshot service previously consulted
+only the project's owners, so the celery screenshot task denied every
+duplicated dashboard with::
+
+    Screenshot denied: user <copier> is not owner of dashboard <copy>
+
+These tests pin the new behaviour: dashboard-level owners win, with a
+fallback to project owners for seeded dashboards that don't carry their
+own owner list.
+"""
+
+from __future__ import annotations
+
+from bson import ObjectId
+
+from depictio.api.v1.services import screenshot_service
+
+
+def _user_doc(user_id: ObjectId) -> dict:
+    return {"_id": user_id, "email": f"user-{user_id}@example.com"}
+
+
+def _stub_collections(monkeypatch, *, dashboard: dict | None, project: dict | None) -> None:
+    class _Coll:
+        def __init__(self, doc):
+            self.doc = doc
+
+        def find_one(self, _query):
+            return self.doc
+
+    monkeypatch.setattr(screenshot_service, "dashboards_collection", _Coll(dashboard))
+    monkeypatch.setattr(screenshot_service, "projects_collection", _Coll(project))
+
+
+def test_dashboard_level_owner_grants_access(monkeypatch) -> None:
+    """Duplicated dashboard: owner is on the dashboard, NOT on the project."""
+    copier = ObjectId()
+    original_owner = ObjectId()
+    project_id = ObjectId()
+    dashboard_id = ObjectId()
+
+    dashboard = {
+        "dashboard_id": dashboard_id,
+        "project_id": project_id,
+        "permissions": {"owners": [_user_doc(copier)]},
+    }
+    project = {
+        "_id": project_id,
+        "permissions": {"owners": [_user_doc(original_owner)]},
+    }
+    _stub_collections(monkeypatch, dashboard=dashboard, project=project)
+
+    assert (
+        screenshot_service.check_dashboard_owner_permission_sync(str(dashboard_id), str(copier))
+        is True
+    )
+
+
+def test_project_level_fallback_for_seeded_dashboard(monkeypatch) -> None:
+    """Seeded dashboards have no dashboard-level owners — project owners still grant access."""
+    project_owner = ObjectId()
+    project_id = ObjectId()
+    dashboard_id = ObjectId()
+
+    dashboard = {
+        "dashboard_id": dashboard_id,
+        "project_id": project_id,
+        "permissions": {"owners": []},
+    }
+    project = {
+        "_id": project_id,
+        "permissions": {"owners": [_user_doc(project_owner)]},
+    }
+    _stub_collections(monkeypatch, dashboard=dashboard, project=project)
+
+    assert (
+        screenshot_service.check_dashboard_owner_permission_sync(
+            str(dashboard_id), str(project_owner)
+        )
+        is True
+    )
+
+
+def test_unrelated_user_is_denied(monkeypatch) -> None:
+    """User who is neither dashboard-owner nor project-owner gets denied."""
+    dashboard_owner = ObjectId()
+    project_owner = ObjectId()
+    stranger = ObjectId()
+    project_id = ObjectId()
+    dashboard_id = ObjectId()
+
+    dashboard = {
+        "dashboard_id": dashboard_id,
+        "project_id": project_id,
+        "permissions": {"owners": [_user_doc(dashboard_owner)]},
+    }
+    project = {
+        "_id": project_id,
+        "permissions": {"owners": [_user_doc(project_owner)]},
+    }
+    _stub_collections(monkeypatch, dashboard=dashboard, project=project)
+
+    assert (
+        screenshot_service.check_dashboard_owner_permission_sync(str(dashboard_id), str(stranger))
+        is False
+    )
+
+
+def test_owner_id_stored_as_string(monkeypatch) -> None:
+    """Some import paths serialise ``_id`` as a string — must still match."""
+    copier = ObjectId()
+    project_id = ObjectId()
+    dashboard_id = ObjectId()
+
+    dashboard = {
+        "dashboard_id": dashboard_id,
+        "project_id": project_id,
+        "permissions": {"owners": [{"_id": str(copier), "email": "x@example.com"}]},
+    }
+    project = {"_id": project_id, "permissions": {"owners": []}}
+    _stub_collections(monkeypatch, dashboard=dashboard, project=project)
+
+    assert (
+        screenshot_service.check_dashboard_owner_permission_sync(str(dashboard_id), str(copier))
+        is True
+    )
+
+
+def test_missing_dashboard_returns_false(monkeypatch) -> None:
+    _stub_collections(monkeypatch, dashboard=None, project=None)
+    assert (
+        screenshot_service.check_dashboard_owner_permission_sync(str(ObjectId()), str(ObjectId()))
+        is False
+    )
+
+
+def test_dashboard_with_no_project_id_and_no_owners(monkeypatch) -> None:
+    """Edge case: orphaned dashboard with no project_id and no owners."""
+    dashboard = {
+        "dashboard_id": ObjectId(),
+        "permissions": {"owners": []},
+    }
+    _stub_collections(monkeypatch, dashboard=dashboard, project=None)
+
+    assert (
+        screenshot_service.check_dashboard_owner_permission_sync(
+            str(dashboard["dashboard_id"]), str(ObjectId())
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
- Dashboard duplication writes the new owner into `dashboard.permissions.owners` and keeps the original `project_id`, but the screenshot ownership check only consulted the **project's** owners. Every screenshot job on a duplicated dashboard was denied with `Screenshot denied: user <copier> is not owner of dashboard <copy>` — so duplicates never got fresh thumbnails generated.
- `check_dashboard_owner_permission_sync` now checks the dashboard's own owner list first and falls back to the parent project's owners for seeded dashboards.
- Added a regression test module (`test_screenshot_owner_check.py`, 6 cases) covering duplicates, seed-style fallback, stranger denial, string-form `_id`, missing dashboard, and orphan dashboards.

## Test plan
- [x] `pytest depictio/tests/api/v1/test_screenshot_owner_check.py -xvs` — 6/6 pass
- [x] `ruff check` + `ruff format` clean on touched files
- [x] `ty check depictio/api/v1/services/screenshot_service.py` clean
- [ ] Duplicate a seeded dashboard on devdemo, confirm the celery screenshot job writes new `_light.png`/`_dark.png` instead of logging `Screenshot denied`