### PR TITLE
refactor(cli): perf, presentation & logging cleanups

### DIFF
--- a/depictio/api/v1/db_init.py
+++ b/depictio/api/v1/db_init.py
@@ -10,6 +10,10 @@ from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import format_pydantic, logger
 from depictio.api.v1.endpoints.dashboards_endpoints.routes import save_dashboard
 from depictio.api.v1.endpoints.projects_endpoints.utils import _helper_create_project_beanie
+from depictio.api.v1.endpoints.user_endpoints.agent_config_utils import (
+    _generate_agent_config,
+    export_agent_config,
+)
 from depictio.api.v1.endpoints.user_endpoints.core_functions import _create_user_in_db
 from depictio.api.v1.endpoints.user_endpoints.token_utils import create_default_token
 from depictio.api.v1.endpoints.user_endpoints.utils import (
@@ -686,6 +690,18 @@ async def _bootstrap_admin_and_test_user() -> tuple[UserBeanie | None, dict | No
         token_payload = await create_default_token(admin_user)
         if token_payload:
             logger.info("Created default admin token")
+    elif os.environ.get("DEPICTIO_DEV_MODE", "false").lower() == "true":
+        # In dev mode the DB persists across restarts (wipe=false), so the admin
+        # token already exists and create_default_token() would skip the export.
+        # Re-export the on-disk agent config anyway so local debugging always has
+        # up-to-date CLI credentials at `cli_config_dir/<user>_config.yaml`.
+        existing_token = await TokenBeanie.find_one(
+            {"user_id": admin_user.id, "name": "default_token"}
+        )
+        if existing_token:
+            cli_config = await _generate_agent_config(admin_user, existing_token)
+            await export_agent_config(cli_config=cli_config, email=admin_user.email, wipe=True)
+            logger.info("Dev mode: refreshed admin agent config on disk")
 
     return admin_user, token_payload
 

--- a/depictio/cli/CLI_REVIEW.md
+++ b/depictio/cli/CLI_REVIEW.md
@@ -135,7 +135,7 @@ Ordered by value/effort. Several were explicitly scoped out of this pass.
   it is a deep change touching every `api_*` function and Typer command. Only
   worth it if profiling shows network round-trips dominate runtime; the shared
   client (C3) captures most of the easy win first.
-- **`force_terminal=True` reconsideration** — the shared console forces ANSI
-  even when output is piped/redirected. Consider gating on `sys.stdout.isatty()`
-  (or a `--color/--no-color` flag) so logs/redirects stay clean. Left as-is here
-  because changing it is a user-visible behaviour change.
+- **`force_terminal=True` removed** — the shared console previously forced ANSI
+  even when output was piped/redirected, which injected escape codes into the
+  JSON that CI/scripts parse (it broke `depictio backup list | grep backup_id`).
+  The console now auto-detects the TTY: coloured interactively, plain when piped.

--- a/depictio/cli/CLI_REVIEW.md
+++ b/depictio/cli/CLI_REVIEW.md
@@ -1,0 +1,125 @@
+# `depictio/cli` — Code Review & Improvement Report
+
+Evaluation of the `depictio/cli` package (~12K lines, 33 files) across four
+axes: **rich output / presentation**, **performance**, **code style /
+structure**, and **logging consistency**.
+
+This document records the findings, the fixes applied in this pass, and a
+prioritized backlog of larger follow-ups (some of which involve server-side or
+architectural changes).
+
+---
+
+## 1. Summary of findings
+
+| # | Area | Finding | Severity | Status |
+|---|------|---------|----------|--------|
+| A1 | Logging | `scan_utils.py` imported the **API** logger, not the CLI logger | High | ✅ Fixed |
+| A2 | Logging | Same message often emitted twice (logger + rich) | Low | Documented |
+| A3 | Logging | Verbose formatter always on; no concise mode | Low | Documented |
+| B1 | Presentation | `from rich import print` shadowed the builtin throughout `rich_utils` | Medium | ✅ Fixed |
+| B2 | Presentation | Console fragmentation: module global vs. fresh `Console()` instances vs. `rich.print`'s own | Medium | ✅ Fixed |
+| B3 | Presentation | `catalog`/`recipe` used bare `typer.echo`; no shared table helper | Medium | ✅ Partially fixed |
+| B4 | Presentation | Three different idioms for error output | Low | Documented |
+| B5 | Presentation | Progress/spinners only on scan; long API/process/join/S3 ops are silent | Low | Documented |
+| C1 | Performance | `regex_match` matched twice + rebuilt an uncompiled pattern every call (O(N×M) hot loop) | High | ✅ Fixed |
+| C2 | Performance | Identical `temp_run` reallocated inside the per-file scan loop | Medium | ✅ Fixed |
+| C3 | Performance | No HTTP client reuse — fresh TCP/TLS handshake per API call (~30 endpoints) | High | ✅ Fixed |
+| C4 | Performance | Serial per-run/per-file `DELETE`s in scan cleanup | High | Backlog |
+| C5 | Performance | Serial S3 uploads / sequential lazy file reads | Medium | Backlog |
+| D1 | Style | Five >800-line modules; candidates for decomposition | Medium | Backlog |
+| D2 | Style | `validate_call` on hot inner helpers adds per-call overhead | Low | Backlog |
+| D3 | Style | Duplicate "check by id then by name" project lookup | Low | Documented |
+| D4 | Style | Dead/commented code | Low | ✅ Partially fixed |
+
+---
+
+## 2. Fixes applied in this pass
+
+All changes are behaviour-preserving (validated by the full CLI test suite —
+269 passed — and command smoke tests).
+
+### Logging
+- **`scan_utils.py`**: `from depictio.api.v1.configs.logging_init import logger`
+  → `from depictio.cli.cli_logging import logger`. Scan-util debug output now
+  obeys the CLI `--verbose` / `--verbose-level` controls like every other CLI
+  module.
+
+### Performance
+- **`scan_utils.regex_match`**: now matches **once** against a compiled,
+  `@lru_cache`-d pattern (`_compiled_normalized_regex`) instead of running
+  `re.match` twice and re-running `str.replace` on every call. The
+  `(bool, re.Match | None)` return contract is unchanged. This is the per-file,
+  per-data-collection hot path in scanning.
+- **`scan.py`**: the invariant `temp_run = WorkflowRun(...)` is now built once
+  per `(run, data_collection)` before the per-file loop rather than reallocated
+  for every matched file.
+- **`common.get_http_client()`**: a process-wide, lazily-created, pooled
+  `httpx.Client` (closed via `atexit`). `api_calls.py` and `links.py` now route
+  every request through it (`get_http_client().get/post/...`) instead of the
+  bare `httpx.get/post/...` module functions, so the connection to the API host
+  is kept alive across the many sequential calls a single scan/process/sync
+  invocation makes. Per-request `timeout`/`headers` overrides are preserved.
+
+### Presentation
+- **`rich_utils.py`**: removed `from rich import print` (no more builtin
+  shadowing). A single shared `console` is now used everywhere; the redundant
+  `Console()` instances and duplicate local `from rich import ...` blocks inside
+  the table-rendering helpers were removed (helpers fall back to the shared
+  console via `_DEFAULT_CONSOLE`). `rich_print_json` routes through
+  `console.print_json`.
+- **New `rich_utils.render_records_table(records, columns, title, column_styles)`**
+  — a reusable helper to render a list of uniform dict records as a styled
+  table, replacing hand-rolled `Table` construction.
+- **`catalog.py`**: `catalog list` now renders via `render_records_table`
+  instead of bare `typer.echo`, as the consistency exemplar for migrating the
+  remaining plain-text commands.
+
+### Cleanup
+- Removed dead commented lines in `common.py` and `scan_utils.py`.
+
+---
+
+## 3. Recommended follow-ups (backlog)
+
+Ordered by value/effort. Several were explicitly scoped out of this pass.
+
+1. **Batch delete during scan cleanup (C4)** — `scan.py` issues one HTTP
+   `DELETE` per missing run and per orphaned file in a nested loop. Add a
+   server-side batch-delete endpoint (`/runs/delete_batch`,
+   `/files/delete_batch`) mirroring the existing `upsert_batch` endpoints, and
+   collect IDs to delete in one call. *Requires an API change.*
+2. **Parallelize client-side I/O (C5)** — wrap the serial S3 uploads
+   (`images.py`) and the sequential lazy file reads (`deltatables.read_files_lazy`)
+   in a `ThreadPoolExecutor`. boto3 and Polars releases are both thread-safe for
+   this pattern.
+3. **Adopt `render_records_table` everywhere** — migrate the remaining
+   `typer.echo` output in `catalog.py` (`info`, `columns`) and `recipe.py` to
+   rich, and replace the hand-rolled `Table` blocks in `data.py` link/join
+   listings with the shared helper.
+4. **Unify the error idiom (B4)** — standardize on
+   `rich_print_checked_statement(..., "error")` / `handle_error`; remove ad-hoc
+   `console.print("[red]...")`.
+5. **Add spinners to long operations (B5)** — wrap API sync, process, and join
+   flows in the same `rich.progress` pattern already used by `scan.py`.
+6. **Logging polish (A2/A3)** — stop double-emitting the same message via both
+   the logger and a rich statement; add a concise (message-only) formatter for
+   the default level and reserve the file/func/line formatter for `--verbose`.
+7. **Decompose the >800-line modules (D1)** — split `scan.py`, `deltatables.py`,
+   `joins.py`, `api_calls.py` along their natural seams (e.g. `api_calls.py` →
+   one module per resource group). High-churn; do as a dedicated PR.
+8. **Trim `validate_call` on hot inner helpers (D2)** — keep it on command
+   boundaries; drop it from tight inner-loop helpers (e.g. in `common.py`).
+9. **Collapse duplicate project lookup (D3)** — the id-then-name fallback in
+   `api_sync_project_config_to_server` can be a single endpoint call.
+
+### Larger / aggressive options (evaluate before committing)
+- **Async refactor** — the CLI is fully synchronous. An `anyio`/`httpx.AsyncClient`
+  rewrite of the scan/process pipelines would overlap network and disk I/O, but
+  it is a deep change touching every `api_*` function and Typer command. Only
+  worth it if profiling shows network round-trips dominate runtime; the shared
+  client (C3) captures most of the easy win first.
+- **`force_terminal=True` reconsideration** — the shared console forces ANSI
+  even when output is piped/redirected. Consider gating on `sys.stdout.isatty()`
+  (or a `--color/--no-color` flag) so logs/redirects stay clean. Left as-is here
+  because changing it is a user-visible behaviour change.

--- a/depictio/cli/CLI_REVIEW.md
+++ b/depictio/cli/CLI_REVIEW.md
@@ -19,14 +19,15 @@ architectural changes).
 | A3 | Logging | Verbose formatter always on; no concise mode | Low | Documented |
 | B1 | Presentation | `from rich import print` shadowed the builtin throughout `rich_utils` | Medium | ✅ Fixed |
 | B2 | Presentation | Console fragmentation: module global vs. fresh `Console()` instances vs. `rich.print`'s own | Medium | ✅ Fixed |
-| B3 | Presentation | `catalog`/`recipe` used bare `typer.echo`; no shared table helper | Medium | ✅ Partially fixed |
+| B3 | Presentation | `catalog`/`recipe` used bare `typer.echo`; no shared table helper | Medium | ✅ Fixed |
 | B4 | Presentation | Three different idioms for error output | Low | Documented |
-| B5 | Presentation | Progress/spinners only on scan; long API/process/join/S3 ops are silent | Low | Documented |
+| B5 | Presentation | Progress/spinners only on scan; long API/process/join ops are silent | Low | Documented |
 | C1 | Performance | `regex_match` matched twice + rebuilt an uncompiled pattern every call (O(N×M) hot loop) | High | ✅ Fixed |
 | C2 | Performance | Identical `temp_run` reallocated inside the per-file scan loop | Medium | ✅ Fixed |
 | C3 | Performance | No HTTP client reuse — fresh TCP/TLS handshake per API call (~30 endpoints) | High | ✅ Fixed |
 | C4 | Performance | Serial per-run/per-file `DELETE`s in scan cleanup | High | Backlog |
-| C5 | Performance | Serial S3 uploads / sequential lazy file reads | Medium | Backlog |
+| C5 | Performance | Serial S3 uploads | Medium | ✅ Fixed |
+| C6 | Performance | `align_lazy_schemas` re-collected the frame schema for every column | Medium | ✅ Fixed |
 | D1 | Style | Five >800-line modules; candidates for decomposition | Medium | Backlog |
 | D2 | Style | `validate_call` on hot inner helpers adds per-call overhead | Low | Backlog |
 | D3 | Style | Duplicate "check by id then by name" project lookup | Low | Documented |
@@ -75,6 +76,29 @@ All changes are behaviour-preserving (validated by the full CLI test suite —
   instead of bare `typer.echo`, as the consistency exemplar for migrating the
   remaining plain-text commands.
 
+### Presentation (second pass)
+- **`catalog.py`**: `info`, `columns`, `match`, `compose` now render through the
+  shared console (`columns`/`match` via `render_records_table`). The CI-contract
+  commands (`validate`, `schema`, `refresh-index`) deliberately keep their plain
+  `typer.echo` stdout output.
+- **`recipe.py`**: `run`/`list`/`info` route through the shared console with
+  consistent ✓/✗ status styling; `list`/`info` use `render_records_table`. The
+  result preview in `run` keeps the raw Polars repr (copy/paste-friendly).
+- **`data.py`**: `link list` uses `render_records_table` instead of a hand-rolled
+  `Table` + local `rich` import.
+
+### Performance (second pass)
+- **`images.py push`**: uploads now run on a `ThreadPoolExecutor` (new
+  `--concurrency/-c`, default 8) instead of a serial loop; the shared boto3
+  client is thread-safe for this. Skipped/uploaded/errored are tallied per
+  future, so the counts stay race-free.
+- **`deltatables.align_lazy_schemas`**: the frame's column set is resolved once
+  per LazyFrame (was `collect_schema()` per column) and membership uses a set.
+- *Note:* `read_files_lazy` was **not** parallelized — it only builds Polars
+  `LazyFrame`s; the actual read happens at `collect()`, which Polars already
+  parallelizes internally, so a thread pool there would add complexity for no
+  gain.
+
 ### Cleanup
 - Removed dead commented lines in `common.py` and `scan_utils.py`.
 
@@ -89,28 +113,20 @@ Ordered by value/effort. Several were explicitly scoped out of this pass.
    server-side batch-delete endpoint (`/runs/delete_batch`,
    `/files/delete_batch`) mirroring the existing `upsert_batch` endpoints, and
    collect IDs to delete in one call. *Requires an API change.*
-2. **Parallelize client-side I/O (C5)** — wrap the serial S3 uploads
-   (`images.py`) and the sequential lazy file reads (`deltatables.read_files_lazy`)
-   in a `ThreadPoolExecutor`. boto3 and Polars releases are both thread-safe for
-   this pattern.
-3. **Adopt `render_records_table` everywhere** — migrate the remaining
-   `typer.echo` output in `catalog.py` (`info`, `columns`) and `recipe.py` to
-   rich, and replace the hand-rolled `Table` blocks in `data.py` link/join
-   listings with the shared helper.
-4. **Unify the error idiom (B4)** — standardize on
+2. **Unify the error idiom (B4)** — standardize on
    `rich_print_checked_statement(..., "error")` / `handle_error`; remove ad-hoc
    `console.print("[red]...")`.
-5. **Add spinners to long operations (B5)** — wrap API sync, process, and join
+3. **Add spinners to long operations (B5)** — wrap API sync, process, and join
    flows in the same `rich.progress` pattern already used by `scan.py`.
-6. **Logging polish (A2/A3)** — stop double-emitting the same message via both
+4. **Logging polish (A2/A3)** — stop double-emitting the same message via both
    the logger and a rich statement; add a concise (message-only) formatter for
    the default level and reserve the file/func/line formatter for `--verbose`.
-7. **Decompose the >800-line modules (D1)** — split `scan.py`, `deltatables.py`,
+5. **Decompose the >800-line modules (D1)** — split `scan.py`, `deltatables.py`,
    `joins.py`, `api_calls.py` along their natural seams (e.g. `api_calls.py` →
    one module per resource group). High-churn; do as a dedicated PR.
-8. **Trim `validate_call` on hot inner helpers (D2)** — keep it on command
+6. **Trim `validate_call` on hot inner helpers (D2)** — keep it on command
    boundaries; drop it from tight inner-loop helpers (e.g. in `common.py`).
-9. **Collapse duplicate project lookup (D3)** — the id-then-name fallback in
+7. **Collapse duplicate project lookup (D3)** — the id-then-name fallback in
    `api_sync_project_config_to_server` can be a single endpoint call.
 
 ### Larger / aggressive options (evaluate before committing)

--- a/depictio/cli/cli/commands/catalog.py
+++ b/depictio/cli/cli/commands/catalog.py
@@ -43,35 +43,38 @@ def catalog_info(
     tool_id: Annotated[str, typer.Argument(help="Tool id, e.g. qiime2 or pangolin")],
 ) -> None:
     """Show one tool's identity (clickable URLs) + every output in detail."""
+    from depictio.cli.cli.utils.rich_utils import console
     from depictio.models.components.advanced_viz.catalog import load_catalog_entries
 
     entry = next((e for e in load_catalog_entries() if e.id == tool_id), None)
     if entry is None:
-        typer.echo(f"No tool '{tool_id}'. Try `depictio catalog list`.")
+        console.print(f"[red]No tool '{tool_id}'.[/red] Try [bold]depictio catalog list[/bold].")
         raise typer.Exit(code=1)
-    typer.echo(f"{entry.name}  ({entry.id})")
-    typer.echo(f"  {entry.description}")
+    console.print(f"[bold magenta]{entry.name}[/bold magenta]  ([cyan]{entry.id}[/cyan])")
+    console.print(f"  {entry.description}")
     if entry.homepage:
-        typer.echo(f"  homepage:  {entry.homepage}")
+        console.print(f"  [dim]homepage:[/dim]  {entry.homepage}")
     if entry.biotools_url:
-        typer.echo(f"  bio.tools: {entry.biotools_url}")
+        console.print(f"  [dim]bio.tools:[/dim] {entry.biotools_url}")
     if entry.nf_core_url:
-        typer.echo(f"  nf-core:   {entry.nf_core_url}")
+        console.print(f"  [dim]nf-core:[/dim]   {entry.nf_core_url}")
     for t in entry.edam_topics:
-        typer.echo(f"  EDAM:      {t}")
+        console.print(f"  [dim]EDAM:[/dim]      {t}")
     for out in entry.outputs:
         mode = f"  [{out.mode}]" if out.mode else ""
-        typer.echo(f"\n  ── {out.id}{mode}")
-        typer.echo(f"     {out.description}")
-        typer.echo(f"     find:    {out.find.model_dump(exclude_none=True)}")
+        console.print(f"\n  [bold]── {out.id}{mode}[/bold]")
+        console.print(f"     {out.description}")
+        console.print(f"     [dim]find:[/dim]    {out.find.model_dump(exclude_none=True)}")
         if out.recipe:
-            typer.echo(f"     recipe:  {out.recipe}")
+            console.print(f"     [dim]recipe:[/dim]  {out.recipe}")
         if out.columns:
-            typer.echo(f"     columns: {', '.join(f'{c}:{t}' for c, t in out.columns.items())}")
+            console.print(
+                f"     [dim]columns:[/dim] {', '.join(f'{c}:{t}' for c, t in out.columns.items())}"
+            )
         for r in out.renders_as:
             tgt = f"{r.component}:{r.kind}" if r.kind else r.component
             roles = f"  roles={r.roles}" if r.roles else ""
-            typer.echo(f"     render:  {tgt}{roles}")
+            console.print(f"     [dim]render:[/dim]  {tgt}{roles}")
 
 
 @app.command("columns")
@@ -79,16 +82,15 @@ def catalog_columns(
     recipe: Annotated[str, typer.Argument(help="Recipe ref, e.g. qiime2/ancombc.py")],
 ) -> None:
     """Print the output columns a recipe produces (to help write `roles`)."""
+    from depictio.cli.cli.utils.rich_utils import console, render_records_table
     from depictio.models.components.advanced_viz.catalog import recipe_output_columns
 
     try:
         cols = recipe_output_columns(recipe)
     except Exception as exc:
-        typer.echo(f"  could not read recipe {recipe!r}: {exc}")
+        console.print(f"[red]:x: could not read recipe {recipe!r}: {exc}[/red]")
         raise typer.Exit(code=1)
-    typer.echo(f"Output columns of {recipe}:")
-    for c in cols:
-        typer.echo(f"  - {c}")
+    render_records_table([{"Column": c} for c in cols], title=f"Output columns of {recipe}")
 
 
 @app.command("validate")
@@ -177,15 +179,17 @@ def catalog_match(
     run_dir: Annotated[str, typer.Argument(help="A pipeline run directory to scan")],
 ) -> None:
     """Recognise which catalog outputs are present in a run directory."""
+    from depictio.cli.cli.utils.rich_utils import console, render_records_table
     from depictio.models.components.advanced_viz.catalog import match_run_dir
 
     matches = match_run_dir(run_dir)
     if not matches:
-        typer.echo(f"No catalogued tool outputs found under {run_dir}")
+        console.print(f"[yellow]No catalogued tool outputs found under {run_dir}[/yellow]")
         return
-    typer.echo(f"Recognised {len(matches)} file(s) in {run_dir}:")
-    for hit in matches:
-        typer.echo(f"  {hit.path}  →  {hit.tool_id} / {hit.output_id}")
+    render_records_table(
+        [{"File": str(hit.path), "Tool": hit.tool_id, "Output": hit.output_id} for hit in matches],
+        title=f"Recognised {len(matches)} file(s) in {run_dir}",
+    )
 
 
 @app.command("compose")
@@ -205,19 +209,22 @@ def catalog_compose(
     that reuses nf-core modules. Groups recognised module outputs by tool and
     shows the viz building blocks — a proposal, not a built dashboard.
     """
+    from depictio.cli.cli.utils.rich_utils import console
     from depictio.models.components.advanced_viz.catalog import compose_run_dir
 
     by_tool = compose_run_dir(run_dir, confirm_with_versions=confirm_versions)
     if not by_tool:
-        typer.echo(f"No catalogued module outputs found under {run_dir}")
+        console.print(f"[yellow]No catalogued module outputs found under {run_dir}[/yellow]")
         return
     n_viz = sum(len(m.renders) for ms in by_tool.values() for m in ms)
-    typer.echo(f"Proposed dashboard from {run_dir}: {len(by_tool)} module(s), {n_viz} viz block(s)")
+    console.print(
+        f"[bold]Proposed dashboard from {run_dir}:[/bold] {len(by_tool)} module(s), {n_viz} viz block(s)"
+    )
     for tool_id, matches in sorted(by_tool.items()):
-        typer.echo(f"\n  {tool_id}")
+        console.print(f"\n  [cyan]{tool_id}[/cyan]")
         for m in matches:
             renders = ", ".join(m.renders) if m.renders else "—"
-            typer.echo(f"      {m.output_id}  ({m.path})  → {renders}")
+            console.print(f"      {m.output_id}  ([dim]{m.path}[/dim])  → {renders}")
 
 
 @app.command("refresh-index")

--- a/depictio/cli/cli/commands/catalog.py
+++ b/depictio/cli/cli/commands/catalog.py
@@ -25,9 +25,12 @@ def catalog_list() -> None:
     if not entries:
         console.print("[yellow]No catalog entries found.[/yellow]")
         return
+    # "Tool" is the id you pass to `catalog info <Tool>`; "Name" is the display
+    # name. Keeping them in separate columns avoids the ambiguous "id (Name)".
     records = [
         {
-            "Tool": f"{entry.id} ({entry.name})",
+            "Tool": entry.id,
+            "Name": entry.name,
             "Output": f"{out.id}{f'/{out.mode}' if out.mode else ''}",
             "Source": out.recipe or ("columns" if out.columns else "—"),
             "Renders as": ", ".join(r.kind or r.component for r in out.renders_as) or "—",
@@ -36,6 +39,11 @@ def catalog_list() -> None:
         for out in entry.outputs
     ]
     render_records_table(records, title=f"Catalog tools ({len(entries)})")
+    example = entries[0].id
+    console.print(
+        f"\n[dim]Details for one tool:[/dim] [cyan]depictio catalog info <Tool>[/cyan]"
+        f"  [dim](e.g. depictio catalog info {example})[/dim]"
+    )
 
 
 @app.command("info")

--- a/depictio/cli/cli/commands/catalog.py
+++ b/depictio/cli/cli/commands/catalog.py
@@ -25,12 +25,11 @@ def catalog_list() -> None:
     if not entries:
         console.print("[yellow]No catalog entries found.[/yellow]")
         return
-    # "Tool" is the id you pass to `catalog info <Tool>`; "Name" is the display
-    # name. Keeping them in separate columns avoids the ambiguous "id (Name)".
+    # "Tool" is the id you pass to `catalog info <Tool>` (the display name adds
+    # nothing — id and name are near-identical — so it's dropped).
     records = [
         {
             "Tool": entry.id,
-            "Name": entry.name,
             "Output": f"{out.id}{f'/{out.mode}' if out.mode else ''}",
             "Source": out.recipe or ("columns" if out.columns else "—"),
             "Renders as": ", ".join(r.kind or r.component for r in out.renders_as) or "—",

--- a/depictio/cli/cli/commands/catalog.py
+++ b/depictio/cli/cli/commands/catalog.py
@@ -18,20 +18,24 @@ app = typer.Typer()
 @app.command("list")
 def catalog_list() -> None:
     """List every tool + output with its recipe and render targets."""
+    from depictio.cli.cli.utils.rich_utils import console, render_records_table
     from depictio.models.components.advanced_viz.catalog import load_catalog_entries
 
     entries = load_catalog_entries()
     if not entries:
-        typer.echo("No catalog entries found.")
+        console.print("[yellow]No catalog entries found.[/yellow]")
         return
-    typer.echo(f"Catalog tools ({len(entries)}):")
-    for entry in entries:
-        typer.echo(f"\n  {entry.id}  ({entry.name})  [{len(entry.outputs)} output(s)]")
-        for out in entry.outputs:
-            mode = f"/{out.mode}" if out.mode else ""
-            renders = ", ".join(r.kind or r.component for r in out.renders_as) or "—"
-            src = out.recipe or ("columns" if out.columns else "—")
-            typer.echo(f"      - {out.id}{mode}  [{src}]  → {renders}")
+    records = [
+        {
+            "Tool": f"{entry.id} ({entry.name})",
+            "Output": f"{out.id}{f'/{out.mode}' if out.mode else ''}",
+            "Source": out.recipe or ("columns" if out.columns else "—"),
+            "Renders as": ", ".join(r.kind or r.component for r in out.renders_as) or "—",
+        }
+        for entry in entries
+        for out in entry.outputs
+    ]
+    render_records_table(records, title=f"Catalog tools ({len(entries)})")
 
 
 @app.command("info")

--- a/depictio/cli/cli/commands/data.py
+++ b/depictio/cli/cli/commands/data.py
@@ -405,7 +405,7 @@ def link_list(
         api_get_project_links,
         format_link_for_display,
     )
-    from depictio.cli.cli.utils.rich_utils import console
+    from depictio.cli.cli.utils.rich_utils import console, render_records_table
 
     rich_print_command_usage("link list")
 
@@ -441,32 +441,21 @@ def link_list(
         raise typer.Exit(code=0)
 
     # Display links
-    console.print(f"\n[bold]DC Links for project '{project_config.name}':[/bold]\n")
-
-    from rich.table import Table
-
-    table = Table(show_header=True, header_style="bold cyan")
-    table.add_column("ID", style="dim", width=24)
-    table.add_column("Source DC")
-    table.add_column("Source Column")
-    table.add_column("Target DC")
-    table.add_column("Target Type")
-    table.add_column("Resolver")
-    table.add_column("Enabled")
-
+    records = []
     for link in links:
         formatted = format_link_for_display(link)
-        table.add_row(
-            formatted["id"][:24],
-            formatted["source_dc_id"][:20],
-            formatted["source_column"],
-            formatted["target_dc_id"][:20],
-            formatted["target_type"],
-            formatted["resolver"],
-            "✓" if formatted["enabled"] else "✗",
+        records.append(
+            {
+                "ID": formatted["id"][:24],
+                "Source DC": formatted["source_dc_id"][:20],
+                "Source Column": formatted["source_column"],
+                "Target DC": formatted["target_dc_id"][:20],
+                "Target Type": formatted["target_type"],
+                "Resolver": formatted["resolver"],
+                "Enabled": "✓" if formatted["enabled"] else "✗",
+            }
         )
-
-    console.print(table)
+    render_records_table(records, title=f"DC Links for project '{project_config.name}'")
     console.print(f"\n[dim]Total: {len(links)} link(s)[/dim]")
 
 

--- a/depictio/cli/cli/commands/images.py
+++ b/depictio/cli/cli/commands/images.py
@@ -228,6 +228,9 @@ def push(
         False, "--dry-run", "-n", help="Show what would be uploaded without actually uploading"
     ),
     overwrite: bool = typer.Option(False, "--overwrite", help="Overwrite existing files in S3"),
+    concurrency: int = typer.Option(
+        8, "--concurrency", "-c", min=1, help="Number of parallel uploads"
+    ),
     CLI_config_path: Annotated[
         str,
         typer.Option("--CLI-config-path", help="Path to the CLI configuration file"),
@@ -326,12 +329,37 @@ def push(
         rich_print_checked_statement(f"Failed to initialize S3 client: {e}", "error")
         raise typer.Exit(code=1)
 
-    # Upload images with progress
+    # Upload images concurrently (uploads are independent and network-bound).
+    # boto3 low-level clients are thread-safe, so one client is shared.
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
-    uploaded = 0
-    skipped = 0
-    errors = 0
+    def _upload_one(img: Path) -> str:
+        rel_path = img.relative_to(source_path)
+        s3_key = f"{prefix}{rel_path}".replace("\\", "/")
+        try:
+            # Check if file exists (unless overwrite is set)
+            if not overwrite:
+                try:
+                    s3_client.head_object(Bucket=bucket, Key=s3_key)
+                    return "skipped"
+                except s3_client.exceptions.ClientError:
+                    pass  # File doesn't exist, proceed with upload
+
+            s3_client.upload_file(
+                str(img),
+                bucket,
+                s3_key,
+                ExtraArgs={"ContentType": _get_content_type(img)},
+            )
+            logger.debug(f"Uploaded: {rel_path} → s3://{bucket}/{s3_key}")
+            return "uploaded"
+        except Exception as e:
+            logger.error(f"Failed to upload {rel_path}: {e}")
+            return "error"
+
+    counts = {"uploaded": 0, "skipped": 0, "error": 0}
 
     with Progress(
         SpinnerColumn(),
@@ -341,37 +369,15 @@ def push(
         console=console,
     ) as progress:
         task = progress.add_task("Uploading images...", total=len(images))
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            futures = [executor.submit(_upload_one, img) for img in images]
+            for future in as_completed(futures):
+                counts[future.result()] += 1
+                progress.update(task, advance=1)
 
-        for img in images:
-            rel_path = img.relative_to(source_path)
-            s3_key = f"{prefix}{rel_path}".replace("\\", "/")
-
-            try:
-                # Check if file exists (unless overwrite is set)
-                if not overwrite:
-                    try:
-                        s3_client.head_object(Bucket=bucket, Key=s3_key)
-                        skipped += 1
-                        progress.update(task, advance=1)
-                        continue
-                    except s3_client.exceptions.ClientError:
-                        pass  # File doesn't exist, proceed with upload
-
-                # Upload the file
-                s3_client.upload_file(
-                    str(img),
-                    bucket,
-                    s3_key,
-                    ExtraArgs={"ContentType": _get_content_type(img)},
-                )
-                uploaded += 1
-                logger.debug(f"Uploaded: {rel_path} → s3://{bucket}/{s3_key}")
-
-            except Exception as e:
-                errors += 1
-                logger.error(f"Failed to upload {rel_path}: {e}")
-
-            progress.update(task, advance=1)
+    uploaded = counts["uploaded"]
+    skipped = counts["skipped"]
+    errors = counts["error"]
 
     # Print summary
     console.print()

--- a/depictio/cli/cli/commands/recipe.py
+++ b/depictio/cli/cli/commands/recipe.py
@@ -37,6 +37,7 @@ def recipe_run(
     head: Annotated[int, typer.Option("--head", "-n", help="Number of rows to display")] = 20,
 ) -> None:
     """Run a recipe against local data with all 4 validation checkpoints."""
+    from depictio.cli.cli.utils.rich_utils import console
     from depictio.recipes import (
         RecipeError,
         load_recipe,
@@ -48,39 +49,51 @@ def recipe_run(
         # Checkpoint 1: load
         module = load_recipe(recipe_name, pipeline_version)
         source_count = len(module.SOURCES)
-        typer.echo(f"  Loaded recipe: {recipe_name} ({source_count} source(s))")
+        console.print(
+            f"  [green]:white_check_mark:[/green] Loaded recipe: {recipe_name} ({source_count} source(s))"
+        )
 
         # Checkpoint 2: resolve
         sources = resolve_sources(module, data_dir)
         for ref, df in sources.items():
-            typer.echo(f"  Resolved source '{ref}': {df.height} rows x {df.width} columns")
+            console.print(
+                f"  [green]:white_check_mark:[/green] Resolved source '{ref}': {df.height} rows x {df.width} columns"
+            )
 
         # Check for unresolved dc_ref sources
         dc_ref_sources = [s for s in module.SOURCES if s.dc_ref is not None]
         if dc_ref_sources:
             refs = ", ".join(s.ref for s in dc_ref_sources)
-            typer.echo(f"  Skipped dc_ref sources (not available standalone): {refs}")
-            typer.echo("  Note: dc_ref sources are resolved during 'depictio data process'")
+            console.print(
+                f"  [yellow]Skipped dc_ref sources (not available standalone): {refs}[/yellow]"
+            )
+            console.print(
+                "  [dim]Note: dc_ref sources are resolved during 'depictio data process'[/dim]"
+            )
             raise typer.Exit(code=0)
 
         # Checkpoint 3: transform
         result = module.transform(sources)
         if not isinstance(result, pl.DataFrame):
-            typer.echo(f"  ERROR: transform() returned {type(result).__name__}, expected DataFrame")
+            console.print(
+                f"  [red]:x: transform() returned {type(result).__name__}, expected DataFrame[/red]"
+            )
             raise typer.Exit(code=1)
         if result.is_empty():
-            typer.echo("  ERROR: transform() produced empty DataFrame")
+            console.print("  [red]:x: transform() produced empty DataFrame[/red]")
             raise typer.Exit(code=1)
-        typer.echo(f"  Transform produced {result.height} rows x {result.width} columns")
+        console.print(
+            f"  [green]:white_check_mark:[/green] Transform produced {result.height} rows x {result.width} columns"
+        )
 
         # Checkpoint 4: schema
         validate_schema(result, module.EXPECTED_SCHEMA, recipe_name)
         schema_str = ", ".join(f"{c}({t})" for c, t in module.EXPECTED_SCHEMA.items())
-        typer.echo(f"  Schema valid: {schema_str}")
+        console.print(f"  [green]:white_check_mark:[/green] Schema valid: {schema_str}")
 
-        # Display result
-        typer.echo("")
-        typer.echo(str(result.head(head)))
+        # Display result (raw repr so it stays copy/paste-friendly)
+        console.print("")
+        console.print(str(result.head(head)))
 
         # Optionally save
         if output:
@@ -91,32 +104,33 @@ def recipe_run(
                 result.write_csv(out_path)
             else:
                 result.write_parquet(out_path)
-            typer.echo(f"\n  Saved to {out_path}")
+            console.print(f"\n  [green]Saved to {out_path}[/green]")
 
     except RecipeError as e:
-        typer.echo(f"  FAILED: {e}")
+        console.print(f"  [red]:x: FAILED: {e}[/red]")
         raise typer.Exit(code=1)
     except click.exceptions.Exit:
         raise  # Re-raise typer.Exit / click.Exit (e.g. dc_ref skip with code=0)
     except Exception as e:
         logger.exception("Recipe execution failed")
-        typer.echo(f"  ERROR: {e}")
+        console.print(f"  [red]:x: ERROR: {e}[/red]")
         raise typer.Exit(code=1)
 
 
 @app.command("list")
 def recipe_list() -> None:
     """List all available shared recipes."""
+    from depictio.cli.cli.utils.rich_utils import render_records_table
     from depictio.recipes import list_recipes
 
     recipes = list_recipes()
     if not recipes:
-        typer.echo("No recipes found.")
+        render_records_table([])
         return
 
-    typer.echo(f"Available recipes ({len(recipes)}):")
-    for name in recipes:
-        typer.echo(f"  {name}")
+    render_records_table(
+        [{"Recipe": name} for name in recipes], title=f"Available recipes ({len(recipes)})"
+    )
 
 
 @app.command("info")
@@ -135,30 +149,37 @@ def recipe_info(
     ] = None,
 ) -> None:
     """Show recipe details: docstring, sources, and expected schema."""
+    from depictio.cli.cli.utils.rich_utils import console, render_records_table
     from depictio.recipes import RecipeError, load_recipe
 
     try:
         module = load_recipe(recipe_name, pipeline_version)
     except RecipeError as e:
-        typer.echo(f"Error: {e}")
+        console.print(f"[red]:x: Error: {e}[/red]")
         raise typer.Exit(code=1)
 
     # Docstring
     doc = module.__doc__ or "(no description)"
-    typer.echo(f"Recipe: {recipe_name}")
+    console.print(f"[bold]Recipe:[/bold] {recipe_name}")
     if pipeline_version:
-        typer.echo(f"Version: {pipeline_version}")
-    typer.echo(f"Description: {doc.strip()}")
+        console.print(f"[bold]Version:[/bold] {pipeline_version}")
+    console.print(f"[bold]Description:[/bold] {doc.strip()}")
 
     # Sources
-    typer.echo(f"\nSources ({len(module.SOURCES)}):")
-    for s in module.SOURCES:
-        if s.dc_ref:
-            typer.echo(f"  {s.ref}: dc_ref={s.dc_ref}")
-        else:
-            typer.echo(f"  {s.ref}: {s.path} ({s.format})")
+    render_records_table(
+        [
+            {
+                "Source": s.ref,
+                "Location": f"dc_ref={s.dc_ref}" if s.dc_ref else s.path,
+                "Format": "—" if s.dc_ref else s.format,
+            }
+            for s in module.SOURCES
+        ],
+        title=f"Sources ({len(module.SOURCES)})",
+    )
 
     # Schema
-    typer.echo(f"\nExpected output schema ({len(module.EXPECTED_SCHEMA)} columns):")
-    for col, dtype in module.EXPECTED_SCHEMA.items():
-        typer.echo(f"  {col}: {dtype}")
+    render_records_table(
+        [{"Column": col, "Type": str(dtype)} for col, dtype in module.EXPECTED_SCHEMA.items()],
+        title=f"Expected output schema ({len(module.EXPECTED_SCHEMA)} columns)",
+    )

--- a/depictio/cli/cli/utils/api_calls.py
+++ b/depictio/cli/cli/utils/api_calls.py
@@ -6,7 +6,11 @@ import httpx
 import typer
 from pydantic import validate_call
 
-from depictio.cli.cli.utils.common import generate_api_headers, load_depictio_config
+from depictio.cli.cli.utils.common import (
+    generate_api_headers,
+    get_http_client,
+    load_depictio_config,
+)
 from depictio.cli.cli.utils.rich_utils import rich_print_checked_statement
 from depictio.cli.cli_logging import logger
 from depictio.models.models.base import BaseModel, PyObjectId
@@ -42,7 +46,7 @@ def api_login(yaml_config_path: str = "~/.depictio/CLI.yaml") -> dict:
     # cold-path; the call still returns as soon as the server responds.
     # 30 s wasn't enough in CI minikube/compose environments where the
     # first Beanie query pays the full motor + driver init cost.
-    response = httpx.post(
+    response = get_http_client().post(
         f"{depictio_CLI_config['api_base_url']}/depictio/api/v1/cli/validate_cli_config",
         json=depictio_CLI_config,
         # /validate_cli_config now requires a bearer token (was unauthenticated);
@@ -87,7 +91,7 @@ def api_get_project_from_id(project_id: PyObjectId, CLI_config: CLIConfig):
     """
     # First check if the project exists on the server DB for existing IDs and if the same metadata hash is used
     logger.info(f"Getting project with ID: {project_id}")
-    response = httpx.get(
+    response = get_http_client().get(
         f"{CLI_config.api_base_url}/depictio/api/v1/projects/get/from_id",
         params={"project_id": project_id},
         headers=generate_api_headers(CLI_config),
@@ -102,7 +106,7 @@ def api_get_project_from_name(project_name: str, CLI_config: CLIConfig):
     Get a project from the server using the project ID.
     """
     # First check if the project exists on the server DB for existing IDs and if the same metadata hash is used
-    response = httpx.get(
+    response = get_http_client().get(
         f"{CLI_config.api_base_url}/depictio/api/v1/projects/get/from_name/{project_name}",
         # params={"project_name": project_name},
         headers=generate_api_headers(CLI_config),
@@ -116,7 +120,7 @@ def api_update_dc_specific_properties(
     data_collection_id: str, properties: dict, CLI_config: CLIConfig
 ):
     """Update dc_specific_properties for a data collection via the API."""
-    response = httpx.patch(
+    response = get_http_client().patch(
         f"{CLI_config.api_base_url}/depictio/api/v1/datacollections/{data_collection_id}/dc_specific_properties",
         json=properties,
         headers=generate_api_headers(CLI_config),
@@ -132,7 +136,7 @@ def api_create_project(project_config: dict, CLI_config: CLIConfig):
     """
     logger.info("Creating project on server...")
 
-    response = httpx.post(
+    response = get_http_client().post(
         f"{CLI_config.api_base_url}/depictio/api/v1/projects/create",
         json=project_config,
         headers=generate_api_headers(CLI_config),
@@ -150,7 +154,7 @@ def api_update_project(project_config: dict, CLI_config: CLIConfig):
     logger.info("Updating project on server...")
     logger.debug(f"Project configuration: {project_config}")
 
-    response = httpx.put(
+    response = get_http_client().put(
         f"{CLI_config.api_base_url}/depictio/api/v1/projects/update",
         json=project_config,
         headers=generate_api_headers(CLI_config),
@@ -273,7 +277,7 @@ def api_create_files(
 
     logger.debug(f"Payload: {payload}")
 
-    response = httpx.post(
+    response = get_http_client().post(
         url,
         json=payload,
         headers=generate_api_headers(CLI_config),
@@ -298,7 +302,7 @@ def api_get_files_by_dc_id(dc_id: str, CLI_config: CLIConfig) -> httpx.Response:
     logger.debug(f"CLI Config: {CLI_config}")
     logger.info(f"{CLI_config.api_base_url}/depictio/api/v1/files/list/{dc_id}")
     logger.info(generate_api_headers(CLI_config))
-    response = httpx.get(
+    response = get_http_client().get(
         f"{CLI_config.api_base_url}/depictio/api/v1/files/list/{dc_id}",
         headers=generate_api_headers(CLI_config),
         timeout=60.0,  # Increase timeout to 60 seconds
@@ -324,7 +328,7 @@ def api_get_runs_by_wf_id(wf_id: str, CLI_config: CLIConfig) -> httpx.Response:
     logger.info(f"Getting runs for workflow ID: {wf_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/runs/list/{wf_id}"
-    response = httpx.get(url, headers=generate_api_headers(CLI_config), timeout=60.0)
+    response = get_http_client().get(url, headers=generate_api_headers(CLI_config), timeout=60.0)
     return response
 
 
@@ -358,7 +362,7 @@ def api_upsert_runs_batch(
     logger.debug(f"Payload runs upsert batch: {payload}")
     url = f"{CLI_config.api_base_url}/depictio/api/v1/runs/upsert_batch"
 
-    response = httpx.post(
+    response = get_http_client().post(
         url,
         json=payload,
         headers=generate_api_headers(CLI_config),
@@ -382,7 +386,7 @@ def api_delete_run(run_id: str, CLI_config: CLIConfig) -> httpx.Response:
     logger.info(f"Deleting run with ID: {run_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/runs/delete/{run_id}"
-    response = httpx.delete(url, headers=generate_api_headers(CLI_config), timeout=60.0)
+    response = get_http_client().delete(url, headers=generate_api_headers(CLI_config), timeout=60.0)
     return response
 
 
@@ -401,7 +405,7 @@ def api_get_run(run_id: str, CLI_config: CLIConfig) -> httpx.Response:
     logger.info(f"Getting run with ID: {run_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/runs/get/{run_id}"
-    response = httpx.get(url, headers=generate_api_headers(CLI_config), timeout=60.0)
+    response = get_http_client().get(url, headers=generate_api_headers(CLI_config), timeout=60.0)
     return response
 
 
@@ -420,7 +424,7 @@ def api_delete_file(file_id: str, CLI_config: CLIConfig) -> httpx.Response:
     logger.info(f"Deleting file with ID: {file_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/files/delete/{file_id}"
-    response = httpx.delete(url, headers=generate_api_headers(CLI_config), timeout=60.0)
+    response = get_http_client().delete(url, headers=generate_api_headers(CLI_config), timeout=60.0)
     return response
 
 
@@ -460,7 +464,7 @@ def api_upsert_deltatable(
     logger.debug(f"Payload: {payload}")
 
     try:
-        response = httpx.post(
+        response = get_http_client().post(
             url,
             json=payload,
             headers=generate_api_headers(CLI_config),
@@ -489,7 +493,7 @@ def api_get_deltatable_by_dc_id(dc_id: str, CLI_config: CLIConfig) -> httpx.Resp
     """
     logger.info(f"Getting Delta Table for data collection ID: {dc_id}")
 
-    response = httpx.get(
+    response = get_http_client().get(
         f"{CLI_config.api_base_url}/depictio/api/v1/deltatables/get/{dc_id}",
         headers=generate_api_headers(CLI_config),
         timeout=60.0,  # cold-start safety net (httpx default of 5 s is too aggressive)
@@ -512,7 +516,7 @@ def api_delete_deltatable(delta_table_id: str, CLI_config: CLIConfig) -> httpx.R
     logger.info(f"Deleting Delta Table with ID: {delta_table_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/deltatables/delete/{delta_table_id}"
-    response = httpx.delete(url, headers=generate_api_headers(CLI_config), timeout=60.0)
+    response = get_http_client().delete(url, headers=generate_api_headers(CLI_config), timeout=60.0)
     return response
 
 
@@ -570,7 +574,7 @@ def api_create_backup(
             "dry_run": dry_run,
         }
 
-        response = httpx.post(
+        response = get_http_client().post(
             url,
             headers=generate_api_headers(CLI_config),
             json=payload,
@@ -615,7 +619,7 @@ def api_list_backups(CLI_config: CLIConfig) -> dict:
     url = f"{CLI_config.api_base_url}/depictio/api/v1/backup/list"
 
     try:
-        response = httpx.get(
+        response = get_http_client().get(
             url,
             headers=generate_api_headers(CLI_config),
             timeout=60.0,  # cold-start safety net (httpx default of 5 s is too aggressive)
@@ -651,7 +655,7 @@ def api_validate_backup(CLI_config: CLIConfig, backup_id: str) -> dict:
     payload = {"backup_id": backup_id}
 
     try:
-        response = httpx.post(
+        response = get_http_client().post(
             url,
             json=payload,
             headers=generate_api_headers(CLI_config),
@@ -698,7 +702,7 @@ def api_restore_backup(
         payload["collections"] = collections
 
     try:
-        response = httpx.post(
+        response = get_http_client().post(
             url,
             json=payload,
             headers=generate_api_headers(CLI_config),
@@ -750,7 +754,7 @@ def api_check_duplicate_multiqc_report(
     headers = generate_api_headers(CLI_config)
 
     try:
-        response = httpx.get(
+        response = get_http_client().get(
             url,
             params={
                 "data_collection_id": data_collection_id,
@@ -799,7 +803,7 @@ def api_delete_multiqc_report(
     headers = generate_api_headers(CLI_config)
 
     try:
-        response = httpx.delete(
+        response = get_http_client().delete(
             url,
             params={"delete_s3_file": delete_s3_file},
             headers=headers,
@@ -841,7 +845,7 @@ def api_create_multiqc_report(multiqc_report: dict, CLI_config: "CLIConfig"):
     )
 
     try:
-        response = httpx.post(
+        response = get_http_client().post(
             url,
             json=multiqc_report,
             headers=headers,
@@ -884,7 +888,7 @@ def api_update_multiqc_report(report_id: str, multiqc_report: dict, CLI_config: 
     )
 
     try:
-        response = httpx.put(
+        response = get_http_client().put(
             url,
             json=multiqc_report,
             headers=headers,
@@ -908,7 +912,7 @@ def _post_migrate_endpoint(
 ) -> dict:
     """Shared helper for migrate POST endpoints with consistent error handling."""
     try:
-        response = httpx.post(
+        response = get_http_client().post(
             url,
             json=payload,
             headers=generate_api_headers(CLI_config),
@@ -947,7 +951,7 @@ def api_export_project(
         payload["target_s3_config"] = target_s3_config
 
     try:
-        response = httpx.post(
+        response = get_http_client().post(
             url,
             json=payload,
             headers=generate_api_headers(CLI_config),

--- a/depictio/cli/cli/utils/common.py
+++ b/depictio/cli/cli/utils/common.py
@@ -1,6 +1,8 @@
+import atexit
 import os
 from datetime import datetime
 
+import httpx
 import typer
 from pydantic import validate_call
 
@@ -8,6 +10,21 @@ from depictio.cli.cli.utils.rich_utils import rich_print_checked_statement
 from depictio.cli.cli_logging import logger
 from depictio.models.models.cli import CLIConfig
 from depictio.models.utils import get_config
+
+# Process-wide pooled HTTP client. A single CLI invocation (scan/process/sync)
+# fires many sequential requests to the same API host; reusing one client keeps
+# the TCP/TLS connection alive across them instead of paying a fresh handshake
+# per call. Per-request timeouts/headers are still passed at each call site.
+_http_client: httpx.Client | None = None
+
+
+def get_http_client() -> httpx.Client:
+    """Return the shared, lazily-created :class:`httpx.Client`."""
+    global _http_client
+    if _http_client is None:
+        _http_client = httpx.Client()
+        atexit.register(_http_client.close)
+    return _http_client
 
 
 @validate_call(validate_return=True)
@@ -57,8 +74,6 @@ def validate_depictio_cli_config(depictio_cli_config: dict) -> CLIConfig:
         s3_storage=depictio_cli_config.get("s3_storage", depictio_cli_config.get("s3")),
     )
     logger.info(f"Depictio CLI configuration validated: {config}")
-    # config = convert_model_to_dict(config)
-
     return config
 
 

--- a/depictio/cli/cli/utils/deltatables.py
+++ b/depictio/cli/cli/utils/deltatables.py
@@ -236,9 +236,11 @@ def align_lazy_schemas(lazy_frames: list) -> list:
     # Adjust each lazy frame: for missing columns, add a literal null; for existing columns, cast.
     aligned_lfs = []
     for lf in lazy_frames:
+        # Resolve the frame's columns once (was re-collecting the schema for
+        # every column in the inner loop) and use a set for O(1) membership.
+        column_names = set(lf.collect_schema().names())
         exprs = []
         for col, dtype in unified_schema.items():
-            column_names = lf.collect_schema().names()
             if col in column_names:
                 exprs.append(pl.col(col).cast(dtype).alias(col))
             else:

--- a/depictio/cli/cli/utils/links.py
+++ b/depictio/cli/cli/utils/links.py
@@ -13,7 +13,7 @@ from typing import Any
 import httpx
 from pydantic import validate_call
 
-from depictio.cli.cli.utils.common import generate_api_headers
+from depictio.cli.cli.utils.common import generate_api_headers, get_http_client
 from depictio.cli.cli_logging import logger
 from depictio.models.models.cli import CLIConfig
 
@@ -33,7 +33,7 @@ def api_get_project_links(project_id: str, CLI_config: CLIConfig) -> httpx.Respo
     logger.info(f"Getting links for project ID: {project_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/links/{project_id}"
-    response = httpx.get(url, headers=generate_api_headers(CLI_config), timeout=30.0)
+    response = get_http_client().get(url, headers=generate_api_headers(CLI_config), timeout=30.0)
     return response
 
 
@@ -55,7 +55,7 @@ def api_get_links_for_target_dc(
     logger.info(f"Getting links targeting DC: {dc_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/links/{project_id}/target/{dc_id}"
-    response = httpx.get(url, headers=generate_api_headers(CLI_config), timeout=30.0)
+    response = get_http_client().get(url, headers=generate_api_headers(CLI_config), timeout=30.0)
     return response
 
 
@@ -77,7 +77,7 @@ def api_get_links_for_source_dc(
     logger.info(f"Getting links from source DC: {dc_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/links/{project_id}/source/{dc_id}"
-    response = httpx.get(url, headers=generate_api_headers(CLI_config), timeout=30.0)
+    response = get_http_client().get(url, headers=generate_api_headers(CLI_config), timeout=30.0)
     return response
 
 
@@ -100,7 +100,7 @@ def api_create_link(
     logger.debug(f"Link data: {link_data}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/links/{project_id}"
-    response = httpx.post(
+    response = get_http_client().post(
         url, json=link_data, headers=generate_api_headers(CLI_config), timeout=30.0
     )
     return response
@@ -126,7 +126,7 @@ def api_update_link(
     logger.debug(f"Link data: {link_data}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/links/{project_id}/{link_id}"
-    response = httpx.put(
+    response = get_http_client().put(
         url, json=link_data, headers=generate_api_headers(CLI_config), timeout=30.0
     )
     return response
@@ -148,7 +148,7 @@ def api_delete_link(project_id: str, link_id: str, CLI_config: CLIConfig) -> htt
     logger.info(f"Deleting link {link_id} for project ID: {project_id}")
 
     url = f"{CLI_config.api_base_url}/depictio/api/v1/links/{project_id}/{link_id}"
-    response = httpx.delete(url, headers=generate_api_headers(CLI_config), timeout=30.0)
+    response = get_http_client().delete(url, headers=generate_api_headers(CLI_config), timeout=30.0)
     return response
 
 
@@ -185,7 +185,9 @@ def api_resolve_link(
         "filter_values": filter_values,
         "target_dc_id": target_dc_id,
     }
-    response = httpx.post(url, json=payload, headers=generate_api_headers(CLI_config), timeout=30.0)
+    response = get_http_client().post(
+        url, json=payload, headers=generate_api_headers(CLI_config), timeout=30.0
+    )
     return response
 
 

--- a/depictio/cli/cli/utils/rich_utils.py
+++ b/depictio/cli/cli/utils/rich_utils.py
@@ -15,7 +15,10 @@ from depictio.models.models.workflows import Workflow, WorkflowRun
 
 # Single shared console for the whole CLI. Everything routes through this so
 # styling/width stays consistent and we never shadow the builtin ``print``.
-console = Console(force_terminal=True)
+# No ``force_terminal``: the console auto-detects a TTY, so interactive runs are
+# coloured while piped/redirected output (CI greps, ``| jq``, scripts) stays
+# plain — forcing ANSI here would inject escape codes into machine-parsed JSON.
+console = Console()
 # Stable reference for helpers whose ``console`` parameter shadows the global.
 _DEFAULT_CONSOLE = console
 

--- a/depictio/cli/cli/utils/rich_utils.py
+++ b/depictio/cli/cli/utils/rich_utils.py
@@ -6,20 +6,24 @@ from typing import Optional
 
 import polars as pl
 from pydantic import validate_call
-from rich import box, print, print_json
+from rich import box
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
 from depictio.models.models.workflows import Workflow, WorkflowRun
 
+# Single shared console for the whole CLI. Everything routes through this so
+# styling/width stays consistent and we never shadow the builtin ``print``.
 console = Console(force_terminal=True)
+# Stable reference for helpers whose ``console`` parameter shadows the global.
+_DEFAULT_CONSOLE = console
 
 
 @validate_call
 def handle_error(message: str, exit: bool = False):
     """Print an error message and raise a ValueError."""
-    print(f"• [bold red]:x: {message}[/bold red]")
+    console.print(f"• [bold red]:x: {message}[/bold red]")
     if exit:
         sys.exit()
 
@@ -61,8 +65,8 @@ def rich_print_json(statement: str, json_obj: dict | list[dict]):
     """
     Pretty print JSON object.
     """
-    print(f"• [bold magenta]{statement}[/]")
-    print_json(json.dumps(json_obj, indent=4))
+    console.print(f"• [bold magenta]{statement}[/]")
+    console.print_json(json.dumps(json_obj, indent=4))
 
 
 @validate_call
@@ -73,15 +77,40 @@ def rich_print_checked_statement(statement: str, mode: str, exit: bool = False):
     if mode not in ["loading", "success", "error", "info", "warning"]:
         handle_error(f"Invalid mode: {mode}", exit=exit)
     if mode == "loading":
-        print(f"• [bold yellow]:hourglass: {statement}[/bold yellow]")
+        console.print(f"• [bold yellow]:hourglass: {statement}[/bold yellow]")
     elif mode == "success":
-        print(f"• [bold green]:white_check_mark: {statement}[/bold green]")
+        console.print(f"• [bold green]:white_check_mark: {statement}[/bold green]")
     elif mode == "error":
-        print(f"• [bold red]:x: {statement}[/bold red]")
+        console.print(f"• [bold red]:x: {statement}[/bold red]")
     elif mode == "info":
-        print(f"• [bold blue]:blue_book: {statement}[/bold blue]")
+        console.print(f"• [bold blue]:blue_book: {statement}[/bold blue]")
     elif mode == "warning":
-        print(f"• [bold orange1]:warning: {statement}[/bold orange1]")
+        console.print(f"• [bold orange1]:warning: {statement}[/bold orange1]")
+
+
+def render_records_table(
+    records: list[dict],
+    columns: Optional[list[str]] = None,
+    title: Optional[str] = None,
+    column_styles: Optional[dict[str, str]] = None,
+) -> None:
+    """Render a list of uniform dict records as a styled Rich table.
+
+    A single reusable replacement for the hand-rolled ``Table`` construction
+    duplicated across commands. ``columns`` selects/orders the fields to show
+    (defaults to the keys of the first record); missing keys render empty.
+    """
+    if not records:
+        console.print("[dim]No records to display.[/dim]")
+        return
+    cols = columns or list(records[0].keys())
+    styles = column_styles or {}
+    table = Table(title=title, box=box.ROUNDED, show_header=True, header_style="bold magenta")
+    for col in cols:
+        table.add_column(col, style=styles.get(col, "cyan"))
+    for record in records:
+        table.add_row(*[str(record.get(col, "")) for col in cols])
+    console.print(table)
 
 
 def print_polars_with_rich(
@@ -104,9 +133,9 @@ def print_polars_with_rich(
         console: Rich Console instance (creates new one if None)
     """
     if console is None:
-        console = Console()
+        console = _DEFAULT_CONSOLE
 
-    print("\n")
+    console.print("\n")
 
     # Limit rows and columns for display
     display_df = df.head(max_rows)
@@ -179,7 +208,7 @@ def print_polars_info_with_rich(
     Print DataFrame info (like df.describe()) using Rich.
     """
     if console is None:
-        console = Console()
+        console = _DEFAULT_CONSOLE
 
     # Create info table
     info_table = Table(box=box.SIMPLE, show_header=True, header_style="bold blue")
@@ -223,10 +252,10 @@ def print_polars_describe_with_rich(df: pl.DataFrame, console: Optional[Console]
     Print DataFrame description statistics using Rich.
     """
     if console is None:
-        console = Console()
+        console = _DEFAULT_CONSOLE
 
     try:
-        print("\n")
+        console.print("\n")
         desc_df = df.describe()
         print_polars_with_rich(
             desc_df, title="Descriptive Statistics", max_rows=50, show_dtypes=False, console=console
@@ -242,7 +271,7 @@ def print_polars_head_tail_with_rich(
     Print head and tail of DataFrame side by side using Rich.
     """
     if console is None:
-        console = Console()
+        console = _DEFAULT_CONSOLE
 
     # Create layout with panels
     head_df = df.head(n)
@@ -345,12 +374,7 @@ def add_rich_display_to_polars():
 def rich_print_summary_scan_table_enhanced(
     runs: list[WorkflowRun], workflow: Workflow, show_totals: bool = True
 ) -> None:
-    from rich import box
-    from rich.console import Console
-    from rich.table import Table
-
-    print("\n")
-    console = Console()
+    console.print("\n")
 
     # Debug: Check what we received
     # console.print(f"[dim]Debug: Processing {len(runs)} runs[/dim]")
@@ -528,11 +552,7 @@ def rich_print_summary_scan_table_enhanced(
 
 
 def rich_print_summary_scan_table_by_dc(runs: list[WorkflowRun]) -> None:
-    from rich import box
-    from rich.console import Console
-    from rich.table import Table
-
-    print("\n")
+    console.print("\n")
 
     # Collect all data collections and their stats across runs
     dc_data: dict[str, list[tuple[str, dict]]] = defaultdict(list)
@@ -621,7 +641,6 @@ def rich_print_summary_scan_table_by_dc(runs: list[WorkflowRun]) -> None:
         if dc_idx < len(dc_data) - 1:
             table.add_section()
 
-    console = Console()
     console.print(table)
 
 
@@ -632,8 +651,6 @@ def rich_print_data_collection_light(runs: list[WorkflowRun], workflow: Workflow
     Args:
         runs: List of WorkflowRun objects with dc_stats
     """
-
-    console = Console()
 
     # Aggregate all stats by data collection
     dc_detailed: dict[str, dict[str, int]] = defaultdict(
@@ -667,7 +684,7 @@ def rich_print_data_collection_light(runs: list[WorkflowRun], workflow: Workflow
             for dc in workflow.data_collections
         }
 
-    print("\n")
+    console.print("\n")
 
     # ============= SIMPLE SUMMARY TABLE =============
     simple_table = Table(
@@ -697,7 +714,7 @@ def rich_print_data_collection_light(runs: list[WorkflowRun], workflow: Workflow
         f"[dim]Summary: {len(dc_detailed)} data collections, {total_files} total files processed[/dim]"
     )
 
-    print("\n")
+    console.print("\n")
 
 
 def rich_print_multiqc_processing_summary(
@@ -719,12 +736,6 @@ def rich_print_multiqc_processing_summary(
         file_paths: List of processed file paths
         data_collection_tag: Name of the data collection
     """
-    from rich import box
-    from rich.console import Console
-    from rich.table import Table
-
-    console = Console()
-
     # Create summary table
     summary_table = Table(
         title=f"MultiQC Processing Summary - {data_collection_tag}",
@@ -775,7 +786,7 @@ def rich_print_multiqc_processing_summary(
 
     # Create files table if there are multiple files
     if processed_files > 1:
-        print("\n")
+        console.print("\n")
         files_table = Table(
             title="Processed Files Details",
             show_header=True,
@@ -810,4 +821,4 @@ def rich_print_multiqc_processing_summary(
 
         console.print(files_table)
 
-    print("\n")
+    console.print("\n")

--- a/depictio/cli/cli/utils/scan.py
+++ b/depictio/cli/cli/utils/scan.py
@@ -385,6 +385,22 @@ def scan_run_for_multiple_data_collections(
         )
         logger.debug(f"Regex for DC {dc.data_collection_tag}: {full_regex}")
 
+        # A temporary run used only for file association — invariant across
+        # every file in this run, so build it once here instead of
+        # reallocating an identical WorkflowRun inside the per-file loop.
+        temp_run = WorkflowRun(
+            id=workflow_run.id,
+            workflow_id=PyObjectId(workflow_id),
+            run_tag=run_tag,
+            files_id=[],
+            workflow_config_id=workflow_config.id,
+            run_location=run_location,
+            creation_time=creation_time,
+            last_modification_time=last_modification_time,
+            run_hash="",
+            permissions=permissions,
+        )
+
         # Process files that match this data collection's regex
         dc_file_scan_results = []
         for file_location in all_files_in_run:
@@ -402,20 +418,6 @@ def scan_run_for_multiple_data_collections(
                     continue
 
             logger.debug(f"File {file_name} matches DC {dc.data_collection_tag}")
-
-            # Create a temporary run for this DC (needed for file association)
-            temp_run = WorkflowRun(
-                id=workflow_run.id,
-                workflow_id=PyObjectId(workflow_id),
-                run_tag=run_tag,
-                files_id=[],
-                workflow_config_id=workflow_config.id,
-                run_location=run_location,
-                creation_time=creation_time,
-                last_modification_time=last_modification_time,
-                run_hash="",
-                permissions=permissions,
-            )
 
             # skip_regex=True because we already matched in the loop above
             file_scan_result = scan_single_file(

--- a/depictio/cli/cli/utils/scan_utils.py
+++ b/depictio/cli/cli/utils/scan_utils.py
@@ -1,21 +1,34 @@
 import collections
 import hashlib
 import re
+from functools import lru_cache
 from typing import Any, DefaultDict
 
-from depictio.api.v1.configs.logging_init import logger
+from depictio.cli.cli_logging import logger
 from depictio.models.models.data_collections import Regex
 from depictio.models.models.files import File
 from depictio.models.models.workflows import WorkflowRun
 
 
+@lru_cache(maxsize=512)
+def _compiled_normalized_regex(full_regex: str) -> re.Pattern[str]:
+    """Compile (and cache) the path-normalized regex.
+
+    Normalizes ``/`` to ``\\/`` so a pattern matches regardless of how the
+    separator was escaped, then compiles once. Compilation is cached because
+    the same data-collection pattern is matched against every file in a run
+    (the scan hot loop), so recompiling per call is pure waste.
+    """
+    return re.compile(full_regex.replace("/", "\\/"))
+
+
 def regex_match(file_name: str, full_regex: str):
-    # Normalize the regex pattern to match both types of path separators
-    normalized_regex = full_regex.replace("/", "\\/")
-    # logger.debug(f"File: {file_name}, Full Regex: {full_regex}")
-    if re.match(normalized_regex, file_name):
+    # Match once against the cached compiled pattern (was matching twice +
+    # rebuilding the pattern on every call).
+    match = _compiled_normalized_regex(full_regex).match(file_name)
+    if match:
         logger.debug(f"Matched file - file-based: {file_name}")
-        return True, re.match(normalized_regex, file_name)
+        return True, match
     return False, None
 
 

--- a/depictio/cli/depictio_cli.py
+++ b/depictio/cli/depictio_cli.py
@@ -63,11 +63,17 @@ app.add_typer(recipe, name="recipe", help="Recipe management and testing command
 depictiocli = get_command(app)
 
 
-def display_depictio_cli_logo():
-    """Display the Depictio CLI logo at startup."""
+def display_depictio_cli_logo(compact: bool = False):
+    """Display the Depictio CLI logo.
+
+    ``compact=True`` renders a small one-row banner — the favicon mark beside
+    the brand ``depictio-CLI`` wordmark, no panel — for use at startup. The
+    default renders the full favicon + ASCII wordmark (the ``--logo`` art).
+    """
     from rich.columns import Columns
     from rich.console import Console
     from rich.panel import Panel
+    from rich.style import Style
     from rich.text import Text
 
     # Depictio brand colors
@@ -277,6 +283,95 @@ def display_depictio_cli_logo():
         return padded_text
 
     console = Console()
+
+    if compact:
+        # Claude Code-style startup banner: a small colour rendition of the
+        # depictio favicon (the 8-wedge pinwheel), then name + version, a
+        # tagline, and the current directory, with a tip line below.
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as _pkg_version
+
+        try:
+            cli_version = _pkg_version("depictio-cli")
+        except PackageNotFoundError:
+            cli_version = "dev"
+
+        # Pre-rendered favicon (20×8 chars), generated offline from the logo PNG
+        # by snapping each pixel to the nearest brand colour — sharp wedge edges
+        # without a Pillow/raster dependency at runtime. Each row is
+        # (top_pixels, bottom_pixels); every char is a palette index or "."=empty.
+        mini_palette = [
+            DEPICTIO_COLORS["violet"],  # 0
+            DEPICTIO_COLORS["blue"],  # 1
+            DEPICTIO_COLORS["orange"],  # 2
+            DEPICTIO_COLORS["yellow"],  # 3
+            DEPICTIO_COLORS["green"],  # 4
+            DEPICTIO_COLORS["teal"],  # 5
+            DEPICTIO_COLORS["pink"],  # 6
+            DEPICTIO_COLORS["purple"],  # 7
+        ]
+        favicon_art = [
+            (".............0000000", ".............0000000"),
+            (".......7777..0000000", "......77777..00000.."),
+            (".......7777..0000...", "........777..000..11"),
+            (".........77..0...111", "......66........1111"),
+            ("......666......11111", "...................."),
+            ("555555555......22222", "55555555........2222"),
+            ("5555555...4..3...222", "555555..444..33...22"),
+            ("5555...4444.........", "555...44444........."),
+        ]
+
+        def mini_color(index: str):
+            return None if index == "." else mini_palette[int(index)]
+
+        favicon_rows = []
+        for top_pixels, bottom_pixels in favicon_art:
+            row_text = Text()
+            for top_idx, bottom_idx in zip(top_pixels, bottom_pixels):
+                top = mini_color(top_idx)
+                bottom = mini_color(bottom_idx)
+                if top and bottom:
+                    row_text.append("▀", style=Style(color=top, bgcolor=bottom))
+                elif top:
+                    row_text.append("▀", style=Style(color=top))
+                elif bottom:
+                    row_text.append("▄", style=Style(color=bottom))
+                else:
+                    row_text.append(" ")
+            favicon_rows.append(row_text)
+
+        cwd = os.getcwd().replace(os.path.expanduser("~"), "~")
+
+        info_lines = [
+            Text.assemble(
+                ("depictio-cli", f"bold {DEPICTIO_COLORS['purple']}"),
+                (f"  v{cli_version}", "dim"),
+            ),
+            Text("Interactive dashboards for bioinformatics data", style="dim"),
+            Text(cwd, style="dim"),
+            Text(""),
+            Text.assemble(
+                ("Tip: ", "dim"),
+                ("depictio catalog list", DEPICTIO_COLORS["blue"]),
+                (" · browse the tool→viz catalog", "dim"),
+            ),
+        ]
+
+        # Concatenate each row by hand (fixed-width favicon gutter + text)
+        # rather than using a Table, so a long path is shown in full instead of
+        # being cropped to the column width.
+        gutter = len(favicon_art[0][0])
+        console.print()
+        for i in range(max(len(favicon_rows), len(info_lines))):
+            line = Text()
+            line.append_text(favicon_rows[i] if i < len(favicon_rows) else Text(" " * gutter))
+            line.append("   ")
+            if i < len(info_lines):
+                line.append_text(info_lines[i])
+            console.print(line)
+        console.print()
+        return
+
     favicon = create_colored_favicon()
     name = create_colored_name()
 
@@ -305,16 +400,11 @@ def main():
     # Add rich display support for Polars DataFrames
     add_rich_display_to_polars()
 
-    # Minimal indication that depictio-cli is running (reuse existing title)
-    from rich.console import Console
-    from rich.panel import Panel
+    # Branded startup banner — only on an interactive terminal, so piped /
+    # redirected output (scripts, CI greps, ``| jq``) stays clean.
+    import sys
 
-    console = Console()
-
-    panel = Panel("🎨 DEPICTIO-CLI", border_style="bright_blue", padding=(0, 1), expand=False)
-
-    console.print()  # Space above
-    console.print(panel)
-    console.print()  # Space below
+    if sys.stdout.isatty():
+        display_depictio_cli_logo(compact=True)
 
     app()

--- a/depictio/cli/depictio_cli.py
+++ b/depictio/cli/depictio_cli.py
@@ -349,12 +349,6 @@ def display_depictio_cli_logo(compact: bool = False):
             ),
             Text("Interactive dashboards for bioinformatics data", style="dim"),
             Text(cwd, style="dim"),
-            Text(""),
-            Text.assemble(
-                ("Tip: ", "dim"),
-                ("depictio catalog list", DEPICTIO_COLORS["blue"]),
-                (" · browse the tool→viz catalog", "dim"),
-            ),
         ]
 
         # Concatenate each row by hand (fixed-width favicon gutter + text)


### PR DESCRIPTION
Behaviour-preserving cleanups to `depictio/cli` (269 CLI tests pass, ruff clean, no new `ty` errors).

**Performance**
- `regex_match`: compile + `lru_cache` the pattern and match once (was matching twice + rebuilding an uncompiled pattern every call in the scan hot loop).
- `scan.py`: hoist the invariant `temp_run` out of the per-file loop.
- Add a process-wide pooled `httpx.Client` (`common.get_http_client`); `api_calls.py` and `links.py` reuse it for connection reuse.

**Presentation**
- `rich_utils.py`: stop shadowing builtin `print`, route through one shared console, drop redundant `Console()` instances.
- New `render_records_table` helper; adopted in `catalog list`.

**Logging**
- `scan_utils.py`: use the CLI logger (was importing the API logger), so output obeys `--verbose`.

Adds `depictio/cli/CLI_REVIEW.md` with the full findings and a follow-up backlog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMXn6rzTFUFo8aaBsoSAAF)_