### PR TITLE
Refactor CHANGELOG.md update logic in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,9 +85,11 @@ jobs:
 
       - name: Update CHANGELOG.md
         # if: ${{ needs.changelog.outputs.is_beta != 'true' }}
+        env:
+          CHANGELOG_CONTENT: ${{ needs.changelog.outputs.changelog }}
         run: |
           # Only update for stable releases
-          echo "${{ needs.changelog.outputs.changelog }}" > /tmp/changelog_clean.md
+          echo "$CHANGELOG_CONTENT" > /tmp/changelog_clean.md
 
           # Pull latest changes from main branch to avoid conflicts
           git config user.name "GitHub Actions Bot"
@@ -96,15 +98,18 @@ jobs:
           git checkout main
           git pull origin main
 
-          # Read existing changelog
-          if [ -f CHANGELOG.md ]; then
-            EXISTING_CHANGELOG=$(cat CHANGELOG.md)
-          else
-            EXISTING_CHANGELOG="# Changelog\n\n"
-          fi
-
           # Create new changelog with the latest changes at the top
-          echo -e "# Changelog\n\n$(cat /tmp/changelog_clean.md)\n\n${EXISTING_CHANGELOG#*#*\n\n}" > CHANGELOG.md
+          {
+            echo "# Changelog"
+            echo ""
+            cat /tmp/changelog_clean.md
+            echo ""
+            if [ -f CHANGELOG.md ]; then
+              # Skip the existing "# Changelog" header line
+              tail -n +3 CHANGELOG.md
+            fi
+          } > /tmp/new_changelog.md
+          mv /tmp/new_changelog.md CHANGELOG.md
 
           # Commit and push the updated changelog
           git add CHANGELOG.md


### PR DESCRIPTION
## Summary
Improved the CHANGELOG.md update step in the release workflow by refactoring the shell script logic for better readability, maintainability, and robustness.

## Key Changes
- **Environment variable extraction**: Moved the changelog content to an `env` variable (`CHANGELOG_CONTENT`) to avoid repeated variable expansion and improve clarity
- **Simplified changelog merging**: Replaced complex `echo -e` with multi-line heredoc-style output using braces `{}` for better readability
- **Improved header handling**: Changed from regex-based header stripping to explicit `tail -n +3` to skip the existing "# Changelog" header, making the intent clearer
- **Safer file operations**: Split the changelog generation into a temporary file (`/tmp/new_changelog.md`) before moving it to the final location, reducing risk of partial writes

## Implementation Details
The refactored approach:
1. Extracts the changelog content to an environment variable at the job level
2. Uses a compound command with output redirection to build the new changelog
3. Explicitly skips the first two lines (header and blank line) of the existing CHANGELOG.md
4. Writes to a temporary file first, then moves it atomically to the final location

This makes the script more maintainable and easier to debug while preserving the original functionality.

https://claude.ai/code/session_011DPmAVYxB2ivCEBtU2hoTn