### PR TITLE
fix(react-viewer): correct import endpoint URL and per-project timestamps

### DIFF
--- a/depictio/models/models/deltatables.py
+++ b/depictio/models/models/deltatables.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from depictio.models.models.base import MongoModel, PyObjectId
 from depictio.models.models.users import UserBase
@@ -35,7 +35,7 @@ class DeltaTableColumn(BaseModel):
 
 
 class Aggregation(MongoModel):
-    aggregation_time: datetime = datetime.now()
+    aggregation_time: datetime = Field(default_factory=datetime.now)
     aggregation_by: UserBase
     aggregation_version: int = 1
     aggregation_hash: str

--- a/depictio/models/models/files.py
+++ b/depictio/models/models/files.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from depictio.models.config import DEPICTIO_CONTEXT
 from depictio.models.models.base import MongoModel, PyObjectId
@@ -21,7 +21,9 @@ class File(MongoModel):
     run_id: PyObjectId | str | None = None
     run_tag: str | None = None
     data_collection_id: PyObjectId
-    registration_time: str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    registration_time: str = Field(
+        default_factory=lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
     file_hash: str
     filesize: int
     permissions: Permission

--- a/depictio/models/models/projects.py
+++ b/depictio/models/models/projects.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Literal
 
 from beanie import Document
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from depictio.models.config import DEPICTIO_CONTEXT
 from depictio.models.logging import logger
@@ -35,7 +35,9 @@ class Project(MongoModel):
     permissions: Permission
     is_public: bool = False
     hash: str | None = None
-    registration_time: str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    registration_time: str = Field(
+        default_factory=lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
     project_type: Literal["basic", "advanced"] = "basic"
     realtime: RealtimeConfig | None = None  # Optional real-time event configuration
     template_origin: TemplateOrigin | None = None  # Tracks if project was created from a template

--- a/depictio/models/models/workflows.py
+++ b/depictio/models/models/workflows.py
@@ -75,7 +75,7 @@ class WorkflowConfig(MongoModel):
 class WorkflowRunScan(BaseModel):
     stats: dict[str, int]
     files_id: dict[str, list[PyObjectId]]
-    scan_time: str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    scan_time: str = Field(default_factory=lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
     dc_stats: Optional[Dict[str, Dict[str, int]]] = None  # Per-data-collection stats
 
 
@@ -87,7 +87,9 @@ class WorkflowRun(MongoModel):
     run_location: str
     creation_time: str
     last_modification_time: str
-    registration_time: str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    registration_time: str = Field(
+        default_factory=lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
     run_hash: str = ""
     scan_results: list[WorkflowRunScan] | None = []
     permissions: Permission
@@ -241,7 +243,9 @@ class Workflow(MongoModel):
     runs: dict[str, WorkflowRun] | None = dict()
     config: WorkflowConfig | None = Field(default_factory=WorkflowConfig)
     data_location: WorkflowDataLocation
-    registration_time: str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    registration_time: str = Field(
+        default_factory=lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
 
     @field_validator("version", mode="before")
     def validate_version(cls, value):

--- a/depictio/viewer/src/projects/CreateProjectModal.tsx
+++ b/depictio/viewer/src/projects/CreateProjectModal.tsx
@@ -112,10 +112,7 @@ const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
     try {
       await onImport(importFile, overwrite);
     } catch (err) {
-      setError(
-        (err as Error).message ||
-          'Failed to import project. The /projects/import endpoint may not yet be available.',
-      );
+      setError((err as Error).message || 'Failed to import project.');
     } finally {
       setSubmitting(false);
     }
@@ -354,14 +351,6 @@ const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
                 onChange={(e) => setOverwrite(e.currentTarget.checked)}
                 color="teal"
               />
-              <Alert
-                color="yellow"
-                variant="light"
-                icon={<Icon icon="mdi:information-outline" width={18} />}
-              >
-                The /projects/import endpoint is not yet wired on the backend.
-                Submitting will fail until that endpoint lands.
-              </Alert>
               {error && (
                 <Alert color="red" variant="light">
                   {error}

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -2216,8 +2216,8 @@ export async function updateProjectPermissions(
 }
 
 /** Upload a project .zip and create the project from its contents.
- *  ⚠️ Backend endpoint POST /projects/import does NOT exist yet — this client
- *  function is staged for when it lands. Until then, calls will 404. */
+ *  Hits the migrate router's import-project-zip endpoint (the sibling of
+ *  exportProjectZip's /migrate/export-project below). */
 export async function importProjectZip(
   file: File,
   overwrite: boolean,
@@ -2230,7 +2230,7 @@ export async function importProjectZip(
   // shared authHeaders() to avoid corrupting the multipart frame.
   const headers = { ...authHeaders() } as Record<string, string>;
   delete headers['Content-Type'];
-  const res = await fetch(`${API_BASE}/projects/import?${params}`, {
+  const res = await fetch(`${API_BASE}/migrate/import-project-zip?${params}`, {
     method: 'POST',
     headers,
     body: formData,


### PR DESCRIPTION
## Summary

Fixes two React-viewer bugs reported during project import and project listing:

- **Import 404** — the React `importProjectZip` client was POSTing to a non-existent `/projects/import` path. Repointed it at the real backend route `/migrate/import-project-zip` (sibling of the export endpoint), and dropped the now-obsolete *"endpoint not yet wired"* warning Alert in the import modal.
- **Inaccurate creation timestamps** — bare class-level `datetime.now()` defaults were evaluated once at module import, so every newly created/imported record shared the same timestamp. Replaced with `Field(default_factory=...)` across the project, workflow, file, and deltatable (aggregation) models so each instance gets its own creation time.

## Files changed

- `packages/depictio-react-core/src/api.ts` — correct import endpoint URL
- `depictio/viewer/src/projects/CreateProjectModal.tsx` — remove stale "not wired" Alert
- `depictio/models/models/projects.py`, `workflows.py`, `files.py`, `deltatables.py` — `Field(default_factory=...)` timestamp defaults

## Notes

- Timestamp fix only affects newly created/imported records; existing DB rows are unchanged.
- Verified live: import now returns `200 OK`; new projects show distinct creation times in `/projects-beta`.

## Test plan

- [x] Import a project `.zip` through the React interface → succeeds (no 404)
- [x] Create/import multiple projects → each shows its own creation timestamp
- [x] `ruff format --check` and `ruff check` pass on the edited model files
