### PR TITLE
fix(filters): cross-DC link filter uses join column, not filter column

### DIFF
--- a/depictio/api/v1/filter_links.py
+++ b/depictio/api/v1/filter_links.py
@@ -277,23 +277,44 @@ def extend_filters_via_links(
 
             if resolved and resolved.get("resolved_values"):
                 resolved_values = resolved["resolved_values"]
-                # ``dict.get(key, default)`` returns the *value* when the key is
-                # present even if it's ``None`` — so the historical
-                # ``.get("target_field", source_column)`` chain silently
-                # produced ``target_column = None`` whenever link_config had
-                # ``target_field: null`` (which is common for the 'direct'
-                # resolver where users leave the field empty). Use an explicit
-                # ``or`` chain so each None falls through to the next fallback.
+                # Resolve the column to filter on the *target* DC.
+                #
+                # ``resolved_values`` are values of the link's join column on the
+                # target side (the resolver translated the user's filter values
+                # through it — see links_endpoints resolve_link). So the filter we
+                # synthesise must name the *link's join column*, not the column the
+                # user happened to filter on.
+                #
+                # Order of preference:
+                #   1. resolved.target_column   — explicit, if the resolver ever
+                #      starts returning it (LinkResolutionResponse has no such
+                #      field today, so this is None).
+                #   2. link_config.target_field — the target-side column for
+                #      resolvers that rename across DCs (e.g. MultiQC
+                #      sample_mapping). Often null for the 'direct' resolver.
+                #   3. link.source_column       — the link's join column. For a
+                #      'direct' table→table link the join column has the same name
+                #      on both DCs, so this is the correct target column (e.g.
+                #      'sample_id'). DCLink has no separate target column field.
+                #
+                # NB: ``source_column`` here is the *user's filter column* (e.g.
+                # 'habitat'), NOT the join column — it must never be the fallback,
+                # or the synthetic filter names a column absent from the target DC
+                # and apply_runtime_filters silently drops it (→ every row
+                # returned, component never refreshes). ``dict.get(key, default)``
+                # returns the value even when it's ``None``, so use an explicit
+                # ``or`` chain and let each None fall through.
                 link_config = link.get("link_config") or {}
                 target_column = (
                     resolved.get("target_column")
                     or link_config.get("target_field")
-                    or source_column
+                    or link.get("source_column")
                 )
                 if not target_column:
                     logger.warning(
                         f"[{component_type}] Skipping link {link.get('id')!r}: "
-                        f"could not resolve a target column (source_column={source_column!r}, "
+                        f"could not resolve a target column (filter_column={source_column!r}, "
+                        f"link.source_column={link.get('source_column')!r}, "
                         f"link_config.target_field={link_config.get('target_field')!r})"
                     )
                     continue

--- a/depictio/tests/api/v1/test_filter_links.py
+++ b/depictio/tests/api/v1/test_filter_links.py
@@ -1,0 +1,144 @@
+"""Tests for cross-DC link filter resolution in ``extend_filters_via_links``.
+
+Regression coverage for the bug where a cross-DC link whose ``target_field`` is
+null (the common 'direct' table→table case) produced a synthetic filter naming
+the *user's filter column* instead of the link's *join column*. The resolved
+values were correct but attached to the wrong column, so ``apply_runtime_filters``
+silently dropped the filter and every row was returned (component never refreshed).
+"""
+
+from unittest.mock import patch
+
+from depictio.api.v1.filter_links import extend_filters_via_links
+
+# DC ids: source = metadata DC the user filters on, target = the canonical
+# advanced-viz DC (e.g. rarefaction) we want to filter via the link.
+SOURCE_DC = "6a19541470f089f587c39c64"
+TARGET_DC = "6a1954189fa2f2d1ffc39c76"
+
+
+def _project_metadata(*, target_field):
+    """Project metadata with a single direct table→table link, mirroring the
+    seeded ``sample_id`` link on the devdemo deployment."""
+    return {
+        "project": {
+            "_id": "fcf60afdea2241b493b9c473",
+            "links": [
+                {
+                    "id": "6a19541e70f089f587c39c6a",
+                    "enabled": True,
+                    "source_dc_id": SOURCE_DC,
+                    # The link's join column — same name on both DCs for a
+                    # 'direct' link. This is the column that exists on the target.
+                    "source_column": "sample_id",
+                    "target_dc_id": TARGET_DC,
+                    "target_type": "table",
+                    "link_config": {"resolver": "direct", "target_field": target_field},
+                }
+            ],
+        }
+    }
+
+
+def _habitat_filter():
+    """A MultiSelect filter on the source DC's ``habitat`` column — a column that
+    does NOT exist on the target DC, so the link must translate it to ``sample_id``."""
+    return {
+        SOURCE_DC: [
+            {
+                "value": ["Groundwater"],
+                "metadata": {
+                    "column_name": "habitat",
+                    "interactive_component_type": "MultiSelect",
+                },
+            }
+        ]
+    }
+
+
+def test_link_filter_uses_join_column_not_filter_column():
+    """When the resolver returns target-DC values but no ``target_column`` and the
+    link has ``target_field: null``, the synthetic filter must name the link's
+    join column (``sample_id``), not the user's filter column (``habitat``)."""
+    resolved = {
+        "resolved_values": ["SRR10070141", "SRR10070133", "SRR10070132"],
+        "resolver_used": "direct",
+    }
+    with patch(
+        "depictio.api.v1.filter_links.resolve_link_values", return_value=resolved
+    ) as mock_resolve:
+        link_filters = extend_filters_via_links(
+            target_dc_id=TARGET_DC,
+            filters_by_dc=_habitat_filter(),
+            project_metadata=_project_metadata(target_field=None),
+            access_token="fake-token",
+            component_type="figure",
+        )
+
+    mock_resolve.assert_called_once()
+    assert len(link_filters) == 1
+    meta = link_filters[0]["metadata"]
+    # The crux of the regression: column must be the join column, not 'habitat'.
+    assert meta["column_name"] == "sample_id"
+    assert meta["dc_id"] == TARGET_DC
+    assert link_filters[0]["value"] == [
+        "SRR10070141",
+        "SRR10070133",
+        "SRR10070132",
+    ]
+
+
+def test_target_field_override_takes_precedence_over_join_column():
+    """If the link explicitly sets ``target_field`` (cross-DC rename, e.g. MultiQC
+    sample_mapping), that wins over the join-column fallback."""
+    resolved = {"resolved_values": ["s1", "s2"], "resolver_used": "sample_mapping"}
+    with patch("depictio.api.v1.filter_links.resolve_link_values", return_value=resolved):
+        link_filters = extend_filters_via_links(
+            target_dc_id=TARGET_DC,
+            filters_by_dc=_habitat_filter(),
+            project_metadata=_project_metadata(target_field="sample_name"),
+            access_token="fake-token",
+            component_type="figure",
+        )
+
+    assert len(link_filters) == 1
+    assert link_filters[0]["metadata"]["column_name"] == "sample_name"
+
+
+def test_resolver_target_column_takes_top_precedence():
+    """If the resolver ever returns an explicit ``target_column`` it wins over
+    everything else."""
+    resolved = {
+        "resolved_values": ["s1"],
+        "resolver_used": "direct",
+        "target_column": "explicit_col",
+    }
+    with patch("depictio.api.v1.filter_links.resolve_link_values", return_value=resolved):
+        link_filters = extend_filters_via_links(
+            target_dc_id=TARGET_DC,
+            filters_by_dc=_habitat_filter(),
+            project_metadata=_project_metadata(target_field="sample_name"),
+            access_token="fake-token",
+            component_type="figure",
+        )
+
+    assert link_filters[0]["metadata"]["column_name"] == "explicit_col"
+
+
+def test_link_skipped_when_no_join_column_resolvable():
+    """If none of resolver/target_field/join-column yield a column, the link is
+    skipped (not emitted with a None column that would crash downstream)."""
+    resolved = {"resolved_values": ["s1"], "resolver_used": "direct"}
+    md = _project_metadata(target_field=None)
+    # Remove the join column so every fallback is empty.
+    md["project"]["links"][0]["source_column"] = ""
+    with patch("depictio.api.v1.filter_links.resolve_link_values", return_value=resolved):
+        link_filters = extend_filters_via_links(
+            target_dc_id=TARGET_DC,
+            filters_by_dc=_habitat_filter(),
+            project_metadata=md,
+            access_token="fake-token",
+            component_type="figure",
+        )
+
+    assert link_filters == []


### PR DESCRIPTION
## Summary

Follow-up to #776. That PR fixed the `target_column=None` → 500 crash but left a **second defect** that made cross-DC link filters silently no-op on the React viewer: the synthetic filter was emitted naming the user's *filter* column instead of the link's *join* column, so every row was returned and the component never refreshed.

Reported as still-broken on the devdemo deployment (`dashboard-beta-edit/e0f0c08bf6f747bba353fb32`) even after #776 shipped in `0.13.11`.

## Root cause

In `extend_filters_via_links` (`depictio/api/v1/filter_links.py`) the target-column fallback chain was:

```python
target_column = (
    resolved.get("target_column")        # None — not a field on LinkResolutionResponse
    or link_config.get("target_field")   # null for the 'direct' resolver
    or source_column                     # ← the user's FILTER column, WRONG
)
```

`source_column` here is the column the user filtered on (e.g. `habitat`), read from `source_filter.metadata.column_name`. For a `habitat → sample_id` direct link the resolver **correctly** translates habitat values into sample_id values, but the filter was then emitted with `column_name=habitat` — a column that doesn't exist on the target DC. `apply_runtime_filters` logged `FILTER MISMATCH: Skipping ... 'habitat' not in DataFrame` and dropped it → all rows returned.

Confirmed on the live deployment logs:
```
resolve_link: habitat -> sample_id
_translate_filter_values: 1 habitat value -> 3 sample_id values
apply_runtime_filters: ⚠️ FILTER MISMATCH: Skipping 2 filter(s)
  ❌ Column 'habitat' value=['SRR10070141','SRR10070133','SRR10070132'] not in DataFrame
  📋 Available columns: [...,'sample_id','shannon']
```
And against the seeded link `6a19541e70f089f587c39c6a`: `source_column=sample_id`, `resolver=direct`, `target_field=null` — exactly the case that fell through to the wrong column.

## Fix

Fall back to `link.source_column` (the link's join column, which has the same name on both DCs for a direct link) instead of the filter column. Final order: resolver `target_column` → `link_config.target_field` → `link.source_column`.

## Tests

Adds `depictio/tests/api/v1/test_filter_links.py` covering:
- join-column fallback (the regression — fails on the old code)
- `target_field` override precedence
- explicit resolver `target_column` precedence
- skip when no column is resolvable

All 4 pass; the first fails when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)