### PR TITLE
Enable project export in public & demo mode

### DIFF
--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -37,7 +37,10 @@ from depictio.api.v1.db import (
     users_collection,
 )
 from depictio.api.v1.endpoints.backup_endpoints.routes import _convert_complex_objects_to_strings
-from depictio.api.v1.endpoints.user_endpoints.routes import get_current_user
+from depictio.api.v1.endpoints.user_endpoints.routes import (
+    get_current_user,
+    get_user_or_anonymous,
+)
 from depictio.models.models.users import User
 
 migrate_endpoint_router = APIRouter()
@@ -316,7 +319,7 @@ def _copy_s3_locations(
 @migrate_endpoint_router.post("/export-project")
 async def export_project(
     request: MigrateExportRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_anonymous),
 ) -> StreamingResponse:
     """
     Export a project bundle from this instance.
@@ -324,17 +327,51 @@ async def export_project(
     Scoped to one project: cascades through workflows → data_collections →
     files / deltatables / runs → dashboards.  Optionally copies S3 data to
     a target MinIO (modes all / files).
+
+    Access rules:
+    - Admins can export any project, in every mode.
+    - In public/demo mode the anonymous and temporary visitors are non-admin,
+      so they're allowed to export too — but only projects they can actually
+      read (public projects or ones shared with them), never arbitrary private
+      projects. Uses ``get_user_or_anonymous`` so tokenless public-mode
+      visitors resolve to the anonymous user instead of 401-ing.
+    - On standard (non-public) instances export stays admin-only.
+
+    Non-admin callers may not supply ``target_s3_config``: that triggers the
+    server-to-server S3 copy path (an exfiltration vector gated by
+    ``_validate_target_s3_endpoint``), which has no place in the UI export flow
+    that bundles S3 objects straight into the ZIP.
     """
     if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Only administrators can export projects")
+        if not settings.auth.is_public_mode:
+            raise HTTPException(status_code=403, detail="Only administrators can export projects")
+        if request.target_s3_config:
+            raise HTTPException(
+                status_code=403,
+                detail="Non-admin users cannot specify a target S3 config for export",
+            )
 
-    # Resolve project
+    # Resolve project (permission-scoped for non-admin callers)
+    query: dict[str, Any]
     if request.project_id:
-        project = projects_collection.find_one({"_id": ObjectId(request.project_id)})
+        query = {"_id": ObjectId(request.project_id)}
     elif request.project_name:
-        project = projects_collection.find_one({"name": request.project_name})
+        query = {"name": request.project_name}
     else:
         raise HTTPException(status_code=400, detail="Provide project_id or project_name")
+
+    if not current_user.is_admin:
+        # Mirror _async_get_project_from_id: a non-admin may only reach projects
+        # they own/edit/view or that are explicitly public.
+        user_oid = ObjectId(current_user.id)
+        query["$or"] = [
+            {"permissions.owners._id": user_oid},
+            {"permissions.editors._id": user_oid},
+            {"permissions.viewers._id": user_oid},
+            {"is_public": True},
+        ]
+
+    project = projects_collection.find_one(query)
 
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")

--- a/depictio/tests/api/v1/test_demo_mode_regressions.py
+++ b/depictio/tests/api/v1/test_demo_mode_regressions.py
@@ -108,3 +108,120 @@ async def test_rearm_temporary_user_expiry_skips_regular_and_missing_user() -> N
 
     # No user resolved (revoked token edge case) is a safe no-op.
     await routes._rearm_temporary_user_expiry(None)
+
+
+# ---------------------------------------------------------------------------
+# Regression C — project export usable by public/demo-mode (non-admin) visitors
+# ---------------------------------------------------------------------------
+
+
+def _export_request(**overrides):
+    """Build a MigrateExportRequest with sensible UI-flow defaults."""
+    from depictio.api.v1.endpoints.migrate_endpoints.routes import MigrateExportRequest
+
+    params = {"project_id": str(PyObjectId()), "mode": "all"}
+    params.update(overrides)
+    return MigrateExportRequest(**params)
+
+
+def _user(is_admin: bool):
+    user = MagicMock()
+    user.id = PyObjectId()
+    user.is_admin = is_admin
+    return user
+
+
+@pytest.mark.asyncio
+async def test_export_blocked_for_non_admin_on_standard_instance() -> None:
+    """On a standard (non-public) deployment, export stays admin-only."""
+    from fastapi import HTTPException
+
+    from depictio.api.v1.endpoints.migrate_endpoints import routes
+
+    mock_settings = MagicMock()
+    mock_settings.auth.is_public_mode = False
+
+    with patch.object(routes, "settings", mock_settings):
+        with pytest.raises(HTTPException) as exc_info:
+            await routes.export_project(_export_request(), current_user=_user(is_admin=False))
+
+    assert exc_info.value.status_code == 403
+    assert "administrators" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_non_admin_target_s3_config_in_public_mode() -> None:
+    """Public-mode visitors may export, but never via the server-to-server S3
+    copy path (an exfiltration vector) — only the in-ZIP bundling UI flow."""
+    from fastapi import HTTPException
+
+    from depictio.api.v1.endpoints.migrate_endpoints import routes
+
+    mock_settings = MagicMock()
+    mock_settings.auth.is_public_mode = True
+
+    with patch.object(routes, "settings", mock_settings):
+        with pytest.raises(HTTPException) as exc_info:
+            await routes.export_project(
+                _export_request(target_s3_config={"endpoint_url": "http://evil:9000"}),
+                current_user=_user(is_admin=False),
+            )
+
+    assert exc_info.value.status_code == 403
+    assert "target s3" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_export_in_public_mode_scopes_query_to_readable_projects() -> None:
+    """A non-admin public-mode caller clears the admin gate and the project
+    lookup is permission-scoped: the Mongo query carries the owner/editor/viewer
+    /``is_public`` ``$or`` filter, so a private project they can't read 404s."""
+    from fastapi import HTTPException
+
+    from depictio.api.v1.endpoints.migrate_endpoints import routes
+
+    mock_settings = MagicMock()
+    mock_settings.auth.is_public_mode = True
+
+    mock_projects = MagicMock()
+    mock_projects.find_one.return_value = None  # not readable by this visitor
+
+    visitor = _user(is_admin=False)
+
+    with (
+        patch.object(routes, "settings", mock_settings),
+        patch.object(routes, "projects_collection", mock_projects),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await routes.export_project(_export_request(), current_user=visitor)
+
+    assert exc_info.value.status_code == 404
+    query = mock_projects.find_one.call_args.args[0]
+    assert "$or" in query
+    assert {"is_public": True} in query["$or"]
+
+
+@pytest.mark.asyncio
+async def test_export_admin_query_is_not_permission_scoped() -> None:
+    """Admins keep full reach: the lookup is keyed on the project id alone,
+    with no permission ``$or`` filter, in every mode."""
+    from fastapi import HTTPException
+
+    from depictio.api.v1.endpoints.migrate_endpoints import routes
+
+    mock_settings = MagicMock()
+    mock_settings.auth.is_public_mode = False
+
+    mock_projects = MagicMock()
+    mock_projects.find_one.return_value = None
+
+    with (
+        patch.object(routes, "settings", mock_settings),
+        patch.object(routes, "projects_collection", mock_projects),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await routes.export_project(_export_request(), current_user=_user(is_admin=True))
+
+    assert exc_info.value.status_code == 404
+    query = mock_projects.find_one.call_args.args[0]
+    assert "$or" not in query


### PR DESCRIPTION
## Problem

Project export (`POST /depictio/api/v1/migrate/export-project`) was gated behind a blanket `current_user.is_admin` check using the strict `get_current_user` dependency. In **public/demo mode**, visitors resolve to the anonymous user or an auto-minted temporary user — both **non-admin** — so the Export button (shown to everyone in the React UI via `ProjectActionsMenu.tsx` / `ProjectCard.tsx`) always failed with `403 Only administrators can export projects`. The feature was visible but unusable.

The block was entirely server-side; the frontend never hid or disabled the button.

## Fix

In `depictio/api/v1/endpoints/migrate_endpoints/routes.py`, the export endpoint now:

1. **Uses `get_user_or_anonymous`** instead of `get_current_user`, so tokenless public-mode visitors resolve to the anonymous user rather than getting a 401.
2. **Allows non-admin export only in public/demo mode** (`settings.auth.is_public_mode`); standard deployments keep export admin-only (no behavior change there).
3. **Scopes the project lookup permission-aware for non-admins** — the query carries an owner/editor/viewer/`is_public` `$or` filter (mirroring `_async_get_project_from_id`), so visitors can only export public or shared projects, never arbitrary private ones.
4. **Rejects non-admin `target_s3_config`** — that's the server-to-server S3 copy / exfiltration path (gated by `_validate_target_s3_endpoint`); the UI flow bundles S3 objects straight into the ZIP and never sends it.

## Access matrix

| Mode | Admin | Non-admin (anonymous / temp) |
|------|-------|------------------------------|
| Standard | export any project | 403 (unchanged) |
| Public / demo | export any project | export only readable projects (public/shared); no `target_s3_config` |

## Tests

Added 4 regression tests in `test_demo_mode_regressions.py`:
- Non-admin blocked on standard instances
- `target_s3_config` rejection for non-admin in public mode
- Permission-scoped 404 for non-readable projects (asserts the `$or` filter is applied)
- Admin queries stay unscoped

All pass; `ruff format`, `ruff check`, and `ty check` are clean on the changed files.

https://claude.ai/code/session_011aKwutUkW77zNxP6kzUFPM

---
_Generated by [Claude Code](https://claude.ai/code/session_011aKwutUkW77zNxP6kzUFPM)_