### PR TITLE
fix(auth): multi-replica key-wipe race breaking dev-demo ingestion + React default-thumbnail fallback

### DIFF
--- a/depictio/api/v1/configs/config.py
+++ b/depictio/api/v1/configs/config.py
@@ -1,11 +1,6 @@
 from depictio.api.v1.configs.logging_init import initialize_loggers
 from depictio.api.v1.configs.settings_models import Settings
-from depictio.api.v1.key_utils import (
-    check_and_generate_keys,
-    generate_keys,
-    load_private_key,
-    load_public_key,
-)
+from depictio.api.v1.key_utils import check_and_generate_keys
 
 # Explicitly load environment variables
 # load_dotenv(BASE_PATH.parent / ".env", override=False)
@@ -42,35 +37,18 @@ _KEYS_DIR = settings.auth.keys_dir
 # Algorithm used for signing
 ALGORITHM = settings.auth.keys_algorithm
 
-# Lazy-loaded settings and paths
-_KEYS_DIR = settings.auth.keys_dir
-DEFAULT_PRIVATE_KEY_PATH = None
-DEFAULT_PUBLIC_KEY_PATH = None
+# Generate keys only if missing (file-locked to avoid races between workers
+# sharing the keys volume). Key rotation is done by deleting the keys dir
+# (e.g. the Helm demo wipe-job removes the keys PVC pre-upgrade) — never by
+# wiping at import time: with >1 replica each pod would wipe the others' keys
+# and end up holding a different in-memory pair, so ~half of all JWTs would
+# be rejected with "Signature verification failed".
+check_and_generate_keys(keys_dir=_KEYS_DIR, algorithm=ALGORITHM)
 
-# Use check_and_generate_keys to avoid race conditions between workers
-# Only use generate_keys with wipe when explicitly requested
-if bool(settings.mongodb.wipe):
-    # When wiping, we need to regenerate keys
-    generate_keys(
-        private_key_path=DEFAULT_PRIVATE_KEY_PATH,
-        public_key_path=DEFAULT_PUBLIC_KEY_PATH,
-        keys_dir=_KEYS_DIR,
-        algorithm=ALGORITHM,
-        wipe=True,
-    )
-else:
-    # Normal case: only generate if keys don't exist (prevents race condition)
-    check_and_generate_keys(
-        private_key_path=DEFAULT_PRIVATE_KEY_PATH,
-        public_key_path=DEFAULT_PUBLIC_KEY_PATH,
-        keys_dir=_KEYS_DIR,
-        algorithm=ALGORITHM,
-    )
-
-PRIVATE_KEY = load_private_key(
-    settings.auth.keys_dir / "private_key.pem"
-)  # Load private key from file
-PUBLIC_KEY = load_public_key(settings.auth.keys_dir / "public_key.pem")  # Load public key from file
+# Canonical key file locations — consumers load keys via
+# key_utils.get_private_key / get_public_key, which re-read on file change.
+PRIVATE_KEY_PATH = _KEYS_DIR / "private_key.pem"
+PUBLIC_KEY_PATH = _KEYS_DIR / "public_key.pem"
 
 # Generate/load the internal API key during startup (creates api_internal_key.pem file)
 # This ensures the key file exists before other services (frontend, celery) need it

--- a/depictio/api/v1/endpoints/user_endpoints/core_functions.py
+++ b/depictio/api/v1/endpoints/user_endpoints/core_functions.py
@@ -7,9 +7,10 @@ from fastapi import HTTPException
 from jwt import ExpiredSignatureError, InvalidTokenError
 from pydantic import EmailStr, validate_call
 
-from depictio.api.v1.configs.config import ALGORITHM, PUBLIC_KEY, settings
+from depictio.api.v1.configs.config import ALGORITHM, PUBLIC_KEY_PATH, settings
 from depictio.api.v1.configs.logging_init import logger
 from depictio.api.v1.endpoints.user_endpoints.utils import create_access_token
+from depictio.api.v1.key_utils import get_public_key
 from depictio.models.models.base import PyObjectId
 from depictio.models.models.users import TokenBase, TokenBeanie, TokenData, UserBeanie
 
@@ -328,7 +329,7 @@ async def _async_fetch_user_from_token(token: str) -> UserBeanie | None:
         # algorithm-confusion vulnerabilities.
         jwt.decode(
             token,
-            PUBLIC_KEY,
+            get_public_key(PUBLIC_KEY_PATH),
             algorithms=[ALGORITHM],
             options={"require": ["exp"]},
         )

--- a/depictio/api/v1/endpoints/user_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/user_endpoints/utils.py
@@ -8,8 +8,9 @@ from bson import ObjectId
 from fastapi import HTTPException
 from pydantic import validate_call
 
-from depictio.api.v1.configs.config import ALGORITHM, PRIVATE_KEY
+from depictio.api.v1.configs.config import ALGORITHM, PRIVATE_KEY_PATH
 from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.key_utils import get_private_key
 from depictio.models.models.base import PyObjectId, convert_objectid_to_str
 from depictio.models.models.users import (
     Group,
@@ -168,7 +169,7 @@ async def create_access_token(
     to_encode = token_data.model_dump()
     expire = datetime.now() + expires_delta
     to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, PRIVATE_KEY, algorithm=ALGORITHM)
+    encoded_jwt = jwt.encode(to_encode, get_private_key(PRIVATE_KEY_PATH), algorithm=ALGORITHM)
     return encoded_jwt, expire
 
 

--- a/depictio/api/v1/key_utils.py
+++ b/depictio/api/v1/key_utils.py
@@ -318,6 +318,54 @@ def load_public_key(public_key_path: Path) -> RSAPublicKey:
         raise
 
 
+# Keys can live on a volume shared by several pods/workers. Module-level
+# constants snapshot whatever was on disk at import time, so a pod whose key
+# pair gets overwritten by a sibling (e.g. two replicas generating keys on an
+# empty shared volume) keeps signing/verifying with stale keys forever. These
+# accessors re-read the PEM file whenever its mtime changes, so every pod
+# converges on the on-disk pair.
+_private_key_cache: dict[str, tuple[float, RSAPrivateKey]] = {}
+_public_key_cache: dict[str, tuple[float, RSAPublicKey]] = {}
+
+
+def get_private_key(private_key_path: Path) -> RSAPrivateKey:
+    """Load a private key, re-reading from disk when the file changes."""
+    path = str(private_key_path)
+    cached = _private_key_cache.get(path)
+    try:
+        mtime = os.stat(path).st_mtime
+    except OSError:
+        # Transient volume hiccup (or a wipe-job mid-delete): keep serving
+        # the cached key rather than turning every request into a 500.
+        if cached is not None:
+            logger.warning(f"Private key file unreadable at {path}; using cached key")
+            return cached[1]
+        raise
+    if cached is None or cached[0] != mtime:
+        cached = (mtime, load_private_key(private_key_path))
+        _private_key_cache[path] = cached
+    return cached[1]
+
+
+def get_public_key(public_key_path: Path) -> RSAPublicKey:
+    """Load a public key, re-reading from disk when the file changes."""
+    path = str(public_key_path)
+    cached = _public_key_cache.get(path)
+    try:
+        mtime = os.stat(path).st_mtime
+    except OSError:
+        # Transient volume hiccup (or a wipe-job mid-delete): keep serving
+        # the cached key rather than turning every request into a 500.
+        if cached is not None:
+            logger.warning(f"Public key file unreadable at {path}; using cached key")
+            return cached[1]
+        raise
+    if cached is None or cached[0] != mtime:
+        cached = (mtime, load_public_key(public_key_path))
+        _public_key_cache[path] = cached
+    return cached[1]
+
+
 @validate_call(validate_return=True)
 def import_keys(
     private_key_content: str,

--- a/depictio/viewer/src/dashboards/DashboardCard.tsx
+++ b/depictio/viewer/src/dashboards/DashboardCard.tsx
@@ -24,6 +24,7 @@ import MultiTabPreview from './MultiTabPreview';
 import DashboardActionsMenu from './DashboardActionsMenu';
 import {
   coerceString,
+  DEFAULT_THUMBNAIL_URL,
   formatLastSaved,
   isImagePath,
   resolveAssetUrl,
@@ -56,11 +57,13 @@ const SingleThumbnail: React.FC<{
   dashboard: DashboardListEntry;
   theme: 'light' | 'dark';
 }> = ({ dashboard, theme }) => {
-  const [errored, setErrored] = useState(false);
+  // Fallback chain: real screenshot → shared default thumbnail → icon
+  // (last resort if the default asset itself fails to load).
+  const [fallback, setFallback] = useState<'none' | 'default' | 'icon'>('none');
   const icon = coerceString(dashboard.icon, 'mdi:view-dashboard');
   const color = coerceString(dashboard.icon_color, 'orange');
 
-  if (errored) {
+  if (fallback === 'icon') {
     return (
       <Center h="100%" w="100%" bg="var(--mantine-color-default-hover)">
         <ThemeIcon size={64} variant="light" color={color} radius="md">
@@ -71,12 +74,16 @@ const SingleThumbnail: React.FC<{
   }
   return (
     <img
-      key={`${theme}-${dashboard.last_saved_ts ?? ''}`}
-      src={screenshotUrl(dashboard.dashboard_id, theme, dashboard.last_saved_ts)}
+      key={`${theme}-${dashboard.last_saved_ts ?? ''}-${fallback}`}
+      src={
+        fallback === 'default'
+          ? DEFAULT_THUMBNAIL_URL
+          : screenshotUrl(dashboard.dashboard_id, theme, dashboard.last_saved_ts)
+      }
       alt={dashboard.title || dashboard.dashboard_id}
       loading="lazy"
       decoding="async"
-      onError={() => setErrored(true)}
+      onError={() => setFallback(fallback === 'none' ? 'default' : 'icon')}
       style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
     />
   );
@@ -144,6 +151,9 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     theme,
     dashboard.last_saved_ts,
   );
+  // Same fallback chain as SingleThumbnail for the hover-popover preview:
+  // real screenshot → default thumbnail → no popover image at all.
+  const [popoverFallback, setPopoverFallback] = useState<'none' | 'default' | 'hidden'>('none');
 
   return (
     <Card
@@ -232,24 +242,36 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
                   <SingleThumbnail dashboard={dashboard} theme={theme} />
                 </UnstyledButton>
               </HoverCard.Target>
-              <HoverCard.Dropdown p={0} style={{ overflow: 'hidden' }}>
-                <Box w={720}>
-                  <AspectRatio ratio={16 / 10}>
-                    <img
-                      src={thumbnailSrc}
-                      alt=""
-                      loading="lazy"
-                      decoding="async"
-                      style={{
-                        width: '100%',
-                        height: '100%',
-                        objectFit: 'cover',
-                        display: 'block',
-                      }}
-                    />
-                  </AspectRatio>
-                </Box>
-              </HoverCard.Dropdown>
+              {popoverFallback !== 'hidden' && (
+                <HoverCard.Dropdown p={0} style={{ overflow: 'hidden' }}>
+                  <Box w={720}>
+                    <AspectRatio ratio={16 / 10}>
+                      <img
+                        key={`${thumbnailSrc}-${popoverFallback}`}
+                        src={
+                          popoverFallback === 'default'
+                            ? DEFAULT_THUMBNAIL_URL
+                            : thumbnailSrc
+                        }
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        onError={() =>
+                          setPopoverFallback(
+                            popoverFallback === 'none' ? 'default' : 'hidden',
+                          )
+                        }
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          objectFit: 'cover',
+                          display: 'block',
+                        }}
+                      />
+                    </AspectRatio>
+                  </Box>
+                </HoverCard.Dropdown>
+              )}
             </HoverCard>
           )}
         </AspectRatio>

--- a/depictio/viewer/src/dashboards/MultiTabPreview.tsx
+++ b/depictio/viewer/src/dashboards/MultiTabPreview.tsx
@@ -14,6 +14,7 @@ import { Icon } from '@iconify/react';
 
 import type { DashboardListEntry } from 'depictio-react-core';
 import { dashboardHref, dashboardLinkClickHandler } from './lib/dashboardLinks';
+import { DEFAULT_THUMBNAIL_URL } from './lib/format';
 
 interface MultiTabPreviewProps {
   parent: DashboardListEntry;
@@ -58,8 +59,10 @@ const SlideImage: React.FC<{
   theme: 'light' | 'dark';
   iconSize: number;
 }> = ({ slide, theme, iconSize }) => {
-  const [errored, setErrored] = useState(false);
-  if (errored) {
+  // Fallback chain: real screenshot → shared default thumbnail → icon
+  // (last resort if the default asset itself fails to load).
+  const [fallback, setFallback] = useState<'none' | 'default' | 'icon'>('none');
+  if (fallback === 'icon') {
     return (
       <Center h="100%" w="100%" bg="var(--mantine-color-default-hover)">
         <ThemeIcon size={iconSize} variant="light" color={slide.color} radius="md">
@@ -71,12 +74,16 @@ const SlideImage: React.FC<{
   const versionQuery = slide.version ? `?v=${encodeURIComponent(slide.version)}` : '';
   return (
     <img
-      key={`${theme}-${slide.version ?? ''}`}
-      src={`/static/screenshots/${slide.id}_${theme}.png${versionQuery}`}
+      key={`${theme}-${slide.version ?? ''}-${fallback}`}
+      src={
+        fallback === 'default'
+          ? DEFAULT_THUMBNAIL_URL
+          : `/static/screenshots/${slide.id}_${theme}.png${versionQuery}`
+      }
       alt={slide.title}
       loading="lazy"
       decoding="async"
-      onError={() => setErrored(true)}
+      onError={() => setFallback(fallback === 'none' ? 'default' : 'icon')}
       style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
     />
   );

--- a/depictio/viewer/src/dashboards/lib/format.ts
+++ b/depictio/viewer/src/dashboards/lib/format.ts
@@ -35,6 +35,12 @@ export function formatLastSaved(raw: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+/** Generic placeholder shown when a dashboard has no screenshot yet (e.g. a
+ *  freshly created dashboard before the first auto-screenshot run). Shipped
+ *  with the backend image and served by the FastAPI /assets StaticFiles
+ *  mount; both the vite dev proxy and the prod nginx forward /assets/. */
+export const DEFAULT_THUMBNAIL_URL = '/assets/images/backgrounds/default_thumbnail.png';
+
 export function screenshotUrl(
   dashboardId: string,
   theme: 'light' | 'dark',

--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -289,40 +289,6 @@ spec:
       securityContext:
         {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
       initContainers:
-        # Generate new ObjectId and create updated config files in writable volume
-        - name: update-iris-configs
-          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
-          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
-          command: ["/bin/sh"]
-          args:
-          - -c
-          - |
-            echo "Creating updated iris dataset configs with new ObjectId..."
-
-            # Generate a new ObjectId to replace the hardcoded one
-            old_id="646b0f3c1e4a2d7f8e5b8c9c"
-            new_id=$(python3 -c "from bson import ObjectId; print(str(ObjectId()))")
-
-            echo "Replacing $old_id with $new_id"
-
-            # Copy the entire iris_dataset directory to writable volume
-            cp -r /app/depictio/api/v1/configs/iris_dataset /iris-config/
-
-            # Update the ObjectIds in the copied files
-            sed -i "s/$old_id/$new_id/g" /iris-config/iris_dataset/initial_dashboard.json
-            sed -i "s/$old_id/$new_id/g" /iris-config/iris_dataset/initial_project.yaml
-
-            echo "Updated iris configs created in /iris-config/ with ObjectId: $new_id"
-            echo "Files updated:"
-            echo "  - /iris-config/iris_dataset/initial_dashboard.json"
-            echo "  - /iris-config/iris_dataset/initial_project.yaml"
-          securityContext:
-            {{- toYaml .Values.backend.securityContext | nindent 12 }}
-          resources:
-            {{- toYaml .Values.initContainerResources | nindent 12 }}
-          volumeMounts:
-            - name: iris-config-volume
-              mountPath: /iris-config
         {{- if .Values.local_development }}
         - name: fix-permissions
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
@@ -544,9 +510,6 @@ spec:
               mountPath: /app/depictio/.depictio
             - name: depictio-uploads
               mountPath: /tmp/depictio-uploads
-            - name: iris-config-volume
-              mountPath: /app/depictio/api/v1/configs/iris_dataset
-              subPath: iris_dataset
             {{- if .Values.local_development }}
             # DEV ONLY: mount the depictio source code for development
             ## Use minikube mount or similar to mount the local source code
@@ -566,8 +529,6 @@ spec:
         - name: depictio-uploads
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-depictio-uploads-pvc
-        - name: iris-config-volume
-          emptyDir: {}
         {{- if .Values.local_development }}
         # DEV ONLY: mount the depictio source code for development
         ## Use minikube mount or similar to mount the local source code


### PR DESCRIPTION
## Context

Two issues observed on https://dev.demo.depictio.embl.org/dashboards after the 1.0.0-b4 deploy:
1. **Data ingestion failing** — reference dashboards rendered empty (`deltatables/get` 404s, `bulk_compute_cards` DC-load failures).
2. **Default thumbnails still not used** — cards without a screenshot showed a bare icon.

## Root cause 1 — RSA key-wipe race between the 2 backend replicas

With `DEPICTIO_MONGODB_WIPE=true` and `backend.replicas: 2` (dev-demo since #770), `config.py` ran `generate_keys(wipe=True)` at import in **every** pod on the **shared keys PVC**. Observed timeline (pod logs, 2026-06-04):

- `15:42:32` pod A wipes keys, generates pair **A**, loads it into module-level `PRIVATE_KEY`/`PUBLIC_KEY`
- `15:42:36` pod B wipes pair A off disk, generates pair **B**, loads it
- `15:42:38` pod A (init-lock holder) signs the bootstrap admin token with **A** and starts reference-dataset ingestion via the load-balanced service
- every ingestion call landing on pod B → `Rejected invalid JWT: Signature verification failed` → 401 on `files/upsert_batch` / `runs/upsert_batch` / deltatable registration → no delta tables → empty dashboards — and ~50% of **all** user JWTs randomly rejected until restart (which re-runs the same race)

### Fix
- **`config.py`**: drop the wipe branch; always `check_and_generate_keys()` (file-locked, generate-if-missing). DB wipe doesn't need key rotation — tokens live in the wiped DB, and demo envs already rotate keys via the `wipe-job` deleting the keys PVC pre-upgrade.
- **`key_utils.py`**: new mtime-cached `get_private_key`/`get_public_key` accessors replace import-time constants — a pod whose on-disk pair is replaced self-heals on the next request; transient volume hiccups fall back to the cached key.
- Sign (`create_access_token`) and verify (`_async_fetch_user_from_token`) load keys through the accessors.

## Root cause 2 — default-thumbnail fallback never ported from Dash to React

The Dash page used `dmc.Image(fallbackSrc=default_thumbnail)`; #770 kept the asset (`/assets/images/backgrounds/default_thumbnail.png`, proxied by vite dev + prod nginx) but the React cards only fell back to an icon.

### Fix
`DashboardCard` (card + hover-popover) and `MultiTabPreview` carousel now degrade **screenshot → default thumbnail → icon** (popover: hidden).

## Bonus cleanup
Removed the dead `update-iris-configs` init container + `iris-config-volume` from the helm chart — it referenced `configs/iris_dataset`, deleted from the repo in 286b917e3 (Jan 2026), and logged `sed: can't read ...` on every boot.

## Verification
- Full pytest suite: **1347 passed, 9 skipped** (one docker-daemon-dependent integration test skipped — environmental)
- `ty` diagnostics identical to main baseline (235 pre-existing, none in touched files); `ruff` clean; viewer `pnpm build` OK; `helm template` renders with the dev-demo values
- Smoke test: JWT sign/verify roundtrip through the new accessors, cache-hit on unchanged mtime
- After deploy, confirm on dev-demo: no `Wiping existing keys` / `Signature verification failed` spam during init, ingestion completes, `/dashboards` shows default thumbnails for screenshot-less dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)