### PR TITLE
Helm chart: viewer startup order, MongoDB Community Operator HA, resource rebalance

### DIFF
--- a/.github/workflows/test-and-package-helm-chart.yaml
+++ b/.github/workflows/test-and-package-helm-chart.yaml
@@ -159,7 +159,10 @@ jobs:
 
       - name: Lint Helm chart
         run: |
+          # Lint with defaults (useOperator: false — validates self-managed StatefulSet path)
           helm lint ./helm-charts/depictio
+          # Lint with CI overrides to catch any values-gh-actions.yaml interaction
+          helm lint ./helm-charts/depictio -f ./helm-charts/depictio/values-gh-actions.yaml
 
       - name: Test chart packaging
         run: |
@@ -245,7 +248,7 @@ jobs:
           timeout=180  # 3 minutes total timeout
           elapsed=0
           expected_deployments=4  # minio, backend, viewer, celery-worker
-          expected_statefulsets=2  # mongo, redis
+          expected_statefulsets=2  # mongo (self-managed StatefulSet, useOperator: false in CI), redis
 
           while [ $elapsed -lt $timeout ]; do
             # Count deployments by their names
@@ -312,8 +315,10 @@ jobs:
               kubectl describe pod $FRONTEND_POD | grep -A 10 -E "(Conditions:|Init Containers:|Containers:)"
 
               echo ""
-              echo "📋 Frontend init container logs (last 20 lines):"
-              kubectl logs $FRONTEND_POD --all-containers=true --tail=20 2>/dev/null || echo "❌ No logs available yet"
+              echo "📋 Frontend init container logs (wait-for-backend — added in PR #788):"
+              kubectl logs $FRONTEND_POD -c wait-for-backend --tail=20 2>/dev/null || echo "  (not started or already completed)"
+              echo "📋 Frontend main container logs (last 20 lines):"
+              kubectl logs $FRONTEND_POD -c depictio-viewer --tail=20 2>/dev/null || echo "  (not started yet)"
 
               # Check if frontend is ready
               FRONTEND_READY=$(kubectl get pod $FRONTEND_POD -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
@@ -500,11 +505,14 @@ jobs:
             exit 1
           }
 
-          echo "⏳ Waiting for frontend pods to be ready..."
+          echo "⏳ Waiting for frontend pods to be ready (viewer has wait-for-backend init container — starts after backend)..."
           kubectl wait --for=condition=ready pod -l "release=${RELEASE_NAME},app=depictio-viewer" --timeout=300s || {
             echo "❌ Frontend pods failed to be ready"
             echo "📊 Frontend pod details:"
             kubectl describe pods -l "release=${RELEASE_NAME},app=depictio-viewer"
+            echo "📋 wait-for-backend init container logs:"
+            VIEWER_POD=$(kubectl get pods -l "release=${RELEASE_NAME},app=depictio-viewer" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+            [ -n "$VIEWER_POD" ] && kubectl logs $VIEWER_POD -c wait-for-backend --tail=30 2>/dev/null || echo "  (not available)"
             exit 1
           }
 

--- a/depictio/api/v1/configs/config.py
+++ b/depictio/api/v1/configs/config.py
@@ -19,6 +19,8 @@ initialize_loggers(verbose_level=settings.logging.verbosity_level)
 
 API_BASE_URL = settings.fastapi.internal_url
 DASH_BASE_URL = settings.viewer.internal_url
+
+
 def _build_mongodb_url() -> str:
     cfg = settings.mongodb
     if cfg.username and cfg.password:

--- a/depictio/api/v1/configs/config.py
+++ b/depictio/api/v1/configs/config.py
@@ -19,7 +19,19 @@ initialize_loggers(verbose_level=settings.logging.verbosity_level)
 
 API_BASE_URL = settings.fastapi.internal_url
 DASH_BASE_URL = settings.viewer.internal_url
-MONGODB_URL = f"mongodb://{settings.mongodb.service_name}:{settings.mongodb.service_port}"
+def _build_mongodb_url() -> str:
+    cfg = settings.mongodb
+    if cfg.username and cfg.password:
+        pw = cfg.password.get_secret_value()
+        url = f"mongodb://{cfg.username}:{pw}@{cfg.service_name}:{cfg.service_port}"
+        params = [f"authSource={cfg.auth_source}"]
+        if cfg.replica_set:
+            params.append(f"replicaSet={cfg.replica_set}")
+        return f"{url}/?{'&'.join(params)}"
+    return f"mongodb://{cfg.service_name}:{cfg.service_port}"
+
+
+MONGODB_URL = _build_mongodb_url()
 _KEYS_DIR = settings.auth.keys_dir
 # The internal API key is now automatically managed via the computed field
 # No manual assignment needed - it checks environment variables and generates/reads from file

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -147,6 +147,10 @@ class MongoDBConfig(ServiceConfig):
     wipe: bool = Field(
         default=False, description="Wipe the database on startup (destructive — development only)"
     )
+    username: str | None = Field(default=None, description="MongoDB username (operator-managed RS auth)")
+    password: SecretStr | None = Field(default=None, description="MongoDB password (operator-managed RS auth)")
+    replica_set: str | None = Field(default=None, description="MongoDB replica set name, e.g. rs0")
+    auth_source: str = Field(default="admin", description="MongoDB authentication source database")
 
     model_config = SettingsConfigDict(env_prefix="DEPICTIO_MONGODB_")
 

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -147,8 +147,12 @@ class MongoDBConfig(ServiceConfig):
     wipe: bool = Field(
         default=False, description="Wipe the database on startup (destructive — development only)"
     )
-    username: str | None = Field(default=None, description="MongoDB username (operator-managed RS auth)")
-    password: SecretStr | None = Field(default=None, description="MongoDB password (operator-managed RS auth)")
+    username: str | None = Field(
+        default=None, description="MongoDB username (operator-managed RS auth)"
+    )
+    password: SecretStr | None = Field(
+        default=None, description="MongoDB password (operator-managed RS auth)"
+    )
     replica_set: str | None = Field(default=None, description="MongoDB replica set name, e.g. rs0")
     auth_source: str = Field(default="admin", description="MongoDB authentication source database")
 

--- a/helm-charts/depictio/templates/configmaps.yaml
+++ b/helm-charts/depictio/templates/configmaps.yaml
@@ -12,9 +12,15 @@ data:
   DEPICTIO_FASTAPI_PUBLIC_URL: {{ .Values.backend.env.DEPICTIO_FASTAPI_PUBLIC_URL | default (include "depictio.apiUrlWithProtocol" .) | quote }}
   DEPICTIO_VIEWER_SERVICE_PORT: {{ .Values.backend.env.DEPICTIO_VIEWER_SERVICE_PORT | quote }}
   DEPICTIO_VIEWER_SERVICE_NAME: {{ printf "%s-depictio-viewer" .Release.Name | quote }}
+  {{- if .Values.mongo.useOperator }}
+  DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo-svc" .Release.Name | quote }}
+  DEPICTIO_MONGODB_SERVICE_PORT: "27017"
+  DEPICTIO_MONGODB_AUTH_SOURCE: "admin"
+  {{- else }}
   DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo" .Release.Name | quote }}
-  DEPICTIO_MONGODB_WIPE: {{ .Values.backend.env.DEPICTIO_MONGODB_WIPE | quote }}
   DEPICTIO_MONGODB_SERVICE_PORT: {{ .Values.backend.env.DEPICTIO_MONGODB_SERVICE_PORT | quote }}
+  {{- end }}
+  DEPICTIO_MONGODB_WIPE: {{ .Values.backend.env.DEPICTIO_MONGODB_WIPE | quote }}
 
   # Redis Cache Configuration
   {{- if .Values.redis.enabled }}
@@ -137,8 +143,14 @@ data:
   {{- end }}
 
   # Service settings
+  {{- if .Values.mongo.useOperator }}
+  DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo-svc" .Release.Name | quote }}
+  DEPICTIO_MONGODB_SERVICE_PORT: "27017"
+  DEPICTIO_MONGODB_AUTH_SOURCE: "admin"
+  {{- else }}
   DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo" .Release.Name | quote }}
   DEPICTIO_MONGODB_SERVICE_PORT: {{ .Values.backend.env.DEPICTIO_MONGODB_SERVICE_PORT | quote }}
+  {{- end }}
   DEPICTIO_FASTAPI_SERVICE_NAME: {{ printf "%s-depictio-backend" .Release.Name | quote }}
   DEPICTIO_FASTAPI_SERVICE_PORT: {{ .Values.backend.env.DEPICTIO_FASTAPI_SERVICE_PORT | quote }}
   DEPICTIO_FASTAPI_PUBLIC_URL: {{ .Values.backend.env.DEPICTIO_FASTAPI_PUBLIC_URL | default (include "depictio.apiUrlWithProtocol" .) | quote }}

--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -1,4 +1,5 @@
-# MongoDB StatefulSet (for high availability with replica set)
+# MongoDB StatefulSet (self-managed, used when mongo.useOperator is false)
+{{- if not (.Values.mongo.useOperator | default false) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -104,6 +105,7 @@ spec:
       resources:
         requests:
           storage: {{ .Values.persistence.mongo.size }}
+{{- end }}
 ---
 # Redis StatefulSet (for caching and Celery broker)
 {{- if .Values.redis.enabled }}
@@ -400,7 +402,11 @@ spec:
         - name: wait-for-mongo
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
+          {{- if .Values.mongo.useOperator }}
+          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo-svc 27017; do echo "Waiting for mongo..."; sleep 2; done']
+          {{- else }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo {{ .Values.mongo.service.port }}; do echo "Waiting for mongo..."; sleep 2; done']
+          {{- end }}
           securityContext:
             {{- toYaml .Values.backend.securityContext | nindent 12 }}
           resources:
@@ -508,6 +514,17 @@ spec:
                   name: {{ .Release.Name }}-depictio-secrets
                   key: DEPICTIO_BOOTSTRAP_TEST_USER_PASSWORD
                   optional: true
+            {{- if .Values.mongo.useOperator }}
+            - name: DEPICTIO_MONGODB_USERNAME
+              value: {{ .Values.mongo.auth.username | quote }}
+            - name: DEPICTIO_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-mongo-password
+                  key: password
+            - name: DEPICTIO_MONGODB_REPLICA_SET
+              value: "rs0"
+            {{- end }}
             - name: WATCHFILES_FORCE_POLLING
               value: "true"
             - name: PYTHONUNBUFFERED
@@ -608,6 +625,15 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        - name: wait-for-backend
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
+          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-depictio-backend {{ .Values.backend.service.httpPort }}; do echo "Waiting for backend..."; sleep 2; done']
+          securityContext:
+            {{- toYaml .Values.viewer.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.initContainerResources | nindent 12 }}
       containers:
         - name: depictio-viewer
           image: "{{ .Values.viewer.image.repository }}:{{ .Values.viewer.image.tag }}"
@@ -709,7 +735,11 @@ spec:
         - name: wait-for-mongo
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
+          {{- if .Values.mongo.useOperator }}
+          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo-svc 27017; do echo "Waiting for mongo..."; sleep 2; done']
+          {{- else }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo {{ .Values.mongo.service.port }}; do echo "Waiting for mongo..."; sleep 2; done']
+          {{- end }}
           securityContext:
             {{- toYaml .Values.celery.securityContext | nindent 12 }}
           resources:
@@ -800,6 +830,17 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-depictio-secrets
                   key: MINIO_ROOT_PASSWORD
+            {{- if .Values.mongo.useOperator }}
+            - name: DEPICTIO_MONGODB_USERNAME
+              value: {{ .Values.mongo.auth.username | quote }}
+            - name: DEPICTIO_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-mongo-password
+                  key: password
+            - name: DEPICTIO_MONGODB_REPLICA_SET
+              value: "rs0"
+            {{- end }}
             - name: PYTHONUNBUFFERED
               value: "1"
           command:

--- a/helm-charts/depictio/templates/mongo-init-job.yaml
+++ b/helm-charts/depictio/templates/mongo-init-job.yaml
@@ -1,6 +1,7 @@
 # MongoDB Replica Set Initialization Job
-# Runs as a separate job after StatefulSet is ready
-{{- if gt (.Values.mongo.replicas | default 1 | int) 1 }}
+# Runs as a separate job after StatefulSet is ready (self-managed mode only).
+# When mongo.useOperator is true the operator handles RS initialization.
+{{- if and (gt (.Values.mongo.replicas | default 1 | int) 1) (not (.Values.mongo.useOperator | default false)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm-charts/depictio/templates/mongo-operator.yaml
+++ b/helm-charts/depictio/templates/mongo-operator.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.mongo.useOperator }}
+# MongoDB password Secret — read by the Community Operator to generate SCRAM
+# credentials, and injected into backend/celery as DEPICTIO_MONGODB_PASSWORD.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-mongo-password
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mongo
+    release: {{ .Release.Name }}
+type: Opaque
+stringData:
+  password: {{ required "mongo.auth.password is required when mongo.useOperator is true" .Values.mongo.auth.password | quote }}
+---
+# MongoDBCommunity CR — reconciled by the MongoDB Community Kubernetes Operator.
+# Pre-requisite: install the operator namespace-scoped in this namespace:
+#   helm install community-operator mongodb/community-operator \
+#     --namespace <ns> --set operator.watchNamespace=<ns>
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: {{ .Release.Name }}-mongo
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mongo
+    release: {{ .Release.Name }}
+spec:
+  members: {{ .Values.mongo.replicas | default 3 }}
+  type: ReplicaSet
+  version: {{ .Values.mongo.image.tag | quote }}
+  security:
+    authentication:
+      modes: ["SCRAM"]
+  users:
+    - name: {{ .Values.mongo.auth.username }}
+      db: admin
+      passwordSecretRef:
+        name: {{ .Release.Name }}-mongo-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: readWriteAnyDatabase
+          db: admin
+        - name: dbAdminAnyDatabase
+          db: admin
+      scramCredentialsSecretName: {{ .Release.Name }}-mongo-scram
+  statefulSet:
+    spec:
+      selector: {}
+      template:
+        spec:
+          containers:
+            - name: mongod
+              resources:
+                requests:
+                  cpu: {{ .Values.mongo.resources.requests.cpu | quote }}
+                  memory: {{ .Values.mongo.resources.requests.memory | quote }}
+                limits:
+                  cpu: {{ .Values.mongo.resources.limits.cpu | quote }}
+                  memory: {{ .Values.mongo.resources.limits.memory | quote }}
+            - name: mongodb-agent
+              resources:
+                requests:
+                  cpu: {{ .Values.mongo.agentResources.requests.cpu | default "100m" | quote }}
+                  memory: {{ .Values.mongo.agentResources.requests.memory | default "256Mi" | quote }}
+                limits:
+                  cpu: {{ .Values.mongo.agentResources.limits.cpu | default "200m" | quote }}
+                  memory: {{ .Values.mongo.agentResources.limits.memory | default "512Mi" | quote }}
+          securityContext:
+            runAsNonRoot: {{ .Values.mongo.podSecurityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.mongo.podSecurityContext.runAsUser }}
+            runAsGroup: {{ .Values.mongo.podSecurityContext.runAsGroup }}
+            fsGroup: {{ .Values.mongo.podSecurityContext.fsGroup }}
+      volumeClaimTemplates:
+        - metadata:
+            name: data-volume
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            storageClassName: {{ .Values.storageClass }}
+            resources:
+              requests:
+                storage: {{ .Values.persistence.mongo.size }}
+{{- end }}

--- a/helm-charts/depictio/templates/services.yaml
+++ b/helm-charts/depictio/templates/services.yaml
@@ -1,11 +1,10 @@
-# MongoDB Regular Service
+# MongoDB Services (self-managed StatefulSet only — operator creates its own services)
+{{- if not (.Values.mongo.useOperator | default false) }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-mongo
   namespace: {{ .Release.Namespace }}
-  # labels:
-  #   app: mongo
 spec:
   type: {{ .Values.mongo.service.type }}
   ports:
@@ -35,6 +34,7 @@ spec:
     app: mongo
     project: {{ .Values.project.slug }}
     type: app
+{{- end }}
 ---
 # Redis Service
 {{- if .Values.redis.enabled }}

--- a/helm-charts/depictio/values-embl-demo-base.yaml
+++ b/helm-charts/depictio/values-embl-demo-base.yaml
@@ -78,7 +78,13 @@ backend:
 
 
 mongo:
-  replicas: 1  # Temporarily single replica to get system working
+  useOperator: true     # Use MongoDB Community Operator for HA replica set
+  replicas: 3           # 3-member replica set managed by the operator
+  auth:
+    enabled: true
+    username: depictio
+    # password must be set in values-embl-secrets.yaml (never commit)
+    password: ""
   image:
     pullPolicy: Always
   resources:
@@ -86,8 +92,20 @@ mongo:
       memory: "1Gi"
       cpu: "500m"
     limits:
-      memory: "2Gi"
-      cpu: "1"
+      memory: "1Gi"     # Reduced: demo data is small, keep budget for backend/celery
+      cpu: "500m"
+  agentResources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "200m"       # Reduced: agent sidecar is lightweight
+      memory: "512Mi"
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
   securityContext:
     runAsNonRoot: true
     runAsUser: 999

--- a/helm-charts/depictio/values-embl-demo-dev.yaml
+++ b/helm-charts/depictio/values-embl-demo-dev.yaml
@@ -7,15 +7,16 @@
 #   - values-embl-secrets.yaml (S3 credentials)
 #
 # Tenant quota: 32 CPU / 64 GiB / 30 pods, shared between this env and
-# values-embl-demo.yaml. Per-env target: ~6 CPU / 12 GiB requests,
-# ~14 CPU / 28 GiB limits — two envs sum to ~28 / 56 limits with margin
-# for mongo-init / wipe-job hooks.
+# values-embl-demo.yaml. Budget with MongoDB Community Operator HA (3 replicas
+# × 2 envs = 6 pods, ~4.2 CPU / 9 GiB limits for all MongoDB):
 #
-# Celery gets the largest share because it's the advanced-viz compute
-# bottleneck — concurrency bumped to 8 (`replicas: 1` kept; multi-replica
-# celery isn't supported yet on this chart). Dash frontend slimmed because
-# the React viewer (served as static assets by the backend at
-# /dashboard-beta) is taking over.
+#   Component         dev-demo limits    demo limits    Both envs
+#   Backend ×2        4 CPU / 8 GiB      4 CPU / 8 GiB  8 CPU / 16 GiB
+#   Celery            8 CPU / 16 GiB     5 CPU / 10 GiB 13 CPU / 26 GiB
+#   Viewer ×2         1 CPU / 512 Mi     1 CPU / 512 Mi  2 CPU / 1 GiB
+#   MongoDB ×3        2.1 CPU / 4.5 GiB  2.1 CPU / 4.5G  4.2 CPU / 9 GiB
+#   Redis             0.5 CPU / 512 Mi   0.5 CPU / 512M  1 CPU / 1 GiB
+#   TOTAL             ~15.6 CPU / ~29 G  ~12.6 CPU / ~24 ~28 CPU / ~53 GiB ✅
 
 # Demo environment configuration - auto-wipe on upgrades
 demo:
@@ -33,12 +34,9 @@ podDisruptionBudget:
   enabled: true
   minAvailable: 1
 
-# Celery worker — the advanced-viz compute bottleneck (volcano / heatmap /
-# coverage_track / sankey / upset / …). dev is where we VALIDATE multi-replica
-# celery before promoting to stable: Redis is a multi-consumer broker and the
-# screenshots PVC is ReadWriteMany, so 2 workers is architecturally sound.
-# Budget-neutral: per-pod halved, aggregate (3 CPU / 6 Gi requests, 8 CPU /
-# 16 Gi limits, 8 task slots) unchanged vs the old single pod.
+# Celery worker — advanced-viz compute bottleneck (Playwright screenshots,
+# polars C-extension). dev validates multi-replica celery before promoting to
+# stable. 4 CPU / 8 GiB limits per pod × 2 pods = 8 CPU / 16 GiB total.
 celery:
   enabled: true
   replicas: 2

--- a/helm-charts/depictio/values-embl-demo.yaml
+++ b/helm-charts/depictio/values-embl-demo.yaml
@@ -18,10 +18,10 @@
 # bootstrapAdminPassword is unset — that's the fail-fast contract.
 #
 # Tenant quota: 32 CPU / 64 GiB / 30 pods, shared with values-embl-demo-dev.yaml
-# Per-env target: ~6 CPU / 12 GiB requests, ~14 CPU / 28 GiB limits — two
-# envs sum to ~28 / 56 limits with margin for mongo-init / wipe-job hooks.
-# Same rebalance rationale as the dev env values file — see header there
-# for details.
+# With MongoDB HA via Community Operator (3 replicas × 2 envs = 6 pods):
+#   MongoDB limits: 6 × (0.5 CPU + 0.2 agent) = 4.2 CPU / 9 GiB
+#   Both envs combined limits: ~28 CPU / ~53 GiB — within 32/64 quota.
+# See values-embl-demo-dev.yaml header for full budget breakdown.
 
 # Demo environment configuration - auto-wipe on upgrades
 demo:
@@ -41,19 +41,20 @@ podDisruptionBudget:
   enabled: true
   minAvailable: 1
 
-# Celery worker — biggest share of the budget because it's the
-# advanced-viz compute bottleneck. Threads pool so polars C-extension
-# compute scales past the GIL.
+# Celery worker — advanced-viz compute bottleneck (Playwright screenshots,
+# polars C-extension compute). Limits reduced from 8→5 CPU / 16→10Gi to fit
+# both demo+devdemo within the 32 CPU / 64 GiB tenant ResourceQuota when
+# MongoDB HA (3 replicas × 2 deployments = 6 pods) is running in parallel.
 celery:
   enabled: true
-  replicas: 1   # multi-replica celery not validated yet on this chart
+  replicas: 1
   resources:
     requests:
       memory: "6Gi"
       cpu: "3"
     limits:
-      memory: "16Gi"
-      cpu: "8"
+      memory: "10Gi"
+      cpu: "5"
   env:
     DEPICTIO_CELERY_WORKERS: "8"  # parallel tasks per worker
 

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -74,6 +74,15 @@ demo:
 
 # MongoDB settings
 mongo:
+  # useOperator: false = self-managed StatefulSet (default, no auth, single or multi-replica)
+  # useOperator: true  = MongoDB Community Operator manages the replica set (requires operator pre-installed)
+  useOperator: false
+  auth:
+    enabled: false      # Enable SCRAM auth (required when useOperator: true)
+    username: depictio
+    # password must be supplied via a separate secrets values file — never commit it.
+    # The operator reads it from the {release}-mongo-password Secret (key: password).
+    password: ""
   image:
     repository: mongo
     # Pinned to a specific 8.x release — :latest is mutable and was a CI/supply-chain
@@ -88,6 +97,15 @@ mongo:
     limits:
       memory: "1Gi"
       cpu: "1"
+  # Resources for the mongodb-agent sidecar injected by the Community Operator.
+  # Only used when mongo.useOperator: true.
+  agentResources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "200m"
+      memory: "512Mi"
   service:
     type: ClusterIP
     port: 27018
@@ -112,6 +130,9 @@ mongo:
 # Redis settings
 redis:
   enabled: true
+  # useOperator: false = self-managed StatefulSet (default)
+  # Reserved for future Sentinel/Cluster operator support.
+  useOperator: false
   image:
     repository: redis
     tag: "8.2.1"


### PR DESCRIPTION
## Summary

- **Viewer startup ordering**: add `wait-for-backend` init container to the viewer Deployment so the nginx SPA pod waits for the FastAPI service to be accepting connections before coming up — consistent with the existing pattern used by the celery worker.

- **MongoDB Community Operator HA** (`mongo.useOperator` toggle):
  - `false` (default): existing self-managed StatefulSet, Services, and RS init job — zero change for all non-EMBL deployments (minikube, gh-actions, serve, no-ingress).
  - `true`: renders a `MongoDBCommunity` CR and a `{release}-mongo-password` Secret; the operator manages replica set lifecycle, pod services, and RS initialization. MongoDB Services and the init job are suppressed.
  - EMBL base values: `useOperator: true`, `replicas: 3` (3-member HA replica set).
  - New template: `templates/mongo-operator.yaml`

- **Application MongoDB auth support** (`settings_models.py` + `config.py`): `MongoDBConfig` gains optional `username`, `password`, `replica_set`, `auth_source` fields (env prefix `DEPICTIO_MONGODB_`). `config.py` builds a full auth URI when credentials are present; the no-auth path is unchanged.

- **Resource rebalance** for the `tweber` tenant (32 CPU / 64 GiB / 30 pods shared between devdemo + demo):
  - demo celery: 8 → 5 CPU / 16 → 10 GiB limits (Playwright doesn't need 8 CPU)
  - MongoDB per pod: 0.5 CPU / 1 GiB (mongod) + 0.2 CPU / 512 Mi (agent sidecar)
  - Combined limits for both envs: ~28 CPU / ~53 GiB → 3 CPU / 11 GiB headroom ✅

- `redis.useOperator: false` placeholder added for future Sentinel/operator support.

## Deployment notes

- `mongo.auth.password` must be supplied via `values-embl-secrets.yaml` (never committed).
- The MongoDB Community Operator must be installed namespace-scoped before deploying with `useOperator: true`:
  ```bash
  helm install community-operator mongodb/community-operator \
    --namespace <ns> --set operator.watchNamespace=<ns>
  ```

## Test plan

- [ ] `helm template . -f values.yaml` renders StatefulSet (no operator CR), viewer has `wait-for-backend` init container
- [ ] `helm template . -f values.yaml -f values-embl-demo-base.yaml -f values-embl-demo-dev.yaml` renders `MongoDBCommunity` CR, no StatefulSet/Services for mongo, viewer init container present
- [ ] `helm template . -f values.yaml -f values-embl-demo-base.yaml -f values-embl-demo.yaml` same as above with demo-specific resources
- [ ] Combined limits for both EMBL envs sum to ≤ 32 CPU / 64 GiB
- [ ] Deploy to EMBL namespace with operator pre-installed; verify `MongoDBCommunity` reaches `Running` phase and backend connects with auth

---
_Generated by [Claude Code](https://claude.ai/code/session_016MBY1vu7kaPTogiCtzXEC4)_