### PR TITLE
Fix tab three-dots menu triggering URL refresh in React viewer

### DIFF
--- a/depictio/viewer/src/chrome/Sidebar.tsx
+++ b/depictio/viewer/src/chrome/Sidebar.tsx
@@ -409,13 +409,21 @@ const TabMenu: React.FC<TabMenuProps> = ({
   onDeleteTab,
   onMoveTab,
 }) => {
-  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+  const stop = (e: React.SyntheticEvent) => {
+    // Stop the click bubbling to the Tabs.Tab (which would switch tab) AND
+    // cancel the default action: `renderRoot` renders the tab as an
+    // `<a href>` for native open-in-new-tab support, so without
+    // `preventDefault` clicking "..." follows the href and refreshes the URL
+    // instead of opening the menu.
+    e.stopPropagation();
+    e.preventDefault();
+  };
 
   return (
     <Box
       // The Tabs.Tab parent treats any click as a navigation request — wrap
-      // the trigger in a stopPropagation guard so opening the menu doesn't
-      // also switch tab.
+      // the trigger in a stopPropagation + preventDefault guard so opening the
+      // menu doesn't also switch tab or trigger the anchor navigation.
       onClick={stop}
       onMouseDown={stop}
       style={{ display: 'inline-flex', alignItems: 'center' }}


### PR DESCRIPTION
## Problem

In the React viewer, clicking the three-dots (`...`) action menu next to a sidebar tab triggered a URL refresh / navigation instead of opening the ActionMenu, making the **Edit properties** / **Move** / **Delete** options unusable.

## Root cause

Each sidebar tab is rendered as an `<a href>` element (via Mantine's `renderRoot`) so middle/Cmd+click can open the dashboard in a new browser tab natively:

```tsx
renderRoot={(props) => (
  <a {...props} href={dashboardHref(d.dashboard_id, linkMode)} />
)}
```

The three-dots `TabMenu` lives inside that anchor (in the tab's `rightSection`). Its click guard only called `stopPropagation()`:

```tsx
const stop = (e: React.SyntheticEvent) => e.stopPropagation();
```

`stopPropagation()` blocks the React-level tab-switch handler, but does **not** cancel the browser's default action on the anchor — so clicking `...` followed the `href` and refreshed the URL, and the menu never opened.

## Fix

Added `preventDefault()` to the guard so the anchor navigation is cancelled when interacting with the menu trigger:

```tsx
const stop = (e: React.SyntheticEvent) => {
  e.stopPropagation();
  e.preventDefault();
};
```

Regular tab clicks and middle/Cmd+click open-in-new-tab continue to work unchanged.

## Files

- `depictio/viewer/src/chrome/Sidebar.tsx`

## Testing notes

`node_modules` isn't installed in the dev container so `tsc`/build wasn't run here, but the change is type-safe (`preventDefault()` exists on `React.SyntheticEvent`). Worth a quick local `npm run build` and a click-test in the editor before merge.

https://claude.ai/code/session_01PEopxBWyp1ySJyFA217tpt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEopxBWyp1ySJyFA217tpt)_