### PR TITLE
fix(settings): relax password constraints for usability

### DIFF
--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import AliasChoices, Field, SecretStr, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -13,8 +13,6 @@ _WEAK_PASSWORDS: frozenset[str] = frozenset(
         "minio123",
         "password",
         "passw0rd",
-        "changeme",
-        "change_me",
         "admin",
         "admin123",
         "depictio",
@@ -25,7 +23,10 @@ _WEAK_PASSWORDS: frozenset[str] = frozenset(
         "letmein",
     }
 )
-_MIN_SECRET_LEN = 16
+# "changeme" / "change_me" are intentionally NOT in _WEAK_PASSWORDS so they
+# remain usable as a dev/default admin password for quick local starts.
+_WEAK_PASSWORDS_MINIO: frozenset[str] = _WEAK_PASSWORDS | frozenset({"changeme", "change_me"})
+_MIN_SECRET_LEN = 8
 
 # ── Core Services ─────────────────────────────────────────────────────────────
 
@@ -184,7 +185,7 @@ class S3DepictioCLIConfig(ServiceConfig):
         description=(
             "MinIO/S3 root secret key. REQUIRED in server context — set via "
             "DEPICTIO_MINIO_ROOT_PASSWORD. The server refuses to start when this is unset, "
-            "shorter than 16 characters, or matches a well-known default."
+            "shorter than 8 characters, or matches a well-known default."
         ),
     )
     bucket: str = Field(
@@ -287,7 +288,7 @@ class AuthConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="DEPICTIO_AUTH_", case_sensitive=False)
 
-    def __init__(self, **data: object) -> None:
+    def __init__(self, **data: Any) -> None:
         super().__init__(**data)
 
         import os
@@ -385,8 +386,8 @@ class AuthBootstrapConfig(BaseSettings):
     admin_password: SecretStr = Field(
         default=SecretStr(""),
         description=(
-            "Password for the bootstrap admin. REQUIRED, ≥16 characters, must not match "
-            "any well-known default. Set via DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD."
+            "Password for the bootstrap admin. REQUIRED, ≥8 characters. "
+            "Set via DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD."
         ),
     )
 
@@ -1048,12 +1049,16 @@ class Settings(BaseSettings):
         if self.context != "server":
             return self
 
+        # Single-user mode is for local development — no secret enforcement.
+        if self.auth.is_single_user_mode:
+            return self
+
         errors: list[str] = []
 
         # MinIO root password is consumed by API + worker, so it must always
         # be set on a server boot regardless of single-user / public mode.
         minio_pw = self.minio.root_password.get_secret_value()
-        if minio_pw.lower() in _WEAK_PASSWORDS:
+        if minio_pw.lower() in _WEAK_PASSWORDS_MINIO:
             errors.append(
                 "DEPICTIO_MINIO_ROOT_PASSWORD is unset or matches a known-default value. "
                 "Set it to a strong secret before starting the server."
@@ -1073,7 +1078,7 @@ class Settings(BaseSettings):
             if admin_pw.lower() in _WEAK_PASSWORDS:
                 errors.append(
                     "DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD matches a known-default value; "
-                    "choose a strong secret."
+                    "choose a stronger secret."
                 )
             elif len(admin_pw) < _MIN_SECRET_LEN:
                 errors.append(

--- a/depictio/tests/api/v1/test_security_pr1.py
+++ b/depictio/tests/api/v1/test_security_pr1.py
@@ -59,14 +59,26 @@ def test_client_context_skips_minio_check(monkeypatch):
     mod.Settings()  # no raise
 
 
-@pytest.mark.parametrize("weak_pw", ["changeme", "minio123", "short"])
+@pytest.mark.parametrize("weak_pw", ["minio123", "short"])
 def test_server_context_rejects_weak_bootstrap_admin_password(monkeypatch, weak_pw):
+    """minio123 is in _WEAK_PASSWORDS; passwords < 8 chars are rejected."""
     monkeypatch.setenv("DEPICTIO_CONTEXT", "server")
+    monkeypatch.setenv("DEPICTIO_AUTH_SINGLE_USER_MODE", "false")
     monkeypatch.setenv("DEPICTIO_MINIO_ROOT_PASSWORD", "a" * 32)
     monkeypatch.setenv("DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD", weak_pw)
     mod = _reload_settings_module()
     with pytest.raises(Exception, match="DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD"):
         mod.Settings()
+
+
+def test_server_context_allows_changeme_for_admin(monkeypatch):
+    """changeme is intentionally allowed for the bootstrap admin (local dev default)."""
+    monkeypatch.setenv("DEPICTIO_CONTEXT", "server")
+    monkeypatch.setenv("DEPICTIO_AUTH_SINGLE_USER_MODE", "false")
+    monkeypatch.setenv("DEPICTIO_MINIO_ROOT_PASSWORD", "a" * 32)
+    monkeypatch.setenv("DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD", "changeme")
+    mod = _reload_settings_module()
+    mod.Settings()  # must not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Single-user mode skips all secret enforcement** — `minio123` and `changeme` work out of the box; no `.env` file needed for local dev
- **Min password length**: 16 → 8 characters (still enforced in multi-user/production)
- **Split weak-password list**: MinIO keeps the strict blocklist (includes `changeme`); bootstrap admin allows `changeme` for quick local starts
- **Fix pre-existing `ty` error**: `**data: object` → `**data: Any` in `AuthConfig.__init__` (was generating 24 false-positive diagnostics)

## Motivation

The 16-char minimum and `changeme` block made the Quick Start require a `.env` step even for purely local single-user setups, adding friction with no security benefit (single-user mode has no network exposure by design).

## Behaviour matrix

| Mode | MinIO `minio123` | Admin `changeme` | Min length |
|------|-----------------|-----------------|------------|
| Single-user (default) | ✅ allowed | ✅ allowed | not enforced |
| Multi-user / production | ❌ blocked | ✅ allowed | ≥ 8 chars |

## Test plan

- [ ] `docker compose up -d` with no `.env` starts successfully in single-user mode
- [ ] `DEPICTIO_AUTH_SINGLE_USER_MODE=false` + weak passwords triggers validation errors at startup
- [ ] `DEPICTIO_AUTH_SINGLE_USER_MODE=false` + ≥8-char non-default passwords starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)