### PR TITLE
ci: narrow build-images PR trigger to build-recipe files only

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -8,6 +8,13 @@ name: Build images (api / worker / viewer)
 
 on:
   pull_request:
+    # PR runs are a dress-rehearsal for the release build recipe (registry
+    # buildcache + VERSION arg + metadata tags) — not a general code check.
+    # The full CI workflow (depictio-ci.yaml) already builds + boots the
+    # api/worker/viewer images for every code PR, so we deliberately do NOT
+    # trigger on broad source paths (depictio/**, packages/**) here. We only
+    # run when files that change the *build recipe itself* are touched, which
+    # is what could break the release pipeline at tag time.
     paths:
       - "docker-images/Dockerfile.api"
       - "docker-images/Dockerfile.worker"
@@ -19,8 +26,7 @@ on:
       - "uv.lock"
       - "pnpm-workspace.yaml"
       - "pnpm-lock.yaml"
-      - "depictio/**"
-      - "packages/**"
+      - ".dockerignore"
       - ".github/workflows/build-images.yaml"
   push:
     tags:


### PR DESCRIPTION
## Problem

The `build-images.yaml` workflow ran on every PR touching `depictio/**` or `packages/**` — i.e. virtually every code PR. That duplicated the docker image build that `depictio-ci.yaml`'s `docker-build` job already performs (and then **boots** for the integration/E2E/CLI test stack) on every PR to `main`. Most in-repo PRs therefore built the api/worker/viewer images twice.

The two builds are not identical — `build-images.yaml` exercises the *release* recipe (registry buildcache, `VERSION` build-arg, `metadata-action` tags), which is its real value as a pre-tag "dress rehearsal." But that value only applies when the build recipe itself changes; for ordinary source-only PRs the run is pure redundancy.

## Change

Restrict the PR trigger's `paths` filter to files that actually change the release build recipe:

- the three Dockerfiles, `nginx.conf.template`, the two entrypoint scripts
- `pyproject.toml`, `uv.lock`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`
- `.dockerignore` (added — it's part of the build context)
- the workflow file itself

Removed the broad `depictio/**` and `packages/**` source paths.

## Effect

- **Ordinary code PRs** no longer trigger this workflow — the build + boot in `depictio-ci.yaml` already covers them, eliminating the double-build.
- **PRs touching the build recipe** still get the full release dress-rehearsal, catching release-pipeline breakage before tag time.
- **Tag pushes and `workflow_dispatch` are untouched** — real release builds publish exactly as before.

Runtime breakage from a pure source change is still caught, because `depictio-ci.yaml` actually builds **and boots** all three images for its test stack. The only thing dropped is the redundant second build.

https://claude.ai/code/session_01WBH61ZR4rivhNT8BbdyCYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBH61ZR4rivhNT8BbdyCYv)_