### PR TITLE
fix(demo): restore public reference dashboards + keep temp users for the session

### DIFF
--- a/depictio/api/v1/db_init.py
+++ b/depictio/api/v1/db_init.py
@@ -388,9 +388,14 @@ async def create_dashboard_from_json(
         needs_update = False
         update_fields: dict = {}
 
-        # Do NOT re-force is_public=True on existing dashboards. The bootstrap
-        # used to flip every reference dashboard back to public on each restart,
-        # which silently reverted any operator-driven privacy lockdown.
+        # In public/demo mode, ensure existing reference dashboards stay public so
+        # a pod restart (without a DB wipe) doesn't leave them private and invisible
+        # to anonymous/temporary visitors. We do NOT force this in standard mode —
+        # that would silently revert an operator-driven privacy lockdown (the #779
+        # concern).
+        if settings.auth.is_public_mode and not _check.get("is_public", False):
+            update_fields["is_public"] = True
+            needs_update = True
 
         # Only force static DC ID if specified (for single-DC dashboards like Iris)
         if static_dc_id:
@@ -489,13 +494,14 @@ async def create_dashboard_from_json(
         viewers=[],
     )
 
-    # Reference dashboards are NOT public by default — anonymous browsing of
-    # the demo content would expose all stored_metadata to the internet on
-    # public-mode deployments. The EMBL demo values file (or any deployment
-    # that wants public reference dashboards) can opt in by toggling the
-    # ``is_public`` flag via the seed JSON or a post-init job. The dashboard
-    # owner (admin_user) always has full access.
-    dashboard_data.is_public = False
+    # Reference dashboards are public ONLY when the server runs in public/demo
+    # mode — anonymous/temporary visitors must be able to browse the curated demo
+    # content. On standard deployments they stay private, preserving the #779
+    # security fix (anonymous browsing would otherwise expose all stored_metadata
+    # to the internet). Demo mode implies public mode, so gating on
+    # ``is_public_mode`` covers it. The dashboard owner (admin_user) always has
+    # full access regardless.
+    dashboard_data.is_public = settings.auth.is_public_mode
 
     # Create the dashboard object into the database
     response = await save_dashboard(

--- a/depictio/api/v1/endpoints/user_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/user_endpoints/routes.py
@@ -1,6 +1,6 @@
 import hmac
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Annotated, Any
 
 from beanie import PydanticObjectId
@@ -227,6 +227,26 @@ async def create_token(
     return token
 
 
+async def _rearm_temporary_user_expiry(user: UserBeanie | None) -> None:
+    """Slide a temporary (public/demo) user's TTL on each token refresh.
+
+    Public/demo visitors are minted a temporary user whose ``expiration_time``
+    governs when ``_cleanup_expired_temporary_users`` deletes them. Re-arming the
+    TTL whenever an active session refreshes its access token keeps a still-browsing
+    visitor authorized for the duration of their session, so they never lapse back
+    to the ``anonymous`` fallback identity mid-session. Abandoned sessions stop
+    refreshing and lapse after the window (bounded by the 7-day refresh token).
+    Non-temporary users are left untouched.
+    """
+    if user is None or not getattr(user, "is_temporary", False):
+        return
+    user.expiration_time = datetime.now() + timedelta(
+        hours=settings.auth.temporary_user_expiry_hours,
+        minutes=settings.auth.temporary_user_expiry_minutes,
+    )
+    await user.save()
+
+
 @auth_endpoint_router.post("/refresh", include_in_schema=True)
 async def refresh_token_browser(request: dict) -> dict:
     """Browser-safe refresh: uses the refresh token as the only credential.
@@ -269,6 +289,9 @@ async def refresh_token_browser(request: dict) -> dict:
     token_doc.access_token = new_access_token
     token_doc.expire_datetime = expire_datetime
     await token_doc.save()
+
+    # Keep an active public/demo visitor authorized for the duration of their session.
+    await _rearm_temporary_user_expiry(user)
 
     return {
         "access_token": new_access_token,
@@ -313,6 +336,9 @@ async def refresh_token_endpoint(
     token_doc.access_token = new_access_token
     token_doc.expire_datetime = expire_datetime
     await token_doc.save()
+
+    # Keep an active public/demo visitor authorized for the duration of their session.
+    await _rearm_temporary_user_expiry(user)
 
     return {"access_token": new_access_token, "expire_datetime": token_doc.expire_datetime}
 

--- a/depictio/tests/api/v1/test_demo_mode_regressions.py
+++ b/depictio/tests/api/v1/test_demo_mode_regressions.py
@@ -1,0 +1,110 @@
+"""Regression tests for the public/demo-mode deployment fixes.
+
+Covers two behaviors that regressed/were tightened after the #779 security work:
+
+1. Reference dashboards must be seeded ``is_public=True`` ONLY when the server runs
+   in public/demo mode, and stay private on standard deployments (preserving the
+   #779 lockdown). See ``create_dashboard_from_json`` in ``db_init``.
+2. A temporary (public/demo) user's TTL must slide forward on every token refresh so
+   an active visitor is authorized for the duration of their session and never lapses
+   back to the anonymous fallback identity mid-session. See
+   ``_rearm_temporary_user_expiry`` in the user endpoints routes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from depictio.models.models.base import PyObjectId
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+IRIS_SEED = REPO_ROOT / "depictio" / "projects" / "init" / "iris" / ".db_seeds" / "dashboard.json"
+
+
+# ---------------------------------------------------------------------------
+# Regression A — reference dashboards public only in public/demo mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("is_public_mode", [True, False])
+@pytest.mark.asyncio
+async def test_reference_dashboard_is_public_follows_public_mode(is_public_mode: bool) -> None:
+    """``create_dashboard_from_json`` seeds ``is_public`` from ``is_public_mode``.
+
+    The bundled seed JSON ships ``is_public=True``, but the create path must override
+    it to mirror the server's auth mode: public in public/demo deployments, private
+    everywhere else.
+    """
+    from depictio.api.v1 import db_init
+
+    admin_user = MagicMock()
+    admin_user.id = PyObjectId()
+    admin_user.email = "admin@example.com"
+
+    mock_collection = MagicMock()
+    mock_collection.find_one.return_value = None  # force the create branch
+
+    captured: dict = {}
+
+    async def fake_save_dashboard(dashboard_id, data, current_user):  # noqa: ANN001
+        captured["data"] = data
+        return {"success": True}
+
+    mock_settings = MagicMock()
+    mock_settings.auth.is_public_mode = is_public_mode
+
+    with (
+        patch("depictio.api.v1.db.dashboards_collection", mock_collection),
+        patch.object(db_init, "save_dashboard", side_effect=fake_save_dashboard),
+        patch.object(db_init, "settings", mock_settings),
+    ):
+        await db_init.create_dashboard_from_json(admin_user, str(IRIS_SEED), static_dc_id="")
+
+    assert captured["data"].is_public is is_public_mode
+
+
+# ---------------------------------------------------------------------------
+# Regression B — sliding expiration keeps active temp users authorized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rearm_temporary_user_expiry_extends_temp_user() -> None:
+    """A temporary user's ``expiration_time`` is pushed forward and the record saved."""
+    from depictio.api.v1.endpoints.user_endpoints import routes
+
+    mock_settings = MagicMock()
+    mock_settings.auth.temporary_user_expiry_hours = 2
+    mock_settings.auth.temporary_user_expiry_minutes = 0
+
+    user = MagicMock()
+    user.is_temporary = True
+    user.save = AsyncMock()
+
+    before = datetime.now()
+    with patch.object(routes, "settings", mock_settings):
+        await routes._rearm_temporary_user_expiry(user)
+
+    user.save.assert_awaited_once()
+    # Re-armed roughly 2h out — well beyond the original 1h demo window.
+    assert user.expiration_time > before + timedelta(hours=1, minutes=30)
+
+
+@pytest.mark.asyncio
+async def test_rearm_temporary_user_expiry_skips_regular_and_missing_user() -> None:
+    """Non-temporary users (and ``None``) are left untouched."""
+    from depictio.api.v1.endpoints.user_endpoints import routes
+
+    regular = MagicMock()
+    regular.is_temporary = False
+    regular.save = AsyncMock()
+
+    await routes._rearm_temporary_user_expiry(regular)
+    regular.save.assert_not_awaited()
+
+    # No user resolved (revoked token edge case) is a safe no-op.
+    await routes._rearm_temporary_user_expiry(None)


### PR DESCRIPTION
## Problem

When running the helm chart in **demo/public mode** (`DEPICTIO_AUTH_DEMO_MODE=true` + `DEPICTIO_AUTH_PUBLIC_MODE=true`), two regressions appeared after security PR #779 (`3ca5f91`):

1. **Public-project dashboards no longer showed up.** The reference *projects* are still seeded public, but their *dashboards* were forced private, so anonymous/temporary visitors saw an empty demo.
2. **Active visitors lapsed back to `anonymous@depict.io` mid-session** instead of staying a temporary user.

## Root cause

1. `create_dashboard_from_json()` in `db_init.py` was changed to hardcode `dashboard_data.is_public = False` (it was `True` before #779), and the per-restart re-flip was removed.
2. The temporary **user** record expires after `temporary_user_expiry_hours` (1h in the demo) and `_cleanup_expired_temporary_users` deletes it along with its token — but the SPA only refreshes the access token ~hourly. So a still-browsing visitor's temp user got deleted out from under them, and subsequent requests fell through `get_user_or_anonymous` to the anonymous fallback identity.

## Fix

- **`db_init.py`** — gate the seeded dashboard `is_public` on `settings.auth.is_public_mode` (demo implies public). Public/demo deployments publish the curated reference dashboards; standard deployments keep them private, preserving the #779 lockdown. Also restore a **public-mode-gated** re-flip for existing dashboards so a non-wiped restart doesn't leave them invisible — without ever overriding an operator-set lockdown in standard mode.
- **`user_endpoints/routes.py`** — add `_rearm_temporary_user_expiry()` and call it from both refresh endpoints (`/auth/refresh`, `/auth/refresh_token`). A temporary user's `expiration_time` now slides forward on every token refresh, so an active visitor stays authorized for the duration of their session. Abandoned sessions still lapse (bounded by the 7-day refresh token) and get cleaned up.

## Tests

- New `test_demo_mode_regressions.py`:
  - reference dashboard `is_public` follows `is_public_mode` (True in public/demo, False in standard);
  - refreshing a temporary user slides its `expiration_time` forward; non-temporary / missing users are untouched.
- New tests pass (4); related suites pass (unauthenticated mode, security PR1, reference seeds, user routes — 106).
- `ruff format`/`ruff check` clean; `ty` clean on the changed files.

## Notes

This makes a clean build mint and **keep** a temporary user, so the profile badge should show `temp_user_*`. If the live demo still shows `anonymous@depict.io` after this lands, verify the deployed viewer/backend images are built from a commit including the React temp-user bootstrap (a stale pre-cutover bundle could still hold an old anonymous token in `localStorage`).

https://claude.ai/code/session_01UEt5Us9QNjYfrgRTUViZqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEt5Us9QNjYfrgRTUViZqW)_