### PR TITLE
fix(viewer): tab menu refresh + icon handling in tab/dashboard modals

### DIFF
--- a/depictio/viewer/src/chrome/Sidebar.tsx
+++ b/depictio/viewer/src/chrome/Sidebar.tsx
@@ -237,13 +237,22 @@ const Sidebar: React.FC<SidebarProps> = ({
                   const label = isParent
                     ? d.main_tab_name || d.title || d.dashboard_id
                     : d.title || d.dashboard_id;
-                  // Use a YAML-supplied image ONLY when it's explicitly set on
-                  // tab_icon. Don't fall back to `icon` for child tabs because
-                  // children inherit the dashboard `icon` (a generic favicon),
-                  // which would override their per-tab Iconify defaults and
-                  // strip their distinct color.
+                  // Resolve a YAML-supplied image. For the parent (main) tab,
+                  // mirror the Header's `tab_icon || icon` precedence so a
+                  // dashboard-level favicon (stored on `icon`, the common
+                  // single-tab case) shows the SAME image in the sidebar pill
+                  // as in the header — otherwise the two disagree (header shows
+                  // the favicon, sidebar falls through to a keyword default).
+                  // Child tabs deliberately do NOT fall back to `icon`: they
+                  // inherit the dashboard's generic favicon, which would
+                  // override their per-tab Iconify defaults and strip their
+                  // distinct color.
                   const yamlImageRaw =
-                    d.tab_icon && isImagePath(d.tab_icon) ? d.tab_icon : null;
+                    d.tab_icon && isImagePath(d.tab_icon)
+                      ? d.tab_icon
+                      : isParent && d.icon && isImagePath(d.icon)
+                        ? d.icon
+                        : null;
                   const yamlImage = yamlImageRaw
                     ? rewriteLegacyMultiqcIcon(yamlImageRaw, theme, isActive)
                     : null;
@@ -409,13 +418,21 @@ const TabMenu: React.FC<TabMenuProps> = ({
   onDeleteTab,
   onMoveTab,
 }) => {
-  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+  const stop = (e: React.SyntheticEvent) => {
+    // Stop the click bubbling to the Tabs.Tab (which would switch tab) AND
+    // cancel the default action: `renderRoot` renders the tab as an
+    // `<a href>` for native open-in-new-tab support, so without
+    // `preventDefault` clicking "..." follows the href and refreshes the URL
+    // instead of opening the menu.
+    e.stopPropagation();
+    e.preventDefault();
+  };
 
   return (
     <Box
       // The Tabs.Tab parent treats any click as a navigation request — wrap
-      // the trigger in a stopPropagation guard so opening the menu doesn't
-      // also switch tab.
+      // the trigger in a stopPropagation + preventDefault guard so opening the
+      // menu doesn't also switch tab or trigger the anchor navigation.
       onClick={stop}
       onMouseDown={stop}
       style={{ display: 'inline-flex', alignItems: 'center' }}

--- a/depictio/viewer/src/chrome/TabModal.tsx
+++ b/depictio/viewer/src/chrome/TabModal.tsx
@@ -1,15 +1,30 @@
 import React, { useEffect, useState } from 'react';
 import {
+  Anchor,
   Button,
   Group,
   Modal,
   Select,
   Stack,
   TextInput,
+  Title,
 } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
 import type { DashboardSummary } from 'depictio-react-core';
+
+/** True for path-like icon values (asset URLs such as
+ *  `/assets/images/icons/favicon.png`) rather than Iconify names. Mirrors the
+ *  same check in `chrome/Sidebar.tsx` / `chrome/Header.tsx`. */
+function isImagePath(s: string | null | undefined): boolean {
+  if (!s) return false;
+  return /^(\/|https?:\/\/|data:)/.test(s) || /\.(png|svg|jpe?g|webp)$/i.test(s);
+}
+
+/** Material Design Icons (`mdi:`) browser — prefix any icon name shown there
+ *  with `mdi:` to use it here. Same target as the dashboard create/edit
+ *  modals for consistency. */
+const MDI_BROWSER_URL = 'https://pictogrammers.com/library/mdi/';
 
 /** Mirrors the icon-color options in Dash's tab modal (`tab_modal.py:206-362`).
  *  "Auto" leaves the field empty so the parent's auto-resolution kicks in. */
@@ -113,15 +128,49 @@ const TabModal: React.FC<TabModalProps> = ({
     await onSubmit(payload);
   };
 
+  // Live preview matching how the sidebar/header render the icon:
+  //   - image path (asset URL)  → <img> (Iconify can't load file paths)
+  //   - Iconify name            → <Icon> tinted with the selected color
+  //     (empty color = neutral preview, mirroring "Auto")
+  const trimmedIcon = tabIcon.trim();
+  const previewColor = tabIconColor
+    ? `var(--mantine-color-${tabIconColor}-6)`
+    : undefined;
+  const previewIcon = !trimmedIcon ? (
+    <Icon icon="mdi:tab" width={20} style={{ opacity: 0.3 }} />
+  ) : isImagePath(trimmedIcon) ? (
+    <img
+      src={trimmedIcon}
+      alt=""
+      style={{ maxWidth: 20, maxHeight: 20, objectFit: 'contain' }}
+    />
+  ) : (
+    <Icon icon={trimmedIcon} width={20} style={{ color: previewColor }} />
+  );
+
   return (
     <Modal
       opened={opened}
       onClose={onClose}
-      title={mode === 'create' ? 'Add tab' : 'Edit tab'}
+      withCloseButton
       size="md"
       centered
     >
       <Stack gap="sm">
+        {/* Header — consistent with the dashboard create/edit modals:
+            centered orange icon + title. */}
+        <Group justify="center" gap="sm" mb="xs">
+          <Icon
+            icon={mode === 'create' ? 'mdi:tab-plus' : 'mdi:square-edit-outline'}
+            width={28}
+            height={28}
+            color="var(--mantine-color-orange-6)"
+          />
+          <Title order={3} c="orange" m={0}>
+            {mode === 'create' ? 'Add Tab' : 'Edit Tab'}
+          </Title>
+        </Group>
+
         <TextInput
           label="Tab name"
           placeholder="Variants"
@@ -144,7 +193,19 @@ const TabModal: React.FC<TabModalProps> = ({
         <Group align="flex-end" gap="xs" wrap="nowrap">
           <TextInput
             label="Icon"
-            description="Iconify name, e.g. mdi:chart-bar"
+            description={
+              <>
+                Iconify name, e.g. mdi:chart-bar —{' '}
+                <Anchor
+                  href={MDI_BROWSER_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  inherit
+                >
+                  browse icons
+                </Anchor>
+              </>
+            }
             placeholder="mdi:chart-bar"
             value={tabIcon}
             onChange={(e) => setTabIcon(e.currentTarget.value)}
@@ -164,11 +225,7 @@ const TabModal: React.FC<TabModalProps> = ({
             }}
             aria-label="Icon preview"
           >
-            {tabIcon.trim() ? (
-              <Icon icon={tabIcon.trim()} width={20} />
-            ) : (
-              <Icon icon="mdi:tab" width={20} style={{ opacity: 0.3 }} />
-            )}
+            {previewIcon}
           </div>
         </Group>
 
@@ -180,16 +237,30 @@ const TabModal: React.FC<TabModalProps> = ({
           allowDeselect={false}
         />
 
-        <Group justify="flex-end" gap="xs" mt="sm">
-          <Button variant="subtle" onClick={onClose} disabled={submitting}>
+        <Group justify="flex-end" gap="md" mt="sm">
+          <Button
+            variant="outline"
+            color="gray"
+            radius="md"
+            onClick={onClose}
+            disabled={submitting}
+          >
             Cancel
           </Button>
           <Button
+            color="orange"
+            radius="md"
+            leftSection={
+              <Icon
+                icon={mode === 'create' ? 'mdi:plus' : 'mdi:content-save'}
+                width={16}
+              />
+            }
             onClick={handleSubmit}
             loading={submitting}
             disabled={!title.trim()}
           >
-            Save
+            {mode === 'create' ? 'Add Tab' : 'Save Changes'}
           </Button>
         </Group>
       </Stack>

--- a/depictio/viewer/src/dashboards/CreateDashboardModal.tsx
+++ b/depictio/viewer/src/dashboards/CreateDashboardModal.tsx
@@ -28,6 +28,12 @@ import type {
 } from 'depictio-react-core';
 
 import { UnstyledDropZone } from '../components/UnstyledDropZone';
+import {
+  WORKFLOW_SYSTEM_OPTIONS,
+  WORKFLOW_ICON_MAP,
+  WORKFLOW_COLOR_MAP,
+  isWorkflowSelected,
+} from './lib/workflowIcons';
 
 const COLOR_OPTIONS: { value: string; label: string }[] = [
   { value: 'gray', label: 'Gray' },
@@ -44,16 +50,6 @@ const COLOR_OPTIONS: { value: string; label: string }[] = [
   { value: 'yellow', label: 'Yellow' },
   { value: 'orange', label: 'Orange' },
   { value: 'dark', label: 'Dark' },
-];
-
-const WORKFLOW_SYSTEM_OPTIONS: { value: string; label: string }[] = [
-  { value: 'none', label: 'None' },
-  { value: 'snakemake', label: 'Snakemake' },
-  { value: 'nextflow', label: 'Nextflow' },
-  { value: 'galaxy', label: 'Galaxy' },
-  { value: 'cwl', label: 'CWL' },
-  { value: 'smk_wrapper', label: 'Snakemake wrapper' },
-  { value: 'python', label: 'Python' },
 ];
 
 const DEFAULT_ICON = 'mdi:view-dashboard';
@@ -135,6 +131,14 @@ const CreateDashboardModal: React.FC<CreateDashboardModalProps> = ({
   const canCreate =
     trimmedTitle.length > 0 && projectId.length > 0 && !createSubmitting;
 
+  // When a workflow system is selected, its logo + brand color override the
+  // custom icon/color (mirrors Dash's `build_icon_preview`).
+  const workflowActive = isWorkflowSelected(workflowSystem);
+  const effectiveIcon = workflowActive ? WORKFLOW_ICON_MAP[workflowSystem] : icon;
+  const effectiveColor = workflowActive
+    ? WORKFLOW_COLOR_MAP[workflowSystem]
+    : iconColor || DEFAULT_COLOR;
+
   const handleCreate = async () => {
     if (!canCreate) return;
     setCreateSubmitting(true);
@@ -144,8 +148,9 @@ const CreateDashboardModal: React.FC<CreateDashboardModalProps> = ({
         title: trimmedTitle,
         subtitle: subtitle.trim() || undefined,
         project_id: projectId,
-        icon: icon.trim() || undefined,
-        icon_color: iconColor || undefined,
+        icon: workflowActive ? effectiveIcon : icon.trim() || undefined,
+        icon_color: workflowActive ? effectiveColor : iconColor || undefined,
+        workflow_system: workflowSystem,
       });
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : 'Failed to create dashboard');
@@ -189,8 +194,9 @@ const CreateDashboardModal: React.FC<CreateDashboardModalProps> = ({
   };
 
   const previewIsImage =
-    !!icon &&
-    (/^(\/|https?:\/\/|data:)/.test(icon) || /\.(png|svg|jpe?g|webp)$/i.test(icon));
+    !!effectiveIcon &&
+    (/^(\/|https?:\/\/|data:)/.test(effectiveIcon) ||
+      /\.(png|svg|jpe?g|webp)$/i.test(effectiveIcon));
 
   return (
     <Modal
@@ -319,7 +325,7 @@ const CreateDashboardModal: React.FC<CreateDashboardModalProps> = ({
                       </Text>
                       {previewIsImage ? (
                         <img
-                          src={icon}
+                          src={effectiveIcon}
                           alt=""
                           style={{
                             width: 48,
@@ -330,13 +336,17 @@ const CreateDashboardModal: React.FC<CreateDashboardModalProps> = ({
                         />
                       ) : (
                         <ActionIcon
-                          color={iconColor || 'orange'}
+                          color={effectiveColor}
                           radius="xl"
                           size="lg"
                           variant="filled"
                           aria-hidden
                         >
-                          <Icon icon={icon || DEFAULT_ICON} width={24} height={24} />
+                          <Icon
+                            icon={effectiveIcon || DEFAULT_ICON}
+                            width={24}
+                            height={24}
+                          />
                         </ActionIcon>
                       )}
                     </Stack>
@@ -351,6 +361,7 @@ const CreateDashboardModal: React.FC<CreateDashboardModalProps> = ({
                       onChange={(e) => setIcon(e.currentTarget.value)}
                       leftSection={<Icon icon="mdi:emoticon-outline" width={16} />}
                       size="sm"
+                      disabled={workflowActive}
                     />
                     <Box mt={-8}>
                       <a
@@ -378,6 +389,7 @@ const CreateDashboardModal: React.FC<CreateDashboardModalProps> = ({
                       size="sm"
                       allowDeselect={false}
                       comboboxProps={{ withinPortal: false }}
+                      disabled={workflowActive}
                     />
 
                     <Divider

--- a/depictio/viewer/src/dashboards/EditDashboardModal.tsx
+++ b/depictio/viewer/src/dashboards/EditDashboardModal.tsx
@@ -1,19 +1,31 @@
 import React, { useEffect, useState } from 'react';
 import {
+  ActionIcon,
   Alert,
+  Box,
   Button,
+  Divider,
+  Grid,
   Group,
   Modal,
+  Paper,
   Select,
-  SimpleGrid,
   Stack,
   Text,
   Textarea,
   TextInput,
+  Title,
 } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
 import type { DashboardListEntry, EditDashboardInput } from 'depictio-react-core';
+
+import {
+  WORKFLOW_SYSTEM_OPTIONS,
+  WORKFLOW_ICON_MAP,
+  WORKFLOW_COLOR_MAP,
+  isWorkflowSelected,
+} from './lib/workflowIcons';
 
 /** Mantine palette options — empty string = "no override" / inherit. */
 const COLOR_OPTIONS: { value: string; label: string }[] = [
@@ -34,16 +46,8 @@ const COLOR_OPTIONS: { value: string; label: string }[] = [
   { value: 'dark', label: 'Dark' },
 ];
 
-/** Mirrors the backend's accepted `workflow_system` values. */
-const WORKFLOW_SYSTEM_OPTIONS: { value: string; label: string }[] = [
-  { value: 'none', label: 'None' },
-  { value: 'snakemake', label: 'Snakemake' },
-  { value: 'nextflow', label: 'Nextflow' },
-  { value: 'galaxy', label: 'Galaxy' },
-  { value: 'cwl', label: 'CWL' },
-  { value: 'smk_wrapper', label: 'Snakemake wrapper' },
-  { value: 'python', label: 'Python' },
-];
+const DEFAULT_ICON = 'mdi:view-dashboard';
+const DEFAULT_COLOR = 'orange';
 
 interface EditDashboardModalProps {
   opened: boolean;
@@ -89,6 +93,14 @@ const EditDashboardModal: React.FC<EditDashboardModalProps> = ({
   const trimmedTitle = title.trim();
   const canSubmit = !!dashboard && trimmedTitle.length > 0 && !submitting;
 
+  // When a workflow system is selected, its logo + brand color override the
+  // custom icon/color (mirrors Dash's `build_icon_preview`).
+  const workflowActive = isWorkflowSelected(workflowSystem);
+  const effectiveIcon = workflowActive ? WORKFLOW_ICON_MAP[workflowSystem] : icon.trim();
+  const effectiveColor = workflowActive
+    ? WORKFLOW_COLOR_MAP[workflowSystem]
+    : iconColor || DEFAULT_COLOR;
+
   const handleSubmit = async () => {
     if (!dashboard || !trimmedTitle) return;
     setSubmitting(true);
@@ -97,8 +109,8 @@ const EditDashboardModal: React.FC<EditDashboardModalProps> = ({
       await onSubmit(dashboard.dashboard_id, {
         title: trimmedTitle || undefined,
         subtitle: subtitle,
-        icon: icon.trim() || undefined,
-        icon_color: iconColor || undefined,
+        icon: workflowActive ? effectiveIcon : icon.trim() || undefined,
+        icon_color: workflowActive ? effectiveColor : iconColor || undefined,
         workflow_system: workflowSystem || undefined,
       });
     } catch (err) {
@@ -107,121 +119,192 @@ const EditDashboardModal: React.FC<EditDashboardModalProps> = ({
     }
   };
 
-  const previewIcon = icon.trim();
   const previewIsImage =
-    !!previewIcon &&
-    (/^(\/|https?:\/\/|data:)/.test(previewIcon) ||
-      /\.(png|svg|jpe?g|webp)$/i.test(previewIcon));
-  const previewColorVar = iconColor
-    ? `var(--mantine-color-${iconColor}-6)`
-    : 'var(--mantine-color-dimmed)';
-  const resolvedImageSrc = previewIsImage
-    ? previewIcon.startsWith('/') &&
-      typeof window !== 'undefined' &&
-      window.location.port === '8122'
-      ? `${window.location.protocol}//${window.location.hostname}:5122${previewIcon}`
-      : previewIcon
-    : null;
+    !!effectiveIcon &&
+    (/^(\/|https?:\/\/|data:)/.test(effectiveIcon) ||
+      /\.(png|svg|jpe?g|webp)$/i.test(effectiveIcon));
 
   return (
     <Modal
       opened={opened}
       onClose={onClose}
-      title={`Edit "${dashboard?.title || 'dashboard'}"`}
-      size="lg"
+      withCloseButton
       centered
+      shadow="xl"
+      radius="md"
+      size={1000}
+      padding={28}
+      overlayProps={{ blur: 3, backgroundOpacity: 0.55 }}
     >
-      <Stack gap="sm">
-        {errorMessage && (
-          <Alert color="red" variant="light" icon={<Icon icon="mdi:alert-circle" />}>
-            {errorMessage}
-          </Alert>
-        )}
-
-        <TextInput
-          label="Title"
-          placeholder="My dashboard"
-          value={title}
-          onChange={(e) => setTitle(e.currentTarget.value)}
-          required
-          data-autofocus
-        />
-
-        <Textarea
-          label="Subtitle"
-          placeholder="Short description shown under the title"
-          value={subtitle}
-          onChange={(e) => setSubtitle(e.currentTarget.value)}
-          autosize
-          minRows={2}
-          maxRows={4}
-        />
-
-        <Select
-          label="Workflow system"
-          data={WORKFLOW_SYSTEM_OPTIONS}
-          value={workflowSystem || 'none'}
-          onChange={(v) => setWorkflowSystem(v ?? '')}
-          allowDeselect={false}
-        />
-
-        <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-          <TextInput
-            label="Icon"
-            description="Iconify name, e.g. mdi:view-dashboard"
-            placeholder="mdi:view-dashboard"
-            value={icon}
-            onChange={(e) => setIcon(e.currentTarget.value)}
+      <Stack gap="lg" data-testid="edit-dashboard-modal">
+        {/* Header — mirrors CreateDashboardModal's centered orange title. */}
+        <Group justify="center" gap="sm">
+          <Icon
+            icon="mdi:square-edit-outline"
+            width={40}
+            height={40}
+            color="var(--mantine-color-orange-6)"
           />
-          <Select
-            label="Icon color"
-            data={COLOR_OPTIONS}
-            value={iconColor}
-            onChange={(v) => setIconColor(v ?? '')}
-            allowDeselect={false}
-          />
-        </SimpleGrid>
+          <Title order={1} c="orange" m={0}>
+            Edit Dashboard
+          </Title>
+        </Group>
 
-        <Stack gap={4} align="center" mt="xs">
-          <div
-            style={{
-              width: 64,
-              height: 64,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              borderRadius: 8,
-              border: '1px solid var(--mantine-color-default-border)',
-            }}
-            aria-label="Icon preview"
+        <Grid gutter="xl">
+          <Grid.Col span={{ base: 12, sm: 7 }}>
+            <Stack gap="md">
+              <TextInput
+                label="Dashboard Title"
+                description="Give your dashboard a descriptive name"
+                placeholder="Enter dashboard title"
+                value={title}
+                onChange={(e) => setTitle(e.currentTarget.value)}
+                required
+                leftSection={<Icon icon="mdi:text-box-outline" width={16} />}
+                data-autofocus
+              />
+              <Textarea
+                label="Dashboard Subtitle (Optional)"
+                description="Add a brief description for your dashboard"
+                placeholder="Enter subtitle (optional)"
+                value={subtitle}
+                onChange={(e) => setSubtitle(e.currentTarget.value)}
+                autosize
+                minRows={2}
+                maxRows={4}
+              />
+              {errorMessage && (
+                <Alert
+                  color="red"
+                  variant="light"
+                  icon={<Icon icon="mdi:alert-circle" />}
+                >
+                  {errorMessage}
+                </Alert>
+              )}
+            </Stack>
+          </Grid.Col>
+
+          <Grid.Col span={{ base: 12, sm: 5 }}>
+            <Paper shadow="sm" radius="md" withBorder p="md" h="100%">
+              <Stack gap="md">
+                <Text size="sm" fw={700} c="dimmed">
+                  Icon Customization
+                </Text>
+
+                <Stack gap={4} align="center">
+                  <Text size="xs" c="dimmed">
+                    Preview
+                  </Text>
+                  {previewIsImage ? (
+                    <img
+                      src={effectiveIcon}
+                      alt=""
+                      style={{
+                        width: 48,
+                        height: 48,
+                        objectFit: 'contain',
+                        borderRadius: '50%',
+                      }}
+                    />
+                  ) : (
+                    <ActionIcon
+                      color={effectiveColor}
+                      radius="xl"
+                      size="lg"
+                      variant="filled"
+                      aria-hidden
+                    >
+                      <Icon
+                        icon={effectiveIcon || DEFAULT_ICON}
+                        width={24}
+                        height={24}
+                      />
+                    </ActionIcon>
+                  )}
+                </Stack>
+
+                <Divider />
+
+                <TextInput
+                  label="Dashboard Icon"
+                  description="Icon from Iconify (e.g., mdi:chart-line)"
+                  placeholder="mdi:view-dashboard"
+                  value={icon}
+                  onChange={(e) => setIcon(e.currentTarget.value)}
+                  leftSection={<Icon icon="mdi:emoticon-outline" width={16} />}
+                  size="sm"
+                  disabled={workflowActive}
+                />
+                <Box mt={-8}>
+                  <a
+                    href="https://pictogrammers.com/library/mdi/"
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ textDecoration: 'none' }}
+                  >
+                    <Group gap={4}>
+                      <Icon icon="mdi:open-in-new" width={14} />
+                      <Text size="xs" c="blue">
+                        Browse MDI icons
+                      </Text>
+                    </Group>
+                  </a>
+                </Box>
+
+                <Select
+                  label="Icon Color"
+                  description="Color for the dashboard icon"
+                  data={COLOR_OPTIONS}
+                  value={iconColor}
+                  onChange={(v) => setIconColor(v ?? '')}
+                  leftSection={<Icon icon="mdi:palette" width={16} />}
+                  size="sm"
+                  allowDeselect={false}
+                  comboboxProps={{ withinPortal: false }}
+                  disabled={workflowActive}
+                />
+
+                <Divider
+                  label="Workflow System (Optional)"
+                  labelPosition="center"
+                  mt="xs"
+                />
+                <Select
+                  label="Workflow System"
+                  description="Auto-set icon based on workflow"
+                  data={WORKFLOW_SYSTEM_OPTIONS}
+                  value={workflowSystem || 'none'}
+                  onChange={(v) => setWorkflowSystem(v ?? '')}
+                  leftSection={<Icon icon="mdi:cog-outline" width={16} />}
+                  size="sm"
+                  allowDeselect={false}
+                  comboboxProps={{ withinPortal: false }}
+                />
+              </Stack>
+            </Paper>
+          </Grid.Col>
+        </Grid>
+
+        <Group justify="flex-end" gap="md" mt="md">
+          <Button
+            variant="outline"
+            color="gray"
+            radius="md"
+            onClick={onClose}
+            disabled={submitting}
           >
-            {resolvedImageSrc ? (
-              <img
-                src={resolvedImageSrc}
-                alt="icon preview"
-                style={{ width: 48, height: 48, objectFit: 'contain' }}
-              />
-            ) : previewIcon ? (
-              <Icon icon={previewIcon} width={48} color={previewColorVar} />
-            ) : (
-              <Icon
-                icon="mdi:view-dashboard"
-                width={48}
-                style={{ opacity: 0.3 }}
-              />
-            )}
-          </div>
-          <Text size="xs" c="dimmed">
-            Preview
-          </Text>
-        </Stack>
-
-        <Group justify="flex-end" gap="xs" mt="sm">
-          <Button variant="subtle" onClick={onClose} disabled={submitting}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} loading={submitting} disabled={!canSubmit}>
-            Save
+          <Button
+            color="orange"
+            radius="md"
+            leftSection={<Icon icon="mdi:content-save" width={16} />}
+            onClick={handleSubmit}
+            loading={submitting}
+            disabled={!canSubmit}
+          >
+            Save Changes
           </Button>
         </Group>
       </Stack>

--- a/depictio/viewer/src/dashboards/lib/workflowIcons.ts
+++ b/depictio/viewer/src/dashboards/lib/workflowIcons.ts
@@ -1,0 +1,45 @@
+/** Workflow-system → brand-logo mapping for the dashboard create/edit modals.
+ *
+ *  Selecting a workflow system overrides the dashboard's custom icon + color
+ *  with the workflow's logo image and brand color. Mirrors the Dash helpers
+ *  `get_workflow_icon_mapping()` / `get_workflow_icon_color()` from the
+ *  (removed) `depictio/dash/layouts/layouts_toolbox.py`.
+ *
+ *  Only systems that ship a logo asset are listed — `workflow_system` is a
+ *  free-form string on the backend, but the picker offers just the ones we can
+ *  render. */
+
+/** Dropdown options. `none` falls back to the custom Iconify icon. */
+export const WORKFLOW_SYSTEM_OPTIONS: { value: string; label: string }[] = [
+  { value: 'none', label: 'None (Use Custom Icon)' },
+  { value: 'nextflow', label: 'Nextflow' },
+  { value: 'snakemake', label: 'Snakemake' },
+  { value: 'nf-core', label: 'nf-core' },
+  { value: 'galaxy', label: 'Galaxy' },
+  { value: 'iwc', label: 'IWC (Intergalactic Workflow Commission)' },
+];
+
+/** Logo asset path per workflow system. Served by the API at `/assets`
+ *  (proxied by the dev viewer, same-origin in prod). */
+export const WORKFLOW_ICON_MAP: Record<string, string> = {
+  nextflow: '/assets/images/workflows/nextflow.png',
+  snakemake: '/assets/images/workflows/snakemake.png',
+  'nf-core': '/assets/images/workflows/nf-core.png',
+  galaxy: '/assets/images/workflows/galaxy.png',
+  iwc: '/assets/images/workflows/iwc.png',
+};
+
+/** Mantine brand color per workflow system (Dash's "purple" → `grape`). */
+export const WORKFLOW_COLOR_MAP: Record<string, string> = {
+  nextflow: 'teal',
+  snakemake: 'green',
+  'nf-core': 'blue',
+  galaxy: 'blue',
+  iwc: 'grape',
+};
+
+/** True when a workflow system is selected and has a logo (i.e. it overrides
+ *  the custom icon/color). */
+export function isWorkflowSelected(ws: string | null | undefined): boolean {
+  return !!ws && ws !== 'none' && ws in WORKFLOW_ICON_MAP;
+}

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -2435,6 +2435,7 @@ export interface CreateDashboardInput {
   project_id: string;
   icon?: string;
   icon_color?: string;
+  workflow_system?: string;
 }
 
 export async function createDashboard(input: CreateDashboardInput): Promise<string> {
@@ -2455,7 +2456,7 @@ export async function createDashboard(input: CreateDashboardInput): Promise<stri
     icon: input.icon || 'mdi:view-dashboard',
     icon_color: input.icon_color || 'orange',
     icon_variant: 'filled',
-    workflow_system: 'none',
+    workflow_system: input.workflow_system || 'none',
     notes_content: '',
     permissions: { owners: [ownerEntry], editors: [], viewers: [] },
     is_public: false,


### PR DESCRIPTION
## Summary

Fixes the React viewer's tab edit menu (which refreshed the page instead of opening) and reworks icon handling across the tab and dashboard create/edit modals.

### Sidebar (tab menu)
- The per-tab `…` menu lived inside the tab's `<a href>` (rendered for native open-in-new-tab). Its click guard only called `stopPropagation()`, so clicking `…` followed the anchor and refreshed the URL instead of opening Edit/Move/Delete. Added `preventDefault()`.
- The main-tab pill now falls back to the dashboard-level image `icon` (the common single-tab favicon case), matching the Header — previously they disagreed.

### TabModal (add/edit tab)
- Preview now renders image-path icons (`/assets/...`) via `<img>` instead of `<Icon>` (Iconify can't load file paths), and tints Iconify previews with the selected color.
- Added an MDI browse link; adopted the shared centered header + button style.

### Create / Edit dashboard modals
- Wired the **Workflow System** dropdown to its brand logo + color via a shared `dashboards/lib/workflowIcons` map (ported from the removed Dash `layouts_toolbox.py`): selecting a workflow shows its logo in the preview, disables the custom icon/color, and saves the logo path + brand color.
- `createDashboard` now submits `workflow_system` (was hardcoded to `none`).
- Corrected the workflow option list to the five logo-backed systems (`nextflow`, `snakemake`, `nf-core`, `galaxy`, `iwc`).
- Restyled the Edit modal to reuse the New Dashboard header style; aligned icon/color fields; added MDI link.

## Test plan
- [ ] Edit mode → `…` → Edit/Move/Delete open without a page refresh.
- [ ] Single-tab dashboard: sidebar pill icon matches the header.
- [ ] Tab/dashboard modals: asset-path icon previews; color change reflects live.
- [ ] Dashboard modal: pick Nextflow → logo preview, fields disabled, saved icon shows on the card.