### PR TITLE
fix(builder): viz suggestion precision + text-step skip + screenshot regen on Save

### DIFF
--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -614,6 +614,7 @@ async def edit_dashboard(
 async def save_dashboard(
     dashboard_id: PyObjectId,
     data: DashboardData,
+    force_screenshot: bool = False,
     current_user: User = Depends(get_user_or_anonymous),
 ):
     """Check if an entry with the same dashboard_id exists, if not, insert, if yes, update."""
@@ -626,6 +627,16 @@ async def save_dashboard(
             )
 
     existing_dashboard = dashboards_collection.find_one({"dashboard_id": dashboard_id})
+
+    # Bump server-side so the dashboard listing's `?v=last_saved_ts` cache-bust
+    # actually advances on every save. The React client persists whatever it
+    # last loaded, which leaves the timestamp frozen between editor sessions —
+    # browsers then keep showing the stale thumbnail PNG. (The Dash save path
+    # bumps the same field; see dashboards_endpoints/routes.py:3705 etc.)
+    from datetime import datetime
+
+    save_payload = data.mongo()
+    save_payload["last_saved_ts"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     if existing_dashboard:
         project_id = existing_dashboard.get("project_id")
@@ -641,13 +652,13 @@ async def save_dashboard(
 
         result = dashboards_collection.find_one_and_update(
             {"dashboard_id": dashboard_id},
-            {"$set": data.mongo()},
+            {"$set": save_payload},
             return_document=True,
         )
     else:
         result = dashboards_collection.find_one_and_update(
             {"dashboard_id": dashboard_id},
-            {"$set": data.mongo()},
+            {"$set": save_payload},
             upsert=True,
             return_document=True,
         )
@@ -665,18 +676,29 @@ async def save_dashboard(
 
         # Auto-queue screenshot regeneration so /dashboards-beta and any
         # other listing surface picks up the latest dashboard state.
-        # Guarded by `_should_enqueue_screenshot` to avoid the celery
-        # queue storm every React viewer interaction otherwise creates.
+        # The `_should_enqueue_screenshot` debounce throttles implicit
+        # auto-saves (drag/resize/rename produce a save burst each); an
+        # explicit Save click passes `force_screenshot=true` to bypass
+        # the 1h window and always regenerate.
         try:
-            if _should_enqueue_screenshot(dashboard_id_str):
+            if force_screenshot or _should_enqueue_screenshot(dashboard_id_str):
                 # Lazy import keeps API startup independent of the Dash
                 # worker module; broad except so a Celery/broker outage
                 # never breaks the save response itself.
                 from depictio.dash.celery_app import generate_dashboard_screenshot_dual
 
                 user_id = str(getattr(current_user, "id", "") or "")
-                generate_dashboard_screenshot_dual.delay(dashboard_id_str, user_id)
-                logger.debug(f"Queued screenshot regeneration for dashboard {dashboard_id_str}")
+                # `force=True` on explicit Save also bypasses the celery
+                # task's own active-task dedup, so a Save mid-Playwright
+                # doesn't silently drop the new state.
+                generate_dashboard_screenshot_dual.delay(
+                    dashboard_id_str, user_id, force=force_screenshot
+                )
+                logger.debug(
+                    "Queued screenshot regeneration for dashboard %s (force=%s)",
+                    dashboard_id_str,
+                    force_screenshot,
+                )
             else:
                 logger.debug(
                     f"Skipping screenshot enqueue for {dashboard_id_str} — recent PNG exists"

--- a/depictio/dash/celery_app.py
+++ b/depictio/dash/celery_app.py
@@ -65,7 +65,9 @@ def generate_dashboard_screenshot(self, dashboard_id: str) -> dict:
 @celery_app.task(
     bind=True, name="generate_dashboard_screenshot_dual", soft_time_limit=600, time_limit=900
 )
-def generate_dashboard_screenshot_dual(self, dashboard_id: str, user_id: str) -> dict:
+def generate_dashboard_screenshot_dual(
+    self, dashboard_id: str, user_id: str, force: bool = False
+) -> dict:
     """
     Generate dual-theme dashboard screenshots asynchronously with deduplication
     and permission validation.
@@ -75,15 +77,19 @@ def generate_dashboard_screenshot_dual(self, dashboard_id: str, user_id: str) ->
     output filenames stay `{id}_light.png` / `{id}_dark.png` so existing
     dashboard-card consumers keep working unchanged.
 
-    Task signature is preserved (callers in `depictio/dash/layouts/save.py`
-    and `depictio/api/v1/endpoints/dashboards_endpoints/routes.py` don't
-    change). The Dash-targeted body lives at
-    `screenshot_service.generate_dual_theme_screenshots` for emergency
-    rollback only.
+    Task signature is preserved for the original (id, user_id) positional
+    pair. The optional `force` flag was added so explicit Save clicks can
+    bypass the active-task dedup — otherwise a second Save during the ~10s
+    Playwright render is silently dropped and the PNG reflects only the
+    first save's state.
 
     Args:
         dashboard_id: The dashboard ID to screenshot.
         user_id: The user ID requesting the screenshot (for permission validation).
+        force: When True, skip the active-task dedup check. Set by explicit
+            Save clicks (see `dashboards_endpoints/routes.py:save_dashboard`)
+            so the latest state always wins. Auto-save callers omit it to
+            preserve the dedup behaviour that protects against rapid bursts.
 
     Returns:
         dict with status and screenshot paths, or forbidden status if user is not owner.
@@ -100,24 +106,26 @@ def generate_dashboard_screenshot_dual(self, dashboard_id: str, user_id: str) ->
     )
     from depictio.models.models.users import TokenBeanie, UserBeanie
 
-    # Check for duplicate active tasks to avoid redundant screenshot generation
-    try:
-        inspect = celery_app.control.inspect()
-        active_tasks = inspect.active()
+    # Skip dedup on forced runs — explicit Save needs the just-saved state
+    # captured, even if a previous render is still mid-Playwright.
+    if not force:
+        try:
+            inspect = celery_app.control.inspect()
+            active_tasks = inspect.active()
 
-        if active_tasks:
-            for _worker, tasks in active_tasks.items():
-                for task in tasks:
-                    if (
-                        task["name"] == "generate_dashboard_screenshot_dual"
-                        and task["args"] == f"('{dashboard_id}', '{user_id}')"
-                        and task["id"] != self.request.id
-                    ):
-                        raise Ignore()
-    except Ignore:
-        raise
-    except Exception as e:
-        logger.warning(f"Failed to check for duplicate tasks: {e}, proceeding with screenshot")
+            if active_tasks:
+                for _worker, tasks in active_tasks.items():
+                    for task in tasks:
+                        if (
+                            task["name"] == "generate_dashboard_screenshot_dual"
+                            and task["args"] == f"('{dashboard_id}', '{user_id}')"
+                            and task["id"] != self.request.id
+                        ):
+                            raise Ignore()
+        except Ignore:
+            raise
+        except Exception as e:
+            logger.warning(f"Failed to check for duplicate tasks: {e}, proceeding with screenshot")
 
     # Validate user owns dashboard before generating screenshot
     from depictio.api.v1.services.screenshot_service import check_dashboard_owner_permission_sync
@@ -151,6 +159,31 @@ def generate_dashboard_screenshot_dual(self, dashboard_id: str, user_id: str) ->
 
         if result["status"] == "success":
             logger.info(f"✅ Screenshots generated for dashboard {dashboard_id}")
+            # Bump `last_saved_ts` once the PNGs are on disk so the React
+            # listing's `screenshotUrl(..., last_saved_ts)` cache-buster
+            # advances. Without this, a viewer that loaded the listing while
+            # the Playwright job was still running has cached the OLD bytes
+            # against the URL the save endpoint just minted — and would never
+            # refetch until the next save bumped the timestamp again.
+            try:
+                from datetime import datetime
+
+                from depictio.api.v1.db import dashboards_collection
+
+                dashboards_collection.update_one(
+                    {"dashboard_id": dashboard_id},
+                    {
+                        "$set": {
+                            "last_saved_ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        }
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001 — non-fatal best-effort bump
+                logger.warning(
+                    "Could not bump last_saved_ts after screenshot for %s: %s",
+                    dashboard_id,
+                    exc,
+                )
             return {
                 "status": "success",
                 "dashboard_id": dashboard_id,

--- a/depictio/models/components/advanced_viz/producers.py
+++ b/depictio/models/components/advanced_viz/producers.py
@@ -1,6 +1,6 @@
 """Producer registry — known bioinformatics tool outputs and their viz affinity.
 
-Each `Producer` describes the canonical output of a specific tool (e.g.
+Each `Producer` describes the typical output of a specific tool (e.g.
 DESeq2's `results()` TSV, mosdepth's per-region BED) by:
     - a fingerprint of required column names (the smallest set that
       reliably identifies the tool's output among other tabular files);
@@ -217,15 +217,15 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         notes="Distinct from `ivar_variants_vcf`: long-form (no `#CHROM`, has `sample` per row).",
     ),
     # ------------------------------------------------------------------
-    # Canonical-schema fingerprints — match DCs whose columns already use
-    # the advanced-viz role names verbatim (i.e. files coming out of an
-    # nf-core canonical recipe, or hand-curated to match). Each producer
-    # mirrors one entry in CANONICAL_SCHEMAS where the role-name set is
+    # Role-named fingerprints — match DCs whose columns already use the
+    # advanced-viz role names verbatim (files coming out of an nf-core
+    # template recipe, or hand-curated to match). Each producer mirrors
+    # one entry in CANONICAL_SCHEMAS where the role-name set is
     # discriminating enough to fingerprint reliably.
     # ------------------------------------------------------------------
     Producer(
-        name="volcano_canonical_table",
-        tool="Canonical volcano table",
+        name="volcano_role_table",
+        tool="Volcano table",
         description="Differential-expression / abundance table with role-named columns.",
         required_columns=frozenset({"feature_id", "effect_size", "significance"}),
         feeds_viz=("volcano",),
@@ -238,8 +238,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="da_barplot_canonical_table",
-        tool="Canonical DA barplot table",
+        name="da_barplot_role_table",
+        tool="DA barplot table",
         description="Differential-abundance per-contrast log-fold-change table.",
         required_columns=frozenset({"feature_id", "contrast", "lfc"}),
         feeds_viz=("da_barplot",),
@@ -252,16 +252,16 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="manhattan_canonical_table",
-        tool="Canonical Manhattan table",
+        name="manhattan_role_table",
+        tool="Manhattan table",
         description="Genome-wide variant / association track (chr × pos × score).",
         required_columns=frozenset({"chr", "pos", "score"}),
         feeds_viz=("manhattan",),
         role_mapping={"manhattan": {"chr": "chr", "pos": "pos", "score": "score"}},
     ),
     Producer(
-        name="lollipop_canonical_table",
-        tool="Canonical lollipop table",
+        name="lollipop_role_table",
+        tool="Lollipop table",
         description="Per-feature positional variants (feature_id × position × category).",
         required_columns=frozenset({"feature_id", "position", "category"}),
         feeds_viz=("lollipop",),
@@ -274,8 +274,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="oncoplot_canonical_table",
-        tool="Canonical oncoplot table",
+        name="oncoplot_role_table",
+        tool="Oncoplot table",
         description="Sample × gene × mutation_type matrix in long form.",
         required_columns=frozenset({"sample_id", "gene", "mutation_type"}),
         feeds_viz=("oncoplot",),
@@ -288,8 +288,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="coverage_track_canonical_table",
-        tool="Canonical coverage track",
+        name="coverage_track_role_table",
+        tool="Coverage track table",
         description="Per-window coverage depth (chromosome × position × value).",
         required_columns=frozenset({"chromosome", "position", "value"}),
         feeds_viz=("coverage_track",),
@@ -302,8 +302,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="embedding_canonical_table",
-        tool="Canonical embedding table",
+        name="embedding_role_table",
+        tool="Embedding table",
         description="2D sample projection (sample_id × dim_1 × dim_2) — PCA / UMAP / PCoA.",
         required_columns=frozenset({"sample_id", "dim_1", "dim_2"}),
         feeds_viz=("embedding",),
@@ -316,8 +316,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="stacked_taxonomy_canonical_table",
-        tool="Canonical stacked taxonomy",
+        name="stacked_taxonomy_role_table",
+        tool="Stacked taxonomy table",
         description="Per-sample taxonomic abundance (sample_id × taxon × rank × abundance).",
         required_columns=frozenset({"sample_id", "taxon", "rank", "abundance"}),
         feeds_viz=("stacked_taxonomy",),
@@ -331,8 +331,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="rarefaction_canonical_table",
-        tool="Canonical rarefaction table",
+        name="rarefaction_role_table",
+        tool="Rarefaction table",
         description="Alpha-diversity rarefaction curve (sample_id × depth × metric).",
         required_columns=frozenset({"sample_id", "depth", "metric"}),
         feeds_viz=("rarefaction",),
@@ -345,8 +345,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="ma_canonical_table",
-        tool="Canonical MA-plot table",
+        name="ma_role_table",
+        tool="MA-plot table",
         description="Differential-expression MA shape (feature_id × avg_log_intensity × log2_fold_change).",
         required_columns=frozenset({"feature_id", "avg_log_intensity", "log2_fold_change"}),
         feeds_viz=("ma",),
@@ -359,8 +359,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="dot_plot_canonical_table",
-        tool="Canonical dot-plot table",
+        name="dot_plot_role_table",
+        tool="Dot-plot table",
         description="Single-cell marker summary (cluster × gene × mean_expression × frac_expressing).",
         required_columns=frozenset({"cluster", "gene", "mean_expression", "frac_expressing"}),
         feeds_viz=("dot_plot",),
@@ -374,8 +374,8 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
         },
     ),
     Producer(
-        name="enrichment_canonical_table",
-        tool="Canonical enrichment table",
+        name="enrichment_role_table",
+        tool="Enrichment table",
         description="Pathway enrichment results (term × NES × padj × gene_count).",
         required_columns=frozenset({"term", "nes", "padj", "gene_count"}),
         feeds_viz=("enrichment",),
@@ -387,6 +387,100 @@ KNOWN_PRODUCERS: tuple[Producer, ...] = (
                 "gene_count": "gene_count",
             }
         },
+    ),
+    # ------------------------------------------------------------------
+    # Common-shape fingerprints — match real-world file conventions where
+    # column names don't line up with the role names. Cover the gaps the
+    # role-named producers above leave: sankey/sunburst with hierarchical
+    # taxonomy columns, long-form rarefaction with raw metric columns,
+    # wide alpha-diversity summary tables.
+    # ------------------------------------------------------------------
+    Producer(
+        name="taxonomy_levels_long",
+        tool="Hierarchical taxonomy table",
+        description=(
+            "Per-sample hierarchical taxonomy "
+            "(sample × Kingdom × Phylum × Class × Order × Family × Genus × abundance) "
+            "— feeds sankey + sunburst."
+        ),
+        # Kingdom..Genus + abundance is the discriminating shape. We require
+        # all 6 ranks to avoid accidental matches on lower-resolution tables.
+        required_columns=frozenset(
+            {"Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "abundance"}
+        ),
+        feeds_viz=("sankey", "sunburst"),
+        role_mapping={
+            # sankey's step_cols is a multi-column list inferred at render
+            # time from the Kingdom..Genus column block — no single-column
+            # role mapping to declare here.
+            "sankey": {},
+            "sunburst": {"abundance": "abundance"},
+        },
+    ),
+    Producer(
+        name="rarefaction_iter_long",
+        tool="Rarefaction iteration table",
+        description=(
+            "Per-sample rarefaction curve in long form "
+            "(sample_id × depth × iter × metric column(s))."
+        ),
+        # `iter` is the discriminator vs other (sample_id, depth, ...) tables.
+        # The metric column varies by pipeline (shannon, observed_features,
+        # faith_pd, evenness…) so we don't list it in required_columns; the
+        # binding UI lets the user pick at component-creation time.
+        required_columns=frozenset({"sample_id", "depth", "iter"}),
+        feeds_viz=("rarefaction",),
+        role_mapping={
+            "rarefaction": {
+                "sample_id": "sample_id",
+                "depth": "depth",
+                # metric column resolved by the binding UI from the numeric
+                # columns alongside depth/iter.
+            }
+        },
+        notes="Companion to `rarefaction_role_table` for files using raw metric column names.",
+    ),
+    Producer(
+        name="taxonomy_abundance_long",
+        tool="Long-form taxonomy abundance",
+        description=(
+            "Per-sample taxonomy with relative abundance and rank columns "
+            "(sample_id × taxonomy × rel_abundance × Kingdom × Phylum × …). "
+            "Source shape for the ampliseq taxonomy-heatmap recipe."
+        ),
+        # `taxonomy` + `rel_abundance` together discriminate against the
+        # other taxonomy shapes (sankey/sunburst use `abundance`; stacked
+        # uses `taxon`).
+        required_columns=frozenset({"sample_id", "taxonomy", "rel_abundance"}),
+        feeds_viz=("complex_heatmap", "stacked_taxonomy", "sunburst"),
+        role_mapping={
+            "complex_heatmap": {"index": "Phylum"},
+            "stacked_taxonomy": {
+                "sample_id": "sample_id",
+                "taxon": "taxonomy",
+                "abundance": "rel_abundance",
+                # `rank` not directly available — derive from Kingdom/Phylum
+                # columns at component-creation time.
+            },
+            "sunburst": {"abundance": "rel_abundance"},
+        },
+        notes="Pivot to wide (Phylum × sample) for ComplexHeatmap — see recipes/taxonomy_heatmap.py.",
+    ),
+    Producer(
+        name="alpha_diversity_wide",
+        tool="Alpha diversity table",
+        description=(
+            "Per-sample alpha-diversity metrics in wide form "
+            "(sample_id × shannon × observed_features × evenness × …)."
+        ),
+        # `evenness` is the discriminator vs `rarefaction_iter_long`: both
+        # shapes share sample_id/shannon/observed_features, but long-form
+        # rarefaction never carries evenness as a column.
+        required_columns=frozenset({"sample_id", "shannon", "observed_features", "evenness"}),
+        feeds_viz=(),  # No advanced-viz kind for wide alpha-diversity yet —
+        # surfaced as an informational badge only.
+        role_mapping={},
+        notes="Wide summary; reshape to long via .melt(id_vars=['sample_id']) if feeding rarefaction.",
     ),
     Producer(
         name="ivar_variants_vcf",

--- a/depictio/models/components/advanced_viz/schemas.py
+++ b/depictio/models/components/advanced_viz/schemas.py
@@ -130,6 +130,250 @@ CANONICAL_SCHEMAS: dict[AdvancedVizKind, dict[str, frozenset[str]]] = {
     "sankey": {},
 }
 
+# Per-role column-name aliases used by `suggest_viz_kinds`. The suggester
+# matches schemas against viz kinds by checking that each required role has
+# a column whose NAME is in the role's alias set AND whose dtype is in the
+# role's accepted dtype set (CANONICAL_SCHEMAS above). Pure dtype matches no
+# longer count toward confidence — they were turning every Numeric+String
+# DC into a 13-viz suggestion soup.
+#
+# Aliases are matched case-insensitively. Each set contains the literal role
+# name plus common real-world variants (nf-core / QIIME2 / DESeq2 outputs,
+# typical short forms). When adding a producer to producers.py whose columns
+# map to a viz role, mirror those column names here so the dtype-aware
+# suggester surfaces the same viz kind the producer fingerprint does.
+ROLE_NAMES: dict[AdvancedVizKind, dict[str, frozenset[str]]] = {
+    "volcano": {
+        "feature_id": frozenset(
+            {
+                "feature_id",
+                "gene_id",
+                "id",
+                "gene",
+                "feature",
+                "name",
+                "symbol",
+            }
+        ),
+        "effect_size": frozenset(
+            {
+                "effect_size",
+                "log2foldchange",
+                "log2_fold_change",
+                "lfc",
+                "logfc",
+                "log2fc",
+                "fc",
+            }
+        ),
+        "significance": frozenset(
+            {
+                "significance",
+                "padj",
+                "pvalue",
+                "p_value",
+                "p_adj",
+                "q_val",
+                "qvalue",
+                "qval",
+                "fdr",
+            }
+        ),
+    },
+    "embedding": {
+        "sample_id": frozenset({"sample_id", "sample-id", "sample"}),
+        "dim_1": frozenset(
+            {
+                "dim_1",
+                "dim1",
+                "x",
+                "pc1",
+                "pca1",
+                "umap1",
+                "umap_1",
+                "tsne1",
+                "tsne_1",
+                "comp1",
+            }
+        ),
+        "dim_2": frozenset(
+            {
+                "dim_2",
+                "dim2",
+                "y",
+                "pc2",
+                "pca2",
+                "umap2",
+                "umap_2",
+                "tsne2",
+                "tsne_2",
+                "comp2",
+            }
+        ),
+    },
+    "manhattan": {
+        "chr": frozenset({"chr", "chrom", "chromosome", "#chrom"}),
+        "pos": frozenset({"pos", "position", "bp"}),
+        "score": frozenset(
+            {
+                "score",
+                "p_value",
+                "pvalue",
+                "p",
+                "neg_log_p",
+                "minus_log10_p",
+                "af",
+            }
+        ),
+    },
+    "stacked_taxonomy": {
+        "sample_id": frozenset({"sample_id", "sample-id", "sample"}),
+        "taxon": frozenset(
+            {"taxon", "taxonomy", "lineage", "name", "otu", "otu_id", "asv", "taxa"}
+        ),
+        "rank": frozenset({"rank", "taxonomy_lvl", "level", "taxon_rank"}),
+        "abundance": frozenset(
+            {
+                "abundance",
+                "rel_abundance",
+                "relative_abundance",
+                "new_est_reads",
+                "fraction_total_reads",
+                "count",
+                "reads",
+                "frequency",
+            }
+        ),
+    },
+    "phylogenetic": {
+        "taxon": frozenset({"taxon", "tip", "tip_label", "label", "leaf", "name"}),
+    },
+    "rarefaction": {
+        "sample_id": frozenset({"sample_id", "sample-id", "sample"}),
+        "depth": frozenset({"depth", "sampling_depth", "rarefaction_depth"}),
+        "metric": frozenset(
+            {
+                "metric",
+                "shannon",
+                "observed_features",
+                "faith_pd",
+                "evenness",
+                "chao1",
+                "simpson",
+                "value",
+            }
+        ),
+    },
+    "da_barplot": {
+        "feature_id": frozenset({"feature_id", "id", "name", "gene"}),
+        "contrast": frozenset({"contrast", "comparison", "group"}),
+        "lfc": frozenset({"lfc", "log2fc", "log2_fold_change", "logfc"}),
+    },
+    "enrichment": {
+        "term": frozenset({"term", "pathway", "go_term", "gene_set", "description"}),
+        "nes": frozenset({"nes", "normalized_enrichment_score"}),
+        "padj": frozenset({"padj", "p_adj", "fdr", "q_val", "qvalue"}),
+        "gene_count": frozenset({"gene_count", "size", "n_genes", "count"}),
+    },
+    "complex_heatmap": {
+        # complex_heatmap's only required role is a string row-id — make it
+        # explicit rather than matching any String column.
+        "index": frozenset(
+            {
+                "index",
+                "id",
+                "feature_id",
+                "gene_id",
+                "sample_id",
+                "name",
+                "row",
+            }
+        ),
+    },
+    "upset_plot": {},
+    "ma": {
+        "feature_id": frozenset({"feature_id", "gene_id", "id"}),
+        "avg_log_intensity": frozenset(
+            {
+                "avg_log_intensity",
+                "basemean",
+                "log_basemean",
+                "log_intensity",
+                "a",
+            }
+        ),
+        "log2_fold_change": frozenset(
+            {
+                "log2_fold_change",
+                "log2foldchange",
+                "lfc",
+                "logfc",
+                "m",
+            }
+        ),
+    },
+    "dot_plot": {
+        "cluster": frozenset({"cluster", "celltype", "cell_type", "group"}),
+        "gene": frozenset({"gene", "feature", "marker"}),
+        "mean_expression": frozenset(
+            {
+                "mean_expression",
+                "avg_expression",
+                "mean_expr",
+            }
+        ),
+        "frac_expressing": frozenset(
+            {
+                "frac_expressing",
+                "pct_expressing",
+                "frac",
+                "pct",
+            }
+        ),
+    },
+    "lollipop": {
+        "feature_id": frozenset({"feature_id", "gene", "feature"}),
+        "position": frozenset({"position", "pos", "aa_pos", "site"}),
+        "category": frozenset({"category", "effect", "type", "consequence"}),
+    },
+    "qq": {
+        "p_value": frozenset({"p_value", "pvalue", "p", "padj", "fdr"}),
+    },
+    "sunburst": {
+        "abundance": frozenset(
+            {
+                "abundance",
+                "rel_abundance",
+                "relative_abundance",
+                "count",
+                "reads",
+                "frequency",
+                "new_est_reads",
+                "fraction_total_reads",
+            }
+        ),
+    },
+    "oncoplot": {
+        "sample_id": frozenset({"sample_id", "sample", "tumor_sample_barcode"}),
+        "gene": frozenset({"gene", "hugo_symbol"}),
+        "mutation_type": frozenset(
+            {
+                "mutation_type",
+                "variant_classification",
+                "effect",
+                "consequence",
+            }
+        ),
+    },
+    "coverage_track": {
+        "chromosome": frozenset({"chromosome", "chrom", "chr", "#chrom"}),
+        "position": frozenset({"position", "pos", "start"}),
+        "value": frozenset({"value", "coverage", "depth", "score"}),
+    },
+    "sankey": {},
+}
+
+
 # Optional roles — validated only if the user has bound a column for them.
 _OPTIONAL_ROLES: dict[AdvancedVizKind, dict[str, frozenset[str]]] = {
     "volcano": {
@@ -293,14 +537,19 @@ def suggest_viz_kinds(
 ) -> list[VizSuggestion]:
     """Return viz kinds whose required roles can be satisfied by `dc_schema`.
 
+    A role is "satisfied" when the DC has a column whose NAME is in the
+    role's `ROLE_NAMES` alias set AND whose dtype is in the role's accepted
+    dtype set. Dtype-only matches still appear in `role_candidates` so the
+    binding UI can offer them as fallback choices, but they don't count
+    toward confidence — otherwise every Numeric+String DC matches every viz.
+
     Args:
         dc_schema: Map of column name → polars dtype name (the strings
             polars emits via `str(dtype)`).
         min_confidence: Minimum fraction of required roles that must have
-            at least one dtype-compatible candidate column. Default 1.0
-            = only return viz kinds where every required role has a
-            candidate. Drop to ~0.7 to surface "almost a match" viz kinds
-            in an exploratory UI.
+            a name+dtype match. Default 1.0 = only return viz kinds where
+            every required role has a named candidate. Drop to ~0.7 to
+            surface "almost a match" viz kinds in an exploratory UI.
 
     Returns:
         Sorted (by confidence desc, then viz_kind asc) list of
@@ -309,16 +558,19 @@ def suggest_viz_kinds(
     suggestions: list[VizSuggestion] = []
     for kind, required in CANONICAL_SCHEMAS.items():
         if not required:
-            # Schemas with no required roles (sankey, upset_plot, sunburst-ish)
-            # would match every DC — skip them in the suggestion engine; users
-            # who want those pick them from the catalog directly.
+            # Schemas with no required roles (sankey, upset_plot) match
+            # via producer fingerprints in producers.py instead — the
+            # suggestion engine can't say anything useful about them from
+            # schema alone.
             continue
+        role_aliases = ROLE_NAMES.get(kind, {})
         role_candidates: dict[str, list[str]] = {}
         satisfied = 0
         for role, accepted in required.items():
-            matches = [col for col, dtype in dc_schema.items() if dtype in accepted]
-            role_candidates[role] = matches
-            if matches:
+            dtype_matches = [col for col, dtype in dc_schema.items() if dtype in accepted]
+            role_candidates[role] = dtype_matches
+            aliases = {a.lower() for a in role_aliases.get(role, frozenset({role}))}
+            if any(col.lower() in aliases for col in dtype_matches):
                 satisfied += 1
         confidence = satisfied / len(required)
         if confidence >= min_confidence:
@@ -364,6 +616,7 @@ __all__ = [
     "CANONICAL_SCHEMAS",
     "EmbeddingConfig",
     "ManhattanConfig",
+    "ROLE_NAMES",
     "StackedTaxonomyConfig",
     "VizSuggestion",
     "VolcanoConfig",

--- a/depictio/tests/models/test_advanced_viz_suggestions.py
+++ b/depictio/tests/models/test_advanced_viz_suggestions.py
@@ -61,8 +61,13 @@ CASES: list[tuple[str, set[str], str | None, dict]] = [
         {},
     ),
     (
+        # Bracken's per-sample output has no `sample_id` column (the sample
+        # identity comes from the filename), so the name-aware suggester
+        # surfaces only sunburst. Stacked_taxonomy is still reachable via
+        # the producer's `feeds_viz` after the reshape declared in
+        # `bracken_sample.role_mapping["stacked_taxonomy"]`.
         "sunburst/bracken_sample.tsv",
-        {"sunburst", "stacked_taxonomy"},
+        {"sunburst"},
         "bracken_sample",
         {},
     ),
@@ -110,15 +115,22 @@ def test_suggestions_against_nfcore_fixtures(
 
 
 def test_suggest_viz_kinds_returns_empty_on_unfitting_schema() -> None:
+    # Pure-string schema with a column that doesn't match any role's
+    # name-alias set — the suggester should reject everything, including
+    # phylogenetic (whose `taxon` role no longer matches an arbitrary
+    # String column under the name-aware rules).
     schema = {"only_string_col": "String"}
-    # A pure-string schema can't satisfy any numeric-requiring viz.
     suggestions = suggest_viz_kinds(schema)
-    # `phylogenetic` requires only `taxon: String` so it WILL match —
-    # everything else needing a numeric column should not.
     kinds = {s.viz_kind for s in suggestions}
-    assert "phylogenetic" in kinds
-    assert "volcano" not in kinds
-    assert "manhattan" not in kinds
+    assert kinds == set(), f"expected no suggestions, got {kinds}"
+
+
+def test_phylogenetic_matches_on_taxon_aliases() -> None:
+    # A String column whose name IS in the phylogenetic taxon alias set
+    # (e.g. `taxon`, `tip_label`, `label`) should light up phylogenetic.
+    for col_name in ("taxon", "tip_label", "label"):
+        kinds = {s.viz_kind for s in suggest_viz_kinds({col_name: "String"})}
+        assert "phylogenetic" in kinds, f"{col_name}: phylogenetic missing from {kinds}"
 
 
 def test_suggest_viz_kinds_role_candidates_populated() -> None:
@@ -179,19 +191,114 @@ def test_ancombc_joined_results_suggests_volcano_and_da_barplot() -> None:
     assert "ancombc_results_joined" in matches
 
 
-def test_volcano_canonical_table_fingerprint() -> None:
-    """Files already in canonical volcano shape (feature_id / effect_size /
-    significance) must light up — used by ampliseq's `volcano_canonical`
-    DC and any hand-curated DE results saved with role-named columns."""
+def test_volcano_role_table_fingerprint() -> None:
+    """Files already in role-named volcano shape (feature_id / effect_size /
+    significance) must light up — used by ampliseq's volcano DC and any
+    hand-curated DE results saved with role-named columns."""
     schema = {col: "" for col in ("feature_id", "effect_size", "significance")}
     matches = {name for name, _ in suggest_producers(schema)}
-    assert "volcano_canonical_table" in matches
+    assert "volcano_role_table" in matches
 
 
-def test_da_barplot_canonical_table_fingerprint() -> None:
+def test_da_barplot_role_table_fingerprint() -> None:
     schema = {col: "" for col in ("feature_id", "contrast", "lfc")}
     matches = {name for name, _ in suggest_producers(schema)}
-    assert "da_barplot_canonical_table" in matches
+    assert "da_barplot_role_table" in matches
+
+
+def test_taxonomy_levels_long_fingerprint() -> None:
+    """Files with Kingdom..Genus + abundance must fingerprint as the
+    hierarchical taxonomy producer that feeds both sankey + sunburst.
+    Regression for the demo upload flow: sankey/sunburst files used to
+    surface no producer hint at all."""
+    schema = {
+        col: ""
+        for col in (
+            "sample_id",
+            "Habitat",
+            "Kingdom",
+            "Phylum",
+            "Class",
+            "Order",
+            "Family",
+            "Genus",
+            "abundance",
+        )
+    }
+    matches = dict(suggest_producers(schema))
+    assert "taxonomy_levels_long" in matches
+    # Producer must advertise feeding both sankey and sunburst so the UI
+    # surfaces both viz kinds in the modal's "looks like" hint.
+    from depictio.models.components.advanced_viz.producers import get_producer
+
+    p = get_producer("taxonomy_levels_long")
+    assert p is not None
+    assert set(p.feeds_viz) == {"sankey", "sunburst"}
+
+
+def test_rarefaction_iter_long_fingerprint() -> None:
+    """Long-form rarefaction with raw metric columns (sample_id / depth /
+    iter / shannon / observed_features / faith_pd) must fingerprint —
+    distinct from the role-named `rarefaction_role_table` which requires
+    a literal `metric` column."""
+    schema = {
+        col: ""
+        for col in (
+            "sample_id",
+            "depth",
+            "iter",
+            "shannon",
+            "observed_features",
+            "faith_pd",
+            "group",
+        )
+    }
+    matches = {name for name, _ in suggest_producers(schema)}
+    assert "rarefaction_iter_long" in matches
+
+
+def test_taxonomy_abundance_long_fingerprint() -> None:
+    """Long-form ampliseq taxonomy-heatmap source (sample_id × taxonomy ×
+    rel_abundance × Kingdom × Phylum) must fingerprint so the drop modal
+    surfaces complex_heatmap as a downstream option."""
+    schema = {
+        col: ""
+        for col in (
+            "sample_id",
+            "taxonomy",
+            "rel_abundance",
+            "habitat",
+            "Kingdom",
+            "Phylum",
+        )
+    }
+    matches = dict(suggest_producers(schema))
+    assert "taxonomy_abundance_long" in matches
+
+    from depictio.models.components.advanced_viz.producers import get_producer
+
+    p = get_producer("taxonomy_abundance_long")
+    assert p is not None
+    assert "complex_heatmap" in p.feeds_viz
+
+
+def test_alpha_diversity_wide_fingerprint() -> None:
+    """Wide alpha-diversity summary (sample_id × shannon × observed_features
+    × faith_pd × evenness) must fingerprint so the modal shows the badge,
+    even though no advanced-viz kind consumes it directly yet."""
+    schema = {
+        col: ""
+        for col in (
+            "sample_id",
+            "habitat",
+            "shannon",
+            "observed_features",
+            "faith_pd",
+            "evenness",
+        )
+    }
+    matches = {name for name, _ in suggest_producers(schema)}
+    assert "alpha_diversity_wide" in matches
 
 
 def test_viralrecon_variants_long_fingerprint() -> None:

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -121,12 +121,19 @@ function authHeaders(): Record<string, string> {
 }
 
 /** Local POST wrapper for layout/component persistence. Surfaces the response
- *  body on failure so callers can debug 422 validation errors at the console. */
+ *  body on failure so callers can debug 422 validation errors at the console.
+ *  Pass `forceScreenshot=true` for an explicit Save click — the backend bypasses
+ *  its 1h auto-save debounce and re-queues a fresh thumbnail. Auto-saves should
+ *  omit it so drag/resize/rename bursts don't overwhelm the celery worker. */
 async function saveDashboard(
   dashboardId: string,
   dashboardData: DashboardData,
+  opts: { forceScreenshot?: boolean } = {},
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/dashboards/save/${dashboardId}`, {
+  const url = opts.forceScreenshot
+    ? `${API_BASE}/dashboards/save/${dashboardId}?force_screenshot=true`
+    : `${API_BASE}/dashboards/save/${dashboardId}`;
+  const res = await fetch(url, {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify(dashboardData),
@@ -840,7 +847,7 @@ const EditorApp: React.FC = () => {
       withCloseButton: false,
     });
     try {
-      await saveDashboard(dashboardId, cur);
+      await saveDashboard(dashboardId, cur, { forceScreenshot: true });
       setSaveStatus('saved');
       notifications.update({
         id: notifId,

--- a/depictio/viewer/src/builder/steps/StepType.tsx
+++ b/depictio/viewer/src/builder/steps/StepType.tsx
@@ -45,7 +45,10 @@ const StepType: React.FC = () => {
   const onPick = (t: ComponentType) => {
     setComponentType(t);
     // Mirror Dash: card click immediately advances to the next step.
-    setStep(1);
+    // Text components skip Step 1 (Data Source — hidden for text) and land
+    // directly on Step 2 (Design), matching the Next-button + stepper-click
+    // handlers in CreateComponentPage.
+    setStep(t === 'text' ? 2 : 1);
   };
 
   return (


### PR DESCRIPTION
## Summary

Three independent builder/editor UX bugs surfaced while iterating on the
React viewer. All three are small, focused, and ship together because
they share QA flow.

### 1. Viz suggestion engine — drop modal silent on common file shapes

- Dropping `rarefaction.tsv`, `sankey.tsv`, `sunburst.tsv`,
  `alpha_diversity.tsv` or `taxonomy_heatmap.tsv` in the Create DC
  modal showed **no producer hint** because no fingerprint matched.
- Once the DC was created, the post-create card showed a 13-viz
  ``Compatible advanced visualizations`` chip row for **every** file —
  the dtype-only matching in ``suggest_viz_kinds`` matched any role
  with the right dtype regardless of column name.

**Fix** (`depictio/models/components/advanced_viz/`):

- Added 4 new producers covering the missing file shapes:
  - ``taxonomy_levels_long`` — Kingdom..Genus + abundance → feeds
    sankey + sunburst.
  - ``rarefaction_iter_long`` — sample_id × depth × iter.
  - ``alpha_diversity_wide`` — sample_id × shannon × observed_features
    × evenness. ``evenness`` is the discriminator vs rarefaction (both
    shapes share sample_id/shannon/observed_features).
  - ``taxonomy_abundance_long`` — sample_id × taxonomy × rel_abundance
    + Kingdom/Phylum, the source long-form for the ampliseq
    `taxonomy_heatmap` recipe. Feeds complex_heatmap, stacked_taxonomy
    and sunburst.
- Renamed the 12 existing ``*_canonical_table`` producers to
  ``*_role_table`` and dropped "canonical" from their ``tool`` /
  description strings.
- Added ``ROLE_NAMES`` per-role alias sets and rewrote
  ``suggest_viz_kinds`` to count a role as satisfied only when a
  column matches the alias set **and** the dtype. Dtype-only matches
  still populate ``role_candidates`` so the binding UI offers them as
  fallback choices.
- Added regression tests for the 4 new producers + a phylogenetic-
  alias test; updated the ``bracken_sample`` fixture expectation to
  drop ``stacked_taxonomy`` (Bracken has no ``sample_id`` column —
  that route is still advertised via the producer's ``feeds_viz``
  after the documented reshape).

### 2. Text component creation stuck on "Type" step

``StepType``'s card click did ``setStep(1)`` for every type, but step 1
(Data Source) is hidden for text components — leaving the user
visually on step 0 with the internal counter at 1 and requiring a
manual Next-Step click. The stepper-icon and Next-button handlers
already special-cased text → step 2; this aligns the card handler with
them.

### 3. Screenshot never refreshed after clicking Save

Three issues stacked:

- ``_should_enqueue_screenshot`` debounced all saves for 1 h — including
  explicit Save clicks — so the celery task wasn't re-queued during
  normal editing iteration.
- The React save didn't bump ``last_saved_ts``; the listing's
  ``?v=last_saved_ts`` cache-buster stayed frozen and browsers kept
  returning cached PNGs.
- The celery task's own active-task dedup raised ``Ignore`` if a render
  was already in flight for the same dashboard, silently dropping the
  second save's state.

**Fix**:

- ``POST /dashboards/save/{id}`` accepts ``?force_screenshot=true`` and
  OR's it with the debounce gate. ``EditorApp.handleForceSave`` passes
  it on the explicit click; auto-saves leave it unset and keep the 1h
  throttle that protects against celery storms on rapid drag/resize/
  rename bursts.
- Same endpoint bumps ``last_saved_ts`` server-side on every save.
- ``generate_dashboard_screenshot_dual`` takes a new ``force=False``
  kwarg that skips the active-task dedup; passed through from the save
  endpoint on forced runs.
- The celery task bumps ``last_saved_ts`` again on completion so the
  listing's cache-buster advances once the PNG is actually on disk
  (closes the race where a viewer loads the listing during the ~8 s
  Playwright render and caches the stale bytes against the new URL).

## Test plan

- [x] ``pytest depictio/tests/models/test_advanced_viz_suggestions.py`` — 15 pass, 4 skip (fixtures gitignored).
- [x] ``pytest depictio/tests/api/v1/test_dashboard_save_screenshot_guard.py`` — 5 pass.
- [x] ``ruff check`` + ``ruff format`` clean on touched files.
- [ ] Drag-and-drop the 8 demo TSVs into the React Create DC modal —
      each surfaces the expected producer badge with the right
      `Feeds advanced viz:` list (∅ only for `Metadata_full.tsv`).
- [ ] Create a Text component from the type picker — lands directly on
      the Design step, no manual Next-Step click required.
- [ ] Edit a dashboard, click Save → watch celery logs for
      ``Queued screenshot regeneration ... force=True`` and a
      ``generate_dashboard_screenshot_dual`` task succeeding ~8 s later.
      Refresh the listing — thumbnail updates to the latest state.
- [ ] Auto-save (drag/resize) — debounce still skips celery enqueue when
      the existing PNG is < 1 h old (auto-save throttle preserved).