### PR TITLE
ci: add repackage-helm-chart workflow to overwrite OCI tag contents

### DIFF
--- a/.github/workflows/repackage-helm-chart.yaml
+++ b/.github/workflows/repackage-helm-chart.yaml
@@ -1,0 +1,82 @@
+name: Repackage Helm Chart (overwrite OCI tag with rebuilt contents)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: "OCI tag to overwrite in GHCR (e.g. 20260507.1). The chart will be repackaged from the chosen ref and pushed here."
+        required: true
+        type: string
+      chart_ref:
+        description: "Git ref (branch / tag / sha) to package the chart from. values.yaml at this ref dictates the image tags inside the chart."
+        required: true
+        default: "main"
+        type: string
+      app_version:
+        description: "Override Chart.yaml appVersion (e.g. 0.13.7). Leave empty to keep whatever the ref already has."
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  CHART_NAME: depictio-helm
+
+jobs:
+  repackage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout chart ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.chart_ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Log in to Container Registry (helm + oras)
+        run: |
+          echo "${{ secrets.GHCR_PAT }}" | helm registry login "${{ env.REGISTRY }}" \
+            --username "${{ github.repository_owner }}" \
+            --password-stdin
+          echo "${{ secrets.GHCR_PAT }}" | oras login "${{ env.REGISTRY }}" \
+            --username "${{ github.repository_owner }}" \
+            --password-stdin
+
+      - name: Show values.yaml image refs that will be embedded
+        run: |
+          echo "Packaging from ref: ${{ inputs.chart_ref }}"
+          grep -nE 'repository:|tag:' helm-charts/depictio/values.yaml | head -40
+
+      - name: Package chart with overridden version
+        run: |
+          APP_VERSION_FLAG=""
+          if [ -n "${{ inputs.app_version }}" ]; then
+            APP_VERSION_FLAG="--app-version ${{ inputs.app_version }}"
+          fi
+
+          helm package ./helm-charts/depictio \
+            --version "${{ inputs.target_tag }}" \
+            ${APP_VERSION_FLAG} \
+            --destination /tmp/chart
+
+          ls -la /tmp/chart
+
+      - name: Push chart (overwrites target tag)
+        run: |
+          REPO_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          helm push "/tmp/chart/depictio-${{ inputs.target_tag }}.tgz" \
+            "oci://${{ env.REGISTRY }}/${REPO_OWNER_LOWER}/${{ env.CHART_NAME }}"
+
+      - name: Verify new digest under target tag
+        run: |
+          REPO_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          REF="${{ env.REGISTRY }}/${REPO_OWNER_LOWER}/${{ env.CHART_NAME }}/depictio:${{ inputs.target_tag }}"
+          echo "Resolved digest for ${REF}:"
+          oras resolve "${REF}"


### PR DESCRIPTION
## Summary

Adds a manually-triggered workflow `.github/workflows/repackage-helm-chart.yaml` that repackages the Helm chart from a chosen git ref and pushes it to an existing OCI tag in GHCR, **overwriting** the previous manifest.

### Why

`tag-helm-chart.yaml` only adds an alias to an existing manifest — it cannot update what a published tag *contains*. There are cases where a published OCI tag (e.g. `20260507.1`) is already referenced by collaborators' production Kubernetes manifests and must keep its name, but its embedded image references need to be bumped (e.g. `ghcr.io/depictio/depictio:0.11.2` → `:0.13.7`). This workflow covers that case explicitly and auditably.

### How it works

Inputs:
- `target_tag` — OCI tag to overwrite (e.g. `20260507.1`)
- `chart_ref` — git ref to package from (default: `main`). Whatever `values.yaml` says at this ref is what ends up in the chart.
- `app_version` *(optional)* — override `Chart.yaml`'s `appVersion` at package time without editing the file in git (uses `helm package --app-version`).

Steps: checkout ref → install helm + oras → login to GHCR with `GHCR_PAT` → log the `values.yaml` image refs being embedded → `helm package . --version <target_tag> [--app-version ...]` → `helm push` → `oras resolve` to verify the new digest.

### Intended usage flow

1. Run **Repackage Helm Chart** with e.g. `target_tag=20260507.1`, `chart_ref=main`, `app_version=0.13.7`.
2. Confirm the printed digest changed.
3. Re-run **Tag Helm Chart** (`source_tag=20260507.1`, `additional_tag=0.13.7`) so the `0.13.7` alias also points to the new manifest — kept as a separate step so the alias operation stays explicit.

### Notes

- OCI tag mutation is intentionally a separate workflow from the alias-only `tag-helm-chart.yaml` — different blast radius, different audit story.
- Existing in-cluster releases are not affected until `helm upgrade` is run by users of that tag.
- Permissions: `contents: read`, `packages: write`. Uses the existing `GHCR_PAT` secret.

## Test plan

- [ ] Merge to `main` so the workflow appears in the Actions UI dropdown (`workflow_dispatch` requires the file on the default branch).
- [ ] Trigger with `target_tag=20260507.1`, `chart_ref=main`, `app_version=0.13.7`.
- [ ] Verify the workflow log prints `values.yaml` image refs pinned to `0.13.7`.
- [ ] Verify `oras resolve` at the end prints a digest different from `sha256:b3fb8bc327ca8419080844bba19f62cb290be4d97080d88eed0203ce67411222`.
- [ ] `helm pull oci://ghcr.io/depictio/depictio-helm/depictio --version 20260507.1 --untar` locally and confirm `Chart.yaml: appVersion: 0.13.7` and `values.yaml` backend/frontend `tag: "0.13.7"`.
- [ ] Re-run `tag-helm-chart.yaml` (`20260507.1` → `0.13.7`) to bring the alias in sync, then `oras resolve` both tags and confirm they match.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvCf1JtARyRvSVGPoryxsi)_