### PR TITLE
fix(rate-limit): use X-Real-IP for per-user buckets behind nginx

### DIFF
--- a/depictio/api/v1/endpoints/user_endpoints/rate_limit.py
+++ b/depictio/api/v1/endpoints/user_endpoints/rate_limit.py
@@ -109,7 +109,14 @@ def enforce_rate_limit(request: Request, endpoint: str) -> None:
     FAIL-OPEN: any Redis error (unreachable, timeout) allows the request through
     so an outage cannot lock everyone out of auth.
     """
-    client_ip = request.client.host if request.client else "unknown"
+    # Prefer X-Real-IP forwarded by the nginx reverse-proxy over the raw TCP
+    # connection source, which would be the nginx pod IP in k8s (causing all
+    # visitors to share one rate-limit bucket).
+    client_ip = (
+        request.headers.get("x-real-ip")
+        or (request.client.host if request.client else None)
+        or "unknown"
+    )
     client = _get_redis_client()
     if client is None:
         # Fail open — Redis unavailable.


### PR DESCRIPTION
## Problem

`enforce_rate_limit` keyed the Redis bucket on `request.client.host` — in Kubernetes this is the nginx pod IP, not the real client IP. All visitors to a public/demo deployment therefore shared a **single 10-req/60 s bucket** for `POST /auth/public/create_temporary_user`. After ~10 page loads across any combination of users, everyone received a 429, the bootstrap caught it, redirected to `/auth`, hit the same 429 there, and fell back to the standard login form — forcing users to manually click "Sign In" instead of being auto-minted a temporary session.

## Fix

Read `X-Real-IP` (set by `proxy_set_header X-Real-IP $remote_addr` in `nginx.conf.template`) before falling back to the TCP connection source. Each real client now gets its own bucket.

The fallback chain keeps local dev (no proxy, no header) working unchanged.

## Test plan
- [ ] Public/demo deployment: concurrent visitors can each auto-mint a temp user without hitting 429
- [ ] Local dev (`docker compose`): login / register still rate-limited per TCP IP
- [ ] Redis outage: fail-open behaviour unchanged