### PR TITLE
fix: cross-DC filter target_column=None + Add-link modal polish

### DIFF
--- a/depictio/api/v1/deltatables_utils.py
+++ b/depictio/api/v1/deltatables_utils.py
@@ -86,15 +86,17 @@ def _generate_filter_hash(metadata: list[dict] | None) -> str:
     # Sort by column name to ensure consistent ordering
     filter_repr = []
     for component in metadata:
-        # Extract metadata from nested structure if needed
+        # Extract metadata from nested structure if needed. ``dict.get(k, "")``
+        # returns the actual value when the key is present even if it's None,
+        # so coerce None → "" explicitly to keep the sort key well-ordered.
         if "metadata" in component:
             meta = component["metadata"]
-            column_name = meta.get("column_name", "")
-            component_type = meta.get("interactive_component_type", "")
+            column_name = meta.get("column_name") or ""
+            component_type = meta.get("interactive_component_type") or ""
             value = component.get("value")
         else:
-            column_name = component.get("column_name", "")
-            component_type = component.get("interactive_component_type", "")
+            column_name = component.get("column_name") or ""
+            component_type = component.get("interactive_component_type") or ""
             value = component.get("value")
 
         # Create stable representation

--- a/depictio/api/v1/endpoints/advanced_viz_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/advanced_viz_endpoints/routes.py
@@ -341,15 +341,29 @@ def fetch_advanced_viz_data(
             col = (f.get("column_name") if isinstance(f, dict) else None) or (
                 (nested or {}).get("column_name") if nested else None
             )
-            if available_cols is not None and col and col not in available_cols:
+            # Drop filters that don't carry a column at all — link resolution
+            # can synthesise filter dicts where target_column resolves to None
+            # (source_filter has no column_name and the link has no target_field
+            # override), which would later crash _generate_filter_hash's sort
+            # with `'<' not supported between NoneType and str`.
+            if not col:
+                # Always a resolver bug upstream (filter_links can produce a
+                # link_filter with target_column=None when both the resolved
+                # value and link_config.target_field are absent). Log at
+                # WARNING so it shows up in ops aggregators.
+                logger.warning(
+                    "advanced_viz/data: dropping filter with no column_name (dc_id=%s)",
+                    dc_id,
+                )
+                continue
+            if available_cols is not None and col not in available_cols:
                 logger.info(
                     "advanced_viz/data: dropping cross-DC filter on column %r — not in DC %s",
                     col,
                     dc_id,
                 )
                 continue
-            if col:
-                filter_cols.add(col)
+            filter_cols.add(col)
             kept_filters.append(f)
         filter_metadata = kept_filters
 

--- a/depictio/api/v1/filter_links.py
+++ b/depictio/api/v1/filter_links.py
@@ -277,9 +277,26 @@ def extend_filters_via_links(
 
             if resolved and resolved.get("resolved_values"):
                 resolved_values = resolved["resolved_values"]
-                target_column = resolved.get("target_column") or link.get("link_config", {}).get(
-                    "target_field", source_column
+                # ``dict.get(key, default)`` returns the *value* when the key is
+                # present even if it's ``None`` — so the historical
+                # ``.get("target_field", source_column)`` chain silently
+                # produced ``target_column = None`` whenever link_config had
+                # ``target_field: null`` (which is common for the 'direct'
+                # resolver where users leave the field empty). Use an explicit
+                # ``or`` chain so each None falls through to the next fallback.
+                link_config = link.get("link_config") or {}
+                target_column = (
+                    resolved.get("target_column")
+                    or link_config.get("target_field")
+                    or source_column
                 )
+                if not target_column:
+                    logger.warning(
+                        f"[{component_type}] Skipping link {link.get('id')!r}: "
+                        f"could not resolve a target column (source_column={source_column!r}, "
+                        f"link_config.target_field={link_config.get('target_field')!r})"
+                    )
+                    continue
 
                 link_filter = {
                     "index": f"link_{link.get('id', 'unknown')}",

--- a/depictio/viewer/src/projects/detail/LinkEditModal.tsx
+++ b/depictio/viewer/src/projects/detail/LinkEditModal.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   Textarea,
   TextInput,
+  Title,
 } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
@@ -351,19 +352,45 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
     <Modal
       opened={opened}
       onClose={submitting ? () => {} : onClose}
-      title={editing ? 'Edit cross-DC link' : 'Create cross-DC link'}
+      title={null}
       size="lg"
+      centered
+      padding="lg"
       closeOnClickOutside={!submitting}
       closeOnEscape={!submitting}
+      withCloseButton={!submitting}
     >
       <Stack gap="md" data-testid="link-edit-modal">
+        {/* Header mirrors CreateDataCollectionModal / ManageDataCollectionModal:
+            no native title, custom centered icon + Title inside the Stack so
+            the visual language stays consistent across the project's modals. */}
+        <Group justify="center" gap="sm">
+          <Icon
+            icon={editing ? 'mdi:link-edit' : 'mdi:link-plus'}
+            width={32}
+            color="var(--mantine-color-teal-6)"
+          />
+          <Title order={3} c="teal" m={0}>
+            {editing ? 'Edit Cross-DC Link' : 'Create Cross-DC Link'}
+          </Title>
+        </Group>
+
         {error && (
-          <Alert color="red" icon={<Icon icon="mdi:alert-circle" width={18} />}>
+          <Alert
+            color="red"
+            variant="light"
+            icon={<Icon icon="mdi:alert-circle" width={18} />}
+          >
             {error}
           </Alert>
         )}
 
-        <Group grow align="flex-start">
+        {/* Source DC + Source column share a row. Keeping descriptions OFF
+            the inputs themselves (and surfacing the hint below) so the two
+            inputs bottom-align cleanly — Mantine's per-field description
+            pushed the Source DC input down and the Source column input
+            stayed at the label baseline, which looked misaligned. */}
+        <Group grow align="flex-end">
           <Select
             label="Source data collection"
             placeholder="Pick a table DC"
@@ -380,8 +407,8 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
               if (next && next === targetDcId) setTargetDcId('');
             }}
             searchable
+            clearable
             required
-            description="Only table DCs can act as a filter source."
             nothingFoundMessage="No table data collections in this project."
           />
           <Select
@@ -398,10 +425,15 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
             onChange={(v) => setSourceColumn(v || '')}
             disabled={!sourceDcId || sourceColumnsLoading}
             searchable
+            clearable
             required
             nothingFoundMessage="No columns available."
           />
         </Group>
+        <Text size="xs" c="dimmed" mt={-8}>
+          Only table DCs can act as a filter source. Pick the column whose
+          values will be translated to the target DC.
+        </Text>
 
         <Select
           label="Target data collection"
@@ -411,6 +443,7 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
           onChange={(v) => setTargetDcId(v || '')}
           disabled={!sourceDcId}
           searchable
+          clearable
           required
           description={`Detected target type: ${targetType}`}
         />
@@ -492,11 +525,18 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
           onChange={(e) => setEnabled(e.currentTarget.checked)}
         />
 
-        <Group justify="flex-end" mt="md">
+        <Group justify="flex-end" mt="md" gap="xs">
           <Button variant="default" onClick={onClose} disabled={submitting}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} loading={submitting}>
+          <Button
+            color="teal"
+            onClick={handleSubmit}
+            loading={submitting}
+            leftSection={
+              <Icon icon={editing ? 'mdi:content-save' : 'mdi:plus'} width={16} />
+            }
+          >
             {editing ? 'Save changes' : 'Create link'}
           </Button>
         </Group>

--- a/depictio/viewer/src/projects/detail/LinksSection.tsx
+++ b/depictio/viewer/src/projects/detail/LinksSection.tsx
@@ -53,6 +53,12 @@ const LinksSection: React.FC<LinksSectionProps> = ({
   const [modalOpened, setModalOpened] = useState(false);
   const [editing, setEditing] = useState<DCLink | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  // Bumped on every openCreate / openEdit so the modal re-mounts fresh.
+  // Mantine searchable Selects sometimes retain their display text after a
+  // programmatic `value=''` reset; remounting sidesteps that entirely and
+  // guarantees "Target data collection" (and every other field) starts blank
+  // when the user clicks Add link a second time.
+  const [modalKey, setModalKey] = useState(0);
 
   const dcById = useMemo(() => {
     const map = new Map<string, DataCollectionOption>();
@@ -123,12 +129,21 @@ const LinksSection: React.FC<LinksSectionProps> = ({
 
   const openCreate = () => {
     setEditing(null);
+    setModalKey((k) => k + 1);
     setModalOpened(true);
   };
 
   const openEdit = (link: DCLink) => {
     setEditing(link);
+    setModalKey((k) => k + 1);
     setModalOpened(true);
+  };
+
+  const closeModal = () => {
+    setModalOpened(false);
+    // Clear `editing` too — without this, a saved edit would leave the
+    // modal in "edit" mode if it were ever re-mounted with the stale value.
+    setEditing(null);
   };
 
   const disabledTip = canMutate ? undefined : 'Disabled in public/demo mode';
@@ -245,14 +260,15 @@ const LinksSection: React.FC<LinksSectionProps> = ({
       )}
 
       <LinkEditModal
+        key={modalKey}
         opened={modalOpened}
         projectId={projectId}
         link={editing}
         dataCollections={dataCollections}
         resolvers={resolvers}
-        onClose={() => setModalOpened(false)}
+        onClose={closeModal}
         onSaved={() => {
-          setModalOpened(false);
+          closeModal();
           refresh();
         }}
       />

--- a/packages/depictio-react-core/src/components/TableRenderer.tsx
+++ b/packages/depictio-react-core/src/components/TableRenderer.tsx
@@ -109,13 +109,31 @@ const TableRenderer: React.FC<TableRendererProps> = ({
         if (cancelled) return;
         const selectionOn =
           Boolean(metadata.row_selection_enabled) && !!onFilterChange;
+        // Honor per-column visibility from the builder (mirrors
+        // TablePreview's cols_json[col].hide filter). The /render_table
+        // endpoint still returns every column from the dataframe — we
+        // restrict what AG Grid renders here so the preview and the final
+        // dashboard agree on which columns are visible.
+        const colsJson =
+          (metadata.cols_json as Record<string, { hide?: boolean }> | undefined) ?? {};
+        const visibleColumns = res.columns.filter(
+          (c) => colsJson[c.field]?.hide !== true,
+        );
         // Default sort: prefer whatever column the server picked (it does
         // its own ``acquisition*`` lookup so ingest order matches the image
         // grid). Fall back to the same heuristic client-side in case an
-        // older API responds without a ``sort_by`` field.
+        // older API responds without a ``sort_by`` field. Restrict the
+        // fallback to visible columns so we never default-sort on a hidden
+        // one. If the server's pick is itself hidden, drop it too — the
+        // user has chosen not to surface that column.
+        const serverSort = res.sort_by as string | null | undefined;
+        const serverSortVisible =
+          serverSort && visibleColumns.some((c) => c.field === serverSort)
+            ? serverSort
+            : null;
         const defaultSortField =
-          (res.sort_by as string | null | undefined) ??
-          res.columns
+          serverSortVisible ??
+          visibleColumns
             .map((c) => c.field)
             .find(
               (f) =>
@@ -126,7 +144,7 @@ const TableRenderer: React.FC<TableRendererProps> = ({
           (res.sort_dir as 'asc' | 'desc' | undefined) ?? 'desc';
         sortRef.current = { sortBy: defaultSortField, sortDir: defaultSortDir };
         setColDefs(
-          res.columns.map((c, i) => {
+          visibleColumns.map((c, i) => {
             const isNumeric = c.type === 'numericColumn';
             const isDefaultSort = c.field === defaultSortField;
             // ``type: 'numericColumn'`` is a built-in AG Grid type alias that


### PR DESCRIPTION
## Filter fix (root cause)

Cross-DC filter (e.g. habitat → sample_id) was silently broken: 500 on `/advanced_viz/data`, no-op on `/render_figure` / `/render_table`.

`extend_filters_via_links`:
```python
target_column = resolved.get("target_column") or link.get("link_config", {}).get(
    "target_field", source_column,
)
```
`dict.get("target_field", source_column)` returns `None` when the key exists with value `None` — the `source_column` default never fires. With `link_config.target_field: null` (common for `direct` resolver), `target_column` → `None` → synthetic filter with `column_name=None` → `pl.col(None)` crash on advanced viz, silent drop on figures/tables.

Fix: explicit `or`-chain `(resolved.target_column or target_field or source_column)` + skip+warn if all None. Defense-in-depth: drop None-column filters in the advanced_viz schema guard; coerce None → "" in `_generate_filter_hash`.

## Bundled UI

- `TableRenderer.tsx`: honour per-column `cols_json[col].hide` (mirrors `TablePreview`).
- Add-link modal (`LinkEditModal`, `LinksSection`):
  - Restyled to match `CreateDataCollectionModal` (centered icon+title header, teal accent, `padding="lg"`, `withCloseButton`).
  - `clearable` on every Select + bump `modalKey` on each open → fresh remount, no stale "Target data collection" name.
  - Move the Source DC description out of the `Group` so Source DC ↔ Source column inputs align on the same baseline.

## Test plan

- [ ] Habitat filter on dashboard with rarefaction viz → both advanced viz and standard scatter refresh (no 500, no silent no-op).
- [ ] Add link → fill → save → Add link again → all fields blank, X buttons present.
- [ ] Source DC and Source column are baseline-aligned.