### PR TITLE
feat(auth): pipeline-driven user provisioning + passwordless magic-link login

### DIFF
--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -172,6 +172,16 @@ class AuthConfig(BaseSettings):
         default=None,
         description="Internal API key for service-to-service communication (auto-generated if unset)",
     )
+    provisioning_api_key_env: Optional[str] = Field(
+        default=None,
+        description="Shared secret used by pipelines to auto-provision user accounts "
+        "(POST /auth/provision_user). Scoped to provisioning only; kept separate from "
+        "internal_api_key. The provisioning endpoints are disabled when this is unset.",
+    )
+    magic_link_expiry_minutes: int = Field(
+        default=15,
+        description="Lifetime, in minutes, of a single-use magic-link login ticket",
+    )
     unauthenticated_mode: bool = Field(default=False, description="Enable unauthenticated mode")
     single_user_mode: bool = Field(
         default=False,
@@ -227,6 +237,9 @@ class AuthConfig(BaseSettings):
         # read environment variables when instantiated via default_factory
         if self.internal_api_key_env is None:
             self.internal_api_key_env = os.getenv("DEPICTIO_AUTH_INTERNAL_API_KEY")
+
+        if self.provisioning_api_key_env is None:
+            self.provisioning_api_key_env = os.getenv("DEPICTIO_AUTH_PROVISIONING_API_KEY")
 
         # Read auth mode environment variables
         env_public_mode = os.getenv("DEPICTIO_AUTH_PUBLIC_MODE", "").lower()
@@ -294,6 +307,17 @@ class AuthConfig(BaseSettings):
             keys_dir=self.keys_dir,
             algorithm=self.keys_algorithm,
         )
+
+    @computed_field
+    @property
+    def provisioning_api_key(self) -> str | None:
+        """Shared secret for pipeline-side user provisioning.
+
+        Unlike ``internal_api_key`` this is never auto-generated: when it is
+        unset the provisioning endpoints are disabled, so an instance does not
+        silently expose account creation.
+        """
+        return self.provisioning_api_key_env or None
 
 
 # ── Infrastructure ────────────────────────────────────────────────────────────

--- a/depictio/api/v1/endpoints/user_endpoints/core_functions.py
+++ b/depictio/api/v1/endpoints/user_endpoints/core_functions.py
@@ -9,7 +9,13 @@ from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
 from depictio.api.v1.endpoints.user_endpoints.utils import create_access_token
 from depictio.models.models.base import PyObjectId
-from depictio.models.models.users import TokenBase, TokenBeanie, TokenData, UserBeanie
+from depictio.models.models.users import (
+    MagicLinkTicketBeanie,
+    TokenBase,
+    TokenBeanie,
+    TokenData,
+    UserBeanie,
+)
 
 
 async def _create_permanent_token(user: UserBeanie) -> TokenBeanie:
@@ -709,3 +715,103 @@ async def _create_user_in_db(
                 }
         # Re-raise if it's a different error
         raise
+
+
+@validate_call(validate_return=True)
+async def _provision_user(email: EmailStr) -> dict:
+    """Create-or-get a passwordless user and mint a long-lived run token.
+
+    Used by pipelines (gated by the provisioning API key) to obtain a bearer
+    token that lets the CLI act as ``email`` for the duration of a run. The
+    user is created without a usable password — login happens via magic link,
+    never a password.
+
+    Returns:
+        dict with ``user`` (UserBeanie), ``token`` (TokenBeanie) and ``created``
+        (True when the user was newly created, False when it already existed).
+    """
+    payload = await _create_user_in_db(email=email, password="", is_anonymous=False)
+    user = payload.get("user") if payload else None
+    if not isinstance(user, UserBeanie):
+        raise HTTPException(status_code=500, detail="Failed to provision user")
+
+    token_data = TokenData(
+        sub=user.id,  # type: ignore[invalid-argument-type]
+        name=f"pipeline_provision_{datetime.now().strftime('%Y%m%d%H%M%S')}",
+        token_lifetime="long-lived",
+    )
+    token = await _add_token(token_data)
+    if token is None:
+        raise HTTPException(status_code=500, detail="Failed to issue provisioning token")
+
+    created = bool(payload and payload.get("success"))
+    return {"user": user, "token": token, "created": created}
+
+
+@validate_call(validate_return=True)
+async def _create_magic_link_ticket(
+    user_id: PydanticObjectId,
+    expiry_minutes: int = 15,
+) -> MagicLinkTicketBeanie:
+    """Create a short-lived, single-use magic-link ticket for ``user_id``.
+
+    The opaque secret is what travels in the login URL; it is invalidated on
+    first redemption and ignored once expired.
+    """
+    import secrets
+
+    ticket = MagicLinkTicketBeanie(
+        ticket=secrets.token_urlsafe(32),
+        user_id=user_id,
+        expire_datetime=datetime.now() + timedelta(minutes=expiry_minutes),
+    )
+    await ticket.save()
+    return ticket
+
+
+@validate_call(validate_return=True)
+async def _redeem_magic_link_ticket(ticket_secret: str) -> dict:
+    """Redeem a magic-link ticket for a fresh browser session.
+
+    Validates the ticket (exists, unused, unexpired), marks it used so it can
+    never be replayed, then mints a standard short-lived + refresh session for
+    the ticket's user. The returned payload matches what the React viewer
+    persists to local storage.
+
+    Raises:
+        HTTPException: 401 if the ticket is missing, already used, or expired.
+        HTTPException: 404 if the ticket's user no longer exists.
+    """
+    ticket_doc = await MagicLinkTicketBeanie.find_one({"ticket": ticket_secret})
+    if ticket_doc is None or ticket_doc.used or ticket_doc.expire_datetime <= datetime.now():
+        raise HTTPException(status_code=401, detail="Invalid or expired magic link")
+
+    # Single-use: burn the ticket before issuing the session.
+    ticket_doc.used = True
+    await ticket_doc.save()
+
+    user = await UserBeanie.get(ticket_doc.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    token_data = TokenData(
+        sub=user.id,  # type: ignore[invalid-argument-type]
+        name=f"magic_login_{datetime.now().strftime('%Y%m%d%H%M%S')}",
+        token_lifetime="short-lived",
+    )
+    token = await _add_token(token_data)
+    if token is None:
+        raise HTTPException(status_code=500, detail="Failed to issue session token")
+
+    return {
+        "logged_in": True,
+        "email": user.email,
+        "user_id": str(user.id),
+        "access_token": token.access_token,
+        "refresh_token": token.refresh_token,
+        "expire_datetime": token.expire_datetime.isoformat(),
+        "refresh_expire_datetime": token.refresh_expire_datetime.isoformat(),
+        "name": token.name,
+        "token_lifetime": token.token_lifetime,
+        "token_type": token.token_type or "bearer",
+    }

--- a/depictio/api/v1/endpoints/user_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/user_endpoints/routes.py
@@ -20,6 +20,7 @@ from depictio.api.v1.endpoints.user_endpoints.core_functions import (
     _check_if_token_is_valid,
     _check_password,
     _cleanup_expired_temporary_users,
+    _create_magic_link_ticket,
     _create_temporary_user,
     _create_temporary_user_session,
     _create_user_in_db,
@@ -28,7 +29,9 @@ from depictio.api.v1.endpoints.user_endpoints.core_functions import (
     _get_anonymous_user_session,
     _hash_password,
     _list_tokens,
+    _provision_user,
     _purge_expired_tokens,
+    _redeem_magic_link_ticket,
 )
 from depictio.api.v1.endpoints.user_endpoints.utils import (
     create_access_token,
@@ -200,6 +203,99 @@ async def create_token(
         )
 
     return token
+
+
+# ── Pipeline provisioning + passwordless magic-link login ──────────────────────
+
+
+class _ProvisionUserRequest(BaseModel):
+    """Body for POST /auth/provision_user."""
+
+    email: EmailStr
+
+
+class _ExchangeMagicLinkRequest(BaseModel):
+    """Body for POST /auth/magic/exchange — the opaque ticket from the URL."""
+
+    ticket: str
+
+
+def _require_provisioning_key(api_key: str) -> None:
+    """Gate provisioning endpoints on the dedicated provisioning secret.
+
+    The endpoints are disabled (503) when no key is configured, so an instance
+    never silently exposes account creation; a wrong key is rejected (403).
+    """
+    configured = settings.auth.provisioning_api_key
+    if not configured:
+        raise HTTPException(
+            status_code=503,
+            detail="User provisioning is not enabled on this instance",
+        )
+    if api_key != configured:
+        raise HTTPException(status_code=403, detail="Invalid provisioning API key")
+
+
+@auth_endpoint_router.post("/provision_user", include_in_schema=True)
+async def provision_user_endpoint(
+    request: _ProvisionUserRequest,
+    api_key: str = Header(..., description="Provisioning API key"),
+) -> dict:
+    """Create-or-get a passwordless user and return a long-lived run token.
+
+    Called by pipelines (gated by the provisioning API key) so the CLI can act
+    as ``email`` for the rest of a run. Idempotent: re-running for the same
+    email returns a fresh token for the existing user.
+    """
+    _require_provisioning_key(api_key)
+    result = await _provision_user(request.email)
+    user = result["user"]
+    token = result["token"]
+    return {
+        "user_id": str(user.id),
+        "email": user.email,
+        "is_admin": user.is_admin,
+        "created": result["created"],
+        "token": {
+            "access_token": token.access_token,
+            "refresh_token": token.refresh_token,
+            "expire_datetime": token.expire_datetime.strftime("%Y-%m-%d %H:%M:%S"),
+            "refresh_expire_datetime": token.refresh_expire_datetime.strftime("%Y-%m-%d %H:%M:%S"),
+            "name": token.name,
+            "token_lifetime": token.token_lifetime,
+            "token_type": token.token_type,
+        },
+    }
+
+
+@auth_endpoint_router.post("/me/magic_link", include_in_schema=True)
+async def create_my_magic_link(
+    current_user: UserBeanie = Depends(get_current_user),
+) -> dict:
+    """Mint a short-lived, single-use magic-link login ticket for the caller.
+
+    Bearer-authed: the CLI calls this *as the provisioned user* at the end of a
+    run (once the dashboard exists) so the link's lifetime starts when it is
+    handed out, not when the long pipeline began.
+    """
+    ticket = await _create_magic_link_ticket(
+        current_user.id,  # type: ignore[invalid-argument-type]
+        expiry_minutes=settings.auth.magic_link_expiry_minutes,
+    )
+    base = f"{settings.dash.external_url}/auth/magic"
+    return {
+        "ticket": ticket.ticket,
+        "expire_datetime": ticket.expire_datetime.isoformat(),
+        # The secret rides in the URL fragment so it stays out of server/proxy
+        # access logs and Referer headers. The viewer reads it from the hash.
+        "login_url": f"{base}#ticket={ticket.ticket}",
+    }
+
+
+@auth_endpoint_router.post("/magic/exchange", include_in_schema=True)
+async def exchange_magic_link(request: _ExchangeMagicLinkRequest) -> dict:
+    """Redeem a magic-link ticket for a browser session (public, single-use)."""
+    return await _redeem_magic_link_ticket(request.ticket)
 
 
 @auth_endpoint_router.post("/refresh", include_in_schema=True)

--- a/depictio/api/v1/services/lifespan.py
+++ b/depictio/api/v1/services/lifespan.py
@@ -36,7 +36,12 @@ from depictio.api.v1.tasks.cleanup_tasks import start_cleanup_tasks
 from depictio.api.v1.utils import clean_screenshots
 from depictio.models.models.analytics import UserActivity, UserSession
 from depictio.models.models.projects import ProjectBeanie
-from depictio.models.models.users import GroupBeanie, TokenBeanie, UserBeanie
+from depictio.models.models.users import (
+    GroupBeanie,
+    MagicLinkTicketBeanie,
+    TokenBeanie,
+    UserBeanie,
+)
 
 WORKER_ID = os.getpid()
 
@@ -62,6 +67,7 @@ async def init_motor_beanie() -> None:
             TokenBeanie,
             GroupBeanie,
             UserBeanie,
+            MagicLinkTicketBeanie,
             ProjectBeanie,
             UserSession,
             UserActivity,

--- a/depictio/cli/cli/commands/run.py
+++ b/depictio/cli/cli/commands/run.py
@@ -4,8 +4,10 @@ from typing import Annotated
 import typer
 
 from depictio.cli.cli.utils.api_calls import (
+    api_create_magic_link,
     api_get_project_from_name,
     api_login,
+    api_provision_user,
     api_sync_project_config_to_server,
 )
 from depictio.cli.cli.utils.common import generate_api_headers, load_depictio_config
@@ -20,6 +22,52 @@ from depictio.cli.cli.utils.scan import scan_project_files
 from depictio.cli.cli_logging import logger
 from depictio.models.s3_utils import S3_storage_checks
 from depictio.models.utils import convert_model_to_dict
+
+
+def _write_provisioned_cli_config(base_config, provision: dict) -> str:
+    """Write a temporary CLI config that runs the pipeline as the provisioned user.
+
+    Clones the service account's ``api_base_url`` + ``s3_storage`` but swaps in
+    the provisioned user's identity and run token. Pointing the rest of the run
+    at this file makes every step (sync, scan, process, dashboard import) own
+    its resources as that user — with no changes to downstream code. The file
+    holds a token, so it is created 0600 and removed on process exit.
+    """
+    import atexit
+    import os
+    import tempfile
+
+    import yaml
+
+    from depictio.models.models.base import convert_objectid_to_str
+
+    tok = provision["token"]
+    temp_cfg = {
+        "api_base_url": str(base_config.api_base_url),
+        "user": {
+            "id": provision["user_id"],
+            "email": provision["email"],
+            "is_admin": provision["is_admin"],
+            "token": {
+                "user_id": provision["user_id"],
+                "access_token": tok["access_token"],
+                "refresh_token": tok["refresh_token"],
+                "token_type": tok["token_type"],
+                "token_lifetime": tok["token_lifetime"],
+                "expire_datetime": tok["expire_datetime"],
+                "refresh_expire_datetime": tok["refresh_expire_datetime"],
+                "name": tok["name"],
+            },
+        },
+        "s3_storage": convert_objectid_to_str(base_config.s3_storage.model_dump()),
+    }
+
+    fd, path = tempfile.mkstemp(prefix="depictio-cli-provisioned-", suffix=".yaml")
+    with os.fdopen(fd, "w") as fh:
+        yaml.safe_dump(temp_cfg, fh)
+    os.chmod(path, 0o600)
+    atexit.register(lambda: os.path.exists(path) and os.unlink(path))
+    return path
 
 
 def register_run_command(app: typer.Typer):
@@ -81,6 +129,29 @@ def register_run_command(app: typer.Typer):
             "--skip-dashboard-import",
             help="Skip automatic dashboard import from template.",
         ),
+        # Provisioning options
+        user: Annotated[
+            str | None,
+            typer.Option(
+                "--user",
+                help=(
+                    "Provision (create-or-get) this user's account and run the pipeline as "
+                    "them, then emit a passwordless login link to their dashboard. "
+                    "Requires --provisioning-key."
+                ),
+            ),
+        ] = None,
+        provisioning_key: Annotated[
+            str | None,
+            typer.Option(
+                "--provisioning-key",
+                help=(
+                    "Shared provisioning secret used with --user "
+                    "(or set DEPICTIO_AUTH_PROVISIONING_API_KEY)."
+                ),
+                envvar="DEPICTIO_AUTH_PROVISIONING_API_KEY",
+            ),
+        ] = None,
         # Existing options
         workflow_name: Annotated[
             str | None,
@@ -181,13 +252,44 @@ def register_run_command(app: typer.Typer):
         if sync_files or overwrite:
             rescan_folders = True
 
+        if user and not provisioning_key:
+            rich_print_checked_statement(
+                "--user requires --provisioning-key "
+                "(or the DEPICTIO_AUTH_PROVISIONING_API_KEY environment variable).",
+                "error",
+            )
+            raise typer.Exit(code=1)
+
         # Track whether we're in template mode
         is_template_mode = template is not None
         template_resolved_config: dict | None = None
         template_dashboard_paths: list[Path] = []
+        # First dashboard imported for the provisioned user — target of the
+        # passwordless login link emitted at the end of the run.
+        provisioned_dashboard_id: str | None = None
 
         success_count = 0
         total_steps = 8 if is_template_mode else 7
+
+        # Step 0a (provisioning only): create-or-get the user and switch the run
+        # to act as them by pointing CLI_config_path at a temporary per-user
+        # config. Everything downstream then owns its resources as that user.
+        if user and not dry_run:
+            rich_print_section_separator("Provisioning user account")
+            try:
+                base_config = load_depictio_config(yaml_config_path=CLI_config_path)
+                provision = api_provision_user(
+                    str(base_config.api_base_url), user, provisioning_key
+                )
+                CLI_config_path = _write_provisioned_cli_config(base_config, provision)
+                action = "Created account for" if provision.get("created") else "Reusing account"
+                rich_print_checked_statement(
+                    f"{action} {provision['email']} — running pipeline as this user",
+                    "success",
+                )
+            except Exception as e:
+                rich_print_checked_statement(f"User provisioning failed: {e}", "error")
+                raise typer.Exit(code=1)
 
         # Step 0 (template only): Resolve template and validate data
         if is_template_mode:
@@ -595,6 +697,9 @@ def register_run_command(app: typer.Typer):
                     for r in results:
                         (imported if r["success"] else failed).append(r)
 
+                    if user and imported and provisioned_dashboard_id is None:
+                        provisioned_dashboard_id = imported[0].get("dashboard_id")
+
                     for r in imported:
                         action = "updated" if r.get("updated") else "imported"
                         rich_print_checked_statement(
@@ -629,6 +734,20 @@ def register_run_command(app: typer.Typer):
         elif is_template_mode and not template_dashboard_paths:
             rich_print_checked_statement("No dashboards defined in template", "info")
             success_count += 1
+
+        # Passwordless login link for the provisioned user. Minted now (not at
+        # provisioning time) so the short-lived ticket's clock starts when the
+        # link is handed out, not when a long pipeline began.
+        if user and not dry_run and provisioned_dashboard_id:
+            rich_print_section_separator("Passwordless login link")
+            try:
+                magic_config = load_depictio_config(yaml_config_path=CLI_config_path)
+                magic = api_create_magic_link(magic_config)
+                login_url = f"{magic['login_url']}&next=/dashboard-beta/{provisioned_dashboard_id}"
+                rich_print_checked_statement(f"One-time login link for {user}:", "info")
+                rich_print_checked_statement(login_url, "success")
+            except Exception as e:
+                rich_print_checked_statement(f"Could not create login link: {e}", "warning")
 
         # Final summary
         rich_print_section_separator("Depictio-CLI Run Summary")

--- a/depictio/cli/cli/utils/api_calls.py
+++ b/depictio/cli/cli/utils/api_calls.py
@@ -62,6 +62,43 @@ def api_login(yaml_config_path: str = "~/.depictio/CLI.yaml") -> dict:
 
 
 @validate_call
+def api_provision_user(api_base_url: str, email: str, provisioning_key: str) -> dict:
+    """Provision (create-or-get) a user via the shared provisioning key.
+
+    Returns the provisioning payload, which includes a long-lived run token the
+    CLI uses to act as ``email`` for the rest of the run. The provisioning key
+    is the only credential — no per-user identity is needed on the caller side.
+    """
+    response = httpx.post(
+        f"{api_base_url}/depictio/api/v1/auth/provision_user",
+        json={"email": email},
+        headers={"api-key": provisioning_key},
+        timeout=30.0,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"User provisioning failed ({response.status_code}): {response.text}")
+    return response.json()
+
+
+@validate_call
+def api_create_magic_link(CLI_config: CLIConfig) -> dict:
+    """Mint a short-lived, single-use magic-link login for the current user.
+
+    Authenticated as the (provisioned) user via the bearer token in
+    ``CLI_config``. Returns ``{ticket, expire_datetime, login_url}`` where
+    ``login_url`` carries the ticket in its fragment.
+    """
+    response = httpx.post(
+        f"{CLI_config.api_base_url}/depictio/api/v1/auth/me/magic_link",
+        headers=generate_api_headers(CLI_config),
+        timeout=30.0,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"Magic-link creation failed ({response.status_code}): {response.text}")
+    return response.json()
+
+
+@validate_call
 def api_get_project_from_id(project_id: PyObjectId, CLI_config: CLIConfig):
     """
     Get a project from the server using the project ID.

--- a/depictio/models/models/users.py
+++ b/depictio/models/models/users.py
@@ -148,6 +148,31 @@ class TokenBeanie(TokenBase, Document):
         name = "tokens"  # Collection name
 
 
+class MagicLinkTicket(MongoModel):
+    """A short-lived, single-use ticket that logs a user in without a password.
+
+    The opaque ``ticket`` secret travels in the login URL; everything else
+    (the real session) is minted server-side when the ticket is redeemed. The
+    ticket is invalidated on first use (``used=True``) and ignored past
+    ``expire_datetime``.
+    """
+
+    ticket: str  # opaque random secret carried in the magic-link URL
+    user_id: PydanticObjectId
+    expire_datetime: datetime
+    used: bool = False
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    @field_serializer("user_id")
+    def serialize_user_id(self, user_id: PydanticObjectId) -> str:
+        return str(user_id)
+
+
+class MagicLinkTicketBeanie(MagicLinkTicket, Document):
+    class Settings:
+        name = "magic_link_tickets"  # Collection name
+
+
 class Group(MongoModel):
     name: str
     users_ids: list[PyObjectId] = Field(default_factory=list)

--- a/depictio/tests/api/v1/endpoints/user_endpoints/test_provisioning.py
+++ b/depictio/tests/api/v1/endpoints/user_endpoints/test_provisioning.py
@@ -1,0 +1,129 @@
+"""Tests for pipeline provisioning + passwordless magic-link login.
+
+Covers the core functions behind POST /auth/provision_user,
+POST /auth/me/magic_link and POST /auth/magic/exchange.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from depictio.api.v1.endpoints.user_endpoints.core_functions import (
+    _create_magic_link_ticket,
+    _provision_user,
+    _redeem_magic_link_ticket,
+)
+from depictio.models.models.users import (
+    MagicLinkTicketBeanie,
+    TokenBeanie,
+    UserBeanie,
+)
+from depictio.tests.api.v1.endpoints.user_endpoints.conftest import beanie_setup
+
+PROVISION_MODELS = [TokenBeanie, UserBeanie, MagicLinkTicketBeanie]
+
+
+class TestProvisionUser:
+    @pytest.mark.asyncio
+    @beanie_setup(models=PROVISION_MODELS)
+    async def test_provision_creates_passwordless_user_and_token(self):
+        result = await _provision_user("alice@example.com")
+
+        user = result["user"]
+        token = result["token"]
+        assert isinstance(user, UserBeanie)
+        assert user.email == "alice@example.com"
+        assert user.is_anonymous is False
+        # Passwordless: no usable password, but the stored value is a bcrypt hash.
+        assert user.password.startswith("$2b$")
+        assert result["created"] is True
+
+        # A long-lived run token is issued and persisted.
+        assert isinstance(token, TokenBeanie)
+        assert token.token_lifetime == "long-lived"
+        assert token.user_id == user.id
+        saved = await TokenBeanie.find_one({"user_id": user.id})
+        assert saved is not None
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=PROVISION_MODELS)
+    async def test_provision_is_idempotent(self):
+        first = await _provision_user("bob@example.com")
+        second = await _provision_user("bob@example.com")
+
+        # Same user is reused; only the first call reports it as created.
+        assert first["user"].id == second["user"].id
+        assert first["created"] is True
+        assert second["created"] is False
+
+        # Exactly one user, two tokens (a fresh run token each call).
+        users = await UserBeanie.find({"email": "bob@example.com"}).to_list()
+        assert len(users) == 1
+        tokens = await TokenBeanie.find({"user_id": second["user"].id}).to_list()
+        assert len(tokens) == 2
+
+
+class TestMagicLinkTicket:
+    @pytest.mark.asyncio
+    @beanie_setup(models=PROVISION_MODELS)
+    async def test_create_ticket(self):
+        provisioned = await _provision_user("carol@example.com")
+        ticket = await _create_magic_link_ticket(provisioned["user"].id, expiry_minutes=15)
+
+        assert ticket.used is False
+        assert ticket.ticket  # opaque secret present
+        assert ticket.expire_datetime > datetime.now()
+        assert ticket.user_id == provisioned["user"].id
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=PROVISION_MODELS)
+    async def test_redeem_returns_session_and_burns_ticket(self):
+        provisioned = await _provision_user("dave@example.com")
+        ticket = await _create_magic_link_ticket(provisioned["user"].id, expiry_minutes=15)
+
+        session = await _redeem_magic_link_ticket(ticket.ticket)
+
+        assert session["logged_in"] is True
+        assert session["email"] == "dave@example.com"
+        assert session["user_id"] == str(provisioned["user"].id)
+        assert session["access_token"]
+        assert session["refresh_token"]
+
+        # Single-use: the ticket is now burned.
+        redeemed = await MagicLinkTicketBeanie.find_one({"ticket": ticket.ticket})
+        assert redeemed is not None
+        assert redeemed.used is True
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=PROVISION_MODELS)
+    async def test_redeem_twice_is_rejected(self):
+        provisioned = await _provision_user("erin@example.com")
+        ticket = await _create_magic_link_ticket(provisioned["user"].id, expiry_minutes=15)
+
+        await _redeem_magic_link_ticket(ticket.ticket)
+        with pytest.raises(HTTPException) as exc:
+            await _redeem_magic_link_ticket(ticket.ticket)
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=PROVISION_MODELS)
+    async def test_redeem_expired_is_rejected(self):
+        provisioned = await _provision_user("frank@example.com")
+        expired = MagicLinkTicketBeanie(
+            ticket="expired-secret",
+            user_id=provisioned["user"].id,
+            expire_datetime=datetime.now() - timedelta(minutes=1),
+        )
+        await expired.save()
+
+        with pytest.raises(HTTPException) as exc:
+            await _redeem_magic_link_ticket("expired-secret")
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=PROVISION_MODELS)
+    async def test_redeem_unknown_ticket_is_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            await _redeem_magic_link_ticket("does-not-exist")
+        assert exc.value.status_code == 401

--- a/depictio/viewer/src/auth/AuthApp.tsx
+++ b/depictio/viewer/src/auth/AuthApp.tsx
@@ -5,6 +5,7 @@ import { createTemporaryUser, getAnonymousSession, persistSession } from 'depict
 import AuthBackground from './components/AuthBackground';
 import AuthCard from './components/AuthCard';
 import GoogleOAuthCallback from './components/GoogleOAuthCallback';
+import MagicLinkCallback from './components/MagicLinkCallback';
 import LoginForm from './components/LoginForm';
 import RegisterForm from './components/RegisterForm';
 import { useAuthMode } from './hooks/useAuthMode';
@@ -12,10 +13,11 @@ import './styles/auth.css';
 
 const POST_AUTH_REDIRECT = '/dashboards-beta';
 
-type View = 'login' | 'register' | 'oauth-callback';
+type View = 'login' | 'register' | 'oauth-callback' | 'magic-callback';
 
 function detectView(pathname: string): View {
   if (pathname.startsWith('/auth/google/callback')) return 'oauth-callback';
+  if (pathname.startsWith('/auth/magic')) return 'magic-callback';
   if (pathname.startsWith('/auth/register')) return 'register';
   return 'login';
 }
@@ -40,7 +42,7 @@ export default function AuthApp() {
   // 3. Standard mode with an already-resolved session — bounce straight
   //    through without touching localStorage.
   useEffect(() => {
-    if (view === 'oauth-callback') return;
+    if (view === 'oauth-callback' || view === 'magic-callback') return;
     if (loading || !status) return;
 
     let cancelled = false;
@@ -79,6 +81,8 @@ export default function AuthApp() {
       <div className="auth-page-content">
         {view === 'oauth-callback' ? (
           <GoogleOAuthCallback />
+        ) : view === 'magic-callback' ? (
+          <MagicLinkCallback />
         ) : loading ? (
           <AuthCard heading="Welcome to Depictio :">
             <Stack align="center" gap="md">

--- a/depictio/viewer/src/auth/components/MagicLinkCallback.tsx
+++ b/depictio/viewer/src/auth/components/MagicLinkCallback.tsx
@@ -1,0 +1,77 @@
+import { Anchor, Loader, Stack, Text } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { exchangeMagicToken, persistSession } from 'depictio-react-core';
+import AuthCard from './AuthCard';
+
+const DEFAULT_REDIRECT = '/dashboards-beta';
+
+/** Only allow same-origin relative paths as a redirect target, so a crafted
+ *  `next=` can't bounce the freshly-authenticated user to an external site. */
+function safeNext(next: string | null): string {
+  if (!next || !next.startsWith('/') || next.startsWith('//')) return DEFAULT_REDIRECT;
+  return next;
+}
+
+/**
+ * Renders at /auth/magic#ticket=...&next=... — the passwordless login link a
+ * pipeline hands a user. The single-use ticket rides in the URL fragment (kept
+ * out of server/proxy access logs and Referer); we exchange it server-side for
+ * a session, persist it, and redirect to the dashboard.
+ */
+export default function MagicLinkCallback() {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    const ticket = params.get('ticket');
+    const next = safeNext(params.get('next'));
+
+    if (!ticket) {
+      setError('This login link is missing its token. Please request a new one.');
+      return;
+    }
+
+    // Strip the fragment immediately so the ticket doesn't linger in browser
+    // history or a shared/bookmarked URL after we've consumed it.
+    const { pathname, search } = window.location;
+    window.history.replaceState(null, '', pathname + search);
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const session = await exchangeMagicToken(ticket);
+        if (cancelled) return;
+        persistSession(session);
+        window.location.assign(next);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('[auth] magic-link exchange failed:', err);
+        setError(
+          'This login link is invalid or has expired. Please request a new one.',
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <AuthCard heading="Signing you in…">
+      <Stack align="center" gap="md">
+        {error ? (
+          <>
+            <Text c="red" ta="center">{error}</Text>
+            <Anchor href="/auth">Back to sign-in</Anchor>
+          </>
+        ) : (
+          <>
+            <Loader />
+            <Text c="dimmed">Completing sign-in…</Text>
+          </>
+        )}
+      </Stack>
+    </AuthCard>
+  );
+}

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -1962,6 +1962,21 @@ export async function handleGoogleCallback(code: string, state: string): Promise
   };
 }
 
+/** Redeem a single-use magic-link ticket for a browser session.
+ *
+ *  The opaque ticket arrives in the login URL (fragment); this exchanges it
+ *  server-side — where it is burned so it can never be replayed — for a real
+ *  session ready to persist. Throws on an invalid/expired/used ticket. */
+export async function exchangeMagicToken(ticket: string): Promise<SessionPayload> {
+  const res = await fetch(`${API_BASE}/auth/magic/exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ticket }),
+  });
+  if (!res.ok) await throwHttpError(res, 'Magic link is invalid or has expired');
+  return (await res.json()) as SessionPayload;
+}
+
 /** Persist a session payload to localStorage under the same key Dash uses. */
 export function persistSession(session: SessionPayload): void {
   try {

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -109,6 +109,7 @@ export {
   getAnonymousSession,
   startGoogleOAuth,
   handleGoogleCallback,
+  exchangeMagicToken,
   persistSession,
   clearSession,
   validateSession,


### PR DESCRIPTION
## Summary

Adds instance-level, passwordless onboarding driven by pipelines, gated by **one shared secret**:

- A pipeline finishing for a user auto-creates that user's Depictio account and hands them a **one-click login link** to their dashboard.
- No passwords anywhere; no per-user config on the pipeline side — just one shared key + one command.
- The shared key is the **instance gate** (keeps bots/agents out); separation between users is organizational, not adversarial — matching the stated use case.

### Identity model
Auto-provision a user from one shared provisioning key, then run the pipeline **as that user** (via a temporary 0600 CLI config) so the project + dashboard are owned correctly — with no changes to downstream steps.

### Why a single-use ticket (not a raw token in the URL)
The magic link carries a **short-lived, single-use ticket** in the URL **fragment** (kept out of access logs / `Referer`). It's exchanged server-side — where it's **burned on first use** — for a normal session that lives in browser storage and never in a URL. A leaked link is already used or expired. The long-lived run token stays server-side on the pipeline box.

## What's included

**Backend**
- `AuthConfig.provisioning_api_key` (env `DEPICTIO_AUTH_PROVISIONING_API_KEY`) — dedicated, never auto-generated; provisioning endpoints return **503 when unset** (feature stays off until opted in). Plus `magic_link_expiry_minutes`.
- New single-use `MagicLinkTicket(Beanie)` model, registered in Beanie init.
- Core fns: `_provision_user`, `_create_magic_link_ticket`, `_redeem_magic_link_ticket`.
- Endpoints:
  - `POST /auth/provision_user` — provisioning-key gated, create-or-get passwordless user + long-lived run token (idempotent).
  - `POST /auth/me/magic_link` — bearer; mints the ticket at end of run.
  - `POST /auth/magic/exchange` — public, single-use redemption → session.

**React viewer**
- `exchangeMagicToken()` in `depictio-react-core` + `MagicLinkCallback` at `/auth/magic` (mirrors the Google-OAuth callback): reads ticket from the URL fragment, strips it from history, exchanges, persists, redirects (open-redirect guarded). Already exempt from `bootstrapSession`.

**CLI**
- `depictio-cli run --user <email> --provisioning-key …` (key also via `DEPICTIO_AUTH_PROVISIONING_API_KEY`): provisions the account, runs the pipeline as them, prints a one-time login link to their dashboard.

**Tests** — 7 new tests for the core functions.

## Usage

```bash
# server (once): DEPICTIO_AUTH_PROVISIONING_API_KEY=<secret>, DEPICTIO_DASH_PUBLIC_URL=https://...
export DEPICTIO_AUTH_PROVISIONING_API_KEY=<secret>
depictio-cli run --template nf-core/ampliseq/2.16.0 --data-root /out/alice --user alice@lab.org
# → prints: https://INSTANCE/auth/magic#ticket=...&next=/dashboard-beta/<id>
```

## Verification
- `ruff` clean on all changed Python; `ty` clean on new backend code.
- Viewer + `depictio-react-core` `tsc --noEmit` exit 0.
- **7 new tests pass**; **existing 84 user-endpoint/model tests still pass** (mongomock + real JWT signing).

## Notes
- `pre-commit` was **not** run (unavailable in the build container) — please run before merge.
- Requires `settings.dash.external_url` to point at the public viewer URL; **TLS in front is required**.
- With multiple template dashboards, the link targets the first imported dashboard (others reachable after login).

https://claude.ai/code/session_01LWX2UsVU6udfTtbyZkNVQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWX2UsVU6udfTtbyZkNVQV)_