### PR TITLE
Remove -beta suffix from React routes (Dash→React cutover)

### DIFF
--- a/depictio/api/celery_app.py
+++ b/depictio/api/celery_app.py
@@ -78,7 +78,7 @@ def generate_dashboard_screenshot_dual(
     and permission validation.
 
     Captures both light and dark mode shots in a single browser session.
-    Now drives the **React SPA** at `{fastapi.url}/dashboard-beta/{id}`; the
+    Now drives the **React SPA** at `{fastapi.url}/dashboard/{id}`; the
     output filenames stay `{id}_light.png` / `{id}_dark.png` so existing
     dashboard-card consumers keep working unchanged.
 

--- a/depictio/api/main.py
+++ b/depictio/api/main.py
@@ -162,7 +162,7 @@ app.include_router(router, prefix=api_prefix)
 
 
 # ---------------------------------------------------------------------------
-# React viewer SPA — served at /dashboard-beta/{id} alongside the API.
+# React viewer SPA — served at /dashboard/{id} alongside the API.
 #
 # Built artifact lives at depictio/viewer/dist/ (produced by `npm run build`
 # in that directory). FastAPI serves the static bundle and falls back to
@@ -199,19 +199,19 @@ if _STATIC_ASSETS_DIR.is_dir():
 # Require both index.html and assets/ — `dist/` alone may exist as an empty
 # leftover from an interrupted build and would crash StaticFiles at startup.
 if _VIEWER_DIST.is_dir() and _VIEWER_ASSETS.is_dir() and _VIEWER_INDEX.is_file():
-    # /dashboard-beta/assets/... → static bundle assets
+    # /dashboard/assets/... → static bundle assets
     app.mount(
-        "/dashboard-beta/assets",
+        "/dashboard/assets",
         StaticFiles(directory=str(_VIEWER_ASSETS)),
         name="viewer-assets",
     )
-    # /dashboard-beta/logos/... → SPA public/ assets (logos, etc.). Mounted
+    # /dashboard/logos/... → SPA public/ assets (logos, etc.). Mounted
     # only when the directory exists so the SPA still serves when public/ is
     # absent (e.g. older build).
     _viewer_logos = _VIEWER_DIST / "logos"
     if _viewer_logos.is_dir():
         app.mount(
-            "/dashboard-beta/logos",
+            "/dashboard/logos",
             StaticFiles(directory=str(_viewer_logos)),
             name="viewer-logos",
         )
@@ -232,21 +232,21 @@ if _VIEWER_DIST.is_dir() and _VIEWER_ASSETS.is_dir() and _VIEWER_INDEX.is_file()
     _viewer_favicon = _VIEWER_DIST / "favicon.svg"
     if _viewer_favicon.is_file():
 
-        @app.get("/dashboard-beta/favicon.svg")
+        @app.get("/dashboard/favicon.svg")
         async def _serve_viewer_favicon() -> FileResponse:
             return FileResponse(_viewer_favicon, media_type="image/svg+xml")
 
-    @app.get("/dashboard-beta/{_dashboard_id:path}")
+    @app.get("/dashboard/{_dashboard_id:path}")
     async def _serve_viewer_spa(_dashboard_id: str) -> FileResponse:
         """Serve the React viewer SPA. All sub-paths fall through to index.html
         so React's client-side router handles the dashboard ID segment."""
         return _spa_index()
 
-    @app.get("/dashboard-beta-edit/{_dashboard_id:path}")
+    @app.get("/dashboard-edit/{_dashboard_id:path}")
     async def _serve_editor_spa(_dashboard_id: str) -> FileResponse:
         """Serve the React editor SPA. Same bundle as the viewer; the SPA's
         boot routing inspects window.location.pathname to render EditorApp.
-        Asset paths in index.html still resolve via /dashboard-beta/assets/."""
+        Asset paths in index.html still resolve via /dashboard/assets/."""
         return _spa_index()
 
     # /auth and /auth/google/callback → same React bundle. The SPA's boot
@@ -260,74 +260,74 @@ if _VIEWER_DIST.is_dir() and _VIEWER_ASSETS.is_dir() and _VIEWER_INDEX.is_file()
     async def _serve_auth_spa(_auth_path: str) -> FileResponse:
         return _spa_index()
 
-    # /dashboards-beta → React management page (replaces the Dash /dashboards
+    # /dashboards → React management page (replaces the Dash /dashboards
     # listing). Same bundle as the viewer; main.tsx detects the path prefix
     # and renders <DashboardsApp/>. Asset paths in index.html still resolve
-    # via /dashboard-beta/assets/ because Vite stamps them with that base.
-    @app.get("/dashboards-beta")
+    # via /dashboard/assets/ because Vite stamps them with that base.
+    @app.get("/dashboards")
     async def _serve_dashboards_spa_root() -> FileResponse:
         return _spa_index()
 
-    @app.get("/dashboards-beta/{_path:path}")
+    @app.get("/dashboards/{_path:path}")
     async def _serve_dashboards_spa(_path: str) -> FileResponse:
         return _spa_index()
 
-    # /about-beta and /admin-beta → same React bundle. main.tsx detects the
+    # /about and /admin → same React bundle. main.tsx detects the
     # pathname prefix and renders <AboutApp/> or <AdminApp/>. Coexists with
     # the Dash /about and /admin pages until the sidebar is flipped.
-    @app.get("/about-beta")
+    @app.get("/about")
     async def _serve_about_spa_root() -> FileResponse:
         return _spa_index()
 
-    @app.get("/about-beta/{_path:path}")
+    @app.get("/about/{_path:path}")
     async def _serve_about_spa(_path: str) -> FileResponse:
         return _spa_index()
 
-    @app.get("/admin-beta")
+    @app.get("/admin")
     async def _serve_admin_spa_root() -> FileResponse:
         return _spa_index()
 
-    @app.get("/admin-beta/{_path:path}")
+    @app.get("/admin/{_path:path}")
     async def _serve_admin_spa(_path: str) -> FileResponse:
         return _spa_index()
 
-    # /projects-beta → React projects management page (replaces the Dash
+    # /projects → React projects management page (replaces the Dash
     # /projects listing + multi-step create modal + project/{id}/data detail).
     # Same bundle as the viewer; main.tsx detects the path prefix and renders
-    # <ProjectsApp/>. Sub-paths (/projects-beta/{id}, /projects-beta/{id}/permissions)
+    # <ProjectsApp/>. Sub-paths (/projects/{id}, /projects/{id}/permissions)
     # all fall through to index.html so the React app can route internally.
-    @app.get("/projects-beta")
+    @app.get("/projects")
     async def _serve_projects_spa_root() -> FileResponse:
         return _spa_index()
 
-    @app.get("/projects-beta/{_path:path}")
+    @app.get("/projects/{_path:path}")
     async def _serve_projects_spa(_path: str) -> FileResponse:
         return _spa_index()
 
-    # /profile-beta and /cli-agents-beta → React-based replacements for the
+    # /profile and /cli-agents → React-based replacements for the
     # Dash /profile and /cli_configs management pages. Same SPA bundle;
     # main.tsx detects the path prefix and renders <ProfileApp/> or
     # <CliAgentsApp/>. Coexists with the Dash routes during rollout.
-    @app.get("/profile-beta")
+    @app.get("/profile")
     async def _serve_profile_spa_root() -> FileResponse:
         return _spa_index()
 
-    @app.get("/profile-beta/{_path:path}")
+    @app.get("/profile/{_path:path}")
     async def _serve_profile_spa(_path: str) -> FileResponse:
         return _spa_index()
 
-    @app.get("/cli-agents-beta")
+    @app.get("/cli-agents")
     async def _serve_cli_agents_spa_root() -> FileResponse:
         return _spa_index()
 
-    @app.get("/cli-agents-beta/{_path:path}")
+    @app.get("/cli-agents/{_path:path}")
     async def _serve_cli_agents_spa(_path: str) -> FileResponse:
         return _spa_index()
 else:
     logger = logging.getLogger(__name__)
     logger.warning(
         "⚠️  React viewer bundle not built at %s (missing index.html or "
-        "assets/) — /dashboard-beta/ and /dashboard-beta-edit/ routes will "
+        "assets/) — /dashboard/ and /dashboard-edit/ routes will "
         "404 until `cd depictio/viewer && npm install && npm run build` "
         "is executed.",
         _VIEWER_DIST,
@@ -340,7 +340,7 @@ async def _redirect_root() -> RedirectResponse:
     hook handles the anonymous case by routing to /auth, so this single
     server-side redirect serves both signed-in and signed-out visitors and
     makes the sidebar logo's `href="/"` work as a "go home" affordance."""
-    return RedirectResponse("/dashboards-beta", status_code=307)
+    return RedirectResponse("/dashboards", status_code=307)
 
 
 @app.get("/health")

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -422,7 +422,7 @@ async def list_all_dashboards(
 
     By default returns only main-tab dashboards (so multi-tab projects show
     up once). Pass ``?include_child_tabs=true`` to also surface every child
-    tab — used by the /admin-beta project panel to list the full dashboard
+    tab — used by the /admin project panel to list the full dashboard
     tree under each seed project.
     """
     if not current_user.is_admin:
@@ -673,7 +673,7 @@ async def save_dashboard(
         # Convert dashboard_id to string to ensure proper JSON serialization
         dashboard_id_str = str(dashboard_id)
 
-        # Auto-queue screenshot regeneration so /dashboards-beta and any
+        # Auto-queue screenshot regeneration so /dashboards and any
         # other listing surface picks up the latest dashboard state.
         # The `_should_enqueue_screenshot` debounce throttles implicit
         # auto-saves (drag/resize/rename produce a save burst each); an

--- a/depictio/api/v1/endpoints/datacollections_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/datacollections_endpoints/utils.py
@@ -875,7 +875,7 @@ async def _ensure_user_cli_token(current_user) -> None:
     `depictio data process` command, which authenticate back to FastAPI with
     a stored bearer token from the ``tokens`` collection. Browser-only users
     (signed in via session JWT) won't have one yet, so we mint one on demand
-    here — matching the behavior the React `/profile-beta` UI offers via
+    here — matching the behavior the React `/profile` UI offers via
     `POST /auth/me/tokens`, just transparent so first-time DC creation
     doesn't 401 before the user knows they need to click a button.
 

--- a/depictio/api/v1/endpoints/user_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/user_endpoints/routes.py
@@ -466,7 +466,7 @@ async def get_current_user_info_optional(
 
     # Single-user mode: the data endpoints (`get_user_or_anonymous`) auto-resolve
     # to the admin even without a token. Mirror that here so the React
-    # `/dashboards-beta` page knows who owns the seed dashboards — otherwise
+    # `/dashboards` page knows who owns the seed dashboards — otherwise
     # everything not flagged public/example lands in "Accessed" because the
     # client thinks it's anonymous.
     if user_payload is None and settings.auth.is_single_user_mode:
@@ -877,8 +877,8 @@ async def delete_token(
 
 
 # ---------------------------------------------------------------------------
-# Bearer-authed, user-scoped token endpoints for the React /profile-beta and
-# /cli-agents-beta SPA. These mirror /create_token and /delete_token but use
+# Bearer-authed, user-scoped token endpoints for the React /profile and
+# /cli-agents SPA. These mirror /create_token and /delete_token but use
 # the caller's Bearer token instead of the internal API key — safe to call
 # from a browser. Only operate on the current user's tokens.
 # ---------------------------------------------------------------------------

--- a/depictio/api/v1/endpoints/utils_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/utils_endpoints/routes.py
@@ -686,7 +686,7 @@ async def screenshot_react_dual(
     """Generate light + dark screenshots of the React beta viewer.
 
     Sibling of `/screenshot-dash-dual` but drives the SPA bundle at
-    `{settings.fastapi.url}/dashboard-beta/{dashboard_id}` (the React/Vite
+    `{settings.fastapi.url}/dashboard/{dashboard_id}` (the React/Vite
     build that FastAPI itself serves) instead of the Dash app on port 5080.
 
     Single-user mode skips auth; otherwise the caller must be a dashboard owner.

--- a/depictio/api/v1/services/screenshot_service.py
+++ b/depictio/api/v1/services/screenshot_service.py
@@ -1,7 +1,7 @@
 """
 Shared screenshot service for dashboard dual-theme screenshot generation.
 
-The active code path drives the React SPA at `{fastapi.url}/dashboard-beta/{id}`
+The active code path drives the React SPA at `{fastapi.url}/dashboard/{id}`
 via `generate_react_dual_theme_screenshots`. Dash-targeted captures
 (`generate_dual_theme_screenshots`) are kept for emergency rollback only —
 they log a deprecation warning on every call and should not run in normal
@@ -243,7 +243,7 @@ async def generate_dual_theme_screenshots(
         # short-circuit before mounting either tour engine. The legacy
         # ``/dashboard/{id}`` route doesn't render the React walkthrough today,
         # so this is defensive — keeps the PNG clean if/when screenshots ever
-        # target ``/dashboard-beta/{id}``.
+        # target ``/dashboard/{id}``.
         dashboard_url = f"{settings.viewer.internal_url}/dashboard/{dashboard_id}?no-walkthrough=1"
 
         logger.info(f"Starting dual-theme screenshot for dashboard {dashboard_id}")
@@ -393,7 +393,7 @@ async def generate_react_dual_theme_screenshots(
     """Generate light + dark screenshots of the React beta viewer.
 
     This is the canonical production path. Drives the SPA bundle FastAPI
-    serves at `{settings.fastapi.url}/dashboard-beta/{id}` (port 8100 by
+    serves at `{settings.fastapi.url}/dashboard/{id}` (port 8100 by
     default).
 
     Defaults to filenames `{id}_light.png` / `{id}_dark.png` for backward
@@ -440,7 +440,7 @@ async def generate_react_dual_theme_screenshots(
     # contains the popover, anchor, or dim backdrop — even when the
     # seeded admin's localStorage would otherwise auto-start the
     # builder walkthrough on first visit.
-    dashboard_url = f"{origin}/dashboard-beta/{dashboard_id}?no-walkthrough=1"
+    dashboard_url = f"{origin}/dashboard/{dashboard_id}?no-walkthrough=1"
 
     try:
         token_data = await get_admin_auth_token()

--- a/depictio/projects/init/nfcore_megatests_showcase/scripts/upload.sh
+++ b/depictio/projects/init/nfcore_megatests_showcase/scripts/upload.sh
@@ -90,5 +90,5 @@ echo "✓ Done. Open the dashboards:"
 for f in depictio/projects/init/nfcore_megatests_showcase/.db_seeds/dashboard_*.json; do
     id=$(python3 -c "import json,sys; print(json.load(open('$f'))['dashboard_id']['\$oid'])")
     viz=$(basename "$f" .json | sed 's/^dashboard_//')
-    echo "    $viz → http://localhost:8100/dashboard-beta/$id"
+    echo "    $viz → http://localhost:8100/dashboard/$id"
 done

--- a/depictio/projects/test/adapt_feedb_ms/stream_test.sh
+++ b/depictio/projects/test/adapt_feedb_ms/stream_test.sh
@@ -18,7 +18,7 @@
 #                               payload digest.
 #
 # Watch the dashboard at:
-#   http://localhost:8055/dashboard-beta/69f899234da0b143a8538e0e
+#   http://localhost:8055/dashboard/69f899234da0b143a8538e0e
 
 set -euo pipefail
 
@@ -216,7 +216,7 @@ case "$MODE" in
     rows=$(current_data_rows)
     echo "CSV: $CSV"
     echo "Data rows: $rows"
-    echo "Dashboard: $API_URL/dashboard-beta/$DASHBOARD_ID"
+    echo "Dashboard: $API_URL/dashboard/$DASHBOARD_ID"
     echo "Last DC: $DC_ID"
     echo ""
     echo "Latest payload (test-trigger, no append):"

--- a/depictio/viewer/index.html
+++ b/depictio/viewer/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- href is relative to Vite's `base` ('/dashboard-beta/'). Don't hardcode
+    <!-- href is relative to Vite's `base` ('/dashboard/'). Don't hardcode
          the prefix here — Vite already prepends base for `/`-prefixed URLs and
          doing it twice yields a 404 in `vite dev` (the user sees a missing
-         favicon and "did you mean /dashboard-beta/dashboard-beta/favicon.svg?"
+         favicon and "did you mean /dashboard/dashboard/favicon.svg?"
          in the network tab). -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>Depictio — Dashboard (Beta)</title>
+    <title>Depictio — Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/depictio/viewer/src/App.tsx
+++ b/depictio/viewer/src/App.tsx
@@ -94,7 +94,7 @@ const App: React.FC = () => {
   // Fetch dashboard + tab list in parallel
   useEffect(() => {
     if (!dashboardId) {
-      setError('No dashboard ID in URL. Expected /dashboard-beta/<id>.');
+      setError('No dashboard ID in URL. Expected /dashboard/<id>.');
       setLoading(false);
       return;
     }
@@ -512,7 +512,7 @@ export default App;
 
 function extractDashboardId(): string | null {
   const path = window.location.pathname;
-  const match = path.match(/\/dashboard-beta\/([^/?#]+)/);
+  const match = path.match(/\/dashboard\/([^/?#]+)/);
   return match?.[1] || null;
 }
 

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -13,8 +13,8 @@
  * Cross-app navigation URLs:
  *   - Edit component:   /dashboard-edit/{dashboardId}/component/edit/{componentId}
  *   - Add component:    /dashboard-edit/{dashboardId}/component/add/{newUuid}
- *   - Read-only viewer: /dashboard-beta/{dashboardId}
- *   - Editor:           /dashboard-beta/{dashboardId}/edit
+ *   - Read-only viewer: /dashboard/{dashboardId}
+ *   - Editor:           /dashboard/{dashboardId}/edit
  *
  * TODO (post-MVP): factor shared data-loading into a `useDashboardState` hook
  * so App.tsx and EditorApp.tsx don't drift. For now we duplicate the
@@ -197,7 +197,7 @@ const EditorApp: React.FC = () => {
     if (userLoading) return;
     if (!dashboard || !dashboardId) return;
     if (!isOwner) {
-      window.location.replace(`/dashboard-beta/${dashboardId}`);
+      window.location.replace(`/dashboard/${dashboardId}`);
     }
   }, [userLoading, dashboard, dashboardId, isOwner]);
 
@@ -213,7 +213,7 @@ const EditorApp: React.FC = () => {
   // Fetch dashboard + tab list
   useEffect(() => {
     if (!dashboardId) {
-      setError('No dashboard ID in URL. Expected /dashboard-beta/<id>/edit.');
+      setError('No dashboard ID in URL. Expected /dashboard/<id>/edit.');
       setLoading(false);
       return;
     }
@@ -626,7 +626,7 @@ const EditorApp: React.FC = () => {
         : fallbackUuid();
     // React-side stepper page (was: cross-origin Dash editor).
     window.location.assign(
-      `/dashboard-beta-edit/${dashboardId}/component/add/${newId}`,
+      `/dashboard-edit/${dashboardId}/component/add/${newId}`,
     );
   }, [dashboardId]);
 
@@ -696,8 +696,8 @@ const EditorApp: React.FC = () => {
             submitting: false,
           });
           // Navigate to the new tab — preserves edit mode via the same
-          // `/dashboard-beta-edit/{id}` route we're already on.
-          window.location.assign(`/dashboard-beta-edit/${newId}`);
+          // `/dashboard-edit/{id}` route we're already on.
+          window.location.assign(`/dashboard-edit/${newId}`);
           return;
         }
 
@@ -768,7 +768,7 @@ const EditorApp: React.FC = () => {
         // sit on a now-deleted dashboard id.
         const parentId = tab.parent_dashboard_id;
         if (tab.dashboard_id === dashboardId && parentId) {
-          window.location.assign(`/dashboard-beta-edit/${parentId}`);
+          window.location.assign(`/dashboard-edit/${parentId}`);
         } else {
           await refreshTabList();
         }
@@ -1143,7 +1143,7 @@ const RightComponentGrid: React.FC<RightComponentGridProps> = ({
 
 function extractDashboardId(): string | null {
   const path = window.location.pathname;
-  const match = path.match(/\/dashboard-beta-edit\/([^/?#]+)/);
+  const match = path.match(/\/dashboard-edit\/([^/?#]+)/);
   return match?.[1] || null;
 }
 

--- a/depictio/viewer/src/about/AboutApp.tsx
+++ b/depictio/viewer/src/about/AboutApp.tsx
@@ -20,7 +20,7 @@ import { Icon } from '@iconify/react';
 
 import { AppSidebar } from '../chrome';
 
-const LOGO_BASE = '/dashboard-beta/logos';
+const LOGO_BASE = '/dashboard/logos';
 
 interface ResourceCardProps {
   icon: string;

--- a/depictio/viewer/src/admin/AdminApp.tsx
+++ b/depictio/viewer/src/admin/AdminApp.tsx
@@ -85,7 +85,7 @@ const AdminApp: React.FC = () => {
             </Text>
             <Button
               component="a"
-              href="/dashboards-beta"
+              href="/dashboards"
               variant="light"
               leftSection={<Icon icon="material-symbols:dashboard" width={16} />}
             >

--- a/depictio/viewer/src/admin/AdminProjectsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminProjectsPanel.tsx
@@ -217,7 +217,7 @@ const AdminProjectsPanel: React.FC = () => {
                       {projectDashboards.map((entry) => (
                         <List.Item key={entry.main.dashboard_id}>
                           <Anchor
-                            href={`/dashboard-beta/${entry.main.dashboard_id}`}
+                            href={`/dashboard/${entry.main.dashboard_id}`}
                             size="sm"
                           >
                             {entry.main.title ??
@@ -229,7 +229,7 @@ const AdminProjectsPanel: React.FC = () => {
                               {entry.children.map((child) => (
                                 <List.Item key={child.dashboard_id}>
                                   <Anchor
-                                    href={`/dashboard-beta/${child.dashboard_id}`}
+                                    href={`/dashboard/${child.dashboard_id}`}
                                     size="xs"
                                     c="dimmed"
                                   >

--- a/depictio/viewer/src/auth/AuthApp.tsx
+++ b/depictio/viewer/src/auth/AuthApp.tsx
@@ -10,7 +10,7 @@ import RegisterForm from './components/RegisterForm';
 import { useAuthMode } from './hooks/useAuthMode';
 import './styles/auth.css';
 
-const POST_AUTH_REDIRECT = '/dashboards-beta';
+const POST_AUTH_REDIRECT = '/dashboards';
 
 type View = 'login' | 'register' | 'oauth-callback';
 

--- a/depictio/viewer/src/auth/components/AuthCard.tsx
+++ b/depictio/viewer/src/auth/components/AuthCard.tsx
@@ -15,8 +15,8 @@ interface Props {
 export default function AuthCard({ heading, children }: Props) {
   const { colorScheme } = useMantineColorScheme();
   const logoSrc = colorScheme === 'dark'
-    ? '/dashboard-beta/logos/logo_white.svg'
-    : '/dashboard-beta/logos/logo_black.svg';
+    ? '/dashboard/logos/logo_white.svg'
+    : '/dashboard/logos/logo_black.svg';
 
   return (
     <Paper

--- a/depictio/viewer/src/builder/CreateComponentPage.tsx
+++ b/depictio/viewer/src/builder/CreateComponentPage.tsx
@@ -56,13 +56,13 @@ const CreateComponentPage: React.FC<CreateComponentPageProps> = ({
   const stepperActive = isText ? (step >= 2 ? 1 : 0) : step;
 
   const cancel = () => {
-    window.location.assign(`/dashboard-beta-edit/${dashboardId}`);
+    window.location.assign(`/dashboard-edit/${dashboardId}`);
   };
 
   const handleAddToDashboard = () => {
     // The Save action lives inside StepDesign; the completion page only links
     // back to the dashboard once the component has been persisted.
-    window.location.assign(`/dashboard-beta-edit/${dashboardId}`);
+    window.location.assign(`/dashboard-edit/${dashboardId}`);
   };
 
   return (

--- a/depictio/viewer/src/builder/EditComponentPage.tsx
+++ b/depictio/viewer/src/builder/EditComponentPage.tsx
@@ -56,7 +56,7 @@ const EditComponentPage: React.FC<EditComponentPageProps> = ({
   }, [dashboardId, componentId, init, loadExisting, reset]);
 
   const cancel = () => {
-    window.location.assign(`/dashboard-beta-edit/${dashboardId}`);
+    window.location.assign(`/dashboard-edit/${dashboardId}`);
   };
 
   return (

--- a/depictio/viewer/src/builder/data/DataCollectionInfoCard.tsx
+++ b/depictio/viewer/src/builder/data/DataCollectionInfoCard.tsx
@@ -66,7 +66,7 @@ const DataCollectionInfoCard: React.FC<Props> = ({ info }) => {
               isMultiQC ? (
                 <Stack gap={4} align="flex-start">
                   <img
-                    src="/dashboard-beta/logos/multiqc_icon_dark.svg"
+                    src="/dashboard/logos/multiqc_icon_dark.svg"
                     alt="MultiQC"
                     className="multiqc-icon-themed"
                     style={{ width: 24, height: 24, objectFit: 'contain' }}

--- a/depictio/viewer/src/builder/multiqc/MultiQCPreview.tsx
+++ b/depictio/viewer/src/builder/multiqc/MultiQCPreview.tsx
@@ -102,8 +102,8 @@ const MultiQCPreview: React.FC = () => {
           <img
             src={
               colorScheme === 'dark'
-                ? '/dashboard-beta/logos/multiqc_icon_white.svg'
-                : '/dashboard-beta/logos/multiqc_icon_dark.svg'
+                ? '/dashboard/logos/multiqc_icon_white.svg'
+                : '/dashboard/logos/multiqc_icon_dark.svg'
             }
             title="Generated with MultiQC"
             alt="MultiQC"

--- a/depictio/viewer/src/builder/routeMatch.ts
+++ b/depictio/viewer/src/builder/routeMatch.ts
@@ -1,6 +1,6 @@
 /**
  * URL parsing for the editor SPA. Single source of truth for all routes
- * served by /dashboard-beta-edit/. Plain regex — no router lib.
+ * served by /dashboard-edit/. Plain regex — no router lib.
  */
 
 export type EditorRoute =
@@ -9,10 +9,10 @@ export type EditorRoute =
   | { kind: 'edit'; dashboardId: string; componentId: string };
 
 const CREATE_RE =
-  /^\/dashboard-beta-edit\/([^/]+)\/component\/add\/([^/?#]+)/;
+  /^\/dashboard-edit\/([^/]+)\/component\/add\/([^/?#]+)/;
 const EDIT_RE =
-  /^\/dashboard-beta-edit\/([^/]+)\/component\/edit\/([^/?#]+)/;
-const EDITOR_RE = /^\/dashboard-beta-edit\/([^/?#]+)/;
+  /^\/dashboard-edit\/([^/]+)\/component\/edit\/([^/?#]+)/;
+const EDITOR_RE = /^\/dashboard-edit\/([^/?#]+)/;
 
 export function matchEditorRoute(pathname: string): EditorRoute | null {
   const create = pathname.match(CREATE_RE);

--- a/depictio/viewer/src/builder/steps/StepDesign.tsx
+++ b/depictio/viewer/src/builder/steps/StepDesign.tsx
@@ -72,7 +72,7 @@ const StepDesign: React.FC = () => {
       });
       setSavedRedirect(true);
       window.setTimeout(() => {
-        window.location.assign(`/dashboard-beta-edit/${state.dashboardId}`);
+        window.location.assign(`/dashboard-edit/${state.dashboardId}`);
       }, 600);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/depictio/viewer/src/builder/steps/StepType.tsx
+++ b/depictio/viewer/src/builder/steps/StepType.tsx
@@ -137,7 +137,7 @@ const TypeCard: React.FC<TypeCardProps> = ({
         >
           {meta.type === 'multiqc' ? (
             <img
-              src="/dashboard-beta/logos/multiqc_icon_dark.svg"
+              src="/dashboard/logos/multiqc_icon_dark.svg"
               alt="MultiQC"
               className="multiqc-icon-themed"
               style={{ width: 44, height: 44, objectFit: 'contain' }}

--- a/depictio/viewer/src/chrome/AppSidebar.tsx
+++ b/depictio/viewer/src/chrome/AppSidebar.tsx
@@ -41,28 +41,28 @@ const NAV_ENTRIES: NavEntry[] = [
     key: 'dashboards',
     label: 'Dashboards',
     icon: 'material-symbols:dashboard',
-    href: '/dashboards-beta',
+    href: '/dashboards',
     color: 'orange',
   },
   {
     key: 'projects',
     label: 'Projects',
     icon: 'mdi:jira',
-    href: '/projects-beta',
+    href: '/projects',
     color: 'teal',
   },
   {
     key: 'admin',
     label: 'Administration',
     icon: 'material-symbols:settings',
-    href: '/admin-beta',
+    href: '/admin',
     color: 'blue',
   },
   {
     key: 'about',
     label: 'About',
     icon: 'mingcute:question-line',
-    href: '/about-beta',
+    href: '/about',
     color: 'gray',
   },
 ];
@@ -96,7 +96,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ active }) => {
                 raster while preserving brand hues — same trick as
                 `PoweredBy.tsx`. */}
             <img
-              src="/dashboard-beta/logos/logo_black.svg"
+              src="/dashboard/logos/logo_black.svg"
               alt="depictio"
               style={{
                 width: 185,

--- a/depictio/viewer/src/chrome/Header.tsx
+++ b/depictio/viewer/src/chrome/Header.tsx
@@ -22,8 +22,8 @@ function isMultiqcIcon(path: string | null | undefined): boolean {
 function rewriteMultiqcIcon(path: string, theme: 'light' | 'dark'): string {
   if (!isMultiqcIcon(path)) return path;
   return theme === 'dark'
-    ? '/dashboard-beta/logos/multiqc_icon_white.svg'
-    : '/dashboard-beta/logos/multiqc_icon_dark.svg';
+    ? '/dashboard/logos/multiqc_icon_white.svg'
+    : '/dashboard/logos/multiqc_icon_dark.svg';
 }
 
 /** Dash precedence: `tab.tab_icon || tab.icon`, `tab.tab_icon_color || tab.icon_color`. */
@@ -134,13 +134,13 @@ const Header: React.FC<HeaderProps> = ({
 
   const handleEdit = () => {
     if (dashboardId) {
-      window.location.assign(`/dashboard-beta-edit/${dashboardId}`);
+      window.location.assign(`/dashboard-edit/${dashboardId}`);
     }
   };
 
   const handleViewMode = () => {
     if (dashboardId) {
-      window.location.assign(`/dashboard-beta/${dashboardId}`);
+      window.location.assign(`/dashboard/${dashboardId}`);
     }
   };
 

--- a/depictio/viewer/src/chrome/PoweredBy.tsx
+++ b/depictio/viewer/src/chrome/PoweredBy.tsx
@@ -41,7 +41,7 @@ const PoweredBy: React.FC<PoweredByProps> = ({ withRightBorder = false }) => {
           Powered by
         </Text>
         <img
-          src="/dashboard-beta/logos/logo_black.svg"
+          src="/dashboard/logos/logo_black.svg"
           alt="Depictio"
           style={{
             height: 20,

--- a/depictio/viewer/src/chrome/ProfileBadge.tsx
+++ b/depictio/viewer/src/chrome/ProfileBadge.tsx
@@ -49,7 +49,7 @@ const ProfileBadge: React.FC = () => {
       <Menu.Dropdown>
         <Menu.Item
           component="a"
-          href="/profile-beta"
+          href="/profile"
           leftSection={<Icon icon="mdi:account-circle-outline" width={16} />}
         >
           Profile

--- a/depictio/viewer/src/chrome/Sidebar.tsx
+++ b/depictio/viewer/src/chrome/Sidebar.tsx
@@ -38,7 +38,7 @@ function isMultiqcIcon(path: string | null | undefined): boolean {
 
 /** Many legacy YAML/seed entries point at the old MultiQC PNG
  * (`/assets/images/logos/multiqc.png`). Swap those to the new official icon
- * (https://github.com/MultiQC/logo) served via the SPA's `/dashboard-beta/logos/`
+ * (https://github.com/MultiQC/logo) served via the SPA's `/dashboard/logos/`
  * mount.
  *
  *   - Active tab → always white SVG (sits on a filled gray background, white
@@ -51,10 +51,10 @@ function rewriteLegacyMultiqcIcon(
   isActive = false,
 ): string {
   if (!isMultiqcIcon(path)) return path;
-  if (isActive) return '/dashboard-beta/logos/multiqc_icon_white.svg';
+  if (isActive) return '/dashboard/logos/multiqc_icon_white.svg';
   return theme === 'dark'
-    ? '/dashboard-beta/logos/multiqc_icon_white.svg'
-    : '/dashboard-beta/logos/multiqc_icon_dark.svg';
+    ? '/dashboard/logos/multiqc_icon_white.svg'
+    : '/dashboard/logos/multiqc_icon_dark.svg';
 }
 
 /** Resolve a YAML asset path (e.g. `/assets/images/logos/multiqc.png`) to a
@@ -165,7 +165,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   // synthetic "+ Add tab" pill — regular tab switches just let the browser
   // follow the link.
   const linkMode: 'view' | 'edit' = window.location.pathname.startsWith(
-    '/dashboard-beta-edit/',
+    '/dashboard-edit/',
   )
     ? 'edit'
     : 'view';
@@ -183,7 +183,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       {/* Top region — centered, grey back link to match Dash sidebar */}
       <Stack gap="sm" align="stretch">
         <Anchor
-          href="/dashboards-beta"
+          href="/dashboards"
           size="sm"
           fw={500}
           underline="hover"
@@ -261,7 +261,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                     >
                       <img
                         src={
-                          yamlImage.startsWith('/dashboard-beta/')
+                          yamlImage.startsWith('/dashboard/')
                             ? yamlImage
                             : resolveAssetUrl(yamlImage)
                         }

--- a/depictio/viewer/src/cli-agents/CliAgentsApp.tsx
+++ b/depictio/viewer/src/cli-agents/CliAgentsApp.tsx
@@ -204,7 +204,7 @@ const CliAgentsApp: React.FC = () => {
           </Group>
           <Button
             component="a"
-            href="/profile-beta"
+            href="/profile"
             variant="subtle"
             color="gray"
             leftSection={<Icon icon="mdi:arrow-left" width={16} />}

--- a/depictio/viewer/src/components/GridItemEditOverlay.tsx
+++ b/depictio/viewer/src/components/GridItemEditOverlay.tsx
@@ -10,7 +10,7 @@ import { Icon } from '@iconify/react';
  * with Edit / Duplicate / Delete actions:
  *
  *   - Edit:      navigates to the React edit page at
- *                /dashboard-beta-edit/{id}/component/edit/{componentId}
+ *                /dashboard-edit/{id}/component/edit/{componentId}
  *   - Duplicate: fires `onDuplicate` — parent clones metadata + layout, POSTs /save
  *   - Delete:    fires `onDelete` — parent is responsible for the actual API call
  *
@@ -48,7 +48,7 @@ const GridItemEditOverlay: React.FC<GridItemEditOverlayProps> = ({
 
   const handleEdit = () => {
     window.location.assign(
-      `/dashboard-beta-edit/${dashboardId}/component/edit/${componentId}`,
+      `/dashboard-edit/${dashboardId}/component/edit/${componentId}`,
     );
   };
 

--- a/depictio/viewer/src/dashboards/DashboardsApp.tsx
+++ b/depictio/viewer/src/dashboards/DashboardsApp.tsx
@@ -200,7 +200,7 @@ const DashboardsApp: React.FC = () => {
    *  Recently opened pile. localStorage-only — see lib/dashboardRecents.ts. */
   const handleView = useCallback((dashboard: DashboardListEntry) => {
     recordDashboardOpen(String(dashboard.dashboard_id));
-    window.location.assign(`/dashboard-beta/${dashboard.dashboard_id}`);
+    window.location.assign(`/dashboard/${dashboard.dashboard_id}`);
   }, []);
 
   const handleExport = useCallback(async (dashboard: DashboardListEntry) => {

--- a/depictio/viewer/src/dashboards/lib/dashboardLinks.ts
+++ b/depictio/viewer/src/dashboards/lib/dashboardLinks.ts
@@ -12,8 +12,8 @@ export function dashboardHref(
   mode: DashboardMode = 'view',
 ): string {
   return mode === 'edit'
-    ? `/dashboard-beta-edit/${dashboardId}`
-    : `/dashboard-beta/${dashboardId}`;
+    ? `/dashboard-edit/${dashboardId}`
+    : `/dashboard/${dashboardId}`;
 }
 
 export function dashboardHrefFor(d: DashboardListEntry, mode: DashboardMode = 'view'): string {

--- a/depictio/viewer/src/main.tsx
+++ b/depictio/viewer/src/main.tsx
@@ -46,37 +46,37 @@ import { depictioTheme } from './theme';
 import { WalkthroughHost } from './walkthrough';
 
 // Client-side route resolution. FastAPI serves index.html for all paths under
-// /dashboard-beta/, /dashboard-beta-edit/, /auth, /dashboards-beta,
-// /about-beta, and /admin-beta — we pick the right tree at boot.
+// /dashboard/, /dashboard-edit/, /auth, /dashboards,
+// /about, and /admin — we pick the right tree at boot.
 function resolveTree(): React.ReactElement {
   if (window.location.pathname.startsWith('/auth')) {
     return <AuthApp />;
   }
-  if (window.location.pathname.startsWith('/dashboards-beta')) {
+  if (window.location.pathname.startsWith('/dashboards')) {
     return <DashboardsApp />;
   }
-  if (window.location.pathname.startsWith('/projects-beta')) {
-    // /projects-beta                  → list page
-    // /projects-beta/{id}             → data-collections detail
-    // /projects-beta/{id}/permissions → permissions editor
+  if (window.location.pathname.startsWith('/projects')) {
+    // /projects                  → list page
+    // /projects/{id}             → data-collections detail
+    // /projects/{id}/permissions → permissions editor
     if (
-      /\/projects-beta\/[^/]+\/permissions(\/|$)/.test(window.location.pathname)
+      /\/projects\/[^/]+\/permissions(\/|$)/.test(window.location.pathname)
     ) {
       return <PermissionsApp />;
     }
-    const detailMatch = window.location.pathname.match(/^\/projects-beta\/[^/]+/);
+    const detailMatch = window.location.pathname.match(/^\/projects\/[^/]+/);
     return detailMatch ? <ProjectDetailApp /> : <ProjectsApp />;
   }
-  if (window.location.pathname.startsWith('/about-beta')) {
+  if (window.location.pathname.startsWith('/about')) {
     return <AboutApp />;
   }
-  if (window.location.pathname.startsWith('/admin-beta')) {
+  if (window.location.pathname.startsWith('/admin')) {
     return <AdminApp />;
   }
-  if (window.location.pathname.startsWith('/profile-beta')) {
+  if (window.location.pathname.startsWith('/profile')) {
     return <ProfileApp />;
   }
-  if (window.location.pathname.startsWith('/cli-agents-beta')) {
+  if (window.location.pathname.startsWith('/cli-agents')) {
     return <CliAgentsApp />;
   }
   const route = matchEditorRoute(window.location.pathname);
@@ -130,7 +130,7 @@ function readInitialColorScheme(): 'light' | 'dark' | 'auto' {
 //      asking ``/auth/me/optional`` and re-mint or redirect when the
 //      backend doesn't recognize the user.
 //   4. Standard mode without a valid session — redirect to /auth so the
-//      user lands on the login form instead of a broken /dashboards-beta
+//      user lands on the login form instead of a broken /dashboards
 //      where every API call 401s.
 /** Cross-origin hand-off: the Dash app's beta-switcher pill links here
  *  with a `#auth=<base64-utf8 JSON>` fragment carrying the session it
@@ -217,14 +217,14 @@ async function bootstrapSession(): Promise<void> {
 }
 
 // Bare SPA root → dashboards list. Vite/FastAPI mount the SPA at
-// `/dashboard-beta/` so asset URLs resolve correctly, but that path on its
+// `/dashboard/` so asset URLs resolve correctly, but that path on its
 // own has no dashboard id to render. Bounce unparameterized hits (`/`,
-// `/dashboard-beta`, `/dashboard-beta/`) to the list page; if the visitor
+// `/dashboard`, `/dashboard/`) to the list page; if the visitor
 // isn't logged in, `bootstrapSession` on the next load routes them through
 // `/auth`, and `AuthApp.POST_AUTH_REDIRECT` brings them back here.
-const isBareRoot = /^\/(dashboard-beta\/?)?$/.test(window.location.pathname);
+const isBareRoot = /^\/(dashboard\/?)?$/.test(window.location.pathname);
 if (isBareRoot) {
-  window.location.replace('/dashboards-beta');
+  window.location.replace('/dashboards');
 } else {
   bootstrapSession().finally(() => {
     ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/depictio/viewer/src/profile/ProfileApp.tsx
+++ b/depictio/viewer/src/profile/ProfileApp.tsx
@@ -247,7 +247,7 @@ const ProfileApp: React.FC = () => {
 
                     <Button
                       component="a"
-                      href={states.cliAgentsDisabled ? undefined : '/cli-agents-beta'}
+                      href={states.cliAgentsDisabled ? undefined : '/cli-agents'}
                       variant="filled"
                       radius="md"
                       disabled={states.cliAgentsDisabled}

--- a/depictio/viewer/src/projects/ProjectCard.tsx
+++ b/depictio/viewer/src/projects/ProjectCard.tsx
@@ -193,14 +193,14 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
               icon="mdi:database-outline"
               iconColor="var(--mantine-color-cyan-6)"
               label="Workflows & Data"
-              href={`/projects-beta/${projectId}`}
+              href={`/projects/${projectId}`}
             />
 
             <NavRow
               icon="mdi:shield-account-outline"
               iconColor="var(--mantine-color-blue-6)"
               label="Roles and permissions"
-              href={`/projects-beta/${projectId}/permissions`}
+              href={`/projects/${projectId}/permissions`}
             />
 
             <Accordion.Item value="management">

--- a/depictio/viewer/src/projects/ProjectsApp.tsx
+++ b/depictio/viewer/src/projects/ProjectsApp.tsx
@@ -156,7 +156,7 @@ const ProjectsApp: React.FC = () => {
 
   const handleView = useCallback((project: ProjectListEntry) => {
     const projectId = (project._id ?? project.id) as string;
-    if (projectId) window.location.assign(`/projects-beta/${projectId}`);
+    if (projectId) window.location.assign(`/projects/${projectId}`);
   }, []);
 
   const handleDelete = useCallback(

--- a/depictio/viewer/src/projects/detail/PermissionsApp.tsx
+++ b/depictio/viewer/src/projects/detail/PermissionsApp.tsx
@@ -48,7 +48,7 @@ interface UserRow {
 }
 
 function readProjectIdFromPath(): string | null {
-  const m = window.location.pathname.match(/^\/projects-beta\/([^/?#]+)/);
+  const m = window.location.pathname.match(/^\/projects\/([^/?#]+)/);
   return m?.[1] || null;
 }
 
@@ -527,7 +527,7 @@ const PermissionsApp: React.FC = () => {
           <Group gap="xs">
             <Button
               component="a"
-              href={`/projects-beta/${projectId}`}
+              href={`/projects/${projectId}`}
               variant="subtle"
               color="teal"
               leftSection={<Icon icon="mdi:database-outline" width={16} />}
@@ -536,7 +536,7 @@ const PermissionsApp: React.FC = () => {
             </Button>
             <Button
               component="a"
-              href="/projects-beta"
+              href="/projects"
               variant="subtle"
               color="gray"
               leftSection={<Icon icon="mdi:arrow-left" width={16} />}
@@ -566,7 +566,7 @@ const PermissionsApp: React.FC = () => {
                   color="var(--mantine-color-red-6)"
                 />
                 <Text c="red">{loadError}</Text>
-                <Button component="a" href="/projects-beta" variant="light">
+                <Button component="a" href="/projects" variant="light">
                   Back to projects
                 </Button>
               </Stack>

--- a/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
+++ b/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
@@ -212,9 +212,9 @@ function engineDescription(wf: WorkflowShape): string | null {
   return name || null;
 }
 
-/** Read project ID from /projects-beta/{id}[/permissions] pathname. */
+/** Read project ID from /projects/{id}[/permissions] pathname. */
 function readProjectIdFromPath(): string | null {
-  const m = window.location.pathname.match(/^\/projects-beta\/([^/?#]+)/);
+  const m = window.location.pathname.match(/^\/projects\/([^/?#]+)/);
   return m?.[1] || null;
 }
 
@@ -427,7 +427,7 @@ const ProjectDetailApp: React.FC = () => {
           <Group gap="xs">
             <Button
               component="a"
-              href={`/projects-beta/${projectId}/permissions`}
+              href={`/projects/${projectId}/permissions`}
               variant="subtle"
               color="blue"
               leftSection={<Icon icon="mdi:shield-account-outline" width={16} />}
@@ -436,7 +436,7 @@ const ProjectDetailApp: React.FC = () => {
             </Button>
             <Button
               component="a"
-              href="/projects-beta"
+              href="/projects"
               variant="subtle"
               color="gray"
               leftSection={<Icon icon="mdi:arrow-left" width={16} />}
@@ -466,7 +466,7 @@ const ProjectDetailApp: React.FC = () => {
                   color="var(--mantine-color-red-6)"
                 />
                 <Text c="red">{loadError}</Text>
-                <Button component="a" href="/projects-beta" variant="light">
+                <Button component="a" href="/projects" variant="light">
                   Back to projects
                 </Button>
               </Stack>

--- a/depictio/viewer/src/projects/views/ProjectTableView.tsx
+++ b/depictio/viewer/src/projects/views/ProjectTableView.tsx
@@ -400,7 +400,7 @@ const ProjectTableView: React.FC<ProjectTableViewProps> = ({
                           color="cyan"
                           size="sm"
                           component="a"
-                          href={`/projects-beta/${r.id}`}
+                          href={`/projects/${r.id}`}
                           aria-label="Open data manager"
                           onClick={(e) => e.stopPropagation()}
                         >
@@ -413,7 +413,7 @@ const ProjectTableView: React.FC<ProjectTableViewProps> = ({
                           color="blue"
                           size="sm"
                           component="a"
-                          href={`/projects-beta/${r.id}/permissions`}
+                          href={`/projects/${r.id}/permissions`}
                           aria-label="Open permissions"
                           onClick={(e) => e.stopPropagation()}
                         >

--- a/depictio/viewer/src/walkthrough/steps/authBuilder.ts
+++ b/depictio/viewer/src/walkthrough/steps/authBuilder.ts
@@ -18,16 +18,16 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
       body: "👋 Your reads are processed, your dataframes are clean — now let's make them clickable. We start with a project — that's where the data lives.",
       position: 'bottom',
       image: {
-        src: '/dashboard-beta/favicon.svg',
+        src: '/dashboard/favicon.svg',
         alt: 'Depictio',
         height: 64,
       },
-      navigateTo: '/projects-beta',
+      navigateTo: '/projects',
     },
     {
       id: 'projects-page',
       target: 'projects-header',
-      route: /^\/projects-beta\/?$/,
+      route: /^\/projects\/?$/,
       title: 'Projects bundle your data',
       body: "A project groups the data collections your dashboards read from, the permissions controlling who sees them, and optionally one or more workflows that produced the data.",
       position: 'bottom',
@@ -35,7 +35,7 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
     {
       id: 'projects-create',
       target: 'projects-create',
-      route: /^\/projects-beta\/?$/,
+      route: /^\/projects\/?$/,
       title: 'Create your first project',
       body: "Click here to spin up a new project. You'll pick a name and attach the data collections it should hold — without data, a project doesn't do much. The tour resumes once you land on the project page.",
       position: 'left',
@@ -44,16 +44,16 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
     {
       id: 'project-detail',
       target: null,
-      route: /^\/projects-beta\/[^/]+\/?$/,
+      route: /^\/projects\/[^/]+\/?$/,
       title: 'Inside a project',
       body: "Here you can browse this project's data collections and the workflow runs that fed them. Permissions live on a separate page. Next we'll head to the Dashboards page and start visualizing this data.",
       position: 'bottom',
-      navigateTo: '/dashboards-beta',
+      navigateTo: '/dashboards',
     },
     {
       id: 'dashboards-page',
       target: null,
-      route: /^\/dashboards-beta\/?$/,
+      route: /^\/dashboards\/?$/,
       title: 'Dashboards live here',
       body: "A dashboard is a layout of components that read from a project's data. Each dashboard can have multiple tabs and multiple components — figures, cards, tables, interactive filters, MultiQC plots, and geomaps.",
       position: 'bottom',
@@ -61,7 +61,7 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
     {
       id: 'dashboards-create',
       target: 'dashboards-create',
-      route: /^\/dashboards-beta\/?$/,
+      route: /^\/dashboards\/?$/,
       title: 'Create a dashboard',
       body: "Click here to start a new dashboard. Pick the project you just made — the new dashboard will show up in the list, and the tour resumes once you open it.",
       position: 'left',
@@ -70,7 +70,7 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
     {
       id: 'enter-edit-mode',
       target: 'enter-edit-mode',
-      route: /^\/dashboard-beta\/[^/]+/,
+      route: /^\/dashboard\/[^/]+/,
       title: 'Open the editor',
       body: 'Your new dashboard opens in view mode. Click Edit to drop into the editor — that\'s where you add components.',
       position: 'bottom',
@@ -79,7 +79,7 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
     {
       id: 'editor-add',
       target: 'editor-add-component',
-      route: /^\/dashboard-beta-edit\//,
+      route: /^\/dashboard-edit\//,
       title: 'Add your first component',
       body: 'A dashboard is built from components. Click "Add component" to open the builder.',
       position: 'bottom',
@@ -114,7 +114,7 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
     {
       id: 'component-resize',
       target: 'editor-grid',
-      route: /^\/dashboard-beta-edit\//,
+      route: /^\/dashboard-edit\//,
       title: 'Arrange and resize',
       body: 'Drag your component from dedicated button to move it. Drag the bottom-right corner to resize. Add a few more components and lay them out however you like.',
       position: 'left',
@@ -122,7 +122,7 @@ export const authBuilderWalkthrough: WalkthroughDefinition = {
     {
       id: 'editor-save',
       target: 'editor-save',
-      route: /^\/dashboard-beta-edit\//,
+      route: /^\/dashboard-edit\//,
       title: 'Save the dashboard',
       body: 'Components are added on the dashboard, but the layout itself needs an explicit save. Hit Save to persist updated layout.',
       position: 'bottom',

--- a/depictio/viewer/src/walkthrough/steps/publicExplorer.ts
+++ b/depictio/viewer/src/walkthrough/steps/publicExplorer.ts
@@ -23,9 +23,9 @@ function formatExpiry(hours: number, minutes: number): string {
  *  session if they want to tweak things.
  *
  *  Handles two entry points cleanly via auto-advance:
- *  - Lands on /dashboards-beta → welcome → pick a dashboard → tour resumes
- *    on /dashboard-beta/{id} with sidebar/filter/realtime.
- *  - Lands directly on /dashboard-beta/{id} → welcome → Next jumps past the
+ *  - Lands on /dashboards → welcome → pick a dashboard → tour resumes
+ *    on /dashboard/{id} with sidebar/filter/realtime.
+ *  - Lands directly on /dashboard/{id} → welcome → Next jumps past the
  *    list step (route guard doesn't match) → sidebar/filter/realtime.
  */
 export function buildPublicExplorerWalkthrough(
@@ -47,7 +47,7 @@ export function buildPublicExplorerWalkthrough(
         body: `👋 Welcome! This Depictio instance has been made public so the dashboards and datasets it contains can be shared. Open any dashboard below to explore it — or **duplicate** one to get your own editable copy in a temporary session (lasts ${ttl}). The tour walks you through both.`,
         position: 'bottom',
         image: {
-          src: '/dashboard-beta/favicon.svg',
+          src: '/dashboard/favicon.svg',
           alt: 'Depictio',
           height: 64,
         },
@@ -55,7 +55,7 @@ export function buildPublicExplorerWalkthrough(
       {
         id: 'dashboard-actions',
         target: 'dashboard-actions',
-        route: /^\/dashboards-beta\/?$/,
+        route: /^\/dashboards\/?$/,
         title: "Each dashboard's actions menu",
         body: 'Every dashboard has a menu here. Click it to see what you can do with this dashboard — including making your own copy.',
         position: 'left',
@@ -64,7 +64,7 @@ export function buildPublicExplorerWalkthrough(
       {
         id: 'dashboard-duplicate',
         target: 'dashboard-duplicate',
-        route: /^\/dashboards-beta\/?$/,
+        route: /^\/dashboards\/?$/,
         title: 'Duplicate to get your own copy',
         body: `Pick **Duplicate** to spin up your own editable copy in a temporary session (lasts ${ttl}). Tweak filters, rearrange components, save your view — the copy disappears when your session expires. Or hit Next to keep exploring without duplicating.`,
         position: 'left',
@@ -73,7 +73,7 @@ export function buildPublicExplorerWalkthrough(
       {
         id: 'pick-dashboard',
         target: 'dashboard-card',
-        route: /^\/dashboards-beta\/?$/,
+        route: /^\/dashboards\/?$/,
         title: 'Open a dashboard',
         body: 'Click any dashboard card to dive in — the tour resumes inside.',
         position: 'right',
@@ -82,7 +82,7 @@ export function buildPublicExplorerWalkthrough(
       {
         id: 'sidebar',
         target: 'sidebar',
-        route: /^\/dashboard-beta\//,
+        route: /^\/dashboard\//,
         title: 'Navigate dashboard tabs',
         body: 'Each dashboard can have multiple tabs. Switch between them from the sidebar.',
         position: 'right',
@@ -90,7 +90,7 @@ export function buildPublicExplorerWalkthrough(
       {
         id: 'filter-panel',
         target: 'filter-panel',
-        route: /^\/dashboard-beta\//,
+        route: /^\/dashboard\//,
         title: 'Filter the data',
         body: 'Use these interactive controls to narrow what every chart, card, and table shows. Selections propagate across the whole dashboard.',
         position: 'right',
@@ -98,7 +98,7 @@ export function buildPublicExplorerWalkthrough(
       {
         id: 'realtime',
         target: 'realtime-indicator',
-        route: /^\/dashboard-beta\//,
+        route: /^\/dashboard\//,
         title: 'Live updates',
         body: 'When upstream data changes, this pill lights up. Open Settings to switch on auto-refresh, or click to refresh manually.',
         position: 'bottom',

--- a/depictio/viewer/vite.config.ts
+++ b/depictio/viewer/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
-// Dev-only: serve the SPA's index.html (under base /dashboard-beta/) for any
+// Dev-only: serve the SPA's index.html (under base /dashboard/) for any
 // non-asset SPA route so React routes get HMR. Production has the matching
 // FastAPI catch-alls in depictio/api/main.py — this plugin only runs when
 // `vite dev` is the server. The browser URL stays untouched, so main.tsx
@@ -12,13 +12,13 @@ import path from 'path';
 // (resolveTree) and the FastAPI mounts in depictio/api/main.py.
 const SPA_ROUTE_PREFIXES = [
   'auth',
-  'dashboards-beta',
-  'dashboard-beta-edit',
-  'projects-beta',
-  'about-beta',
-  'admin-beta',
-  'profile-beta',
-  'cli-agents-beta',
+  'dashboards',
+  'dashboard-edit',
+  'projects',
+  'about',
+  'admin',
+  'profile',
+  'cli-agents',
 ];
 const SPA_ROUTE_RE = new RegExp(
   `^/(?:${SPA_ROUTE_PREFIXES.join('|')})(/|$|\\?)`,
@@ -30,23 +30,23 @@ const authDevFallback = (): Plugin => ({
   configureServer(server) {
     server.middlewares.use((req, res, next) => {
       // Bare root → dashboards list, in one hop. Without this, Vite
-      // 302-redirects `/` to the SPA base `/dashboard-beta/` first, and only
-      // then does the app bounce to `/dashboards-beta` — a visible
+      // 302-redirects `/` to the SPA base `/dashboard/` first, and only
+      // then does the app bounce to `/dashboards` — a visible
       // singular→plural double redirect. Intercepting here (before Vite's
-      // base-redirect middleware) lands the user on `/dashboards-beta`
+      // base-redirect middleware) lands the user on `/dashboards`
       // directly. Mirrors the nginx `location = /` redirect in prod.
       if (
         req.url === '/' ||
-        req.url === '/dashboard-beta' ||
-        req.url === '/dashboard-beta/'
+        req.url === '/dashboard' ||
+        req.url === '/dashboard/'
       ) {
         res.statusCode = 302;
-        res.setHeader('Location', '/dashboards-beta');
+        res.setHeader('Location', '/dashboards');
         res.end();
         return;
       }
       if (req.url && SPA_ROUTE_RE.test(req.url)) {
-        req.url = '/dashboard-beta/';
+        req.url = '/dashboard/';
       }
       next();
     });
@@ -71,9 +71,9 @@ const HMR_CLIENT_PORT = process.env.VITE_HMR_CLIENT_PORT
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), authDevFallback()],
-  // SPA is mounted at /dashboard-beta/ by FastAPI in depictio/api/main.py.
+  // SPA is mounted at /dashboard/ by FastAPI in depictio/api/main.py.
   // The leading slash + trailing slash matter for bundle asset resolution.
-  base: '/dashboard-beta/',
+  base: '/dashboard/',
   build: {
     outDir: 'dist',
     emptyOutDir: true,
@@ -105,7 +105,7 @@ export default defineConfig({
       },
       // FastAPI serves these at :8058 (StaticFiles mounts in main.py for
       // dashboard thumbnails and Dash-shared assets like the nf-core /
-      // depictio logos). Vite owns /dashboard-beta/ but everything else
+      // depictio logos). Vite owns /dashboard/ but everything else
       // needs to forward to the backend.
       '/static': {
         target: API_TARGET,

--- a/dev/advanced_viz_docs_screenshots/capture_react_screenshots.py
+++ b/dev/advanced_viz_docs_screenshots/capture_react_screenshots.py
@@ -1,6 +1,6 @@
 """Drive the /screenshot-react-dual endpoint for every advanced-viz dashboard.
 
-Hits the React-beta screenshot endpoint once per viz_kind, then converts the
+Hits the React screenshot endpoint once per viz_kind, then converts the
 resulting PNGs to WebP into the docs folder under their canonical viz_kind
 name so the `#only-light` / `#only-dark` refs in components.md resolve.
 

--- a/dev/playwright_debug/docs_screenshots.py
+++ b/dev/playwright_debug/docs_screenshots.py
@@ -132,7 +132,7 @@ async def _page_shot(ctx: ShotContext, route: str, name: str, wait_ms: int = 120
 @register("link_create_modal")
 async def _link_create(ctx: ShotContext) -> None:
     """Cross-DC link Create/Edit modal with resolver picker."""
-    await ctx.page.goto(f"{ctx.viewer_url}/projects-beta/{ctx.project_id}")
+    await ctx.page.goto(f"{ctx.viewer_url}/projects/{ctx.project_id}")
     await ctx.page.get_by_test_id("add-link-btn").click()
     await _shot(ctx, '[data-testid="link-edit-modal"]', "link_create_modal")
 
@@ -140,7 +140,7 @@ async def _link_create(ctx: ShotContext) -> None:
 @register("manage_dc_modal")
 async def _manage_dc(ctx: ShotContext) -> None:
     """Manage Data Collection modal (Modify / Clear tabs)."""
-    await ctx.page.goto(f"{ctx.viewer_url}/projects-beta/{ctx.project_id}")
+    await ctx.page.goto(f"{ctx.viewer_url}/projects/{ctx.project_id}")
     await ctx.page.get_by_test_id("manage-dc-btn").first.click()
     await _shot(ctx, '[data-testid="manage-dc-modal"]', "manage_dc_modal")
 
@@ -148,7 +148,7 @@ async def _manage_dc(ctx: ShotContext) -> None:
 @register("create_dc_modal_table")
 async def _create_dc_table(ctx: ShotContext) -> None:
     """Create DC modal on the Table tab (where coordinates lat/lon detection lives)."""
-    await ctx.page.goto(f"{ctx.viewer_url}/projects-beta/{ctx.project_id}")
+    await ctx.page.goto(f"{ctx.viewer_url}/projects/{ctx.project_id}")
     await ctx.page.get_by_test_id("create-dc-btn").click()
     # Tab is selected by default; click is a no-op safety in case order shifts.
     await ctx.page.get_by_role("tab", name="Table (CSV / TSV / Parquet)").click()
@@ -156,71 +156,71 @@ async def _create_dc_table(ctx: ShotContext) -> None:
 
 
 # ---- Full-page React (Beta) page shots ------------------------------------
-# Output to <version>/react-beta/ so they don't clash with legacy Dash images
+# Output to <version>/react/ so they don't clash with legacy Dash images
 # until the prose is rewritten to reference them.
 
 
 def _rb(name: str) -> str:
-    """Place page-level shots under a react-beta/ subdir within --version."""
-    return f"react-beta/{name}"
+    """Place page-level shots under a react/ subdir within --version."""
+    return f"react/{name}"
 
 
 @register("page_dashboards")
 async def _page_dashboards(ctx: ShotContext) -> None:
-    """React Beta /dashboards-beta landing — dashboard list."""
-    await _page_shot(ctx, "/dashboards-beta", _rb("page_dashboards"))
+    """React Beta /dashboards landing — dashboard list."""
+    await _page_shot(ctx, "/dashboards", _rb("page_dashboards"))
 
 
 @register("page_projects")
 async def _page_projects(ctx: ShotContext) -> None:
-    """React Beta /projects-beta — projects list."""
-    await _page_shot(ctx, "/projects-beta", _rb("page_projects"))
+    """React Beta /projects — projects list."""
+    await _page_shot(ctx, "/projects", _rb("page_projects"))
 
 
 @register("page_project_detail")
 async def _page_project_detail(ctx: ShotContext) -> None:
-    """React Beta /projects-beta/{id} — DC list + cross-DC links + joins graph."""
-    await _page_shot(ctx, f"/projects-beta/{ctx.project_id}", _rb("page_project_detail"))
+    """React Beta /projects/{id} — DC list + cross-DC links + joins graph."""
+    await _page_shot(ctx, f"/projects/{ctx.project_id}", _rb("page_project_detail"))
 
 
 @register("page_profile")
 async def _page_profile(ctx: ShotContext) -> None:
-    """React Beta /profile-beta — user profile."""
-    await _page_shot(ctx, "/profile-beta", _rb("page_profile"))
+    """React Beta /profile — user profile."""
+    await _page_shot(ctx, "/profile", _rb("page_profile"))
 
 
 @register("page_about")
 async def _page_about(ctx: ShotContext) -> None:
-    """React Beta /about-beta — about page."""
-    await _page_shot(ctx, "/about-beta", _rb("page_about"))
+    """React Beta /about — about page."""
+    await _page_shot(ctx, "/about", _rb("page_about"))
 
 
 @register("page_admin")
 async def _page_admin(ctx: ShotContext) -> None:
-    """React Beta /admin-beta — admin users page (admin role required)."""
-    await _page_shot(ctx, "/admin-beta", _rb("page_admin"))
+    """React Beta /admin — admin users page (admin role required)."""
+    await _page_shot(ctx, "/admin", _rb("page_admin"))
 
 
 @register("page_cli_agents")
 async def _page_cli_agents(ctx: ShotContext) -> None:
-    """React Beta /cli-agents-beta — CLI tokens / agents."""
-    await _page_shot(ctx, "/cli-agents-beta", _rb("page_cli_agents"))
+    """React Beta /cli-agents — CLI tokens / agents."""
+    await _page_shot(ctx, "/cli-agents", _rb("page_cli_agents"))
 
 
 @register("page_dashboard_viewer")
 async def _page_dashboard_viewer(ctx: ShotContext) -> None:
-    """React Beta /dashboard-beta/{id} — read-only dashboard view, settles after grid render."""
+    """React Beta /dashboard/{id} — read-only dashboard view, settles after grid render."""
     await _page_shot(
-        ctx, f"/dashboard-beta/{ctx.dashboard_id}", _rb("page_dashboard_viewer"), wait_ms=9_000
+        ctx, f"/dashboard/{ctx.dashboard_id}", _rb("page_dashboard_viewer"), wait_ms=9_000
     )
 
 
 @register("page_dashboard_editor")
 async def _page_dashboard_editor(ctx: ShotContext) -> None:
-    """React Beta /dashboard-beta-edit/{id} — design-mode editor."""
+    """React Beta /dashboard-edit/{id} — design-mode editor."""
     await _page_shot(
         ctx,
-        f"/dashboard-beta-edit/{ctx.dashboard_id}",
+        f"/dashboard-edit/{ctx.dashboard_id}",
         _rb("page_dashboard_editor"),
         wait_ms=4_000,
     )
@@ -231,8 +231,8 @@ async def _page_dashboard_editor(ctx: ShotContext) -> None:
 
 @register("cli_config_create_modal")
 async def _cli_config_create(ctx: ShotContext) -> None:
-    """Add New CLI Configuration modal opened on /cli-agents-beta."""
-    await ctx.page.goto(f"{ctx.viewer_url}/cli-agents-beta", wait_until="domcontentloaded")
+    """Add New CLI Configuration modal opened on /cli-agents."""
+    await ctx.page.goto(f"{ctx.viewer_url}/cli-agents", wait_until="domcontentloaded")
     await ctx.page.wait_for_timeout(800)
     await ctx.page.get_by_test_id("add-cli-config-btn").click()
     await _shot(ctx, '[data-testid="create-cli-token-modal"]', _rb("cli_config_create_modal"))
@@ -240,8 +240,8 @@ async def _cli_config_create(ctx: ShotContext) -> None:
 
 @register("new_dashboard_modal")
 async def _new_dashboard(ctx: ShotContext) -> None:
-    """+ New Dashboard modal opened on /dashboards-beta (project picker)."""
-    await ctx.page.goto(f"{ctx.viewer_url}/dashboards-beta", wait_until="domcontentloaded")
+    """+ New Dashboard modal opened on /dashboards (project picker)."""
+    await ctx.page.goto(f"{ctx.viewer_url}/dashboards", wait_until="domcontentloaded")
     await ctx.page.wait_for_timeout(800)
     await ctx.page.get_by_test_id("new-dashboard-btn").click()
     await _shot(ctx, '[data-testid="create-dashboard-modal"]', _rb("new_dashboard_modal"))

--- a/dev/react-migration-test/manifests.yaml
+++ b/dev/react-migration-test/manifests.yaml
@@ -268,7 +268,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports: [{ containerPort: 80 }]
           readinessProbe:
-            httpGet: { path: /dashboard-beta/, port: 80 }
+            httpGet: { path: /dashboard/, port: 80 }
             initialDelaySeconds: 5
             periodSeconds: 10
 ---

--- a/docker-images/Dockerfile.viewer
+++ b/docker-images/Dockerfile.viewer
@@ -46,9 +46,9 @@ LABEL org.opencontainers.image.version="${VERSION:-latest}"
 LABEL org.opencontainers.image.authors="Thomas Weber <thomas.weber@embl.de>"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Vite builds under base `/dashboard-beta/`, so the bundle lives there on
+# Vite builds under base `/dashboard/`, so the bundle lives there on
 # disk too — keeps nginx's `root` simple and asset URLs untouched.
-COPY --from=builder /build/depictio/viewer/dist /usr/share/nginx/html/dashboard-beta
+COPY --from=builder /build/depictio/viewer/dist /usr/share/nginx/html/dashboard
 
 # Ship the config as an envsubst template. The base image's entrypoint
 # (/docker-entrypoint.d/20-envsubst-on-templates.sh) renders every

--- a/docker-images/nginx.conf.template
+++ b/docker-images/nginx.conf.template
@@ -1,7 +1,7 @@
 # -----------------------------
 # Depictio viewer nginx config
 # -----------------------------
-# Serves the Vite-built React SPA (base `/dashboard-beta/`) and proxies
+# Serves the Vite-built React SPA (base `/dashboard/`) and proxies
 # everything else to the FastAPI backend. Mirrors the dev-server proxy
 # layout in depictio/viewer/vite.config.ts so client code sees the same
 # URL surface in dev and prod.
@@ -71,8 +71,8 @@ server {
     # Emit RELATIVE redirect Location headers. nginx listens on 80 inside the
     # container but is published on a different host port (e.g. 5100 in the
     # multi-instance dev setup, or behind an ingress in k8s). With the default
-    # `absolute_redirect on`, nginx rewrites `return 302 /dashboard-beta/` into
-    # an absolute `http://<host>/dashboard-beta/` using its OWN :80 — dropping
+    # `absolute_redirect on`, nginx rewrites `return 302 /dashboard/` into
+    # an absolute `http://<host>/dashboard/` using its OWN :80 — dropping
     # the real host port, so the browser lands on the wrong URL. Relative
     # redirects let the browser resolve against the address it actually used.
     absolute_redirect off;
@@ -80,7 +80,7 @@ server {
     # Hashed asset URLs (Vite emits `assets/<name>.<hash>.js`) are
     # immutable — long cache is safe. index.html and all other paths
     # stay no-cache so deploys are picked up on the next navigation.
-    location /dashboard-beta/assets/ {
+    location /dashboard/assets/ {
         root /usr/share/nginx/html;
         access_log off;
         expires 1y;
@@ -89,18 +89,18 @@ server {
     }
 
     # SPA shell. try_files falls back to index.html so client-side
-    # routing under /dashboard-beta/* works on hard refresh / deep links.
-    location /dashboard-beta/ {
+    # routing under /dashboard/* works on hard refresh / deep links.
+    location /dashboard/ {
         root /usr/share/nginx/html;
-        try_files $uri $uri/ /dashboard-beta/index.html;
+        try_files $uri $uri/ /dashboard/index.html;
         add_header Cache-Control "no-cache";
     }
 
     # Other React-owned route prefixes — same SPA shell, different entry
     # paths. Keeps the vite.config.ts dev fallback list in sync with prod.
-    location ~ ^/(auth|dashboards-beta|projects-beta|about-beta|admin-beta)(/|$) {
+    location ~ ^/(auth|dashboards|dashboard-edit|projects|about|admin|profile|cli-agents)(/|$) {
         root /usr/share/nginx/html;
-        try_files /dashboard-beta/index.html =404;
+        try_files /dashboard/index.html =404;
         add_header Cache-Control "no-cache";
     }
 
@@ -138,12 +138,12 @@ server {
     }
 
     # Bare `/` lands on the dashboards list. Redirect straight to
-    # /dashboards-beta (not the SPA base /dashboard-beta/) so there's no
+    # /dashboards (not the SPA base /dashboard/) so there's no
     # singular→plural double hop — the app's own bare-root bounce would
     # otherwise fire on top. Relative Location (absolute_redirect off above)
     # keeps the caller's host:port. Mirrors the Vite dev middleware.
     location = / {
-        return 302 /dashboards-beta;
+        return 302 /dashboards;
     }
 
     gzip on;

--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -632,7 +632,7 @@ spec:
             {{- toYaml .Values.viewer.resources | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /dashboard-beta/
+              path: /dashboard/
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -1996,7 +1996,7 @@ export { authFetch, refreshAccessToken };
 
 // ---- Dashboard management (list / create / edit / delete / import / export)
 //
-// These back the React /dashboards-beta page. Mirrors the endpoints today's
+// These back the React /dashboards page. Mirrors the endpoints today's
 // Dash management page consumes (see depictio/dash/layouts/dashboards_management.py).
 
 /** Permissions block embedded in each dashboard list entry. Shapes match
@@ -2670,7 +2670,7 @@ export async function exportDashboardJson(
 
 // ---- Admin (system-wide) helpers ----------------------------------------
 //
-// These back the React /admin-beta page. Backend already enforces `is_admin`
+// These back the React /admin page. Backend already enforces `is_admin`
 // on every endpoint; the SPA just renders them when the current user passes
 // the same check. Mirrors the calls in `depictio/dash/layouts/admin_management.py`.
 
@@ -2789,7 +2789,7 @@ export async function cleanExampleProjects(): Promise<{ deleted: ExampleProject[
   return { deleted };
 }
 
-// ---- Profile + CLI token management (/profile-beta, /cli-agents-beta) -----
+// ---- Profile + CLI token management (/profile, /cli-agents) -----
 //
 // These wrap the FastAPI endpoints used by the React profile and CLI agents
 // pages. Token create/delete go through bearer-authed `/auth/me/tokens`

--- a/packages/depictio-react-core/src/components/multiqc/MultiQCFigure.tsx
+++ b/packages/depictio-react-core/src/components/multiqc/MultiQCFigure.tsx
@@ -189,12 +189,12 @@ const MultiQCFigureBody: React.FC<MultiQCFigureProps> = ({
           {/* MultiQC logo overlay — official icon set
             (https://github.com/MultiQC/logo). Dark icon on light backgrounds,
             white icon in dark mode. Asset shipped via the SPA's public/ folder
-            and served by the FastAPI mount at /dashboard-beta/logos/. */}
+            and served by the FastAPI mount at /dashboard/logos/. */}
           <img
             src={
               theme === 'dark'
-                ? '/dashboard-beta/logos/multiqc_icon_white.svg'
-                : '/dashboard-beta/logos/multiqc_icon_dark.svg'
+                ? '/dashboard/logos/multiqc_icon_white.svg'
+                : '/dashboard/logos/multiqc_icon_dark.svg'
             }
             title="Generated with MultiQC"
             alt="MultiQC"


### PR DESCRIPTION
## Context

The React viewer ran in parallel with the legacy Dash app, served under `-beta`-suffixed routes (`/dashboards-beta`, `/dashboard-beta/{id}`, …) so the two frontends could coexist. The Dash app has since been **fully removed** from the codebase, leaving the unsuffixed routes free. This PR drops the `-beta` suffix everywhere so React serves the normal routes — completing the cutover.

## Route renames

| Before | After |
|---|---|
| `/dashboards-beta` | `/dashboards` |
| `/dashboard-beta/{id}` | `/dashboard/{id}` |
| `/dashboard-beta-edit/` | `/dashboard-edit/` |
| `/about-beta`, `/admin-beta`, `/projects-beta`, `/profile-beta`, `/cli-agents-beta` | unsuffixed |

## What changed (51 files, pure suffix removal — diff is symmetric 224/224)

- **FastAPI** (`api/main.py`): static mounts, SPA catch-all routes, root redirect → `/dashboards`
- **Vite** (`viewer/vite.config.ts`): `base: '/dashboard/'`, `SPA_ROUTE_PREFIXES`, dev fallback middleware
- **nginx** (`nginx.conf.template`): `location` blocks + route regex — also added the previously-missing `profile`, `cli-agents` and `dashboard-edit` prefixes so those routes survive a hard refresh in prod
- **Docker** (`Dockerfile.viewer`): `COPY` target → `/usr/share/nginx/html/dashboard`
- **Helm/k8s**: readiness/liveness probe paths → `/dashboard/`
- **Backend**: screenshot service navigation URL → `/dashboard/{id}` (functional)
- **~30 React source files**: in-app links, boot route detection, asset/logo paths
- Dropped the `(Beta)` browser-tab title

## Out of scope (intentionally untouched)

- Pre-release version tags (`-bN`, e.g. `1.0.0-b1`), bumpversion config, release CI
- npm dependency versions in lockfiles (`gensync@1.0.0-beta.2`, `@rolldown/pluginutils@1.0.0-beta.27`)
- CHANGELOG and pure documentation/comments

## Verification

- ✅ `ruff format` / `ruff check` pass
- ✅ Full `tsc && vite build` succeeds; built `dist/index.html` resolves assets under `/dashboard/assets/`
- ✅ `main.py` / `vite.config.ts` / `nginx` route sets cross-checked and in sync
- ⚠️ `ty` and `pre-commit` could not run in the remote container (no project venv → unresolved `pydantic` imports; `uv`/`helm`/`shellcheck` absent). Changes are string-literal only, so no typing impact — to be confirmed by CI.

E2E Cypress tests already targeted the unsuffixed routes (`/dashboards`, `/profile`, …), so they should now pass against routes that actually exist.

https://claude.ai/code/session_01RJZhBPpdmGTiWoyMLh2XEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJZhBPpdmGTiWoyMLh2XEU)_