### PR TITLE
feat(helm): migrate MongoDB HA to Percona PSMDB Operator

### DIFF
--- a/helm-charts/depictio/templates/configmaps.yaml
+++ b/helm-charts/depictio/templates/configmaps.yaml
@@ -13,7 +13,7 @@ data:
   DEPICTIO_VIEWER_SERVICE_PORT: {{ .Values.backend.env.DEPICTIO_VIEWER_SERVICE_PORT | quote }}
   DEPICTIO_VIEWER_SERVICE_NAME: {{ printf "%s-depictio-viewer" .Release.Name | quote }}
   {{- if .Values.mongo.useOperator }}
-  DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo-svc" .Release.Name | quote }}
+  DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo-rs0" .Release.Name | quote }}
   DEPICTIO_MONGODB_SERVICE_PORT: "27017"
   DEPICTIO_MONGODB_AUTH_SOURCE: "admin"
   {{- else }}
@@ -144,7 +144,7 @@ data:
 
   # Service settings
   {{- if .Values.mongo.useOperator }}
-  DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo-svc" .Release.Name | quote }}
+  DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo-rs0" .Release.Name | quote }}
   DEPICTIO_MONGODB_SERVICE_PORT: "27017"
   DEPICTIO_MONGODB_AUTH_SOURCE: "admin"
   {{- else }}

--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -369,7 +369,7 @@ spec:
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           {{- if .Values.mongo.useOperator }}
-          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo-svc 27017; do echo "Waiting for mongo..."; sleep 2; done']
+          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo-rs0 27017; do echo "Waiting for mongo..."; sleep 2; done']
           {{- else }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo {{ .Values.mongo.service.port }}; do echo "Waiting for mongo..."; sleep 2; done']
           {{- end }}
@@ -697,7 +697,7 @@ spec:
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           {{- if .Values.mongo.useOperator }}
-          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo-svc 27017; do echo "Waiting for mongo..."; sleep 2; done']
+          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo-rs0 27017; do echo "Waiting for mongo..."; sleep 2; done']
           {{- else }}
           command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-mongo {{ .Values.mongo.service.port }}; do echo "Waiting for mongo..."; sleep 2; done']
           {{- end }}

--- a/helm-charts/depictio/templates/mongo-operator.yaml
+++ b/helm-charts/depictio/templates/mongo-operator.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.mongo.useOperator }}
-# MongoDB password Secret — read by the Community Operator to generate SCRAM
-# credentials, and injected into backend/celery as DEPICTIO_MONGODB_PASSWORD.
+# MongoDB password Secret — read by the Percona PSMDB Operator to create the
+# database user, and injected into backend/celery as DEPICTIO_MONGODB_PASSWORD.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,30 +13,50 @@ type: Opaque
 stringData:
   password: {{ required "mongo.auth.password is required when mongo.useOperator is true" .Values.mongo.auth.password | quote }}
 ---
-# MongoDBCommunity CR — reconciled by the MongoDB Community Kubernetes Operator.
-# Pre-requisite: install the operator namespace-scoped in this namespace:
-#   helm install community-operator mongodb/community-operator \
-#     --namespace <ns> --set operator.watchNamespace=<ns>
-apiVersion: mongodbcommunity.mongodb.com/v1
-kind: MongoDBCommunity
+# PerconaServerMongoDB CR — reconciled by the Percona PSMDB Kubernetes Operator.
+# Pre-requisite: operator must be installed by cluster admin (cluster-scoped or
+# namespace-scoped). Contact IT to confirm it is available in this namespace.
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
 metadata:
   name: {{ .Release.Name }}-mongo
   namespace: {{ .Release.Namespace }}
   labels:
     app: mongo
     release: {{ .Release.Name }}
+  finalizers:
+    - delete-psmdb-pods-in-order
 spec:
-  members: {{ .Values.mongo.replicas | default 3 }}
-  type: ReplicaSet
-  version: {{ .Values.mongo.image.tag | quote }}
-  security:
-    authentication:
-      modes: ["SCRAM"]
+  image: "{{ .Values.mongo.image.repository }}:{{ .Values.mongo.image.tag }}"
+  imagePullPolicy: {{ .Values.mongo.image.pullPolicy }}
+  clusterServiceDNSSuffix: {{ .Values.mongo.clusterServiceDNSSuffix | default "svc.cluster.local" | quote }}
+  allowUnsafeConfigurations: true
+  tls:
+    mode: disabled
+  replsets:
+    - name: rs0
+      size: {{ .Values.mongo.replicas | default 3 }}
+      resources:
+        requests:
+          cpu: {{ .Values.mongo.resources.requests.cpu | quote }}
+          memory: {{ .Values.mongo.resources.requests.memory | quote }}
+        limits:
+          cpu: {{ .Values.mongo.resources.limits.cpu | quote }}
+          memory: {{ .Values.mongo.resources.limits.memory | quote }}
+      volumeSpec:
+        persistentVolumeClaim:
+          storageClassName: {{ .Values.storageClass }}
+          resources:
+            requests:
+              storage: {{ .Values.persistence.mongo.size }}
+      podDisruptionBudget:
+        maxUnavailable: 1
   users:
     - name: {{ .Values.mongo.auth.username }}
       db: admin
       passwordSecretRef:
         name: {{ .Release.Name }}-mongo-password
+        key: password
       roles:
         - name: clusterAdmin
           db: admin
@@ -44,41 +64,9 @@ spec:
           db: admin
         - name: dbAdminAnyDatabase
           db: admin
-      scramCredentialsSecretName: {{ .Release.Name }}-mongo-scram
-  statefulSet:
-    spec:
-      selector: {}
-      template:
-        spec:
-          containers:
-            - name: mongod
-              resources:
-                requests:
-                  cpu: {{ .Values.mongo.resources.requests.cpu | quote }}
-                  memory: {{ .Values.mongo.resources.requests.memory | quote }}
-                limits:
-                  cpu: {{ .Values.mongo.resources.limits.cpu | quote }}
-                  memory: {{ .Values.mongo.resources.limits.memory | quote }}
-            - name: mongodb-agent
-              resources:
-                requests:
-                  cpu: {{ .Values.mongo.agentResources.requests.cpu | default "100m" | quote }}
-                  memory: {{ .Values.mongo.agentResources.requests.memory | default "256Mi" | quote }}
-                limits:
-                  cpu: {{ .Values.mongo.agentResources.limits.cpu | default "200m" | quote }}
-                  memory: {{ .Values.mongo.agentResources.limits.memory | default "512Mi" | quote }}
-          securityContext:
-            runAsNonRoot: {{ .Values.mongo.podSecurityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.mongo.podSecurityContext.runAsUser }}
-            runAsGroup: {{ .Values.mongo.podSecurityContext.runAsGroup }}
-            fsGroup: {{ .Values.mongo.podSecurityContext.fsGroup }}
-      volumeClaimTemplates:
-        - metadata:
-            name: data-volume
-          spec:
-            accessModes: ["ReadWriteOnce"]
-            storageClassName: {{ .Values.storageClass }}
-            resources:
-              requests:
-                storage: {{ .Values.persistence.mongo.size }}
+  backup:
+    enabled: false
+    image: "percona/percona-backup-mongodb:2.4.1"
+  sharding:
+    enabled: false
 {{- end }}

--- a/helm-charts/depictio/values-embl-demo-base.yaml
+++ b/helm-charts/depictio/values-embl-demo-base.yaml
@@ -78,7 +78,7 @@ backend:
 
 
 mongo:
-  useOperator: true     # Use MongoDB Community Operator for HA replica set
+  useOperator: true     # Use Percona PSMDB Operator for HA replica set
   replicas: 3           # 3-member replica set managed by the operator
   auth:
     enabled: true
@@ -86,7 +86,10 @@ mongo:
     # password must be set in values-embl-secrets.yaml (never commit)
     password: ""
   image:
+    repository: percona/percona-server-mongodb
+    tag: "6.0.9-7"
     pullPolicy: Always
+  clusterServiceDNSSuffix: "svc.ops-k1.embl.de"
   resources:
     requests:
       memory: "1Gi"
@@ -94,13 +97,6 @@ mongo:
     limits:
       memory: "1Gi"     # Reduced: demo data is small, keep budget for backend/celery
       cpu: "500m"
-  agentResources:
-    requests:
-      cpu: "100m"
-      memory: "256Mi"
-    limits:
-      cpu: "200m"       # Reduced: agent sidecar is lightweight
-      memory: "512Mi"
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 999

--- a/helm-charts/depictio/values-minikube.yaml
+++ b/helm-charts/depictio/values-minikube.yaml
@@ -64,4 +64,3 @@ backend:
     limits:
       memory: "512Mi"
       cpu: "0.5"
-

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -75,7 +75,7 @@ demo:
 # MongoDB settings
 mongo:
   # useOperator: false = self-managed StatefulSet (default, no auth, single or multi-replica)
-  # useOperator: true  = MongoDB Community Operator manages the replica set (requires operator pre-installed)
+  # useOperator: true  = Percona PSMDB Operator manages the replica set (requires operator pre-installed by cluster admin)
   useOperator: false
   auth:
     enabled: false      # Enable SCRAM auth (required when useOperator: true)
@@ -87,9 +87,14 @@ mongo:
     repository: mongo
     # Pinned to a specific 8.x release — :latest is mutable and was a CI/supply-chain
     # risk. Override per-deployment if a different minor is required.
+    # When useOperator: true, set repository to percona/percona-server-mongodb and tag to 6.x.
     tag: "8.0.5"
     pullPolicy: IfNotPresent
   replicas: 1 # Set to 3 for high availability replica set
+  # Cluster DNS suffix used by the Percona operator to build replica set member hostnames.
+  # Only used when mongo.useOperator: true. Override per-cluster if the cluster DNS suffix
+  # differs from the default (e.g. "svc.ops-k1.embl.de" for EMBL ops cluster).
+  clusterServiceDNSSuffix: "svc.cluster.local"
   resources:
     requests:
       memory: "1Gi"
@@ -97,15 +102,6 @@ mongo:
     limits:
       memory: "1Gi"
       cpu: "1"
-  # Resources for the mongodb-agent sidecar injected by the Community Operator.
-  # Only used when mongo.useOperator: true.
-  agentResources:
-    requests:
-      cpu: "100m"
-      memory: "256Mi"
-    limits:
-      cpu: "200m"
-      memory: "512Mi"
   service:
     type: ClusterIP
     port: 27018


### PR DESCRIPTION
## Summary
- Replace the `MongoDBCommunity` CR with a `PerconaServerMongoDB` CR for the `mongo.useOperator: true` HA path (the Community Operator is not available cluster-wide; Percona PSMDB is the operator provided by IT)
- Service name moves from `<release>-mongo-svc` to `<release>-mongo-rs0` — configmaps and init-container wait loops updated accordingly
- EMBL demo values switch to `percona/percona-server-mongodb:6.0.9-7` and set `clusterServiceDNSSuffix: svc.ops-k1.embl.de`; new `mongo.clusterServiceDNSSuffix` value (default `svc.cluster.local`) for clusters with non-default DNS
- Drop `mongo.agentResources` (PSMDB has no mongodb-agent sidecar); TLS disabled, backup/sharding off, PDB `maxUnavailable: 1`

## Test plan
- [ ] `helm template` renders cleanly with `mongo.useOperator: true` and the EMBL demo values
- [ ] Deploy on the EMBL ops cluster: 3-member `rs0` replica set comes up and backend/celery connect via `<release>-mongo-rs0:27017`