### PR TITLE
Graded advanced-viz suggestions + tolerant builder bindings

### DIFF
--- a/depictio/api/v1/endpoints/advanced_viz_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/advanced_viz_endpoints/routes.py
@@ -158,7 +158,7 @@ _KIND_METADATA: dict[AdvancedVizKind, dict[str, Any]] = {
         "icon": "tabler:atom",
     },
     "manhattan": {
-        "label": "GWAS Manhattan (tool)",
+        "label": "Manhattan plot",
         "description": "chr / pos / score scatter — works for true GWAS, peak qvalues, and variant AF.",
         "icon": "tabler:chart-histogram",
         "category": "tool",

--- a/depictio/api/v1/endpoints/advanced_viz_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/advanced_viz_endpoints/routes.py
@@ -28,7 +28,10 @@ from depictio.api.v1.endpoints.user_endpoints.routes import (
     get_user_or_anonymous,
     oauth2_scheme_optional,
 )
-from depictio.models.components.advanced_viz.schemas import CANONICAL_SCHEMAS
+from depictio.models.components.advanced_viz.schemas import (
+    CANONICAL_SCHEMAS,
+    role_dtype_specs,
+)
 from depictio.models.components.types import AdvancedVizKind
 from depictio.models.models.base import PyObjectId
 
@@ -241,7 +244,13 @@ _KIND_METADATA: dict[AdvancedVizKind, dict[str, Any]] = {
 
 @advanced_viz_endpoint_router.get("/kinds")
 def list_kinds(current_user=Depends(get_user_or_anonymous)) -> list[dict[str, Any]]:
-    """Return the metadata payload the React builder uses to populate the viz_kind picker."""
+    """Return the metadata payload the React builder uses to populate the viz_kind picker.
+
+    `roles` carries the per-role accepted dtypes (required + optional) so the
+    builder drives its binding dropdowns + validation from the backend instead
+    of duplicating the dtype tables in TypeScript. `required_roles` is kept for
+    backwards compatibility.
+    """
     return [
         {
             "viz_kind": kind,
@@ -249,6 +258,7 @@ def list_kinds(current_user=Depends(get_user_or_anonymous)) -> list[dict[str, An
             "description": meta["description"],
             "icon": meta["icon"],
             "required_roles": list(CANONICAL_SCHEMAS[kind].keys()),
+            "roles": role_dtype_specs(kind),
             # Entries without an explicit category are pure visualisations.
             "category": meta.get("category", "plot"),
         }

--- a/depictio/api/v1/endpoints/datacollections_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/datacollections_endpoints/routes.py
@@ -2,7 +2,6 @@ import asyncio
 
 from bson import ObjectId
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
-from pydantic import BaseModel, Field
 
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
@@ -54,33 +53,37 @@ async def polars_schema(
 @datacollections_endpoint_router.get("/viz-suggestions/{data_collection_id}")
 async def viz_suggestions(
     data_collection_id: PyObjectId,
-    min_confidence: float = 1.0,
+    min_confidence: float = 0.0,
     current_user: str = Depends(get_user_or_anonymous),
 ) -> dict:
-    """Reverse-lookup viz kinds compatible with this DC.
+    """Rank advanced-viz kinds by how well they fit this DC.
 
-    Drives the React DC card's "Suggested visualisations" chip row and the
-    component-creation flow's DC pre-filter via the pure-Python suggestion
-    engine in `depictio/models/components/advanced_viz/schemas.py`:
+    Drives the React builder's "suggest but tolerate" picker (Recommended vs.
+    the rest) and the DC card's suggestion chips via the graded scoring engine
+    in `depictio/models/components/advanced_viz/schemas.py`. Every viz kind is
+    scored and returned (ranked) — nothing is filtered out by default — so the
+    builder can still let the user pick a low-scoring kind and bind columns
+    manually. Each entry carries:
 
-      - `viz_kinds`: every AdvancedVizKind whose required role schema can be
-        satisfied by some column-dtype combination in this DC. Each entry
-        carries per-role candidate columns the UI uses to pre-fill bindings.
-      - `producers`: always empty. The column-fingerprint suggestion engine
-        (`producers.py`) was retired (dtype-blind, unreliable); the key is
-        kept so existing clients keep deserialising. Removal of the React
-        producer chips is a follow-up frontend change.
+      - `score`: 0.0-1.0 graded fit (dtype compatibility × column-name
+        similarity across required roles, plus optional-role and structural
+        nudges).
+      - `role_candidates`: per required role, dtype-compatible columns ranked
+        best-first — the UI uses these to pre-fill bindings.
+      - `unmet_roles` / `weak_roles`: required roles with no candidate, or
+        satisfied only by dtype/cast — drive the builder's inline guidance.
 
     Query params:
-        min_confidence: 0.0-1.0 — minimum fraction of required roles that
-            must have a candidate column for a viz kind to appear in the
-            suggestions list. Default 1.0 = strict (only full matches).
+        min_confidence: optional score floor (0.0-1.0). Default 0.0 returns
+            every kind ranked; raise it to keep only confident matches.
     """
     from depictio.models.components.advanced_viz.schemas import suggest_viz_kinds
 
+    specs = await _get_data_collection_specs(data_collection_id, current_user)
+    dc_type = (specs.get("config") or {}).get("type")
     schema = await _get_data_collection_polars_schema(data_collection_id, current_user)
 
-    viz = suggest_viz_kinds(schema, min_confidence=min_confidence)
+    viz = suggest_viz_kinds(schema, min_confidence=min_confidence, dc_type=dc_type)
 
     return {
         "data_collection_id": str(data_collection_id),
@@ -88,40 +91,14 @@ async def viz_suggestions(
         "viz_kinds": [
             {
                 "viz_kind": s.viz_kind,
-                "confidence": s.confidence,
+                "score": s.score,
                 "role_candidates": s.role_candidates,
+                "unmet_roles": s.unmet_roles,
+                "weak_roles": s.weak_roles,
             }
             for s in viz
         ],
-        "producers": [],
     }
-
-
-class SuggestFromColumnsRequest(BaseModel):
-    """Body for the pre-DC viz suggestion endpoint.
-
-    The DC creation modal calls this with just column names parsed from the
-    file header — before the file is uploaded.
-    """
-
-    columns: list[str] = Field(..., min_length=1)
-
-
-@datacollections_endpoint_router.post("/suggest-from-columns")
-async def suggest_from_columns(
-    body: SuggestFromColumnsRequest,
-    current_user: str = Depends(get_user_or_anonymous),
-) -> dict:
-    """Pre-DC suggestion from a bare column list (no DC required).
-
-    Always returns an empty `producers` list: the column-fingerprint engine
-    (`producers.py`) was retired (dtype-blind, unreliable), and the viz-kind
-    reverse lookup needs dtype info that isn't available until the file is
-    parsed server-side. The endpoint and response shape are kept so the DC
-    creation modal keeps working; removing the React "looks like X" hint is a
-    follow-up frontend change.
-    """
-    return {"producers": []}
 
 
 @datacollections_endpoint_router.delete("/delete/{workflow_id}/{data_collection_id}")

--- a/depictio/catalog/TODO.md
+++ b/depictio/catalog/TODO.md
@@ -5,15 +5,14 @@ preview (`catalog match`/`compose` + `software_versions.yml` scoping) are done
 and on `claude/optimistic-mayer-iQrTO`. Direction v3 = module-granular,
 pipeline-agnostic (see `docs/design/bioinformatics-catalog.md`).
 
-## Free mode (UI — frontend PR)
-- **Do not gate the UI.** The user must always be able to map an advanced viz
-  directly onto a file's columns (role → column) **by hand, with no condition**
-  — even when nothing is recognised/suggested.
-- Applies in **two places**: the **project data manager** and the
-  **advanced viz section**.
-- Suggestions may *pre-fill* the binding, but must never *block* manual mapping.
-- Check/relax gating in `ProjectDetailApp.tsx` (`hasVizMatch`) and
-  `AdvancedVizBuilder.tsx` (producer-driven pre-selection).
+## Free mode (UI) — DONE
+- **The UI is no longer gated.** The advanced-viz builder ranks every kind by a
+  graded backend fit score and presents a "suggest but tolerate" picker
+  (Recommended + Other visualisations, nothing hidden/disabled); the user can
+  pick any kind and bind columns by hand. Validation is tolerant — a castable
+  dtype is a warning, not a blocker.
+- The `ProjectDetailApp.tsx` `hasVizMatch` coords gating and the
+  `AdvancedVizBuilder.tsx` producer-driven pre-selection are **removed**.
 
 ## Guided mode
 - Wire `compose_run_dir()` into the real ingestion/scan path so it actually
@@ -40,13 +39,13 @@ pipeline-agnostic (see `docs/design/bioinformatics-catalog.md`).
   wiring the scan). This is what lets one module own *N* reshape variants keyed
   by input shape, instead of duplicating a recipe per pipeline.
 
-## Retire `suggest_producers` — DONE (backend), frontend cleanup pending
+## Retire `suggest_producers` — DONE (backend + frontend)
 - Column-fingerprint recognition was unreliable; `producers.py` +
-  `suggest_producers` are **removed**. The API (`/viz-suggestions`,
-  `/suggest-from-columns`) now always returns `producers: []` (shape kept so
-  clients keep deserialising). Remaining: remove the React "suggested producer"
-  chips + the `producers` field/types in a frontend PR. `suggest_viz_kinds`
-  (role/dtype based) is the runtime suggestion engine.
+  `suggest_producers` are **removed**. The React producer chips, the
+  `producers` field/types, and the `/suggest-from-columns` endpoint are now
+  **gone** too. `suggest_viz_kinds` (role/dtype based, now graded 0-1 scoring)
+  is the single runtime suggestion engine; `/viz-suggestions` returns a ranked
+  `viz_kinds` list with per-kind `score` + `role_candidates`.
 
 ## Render enrichment + preview
 - `renders_as` now supports `figure` (UI `visu_type`/`dict_kwargs` **and** code

--- a/depictio/models/components/advanced_viz/schemas.py
+++ b/depictio/models/components/advanced_viz/schemas.py
@@ -12,7 +12,10 @@ column names + dtypes (see depictio/recipes/__init__.py:validate_schema).
 
 from __future__ import annotations
 
+import difflib
+import re
 from dataclasses import dataclass
+from typing import Literal
 
 from depictio.models.components.advanced_viz.configs import (
     EmbeddingConfig,
@@ -430,16 +433,136 @@ _OPTIONAL_ROLES: dict[AdvancedVizKind, dict[str, frozenset[str]]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Graded dtype / name compatibility scoring.
+#
+# These pure helpers turn the old binary "does column X satisfy role Y?" check
+# into a graded score in [0, 1], so the suggester can RANK every viz kind
+# instead of filtering down to perfect matches. Both `validate_binding` and
+# `suggest_viz_kinds` share them, keeping the backend the single source of
+# truth for compatibility (the React builder consumes the scores instead of
+# re-deriving them).
+# ---------------------------------------------------------------------------
+
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+# A column whose dtype isn't an exact member of a role's accepted set may still
+# be *castable* into it. Castable matches score below exact ones so the
+# suggester prefers exact dtypes but tolerates close shapes.
+_CASTABLE_INT_TO_FLOAT = 0.6
+_CASTABLE_CATEGORICAL = 0.8
+
+
+def _normalize_name(name: str) -> str:
+    """Lowercase a column name and collapse separators to ``_`` (snake_case).
+
+    Mirrors the builder's normalisation so ``sample-id`` / ``Sample ID`` /
+    ``sample.id`` all align with the snake_case alias sets.
+    """
+    return _NON_ALNUM_RE.sub("_", name.lower()).strip("_")
+
+
+def _dtype_score(actual: str, accepted: frozenset[str]) -> float:
+    """Graded dtype compatibility: 1.0 exact, castable < 1.0, 0.0 incompatible."""
+    if actual in accepted:
+        return 1.0
+    # Int widens losslessly into a Float role (Int64 → Float64).
+    if actual in _INT and accepted <= _FLOAT:
+        return _CASTABLE_INT_TO_FLOAT
+    # Categorical is interchangeable with String for label/id roles.
+    if actual == "Categorical" and accepted & _STRING:
+        return _CASTABLE_CATEGORICAL
+    return 0.0
+
+
+def _name_score(col: str, aliases: frozenset[str]) -> float:
+    """Fuzzy column-name match against a role's aliases, in [0, 1].
+
+    1.0 = exact alias hit. Otherwise a graded fuzzy score (substring
+    containment, shared snake_case tokens, or `difflib` ratio), capped below
+    1.0 so a fuzzy hit never outranks an exact one. 0.0 = no name signal.
+    """
+    norm_aliases = {_normalize_name(a) for a in aliases if a}
+    if not norm_aliases:
+        return 0.0
+    n = _normalize_name(col)
+    if n in norm_aliases:
+        return 1.0
+    n_tokens = {t for t in n.split("_") if t}
+    best = 0.0
+    for alias in norm_aliases:
+        a_tokens = {t for t in alias.split("_") if t}
+        shared = n_tokens & a_tokens
+        if shared:
+            overlap = len(shared) / max(len(n_tokens), len(a_tokens))
+            best = max(best, 0.5 + 0.35 * overlap)
+        # Substring / fuzzy matching only for aliases long enough to be
+        # meaningful. A 1-2 char alias ("p", "x", "fc", "bp", "es") otherwise
+        # matches any column that merely *contains* that letter, flooding the
+        # picker with false positives (e.g. qq scored ~1.0 on a penguin
+        # morphometrics table because "bill_depth_mm" contains "p"). Such short
+        # aliases still match a column named exactly that, via the exact-hit and
+        # shared-token branches above.
+        if len(alias) >= 3:
+            if alias in n or n in alias:
+                best = max(best, 0.85)
+            ratio = difflib.SequenceMatcher(None, n, alias).ratio()
+            if ratio > 0.8:
+                best = max(best, 0.6 + (ratio - 0.8))
+    return min(best, 0.9)
+
+
+def _score_role(
+    dc_schema: dict[str, str],
+    aliases: frozenset[str],
+    accepted: frozenset[str],
+) -> tuple[float, list[str]]:
+    """Score a single role against the DC schema.
+
+    Returns ``(role_score, candidates)`` where role_score is the best
+    column's combined score ``dtype × (0.5 + 0.5 × name)`` and candidates is
+    the list of dtype-compatible columns ranked best-first (used by the UI to
+    pre-fill the binding dropdown).
+    """
+    scored: list[tuple[float, str]] = []
+    for col, dtype in dc_schema.items():
+        d = _dtype_score(dtype, accepted)
+        if d == 0.0:
+            continue
+        scored.append((d * (0.5 + 0.5 * _name_score(col, aliases)), col))
+    scored.sort(key=lambda sc: (-sc[0], sc[1]))
+    role_score = scored[0][0] if scored else 0.0
+    return role_score, [col for _, col in scored]
+
+
 @dataclass(frozen=True)
 class BindingError:
     role: str
     column: str | None
     reason: str  # e.g. "column not in DC", "wrong dtype: got Int64 expected Float64"
+    # "error" blocks the render; "warning" is a tolerant heads-up (e.g. a
+    # castable dtype mismatch the renderer can coerce) that the editor surfaces
+    # without disabling save.
+    severity: Literal["error", "warning"] = "error"
 
 
 def _role_to_config_field(role: str) -> str:
     """Roles map to ``<role>_col`` fields on each VizConfig submodel."""
     return f"{role}_col"
+
+
+def _dtype_binding_error(
+    role: str, col: str, actual: str, accepted: frozenset[str], *, optional: bool
+) -> BindingError:
+    """Build a dtype-mismatch BindingError, downgrading castable cases to a warning."""
+    castable = _dtype_score(actual, accepted) > 0.0
+    prefix = "optional column" if optional else "column"
+    return BindingError(
+        role=role,
+        column=col,
+        reason=(f"{prefix} '{col}' has dtype {actual!r}, expected one of {sorted(accepted)}"),
+        severity="warning" if castable else "error",
+    )
 
 
 def validate_binding(config: VizConfig, dc_schema: dict[str, str]) -> list[BindingError]:
@@ -451,7 +574,9 @@ def validate_binding(config: VizConfig, dc_schema: dict[str, str]) -> list[Bindi
                    Dtype names are the strings polars produces via ``str(dtype)``.
 
     Returns:
-        List of BindingError. Empty list = valid.
+        List of BindingError (each tagged with ``severity``). A castable dtype
+        mismatch (e.g. an Int column for a Float role) is reported as a
+        ``warning`` rather than a blocking ``error``. Empty list = valid.
     """
     kind: AdvancedVizKind = config.viz_kind
     errors: list[BindingError] = []
@@ -469,16 +594,7 @@ def validate_binding(config: VizConfig, dc_schema: dict[str, str]) -> list[Bindi
             continue
         actual = dc_schema[col]
         if actual not in accepted_dtypes:
-            errors.append(
-                BindingError(
-                    role=role,
-                    column=col,
-                    reason=(
-                        f"column '{col}' has dtype {actual!r}, "
-                        f"expected one of {sorted(accepted_dtypes)}"
-                    ),
-                )
-            )
+            errors.append(_dtype_binding_error(role, col, actual, accepted_dtypes, optional=False))
 
     for role, accepted_dtypes in optional.items():
         col = getattr(config, _role_to_config_field(role), None)
@@ -489,94 +605,210 @@ def validate_binding(config: VizConfig, dc_schema: dict[str, str]) -> list[Bindi
             continue
         actual = dc_schema[col]
         if actual not in accepted_dtypes:
-            errors.append(
-                BindingError(
-                    role=role,
-                    column=col,
-                    reason=(
-                        f"optional column '{col}' has dtype {actual!r}, "
-                        f"expected one of {sorted(accepted_dtypes)}"
-                    ),
-                )
-            )
+            errors.append(_dtype_binding_error(role, col, actual, accepted_dtypes, optional=True))
 
     return errors
 
 
 # ---------------------------------------------------------------------------
-# Reverse-lookup: "given a DC schema, which viz kinds / producers fit?"
+# Reverse-lookup: "given a DC schema, how well does each viz kind fit?"
 #
-# Drives the React DC card "Suggested visualisations" chips and the
-# component-creation flow's DC pre-filter. Pure functions — no DB, no IO,
-# no DC mutation. Testable against any (col → dtype) dict.
+# Drives the React builder's ranked viz-kind picker (Recommended vs. the rest)
+# and the DC card's suggestion chips. Pure functions — no DB, no IO, no DC
+# mutation. Testable against any (col → dtype) dict.
+#
+# Every kind is scored and returned (ranked); nothing is filtered out by
+# default, so the builder can present a "suggest but tolerate" picker where the
+# user may still pick a low-scoring kind and bind columns manually.
 # ---------------------------------------------------------------------------
+
+# Structural gates ported from the builder so the backend stays the single
+# source of truth. Kinds whose Pydantic config has a permissive role schema but
+# whose renderer needs a wide matrix / many set columns get a structural floor;
+# falling short multiplies the score down rather than hiding the kind.
+_MIN_FLOAT_COLS: dict[AdvancedVizKind, int] = {"complex_heatmap": 8}
+_MIN_INT_COLS: dict[AdvancedVizKind, int] = {"upset_plot": 3}
+_MIN_STRING_COLS: dict[AdvancedVizKind, int] = {"sankey": 2}
+_KIND_REQUIRES_DC_TYPE: dict[AdvancedVizKind, str] = {"phylogenetic": "phylogeny"}
+_EMBEDDING_LIVE_MIN_NUMERIC = 10
+
+# Float columns whose name is purely a statistic (DESeq2-style results) — used
+# to reject complex_heatmap / sankey, which want a sample matrix / categorical
+# flow, not a stats table.
+_STAT_LIKE_FLOAT_RE = re.compile(
+    r"^(basemean|log2foldchange|lfcse|stat|pvalue|padj|qvalue|p_?val|fdr|"
+    r"log2fc|effect_size|significance|nes|es|score)$"
+)
+
+# Multiplier applied when a structural gate isn't met: the kind stays in the
+# ranked list but drops well below the "recommended" threshold.
+_GATE_PENALTY = 0.25
+
+# A required role scoring at/above this counts as a strong (name-aware) match;
+# below it the role is "weak" (satisfied by dtype/cast only).
+_STRONG_ROLE_SCORE = 0.75
+
+# Score at/above which the builder surfaces a kind under "Recommended".
+RECOMMENDED_SCORE = 0.8
 
 
 @dataclass(frozen=True)
 class VizSuggestion:
-    """A viz kind that a DC could feasibly satisfy plus the matching detail.
+    """How well a viz kind fits a DC schema, plus the matching detail.
 
-    confidence is 0.0 - 1.0 = fraction of required roles satisfied.
-    A confidence of 1.0 means every required role has at least one
-    candidate column with a compatible dtype.
+    score is 0.0 - 1.0 (graded): a weighted blend of per-role dtype
+    compatibility and column-name similarity across the kind's required roles,
+    nudged by optional-role matches and structural gates. ~1.0 means every
+    required role has a strongly-named, dtype-exact column.
 
-    role_candidates maps each required role → list of column names whose
-    dtype is in the role's accepted set. The UI uses this to pre-fill
-    the binding dropdowns at component-creation time.
+    role_candidates maps each required role → dtype-compatible column names,
+    ranked best-first. The UI uses this to pre-fill the binding dropdowns.
+
+    unmet_roles are required roles with no compatible column at all; weak_roles
+    are satisfied only by dtype/cast (no strong name match). Both drive the
+    builder's inline guidance.
     """
 
     viz_kind: AdvancedVizKind
-    confidence: float
+    score: float
     role_candidates: dict[str, list[str]]
+    unmet_roles: list[str]
+    weak_roles: list[str]
+
+
+def _count_dtypes(dc_schema: dict[str, str], dtypes: frozenset[str]) -> int:
+    return sum(1 for d in dc_schema.values() if d in dtypes)
+
+
+def _apply_structural_gates(
+    kind: AdvancedVizKind, dc_schema: dict[str, str], score: float, dc_type: str | None
+) -> float:
+    """Adjust a kind's base score for renderer-level structural requirements."""
+    min_float = _MIN_FLOAT_COLS.get(kind)
+    if min_float is not None:
+        float_cols = [c for c, d in dc_schema.items() if d in _FLOAT]
+        if len(float_cols) < min_float:
+            score *= _GATE_PENALTY
+        elif float_cols and all(_STAT_LIKE_FLOAT_RE.match(_normalize_name(c)) for c in float_cols):
+            # Structurally a wide matrix but semantically a stats table.
+            score *= _GATE_PENALTY
+
+    min_int = _MIN_INT_COLS.get(kind)
+    if min_int is not None:
+        # upset_plot has no required roles — derive its score from the count of
+        # binary (Int) set-membership columns.
+        ints = _count_dtypes(dc_schema, _INT)
+        score = 0.8 if ints >= min_int else _GATE_PENALTY * min(ints / min_int, 1.0)
+
+    min_string = _MIN_STRING_COLS.get(kind)
+    if min_string is not None:
+        # sankey has no required roles — needs ≥N categorical columns and no
+        # statistic-looking floats (those are results tables, not flows).
+        strings = _count_dtypes(dc_schema, _STRING)
+        stat_floats = any(
+            _STAT_LIKE_FLOAT_RE.match(_normalize_name(c))
+            for c, d in dc_schema.items()
+            if d in _FLOAT
+        )
+        score = 0.8 if (strings >= min_string and not stat_floats) else _GATE_PENALTY
+
+    required_dc_type = _KIND_REQUIRES_DC_TYPE.get(kind)
+    if required_dc_type is not None and dc_type is not None and dc_type != required_dc_type:
+        score *= _GATE_PENALTY
+
+    return min(score, 1.0)
+
+
+def _score_kind(
+    kind: AdvancedVizKind, dc_schema: dict[str, str], dc_type: str | None
+) -> VizSuggestion:
+    """Score one viz kind against the DC schema."""
+    required = CANONICAL_SCHEMAS[kind]
+    role_aliases = ROLE_NAMES.get(kind, {})
+    role_scores: dict[str, float] = {}
+    role_candidates: dict[str, list[str]] = {}
+    for role, accepted in required.items():
+        aliases = role_aliases.get(role, frozenset({role}))
+        role_scores[role], role_candidates[role] = _score_role(dc_schema, aliases, accepted)
+
+    base = sum(role_scores.values()) / len(required) if required else 0.0
+
+    # Optional-role matches nudge an already-matching kind upward (capped).
+    optional = _OPTIONAL_ROLES.get(kind, {})
+    if base > 0 and optional:
+        opt = sum(
+            _score_role(dc_schema, frozenset({role}), accepted)[0]
+            for role, accepted in optional.items()
+        )
+        base = base + 0.1 * (opt / len(optional))
+
+    # Live-compute embedding: a wide numeric matrix with a sample_id column is a
+    # valid embedding even without precomputed dim_1/dim_2.
+    if kind == "embedding":
+        sample_score, _ = _score_role(
+            dc_schema, role_aliases.get("sample_id", frozenset({"sample_id"})), _STRING
+        )
+        if sample_score > 0 and _count_dtypes(dc_schema, _NUMERIC) >= _EMBEDDING_LIVE_MIN_NUMERIC:
+            base = max(base, 0.5 + 0.35 * sample_score)
+
+    score = _apply_structural_gates(kind, dc_schema, base, dc_type)
+
+    unmet = [r for r, s in role_scores.items() if s == 0.0]
+    weak = [r for r, s in role_scores.items() if 0.0 < s < _STRONG_ROLE_SCORE]
+    return VizSuggestion(
+        viz_kind=kind,
+        score=round(score, 4),
+        role_candidates=role_candidates,
+        unmet_roles=unmet,
+        weak_roles=weak,
+    )
 
 
 def suggest_viz_kinds(
     dc_schema: dict[str, str],
-    min_confidence: float = 1.0,
+    min_confidence: float = 0.0,
+    dc_type: str | None = None,
 ) -> list[VizSuggestion]:
-    """Return viz kinds whose required roles can be satisfied by `dc_schema`.
+    """Rank every viz kind by how well `dc_schema` fits it.
 
-    A role is "satisfied" when the DC has a column whose NAME is in the
-    role's `ROLE_NAMES` alias set AND whose dtype is in the role's accepted
-    dtype set. Dtype-only matches still appear in `role_candidates` so the
-    binding UI can offer them as fallback choices, but they don't count
-    toward confidence — otherwise every Numeric+String DC matches every viz.
+    Each kind gets a graded `score` in [0, 1] blending per-role dtype
+    compatibility (exact > castable) and column-name similarity (exact alias >
+    fuzzy), plus optional-role nudges and structural gates (e.g. heatmap needs
+    a wide float matrix, phylogenetic needs a phylogeny-type DC). Unlike the
+    old binary matcher, NO kind is dropped by default — the builder presents a
+    ranked "suggest but tolerate" picker.
 
     Args:
-        dc_schema: Map of column name → polars dtype name (the strings
-            polars emits via `str(dtype)`).
-        min_confidence: Minimum fraction of required roles that must have
-            a name+dtype match. Default 1.0 = only return viz kinds where
-            every required role has a named candidate. Drop to ~0.7 to
-            surface "almost a match" viz kinds in an exploratory UI.
+        dc_schema: Map of column name → polars dtype name (the strings polars
+            emits via `str(dtype)`).
+        min_confidence: Optional score floor. Default 0.0 returns every kind,
+            ranked. Raise it (e.g. 0.8) to keep only confident matches.
+        dc_type: The DC's `config.type` (e.g. "table", "phylogeny"), used by
+            kinds with a hard DC-type requirement. None = unknown (no gate).
 
     Returns:
-        Sorted (by confidence desc, then viz_kind asc) list of
-        VizSuggestion. Empty when nothing fits.
+        List of VizSuggestion sorted by score desc, then viz_kind asc.
     """
-    suggestions: list[VizSuggestion] = []
-    for kind, required in CANONICAL_SCHEMAS.items():
-        if not required:
-            # Schemas with no required roles (sankey, upset_plot) bind derived
-            # DCs and are authored via `use:`; the schema-only suggester can't
-            # say anything useful about them, so skip.
-            continue
-        role_aliases = ROLE_NAMES.get(kind, {})
-        role_candidates: dict[str, list[str]] = {}
-        satisfied = 0
-        for role, accepted in required.items():
-            dtype_matches = [col for col, dtype in dc_schema.items() if dtype in accepted]
-            role_candidates[role] = dtype_matches
-            aliases = {a.lower() for a in role_aliases.get(role, frozenset({role}))}
-            if any(col.lower() in aliases for col in dtype_matches):
-                satisfied += 1
-        confidence = satisfied / len(required)
-        if confidence >= min_confidence:
-            suggestions.append(
-                VizSuggestion(viz_kind=kind, confidence=confidence, role_candidates=role_candidates)
-            )
-    suggestions.sort(key=lambda s: (-s.confidence, s.viz_kind))
+    suggestions = [_score_kind(kind, dc_schema, dc_type) for kind in CANONICAL_SCHEMAS]
+    suggestions = [s for s in suggestions if s.score >= min_confidence]
+    suggestions.sort(key=lambda s: (-s.score, s.viz_kind))
     return suggestions
+
+
+def role_dtype_specs(kind: AdvancedVizKind) -> dict[str, dict[str, object]]:
+    """Per-role accepted dtypes for a viz kind, required first then optional.
+
+    Returns ``{role: {"required": bool, "dtypes": sorted([...])}}``. Exposed via
+    the `/advanced_viz/kinds` descriptor so the React builder drives its binding
+    dropdowns + dtype validation from the backend instead of duplicating the
+    dtype tables in TypeScript.
+    """
+    specs: dict[str, dict[str, object]] = {}
+    for role, accepted in CANONICAL_SCHEMAS[kind].items():
+        specs[role] = {"required": True, "dtypes": sorted(accepted)}
+    for role, accepted in _OPTIONAL_ROLES.get(kind, {}).items():
+        specs[role] = {"required": False, "dtypes": sorted(accepted)}
+    return specs
 
 
 __all__ = [
@@ -584,10 +816,12 @@ __all__ = [
     "CANONICAL_SCHEMAS",
     "EmbeddingConfig",
     "ManhattanConfig",
+    "RECOMMENDED_SCORE",
     "ROLE_NAMES",
     "StackedTaxonomyConfig",
     "VizSuggestion",
     "VolcanoConfig",
+    "role_dtype_specs",
     "suggest_viz_kinds",
     "validate_binding",
 ]

--- a/depictio/models/components/advanced_viz/schemas.py
+++ b/depictio/models/components/advanced_viz/schemas.py
@@ -795,19 +795,77 @@ def suggest_viz_kinds(
     return suggestions
 
 
-def role_dtype_specs(kind: AdvancedVizKind) -> dict[str, dict[str, object]]:
-    """Per-role accepted dtypes for a viz kind, required first then optional.
+# Short human descriptions per role, keyed by role name (roles are reused
+# across viz kinds). Surfaced in the builder's per-binding tooltip alongside the
+# accepted dtypes. Roles without an entry fall back to an empty description.
+_ROLE_DESCRIPTIONS: dict[str, str] = {
+    "feature_id": "Identifier for each feature / gene / row (e.g. gene_id, ENSEMBL id).",
+    "effect_size": "Magnitude of change, typically log2 fold change.",
+    "significance": "Statistical significance — p-value or adjusted p / FDR.",
+    "sample_id": "Identifier for each sample / observation.",
+    "dim_1": "First embedding coordinate (PC1 / UMAP1 / tSNE1).",
+    "dim_2": "Second embedding coordinate (PC2 / UMAP2 / tSNE2).",
+    "dim_3": "Optional third embedding coordinate for 3D plots.",
+    "chr": "Chromosome / contig name.",
+    "chromosome": "Chromosome / contig name.",
+    "pos": "Genomic or sequence position (integer).",
+    "position": "Genomic or sequence position (integer).",
+    "score": "Value plotted on the y-axis (e.g. -log10 p, signal).",
+    "taxon": "Taxon / lineage name, or tree tip label.",
+    "rank": "Taxonomic rank / level (e.g. Phylum, Genus).",
+    "abundance": "Abundance / count / relative frequency.",
+    "depth": "Sequencing / sampling depth.",
+    "metric": "Diversity or summary metric value.",
+    "contrast": "Comparison / contrast label (group vs group).",
+    "lfc": "Log2 fold change.",
+    "term": "Pathway / GO term / gene-set name.",
+    "nes": "Normalised enrichment score.",
+    "padj": "Adjusted p-value / FDR.",
+    "gene_count": "Number of genes in the set.",
+    "index": "Row identifier used as the heatmap index.",
+    "avg_log_intensity": "Average log intensity — MA-plot x-axis (e.g. baseMean).",
+    "log2_fold_change": "Log2 fold change — MA-plot y-axis.",
+    "cluster": "Cluster / cell-type label.",
+    "gene": "Gene / feature name.",
+    "mean_expression": "Mean expression level (dot colour).",
+    "frac_expressing": "Fraction of cells expressing (dot size).",
+    "category": "Categorical grouping / annotation.",
+    "p_value": "P-value for the QQ distribution.",
+    "mutation_type": "Mutation class / variant consequence.",
+    "value": "Numeric value plotted (e.g. coverage).",
+    "label": "Optional text label for points.",
+    "color": "Optional column mapped to point colour.",
+    "feature": "Optional feature annotation.",
+    "effect": "Optional effect-size column.",
+    "iter": "Rarefaction iteration index.",
+    "group": "Grouping column for colouring / faceting.",
+    "source": "Source / database of the term.",
+    "end": "End coordinate of the interval.",
+    "sample": "Optional sample column for faceting.",
+}
 
-    Returns ``{role: {"required": bool, "dtypes": sorted([...])}}``. Exposed via
-    the `/advanced_viz/kinds` descriptor so the React builder drives its binding
-    dropdowns + dtype validation from the backend instead of duplicating the
-    dtype tables in TypeScript.
+
+def role_dtype_specs(kind: AdvancedVizKind) -> dict[str, dict[str, object]]:
+    """Per-role spec for a viz kind, required first then optional.
+
+    Returns ``{role: {"required": bool, "dtypes": sorted([...]), "description": str}}``.
+    Exposed via the `/advanced_viz/kinds` descriptor so the React builder drives
+    its binding dropdowns, dtype validation and per-binding tooltips from the
+    backend instead of duplicating the dtype tables in TypeScript.
     """
     specs: dict[str, dict[str, object]] = {}
     for role, accepted in CANONICAL_SCHEMAS[kind].items():
-        specs[role] = {"required": True, "dtypes": sorted(accepted)}
+        specs[role] = {
+            "required": True,
+            "dtypes": sorted(accepted),
+            "description": _ROLE_DESCRIPTIONS.get(role, ""),
+        }
     for role, accepted in _OPTIONAL_ROLES.get(kind, {}).items():
-        specs[role] = {"required": False, "dtypes": sorted(accepted)}
+        specs[role] = {
+            "required": False,
+            "dtypes": sorted(accepted),
+            "description": _ROLE_DESCRIPTIONS.get(role, ""),
+        }
     return specs
 
 

--- a/depictio/tests/models/test_advanced_viz_suggestions.py
+++ b/depictio/tests/models/test_advanced_viz_suggestions.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from depictio.models.components.advanced_viz.schemas import suggest_viz_kinds
+from depictio.models.components.advanced_viz.schemas import RECOMMENDED_SCORE, suggest_viz_kinds
 
 FIXTURES_DIR = (
     Path(__file__).resolve().parents[3] / "dev" / "advanced_viz_docs_screenshots" / "fixtures"
@@ -41,9 +41,10 @@ def _read_schema(path: Path, **read_kwargs) -> dict[str, str]:
 
 
 # (fixture_path, expected_viz_kinds, read_kwargs)
-# expected_viz_kinds is a subset assertion — the function may surface
-# additional kinds that coincidentally match dtype shapes. The fixture
-# *must* at minimum return everything in this list.
+# The graded suggester ranks *every* kind, so we assert that each promised kind
+# scores well (>= _EXPECTED_SCORE) rather than that it's the only one returned.
+_EXPECTED_SCORE = 0.5
+
 CASES: list[tuple[str, set[str], dict]] = [
     (
         "volcano/deseq2_results.tsv",
@@ -88,10 +89,11 @@ def test_suggestions_against_nfcore_fixtures(
         )
     schema = _read_schema(path, **read_kwargs)
     viz = suggest_viz_kinds(schema)
-    suggested_kinds = {s.viz_kind for s in viz}
-    missing = expected_kinds - suggested_kinds
+    scored = {s.viz_kind: s.score for s in viz}
+    well_scored = {k for k, score in scored.items() if score >= _EXPECTED_SCORE}
+    missing = expected_kinds - well_scored
     assert not missing, (
-        f"{rel_path}: schema {schema} did not suggest {missing}; got {suggested_kinds}"
+        f"{rel_path}: schema {schema} did not score {missing} >= {_EXPECTED_SCORE}; scores={scored}"
     )
 
 
@@ -99,23 +101,33 @@ def test_suggestions_against_nfcore_fixtures(
 # suggestion engine with synthetic schemas to lock down edge-case behaviour.
 
 
-def test_suggest_viz_kinds_returns_empty_on_unfitting_schema() -> None:
-    # Pure-string schema with a column that doesn't match any role's
-    # name-alias set — the suggester should reject everything, including
-    # phylogenetic (whose `taxon` role no longer matches an arbitrary
-    # String column under the name-aware rules).
+def test_suggest_viz_kinds_returns_all_kinds_ranked() -> None:
+    # The graded suggester always returns every kind, sorted by score desc.
+    schema = {"gene_id": "String", "log2FoldChange": "Float64", "padj": "Float64"}
+    viz = suggest_viz_kinds(schema)
+    scores = [s.score for s in viz]
+    assert len(viz) == len({s.viz_kind for s in viz})  # one entry per kind
+    assert scores == sorted(scores, reverse=True)  # ranked
+    assert 0.0 <= min(scores) and max(scores) <= 1.0
+
+
+def test_unfitting_schema_recommends_nothing() -> None:
+    # A lone String column with a name that matches no role alias should leave
+    # nothing in the "recommended" band — every kind is at most a weak,
+    # dtype-only match.
     schema = {"only_string_col": "String"}
-    suggestions = suggest_viz_kinds(schema)
-    kinds = {s.viz_kind for s in suggestions}
-    assert kinds == set(), f"expected no suggestions, got {kinds}"
+    recommended = [s for s in suggest_viz_kinds(schema) if s.score >= RECOMMENDED_SCORE]
+    assert recommended == [], f"expected nothing recommended, got {recommended}"
 
 
 def test_phylogenetic_matches_on_taxon_aliases() -> None:
     # A String column whose name IS in the phylogenetic taxon alias set
-    # (e.g. `taxon`, `tip_label`, `label`) should light up phylogenetic.
+    # (e.g. `taxon`, `tip_label`, `label`) should score phylogenetic highly.
     for col_name in ("taxon", "tip_label", "label"):
-        kinds = {s.viz_kind for s in suggest_viz_kinds({col_name: "String"})}
-        assert "phylogenetic" in kinds, f"{col_name}: phylogenetic missing from {kinds}"
+        [phylo] = [
+            s for s in suggest_viz_kinds({col_name: "String"}) if s.viz_kind == "phylogenetic"
+        ]
+        assert phylo.score >= RECOMMENDED_SCORE, f"{col_name}: phylogenetic score {phylo.score}"
 
 
 def test_suggest_viz_kinds_role_candidates_populated() -> None:
@@ -125,21 +137,52 @@ def test_suggest_viz_kinds_role_candidates_populated() -> None:
         "padj": "Float64",
     }
     [vol] = [s for s in suggest_viz_kinds(schema) if s.viz_kind == "volcano"]
-    assert vol.confidence == 1.0
+    assert vol.score == 1.0
+    assert vol.unmet_roles == []
+    assert vol.weak_roles == []
     # Every required volcano role has at least one candidate column from
-    # the schema (dtype-compatible). The UI uses this to pre-fill bindings.
+    # the schema (dtype-compatible), ranked best-first. The UI uses this to
+    # pre-fill bindings.
     assert vol.role_candidates["feature_id"] == ["gene_id"]
     assert set(vol.role_candidates["effect_size"]) == {"log2FoldChange", "padj"}
     assert set(vol.role_candidates["significance"]) == {"log2FoldChange", "padj"}
+    # The best-named candidate ranks first for each numeric role.
+    assert vol.role_candidates["effect_size"][0] == "log2FoldChange"
+    assert vol.role_candidates["significance"][0] == "padj"
 
 
 def test_suggest_viz_kinds_min_confidence_filters() -> None:
     # Only feature_id is satisfied (String); effect_size + significance are
-    # both Float but the schema has no Float column at all.
+    # both Float but the schema has no Float column at all → volcano scores low.
     schema = {"feature_id": "String"}
-    strict = suggest_viz_kinds(schema, min_confidence=1.0)
-    relaxed = suggest_viz_kinds(schema, min_confidence=0.3)
-    strict_kinds = {s.viz_kind for s in strict}
-    relaxed_kinds = {s.viz_kind for s in relaxed}
-    assert "volcano" not in strict_kinds
-    assert "volcano" in relaxed_kinds  # 1/3 roles satisfied → conf ≈ 0.33
+    strict_kinds = {s.viz_kind for s in suggest_viz_kinds(schema, min_confidence=1.0)}
+    relaxed_kinds = {s.viz_kind for s in suggest_viz_kinds(schema, min_confidence=0.3)}
+    assert "volcano" not in strict_kinds  # ~0.38 < 1.0
+    assert "volcano" in relaxed_kinds  # 1/3 roles satisfied → score ≈ 0.38
+
+
+def test_castable_dtype_scores_below_exact() -> None:
+    # An Int column feeds a Float role (manhattan score) as a castable match —
+    # it should rank, but below a schema with the exact Float dtype.
+    exact = {"chr": "String", "pos": "Int64", "score": "Float64"}
+    castable = {"chr": "String", "pos": "Int64", "score": "Int64"}
+    [exact_man] = [s for s in suggest_viz_kinds(exact) if s.viz_kind == "manhattan"]
+    [cast_man] = [s for s in suggest_viz_kinds(castable) if s.viz_kind == "manhattan"]
+    assert exact_man.score > cast_man.score > 0.0
+
+
+def test_short_aliases_do_not_cause_substring_false_positives() -> None:
+    # Regression: a 1-2 char alias ("p", "x", "y") must NOT match a column that
+    # merely contains that letter. A generic penguin morphometrics table scored
+    # qq ~0.99 (via "p" inside "bill_depth_mm") and embedding ~0.80 (via the
+    # "x"/"y" dim aliases) before the fix — pure false positives.
+    schema = {
+        "individual_id": "String",
+        "bill_length_mm": "Float64",
+        "bill_depth_mm": "Float64",
+        "flipper_length_mm": "Float64",
+        "body_mass_g": "Float64",
+    }
+    by = {s.viz_kind: s.score for s in suggest_viz_kinds(schema)}
+    assert by["qq"] < 0.6, f"qq still spuriously high via short-alias substring: {by['qq']}"
+    assert by["embedding"] < RECOMMENDED_SCORE, f"embedding still recommended: {by['embedding']}"

--- a/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
+++ b/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
@@ -2,19 +2,19 @@
  * Builder for the advanced_viz component family.
  *
  * Two-step inside the per-type panel:
- *   1) Pick viz_kind (gallery of tiles with description + domain badge; tiles
- *      whose required roles can't be satisfied by the bound DC are greyed-out
- *      with a tooltip explaining what's missing).
- *   2) Bind each required role to a column from the chosen DC, with
- *      editor-time validation against the DC's polars schema.
- *
- * Validation mirrors depictio/models/components/advanced_viz/schemas.py
- * (server side) so Save is only enabled once required roles are mapped to
- * existing columns of an acceptable dtype.
+ *   1) Pick viz_kind. The backend's graded suggestion engine ranks every kind
+ *      for the bound DC; the picker surfaces the strong matches under
+ *      "Recommended" (with a fit score) and the rest under "Other
+ *      visualisations". Nothing is hidden or disabled — the user can pick any
+ *      kind and bind columns manually ("suggest but tolerate").
+ *   2) Bind each required role to a column from the chosen DC. Accepted dtypes
+ *      and the candidate pre-fill both come from the backend (single source of
+ *      truth — see /advanced_viz/kinds and /datacollections/viz-suggestions),
+ *      so the TS side never duplicates the schema. A castable-but-inexact dtype
+ *      (e.g. Int for a Float role) is a tolerant warning, not a blocker.
  */
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  Accordion,
   Alert,
   Badge,
   Divider,
@@ -35,6 +35,7 @@ import { Icon } from '@iconify/react';
 import {
   AdvancedVizKind,
   AdvancedVizKindDescriptor,
+  VizKindSuggestion,
   fetchAdvancedVizKinds,
   fetchPolarsSchema,
   fetchVizSuggestions,
@@ -58,216 +59,25 @@ const NUMERIC_INT = [
 const NUMERIC_ANY = [...NUMERIC_INT, ...NUMERIC_FLOAT];
 const STRING_LIKE = ['String', 'Utf8'];
 
-// Mirror of depictio/models/components/advanced_viz/schemas.py CANONICAL_SCHEMAS.
-// Keep this in sync — drift causes the picker to either undergate (showing
-// kinds the backend will reject at save) or overgate (hiding viable kinds).
-const REQUIRED_ROLES: Record<AdvancedVizKind, Record<string, string[]>> = {
-  volcano: {
-    feature_id: STRING_LIKE,
-    effect_size: NUMERIC_FLOAT,
-    significance: NUMERIC_FLOAT,
-  },
-  embedding: {
-    sample_id: STRING_LIKE,
-    dim_1: NUMERIC_FLOAT,
-    dim_2: NUMERIC_FLOAT,
-  },
-  manhattan: {
-    chr: STRING_LIKE,
-    pos: NUMERIC_INT,
-    score: NUMERIC_FLOAT,
-  },
-  stacked_taxonomy: {
-    sample_id: STRING_LIKE,
-    taxon: STRING_LIKE,
-    rank: STRING_LIKE,
-    abundance: NUMERIC_ANY,
-  },
-  phylogenetic: {
-    taxon: STRING_LIKE,
-  },
-  rarefaction: {
-    sample_id: STRING_LIKE,
-    depth: NUMERIC_ANY,
-    metric: NUMERIC_ANY,
-  },
-  da_barplot: {
-    feature_id: STRING_LIKE,
-    contrast: STRING_LIKE,
-    lfc: NUMERIC_FLOAT,
-  },
-  enrichment: {
-    term: STRING_LIKE,
-    nes: NUMERIC_FLOAT,
-    padj: NUMERIC_FLOAT,
-    gene_count: NUMERIC_ANY,
-  },
-  complex_heatmap: {
-    index: STRING_LIKE,
-  },
-  upset_plot: {},
-  ma: {
-    feature_id: STRING_LIKE,
-    avg_log_intensity: NUMERIC_FLOAT,
-    log2_fold_change: NUMERIC_FLOAT,
-  },
-  dot_plot: {
-    cluster: STRING_LIKE,
-    gene: STRING_LIKE,
-    mean_expression: NUMERIC_FLOAT,
-    frac_expressing: NUMERIC_FLOAT,
-  },
-  lollipop: {
-    feature_id: STRING_LIKE,
-    position: NUMERIC_INT,
-    category: STRING_LIKE,
-  },
-  qq: {
-    p_value: NUMERIC_FLOAT,
-  },
-  sunburst: {
-    abundance: NUMERIC_ANY,
-  },
-  oncoplot: {
-    sample_id: STRING_LIKE,
-    gene: STRING_LIKE,
-    mutation_type: STRING_LIKE,
-  },
-  coverage_track: {
-    chromosome: STRING_LIKE,
-    position: NUMERIC_INT,
-    value: NUMERIC_ANY,
-  },
-  // Sankey's step_cols is a multi-column list — no single <role>_col role.
-  // The builder enforces ≥2 columns via a separate `step_cols` UI block, the
-  // same way Sunburst handles rank_cols.
-  sankey: {},
-};
+// Score at/above which a kind is surfaced under "Recommended" (mirrors
+// RECOMMENDED_SCORE in depictio/models/components/advanced_viz/schemas.py).
+const RECOMMENDED_SCORE = 0.8;
 
-const OPTIONAL_ROLES: Record<AdvancedVizKind, Record<string, string[]>> = {
-  volcano: { label: STRING_LIKE, category: STRING_LIKE },
-  embedding: {
-    dim_3: NUMERIC_FLOAT,
-    cluster: STRING_LIKE,
-    color: [...NUMERIC_ANY, ...STRING_LIKE],
-  },
-  manhattan: { feature: STRING_LIKE, effect: NUMERIC_FLOAT },
-  stacked_taxonomy: {},
-  phylogenetic: {},
-  rarefaction: { iter: NUMERIC_ANY, group: STRING_LIKE },
-  da_barplot: { significance: NUMERIC_FLOAT, label: STRING_LIKE },
-  enrichment: { source: STRING_LIKE },
-  complex_heatmap: {},
-  upset_plot: {},
-  ma: { significance: NUMERIC_FLOAT, label: STRING_LIKE },
-  dot_plot: {},
-  lollipop: { effect: NUMERIC_FLOAT },
-  qq: { feature_id: STRING_LIKE, category: STRING_LIKE },
-  sunburst: {},
-  oncoplot: {},
-  coverage_track: {
-    end: NUMERIC_INT,
-    sample: STRING_LIKE,
-    category: STRING_LIKE,
-  },
-  sankey: {},
-};
-
-/** Canonical role → likely column-name aliases (lowercased). Reused by both
- *  the picker's compatibility check AND the auto-suggest binding logic, so
- *  there's one source of truth for "what columns this role can come from".
- *  Adding an alias here makes more DCs viable for the kind it appears in. */
-const ROLE_ALIASES: Record<string, string[]> = {
-  feature_id: [
-    'feature_id',
-    'featureid',
-    'gene_id',
-    'geneid',
-    'gene',
-    'transcript_id',
-    'protein_id',
-    'id',
-    'feature',
-    'feature_name',
-    'symbol',
-    'taxon',
-  ],
-  effect_size: ['effect_size', 'lfc', 'log2foldchange', 'log2fc', 'effect'],
-  significance: ['significance', 'padj', 'q_val', 'qvalue', 'pvalue', 'p_val', 'p_value'],
-  sample_id: ['sample_id', 'sample', 'sampleid', 'sample_name'],
-  dim_1: ['dim_1', 'pc1', 'umap1', 'tsne1', 'x'],
-  dim_2: ['dim_2', 'pc2', 'umap2', 'tsne2', 'y'],
-  chr: ['chr', 'chrom', 'chromosome'],
-  pos: ['pos', 'position', 'start'],
-  score: ['score', 'pvalue', 'p_val', 'qvalue', 'q_val', 'neg_log10_qval'],
-  taxon: ['taxon', 'taxonomy', 'name'],
-  rank: ['rank', 'level', 'taxonomy_lvl'],
-  abundance: ['abundance', 'rel_abundance', 'count', 'value', 'new_est_reads'],
-  avg_log_intensity: ['avg_log_intensity', 'mean_intensity', 'basemean'],
-  log2_fold_change: ['log2_fold_change', 'log2foldchange', 'lfc', 'log2fc', 'effect_size'],
-  cluster: ['cluster', 'cell_type', 'group'],
-  gene: ['gene', 'gene_id', 'geneid', 'feature_id', 'symbol'],
-  mean_expression: ['mean_expression', 'expression', 'mean_expr'],
-  frac_expressing: ['frac_expressing', 'pct_expressing', 'fraction'],
-  position: ['position', 'pos', 'start'],
-  category: ['category', 'consequence', 'type', 'pathway', 'label'],
-  p_value: ['p_value', 'pvalue', 'p_val'],
-  mutation_type: ['mutation_type', 'mutation', 'classification', 'variant_class'],
-  iter: ['iter', 'iteration', 'depth', 'step'],
-  label: ['label', 'name', 'category', 'contrast'],
-  source: ['source', 'pathway', 'term', 'set'],
-  effect: ['effect', 'effect_size', 'lfc'],
-  feature: ['feature', 'feature_id', 'gene', 'gene_id', 'id', 'name'],
-  contrast: ['contrast', 'comparison', 'condition', 'group'],
-  lfc: ['lfc', 'log2foldchange', 'log2_fold_change', 'log2fc', 'effect_size'],
-  term: ['term', 'pathway', 'go_term', 'gene_set', 'set'],
-  nes: ['nes', 'enrichment_score', 'es'],
-  padj: ['padj', 'qvalue', 'q_val', 'p_adj', 'fdr'],
-  gene_count: ['gene_count', 'set_size', 'size', 'n_genes', 'count'],
-  index: ['index', 'feature_id', 'gene', 'gene_id', 'id', 'name', 'row_id', 'sample_id', 'sample'],
-  depth: ['depth', 'sample_depth', 'reads', 'subsample_depth'],
-  metric: ['metric', 'shannon', 'faith_pd', 'observed_features', 'value'],
-};
-
-/** Extra gates beyond REQUIRED_ROLES — for kinds whose Pydantic config has a
- *  permissive single-role schema but whose renderer actually demands a wide
- *  Float matrix (ComplexHeatmap) or many binary set-membership columns
- *  (UpSet). The matrix-style kinds were passing the role check via
- *  name-aliasing alone (e.g. feature_id → index) while the runtime then
- *  errored. Float-only for heatmap because binary 0/1 indicator columns
- *  (Int) are UpSet-style data, not a continuous matrix for clustering —
- *  upset_demo was leaking through MIN_NUMERIC_COLS before this fix. */
-const MIN_FLOAT_COLS: Partial<Record<AdvancedVizKind, number>> = {
-  // Bumped from 4 → 8: a real expression matrix has many sample columns,
-  // whereas a DESeq2/edgeR results table has exactly 6 float stats
-  // (baseMean, log2FoldChange, lfcSE, stat, pvalue, padj) and was leaking
-  // through at 4. Combined with STAT_LIKE_FLOAT_COL_NAMES below.
-  complex_heatmap: 8,
-};
-// UpSet's set-membership columns are 0/1 indicators — typed as Int by polars.
-// Requiring ≥3 Int columns filters out DCs with only float measurements
-// (volcano, embedding) while keeping legitimate upset_demo data.
-const MIN_INT_COLS: Partial<Record<AdvancedVizKind, number>> = {
-  upset_plot: 3,
-};
-// Sankey needs ≥2 categorical (String-like) columns to make a flow. Without
-// this, sankey's empty REQUIRED_ROLES makes it match every DC.
-const MIN_STRING_COLS: Partial<Record<AdvancedVizKind, number>> = {
-  sankey: 2,
-};
-// Reject `complex_heatmap` when *every* float column looks like a statistic
-// (baseMean, log2FoldChange, padj…) — those are DESeq2-style results, not a
-// continuous sample×feature matrix.
-const STAT_LIKE_FLOAT_COL_NAMES =
-  /^(basemean|log2foldchange|lfcse|stat|pvalue|padj|qvalue|p_?val|fdr|log2fc|effect_size|significance|nes|es|score)$/i;
-
-/** Kinds that need a specific DC `config.type` regardless of column matching.
- *  Phylogenetic requires a phylogeny-type DC (the .nwk tree file); any Table
- *  DC with a `taxon` string column was passing the column-alias gate before
- *  this and getting flagged compatible (e.g. stacked_taxonomy_demo). */
-const KIND_REQUIRES_DC_TYPE: Partial<Record<AdvancedVizKind, string>> = {
-  phylogenetic: 'phylogeny',
-};
+// Dtype compatibility for a chosen column, mirroring the cast tiers in the
+// backend scoring engine (schemas.py `_dtype_score`): an Int column feeds a
+// Float role and Categorical feeds a String role — both as tolerant
+// "castable" matches that surface a warning rather than blocking save.
+const _FLOAT_SET = new Set(NUMERIC_FLOAT);
+const _INT_SET = new Set(NUMERIC_INT);
+const _STRING_SET = new Set(STRING_LIKE);
+type DtypeMatch = 'exact' | 'castable' | 'none';
+function dtypeMatch(actual: string, accepted: string[]): DtypeMatch {
+  if (accepted.includes(actual)) return 'exact';
+  if (accepted.length > 0 && accepted.every((d) => _FLOAT_SET.has(d)) && _INT_SET.has(actual))
+    return 'castable';
+  if (actual === 'Categorical' && accepted.some((d) => _STRING_SET.has(d))) return 'castable';
+  return 'none';
+}
 
 /** Live-compute embedding gate — wide feature-matrix DCs (sample_id + many
  *  numeric features) should make Embedding available so the renderer can
@@ -288,10 +98,13 @@ function detectEmbeddingMode(
   );
   const hasNamedDtype = (aliases: string[], accepted: string[]): boolean =>
     aliases.some((a) => lower[a] != null && accepted.includes(lower[a]));
-  const hasSample = hasNamedDtype(ROLE_ALIASES.sample_id ?? [], STRING_LIKE);
+  // Embedding-specific name hints — the only inline aliases the builder still
+  // keeps, used to tell precomputed (dim_1/dim_2 columns) from live-compute
+  // mode (wide numeric matrix). Generic role/dtype tables live backend-side.
+  const hasSample = hasNamedDtype(['sample_id', 'sample', 'sampleid', 'sample_name'], STRING_LIKE);
   if (!hasSample) return null;
-  const hasDim1 = hasNamedDtype(ROLE_ALIASES.dim_1 ?? [], NUMERIC_FLOAT);
-  const hasDim2 = hasNamedDtype(ROLE_ALIASES.dim_2 ?? [], NUMERIC_FLOAT);
+  const hasDim1 = hasNamedDtype(['dim_1', 'pc1', 'umap1', 'tsne1', 'x'], NUMERIC_FLOAT);
+  const hasDim2 = hasNamedDtype(['dim_2', 'pc2', 'umap2', 'tsne2', 'y'], NUMERIC_FLOAT);
   if (hasDim1 && hasDim2) return 'precomputed';
   const numericCount = Object.values(schema).filter((d) =>
     NUMERIC_ANY.includes(d),
@@ -299,125 +112,9 @@ function detectEmbeddingMode(
   return numericCount >= EMBEDDING_LIVE_MIN_NUMERIC ? 'live' : null;
 }
 
-/** Compatibility check: can the DC's schema satisfy a kind's required roles?
- *  Returns `null` when satisfied, otherwise a short reason for the tooltip.
- *
- *  Two-tier match: a role is satisfied iff the schema has at least one
- *  column with (a) an accepted dtype AND (b) a name in the role's alias list.
- *  Dtype-only was too permissive — any DC with one string + one float passed
- *  ten kinds — so unbound-but-numeric volcano data still showed Embedding,
- *  Manhattan, etc. as available.
- *
- *  Falls back to dtype-only when a role has no alias entry (so we don't
- *  accidentally hide everything when ROLE_ALIASES is incomplete). */
-function unmetReason(
-  kind: AdvancedVizKind,
-  schema: Record<string, string> | null,
-  dcConfigType: string | null,
-): string | null {
-  if (!schema) return null; // no schema yet → don't grey-out (avoid flashes)
-
-  // Hard DC-type requirement (phylogenetic needs a phylogeny-type DC, not
-  // any Table with a `taxon` column).
-  const requiredDcType = KIND_REQUIRES_DC_TYPE[kind];
-  if (requiredDcType && dcConfigType !== requiredDcType) {
-    return `Needs a ${requiredDcType}-type data collection`;
-  }
-
-  // Embedding has two valid modes — precomputed (dim_1/dim_2 columns) or
-  // live-compute (wide sample×feature matrix, Celery runs the reduction).
-  // Either is sufficient; reject only if neither holds.
-  if (kind === 'embedding') {
-    return detectEmbeddingMode(schema)
-      ? null
-      : 'Needs: sample_id + either precomputed dim_1/dim_2 columns OR ≥10 numeric feature columns (for live PCA/UMAP/t-SNE/PCoA)';
-  }
-
-  const required = REQUIRED_ROLES[kind];
-  // Normalize column-name separators: schemas in the wild use `sample-id`,
-  // `sample.id`, `Sample ID` etc. for the same role. Mapping all non-alnum
-  // separators to `_` aligns the alias list (which uses snake_case) with
-  // common pipeline conventions.
-  const normalize = (s: string) =>
-    s.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-  const lowerSchema = Object.entries(schema).map(([name, dtype]) => ({
-    name: normalize(name),
-    dtype,
-  }));
-  const missing: string[] = [];
-  for (const [role, accepted] of Object.entries(required)) {
-    const aliases = ROLE_ALIASES[role]?.map(normalize);
-    const hasDtype = lowerSchema.some(({ dtype }) => accepted.includes(dtype));
-    const hasNameMatch = aliases
-      ? lowerSchema.some(
-          ({ name, dtype }) =>
-            accepted.includes(dtype) && aliases.includes(name),
-        )
-      : hasDtype;
-    if (!hasNameMatch) {
-      missing.push(
-        aliases
-          ? `${role} (column named e.g. ${aliases.slice(0, 3).join('/')})`
-          : `${role} (${accepted.join('/')})`,
-      );
-    }
-  }
-  const checkMinDtypeCount = (
-    min: number | undefined,
-    accepted: string[],
-    label: string,
-  ): void => {
-    if (min == null) return;
-    const count = lowerSchema.filter(({ dtype }) => accepted.includes(dtype)).length;
-    if (count < min) missing.push(`≥${min} ${label}`);
-  };
-  checkMinDtypeCount(
-    MIN_FLOAT_COLS[kind],
-    NUMERIC_FLOAT,
-    'float columns (continuous matrix for clustering)',
-  );
-  checkMinDtypeCount(
-    MIN_INT_COLS[kind],
-    NUMERIC_INT,
-    'integer columns (binary 0/1 set indicators)',
-  );
-  checkMinDtypeCount(
-    MIN_STRING_COLS[kind],
-    STRING_LIKE,
-    'string columns (categorical flow steps)',
-  );
-
-  // ComplexHeatmap: reject when every float column has a stats-like name
-  // (DESeq2 results table is structurally a wide matrix but semantically
-  // 6 statistics, not 6 samples).
-  if (kind === 'complex_heatmap') {
-    const floatCols = lowerSchema.filter(({ dtype }) => NUMERIC_FLOAT.includes(dtype));
-    if (
-      floatCols.length > 0 &&
-      floatCols.every(({ name }) => STAT_LIKE_FLOAT_COL_NAMES.test(name))
-    ) {
-      missing.push('float columns look like statistics, not a sample matrix');
-    }
-  }
-
-  // Sankey: a categorical flow doesn't have stat columns. The MIN_STRING_COLS
-  // gate alone passes for results tables that bundle label/category metadata
-  // (volcano_demo has feature_id + label + category = 3 strings), so add a
-  // negative signal — any stat-like float column disqualifies the DC.
-  if (kind === 'sankey') {
-    const floatCols = lowerSchema.filter(({ dtype }) => NUMERIC_FLOAT.includes(dtype));
-    if (floatCols.some(({ name }) => STAT_LIKE_FLOAT_COL_NAMES.test(name))) {
-      missing.push('contains statistic columns — not a categorical flow');
-    }
-  }
-  if (missing.length === 0) return null;
-  return `Needs: ${missing.join(', ')}`;
-}
-
 const AdvancedVizBuilder: React.FC = () => {
   const dcId = useBuilderStore((s) => s.dcId);
   const wfId = useBuilderStore((s) => s.wfId);
-  const dcConfigType = useBuilderStore((s) => s.dcConfigType);
   const config = useBuilderStore((s) => s.config) as {
     viz_kind?: AdvancedVizKind;
     column_mapping?: Record<string, string | string[]>;
@@ -429,6 +126,9 @@ const AdvancedVizBuilder: React.FC = () => {
   const [schema, setSchema] = useState<Record<string, string> | null>(null);
   const [schemaError, setSchemaError] = useState<string | null>(null);
   const [kindsError, setKindsError] = useState<string | null>(null);
+  // Graded fit scores for every viz kind against the bound DC, from the backend
+  // suggestion engine. Drives the ranked picker + the binding pre-fill.
+  const [suggestions, setSuggestions] = useState<VizKindSuggestion[] | null>(null);
 
   const [search, setSearch] = useState<string>('');
 
@@ -469,33 +169,60 @@ const AdvancedVizBuilder: React.FC = () => {
     };
   }, [dcId]);
 
-  // Producer-driven viz_kind pre-selection. When the bound DC matches a
-  // known tool fingerprint (DESeq2, mosdepth, …), the producer registry's
-  // `feeds_viz[0]` is the canonical default viz for that data shape. Skip
-  // when the user (or edit-mode rehydration) has already picked a kind.
   const selectedKind = config.viz_kind || null;
+
+  // Fetch the backend's graded fit scores for the bound DC. Every kind is
+  // scored; the picker ranks them and the binding step pre-fills from each
+  // kind's ranked role_candidates. Failures are silent — the picker still
+  // works, just without scores/pre-fill.
   useEffect(() => {
-    if (!dcId || selectedKind) return;
+    if (!dcId) {
+      setSuggestions(null);
+      return;
+    }
     let cancelled = false;
     fetchVizSuggestions(dcId)
       .then((res) => {
-        if (cancelled) return;
-        const primary = res.producers.find((p) => p.feeds_viz.length > 0);
-        if (primary) {
-          patchConfig({
-            viz_kind: primary.feeds_viz[0] as AdvancedVizKind,
-            column_mapping: {},
-          });
-        }
+        if (!cancelled) setSuggestions(res.viz_kinds);
       })
       .catch(() => {
-        // Silent — picker falls back to manual selection.
+        if (!cancelled) setSuggestions(null);
       });
     return () => {
       cancelled = true;
     };
-  }, [dcId, selectedKind, patchConfig]);
+  }, [dcId]);
 
+  // Backend is the single source of truth for per-role accepted dtypes — read
+  // them off the kind descriptor instead of a duplicated TS table.
+  const kindMap = useMemo(
+    () => new Map((kinds ?? []).map((k) => [k.viz_kind, k] as const)),
+    [kinds],
+  );
+  const scoreMap = useMemo(
+    () => new Map((suggestions ?? []).map((s) => [s.viz_kind, s] as const)),
+    [suggestions],
+  );
+  const descriptor = selectedKind ? (kindMap.get(selectedKind) ?? null) : null;
+  // [role, acceptedDtypes][] for the selected kind, split required vs optional.
+  const requiredRoles = useMemo<[string, string[]][]>(
+    () =>
+      descriptor
+        ? Object.entries(descriptor.roles)
+            .filter(([, spec]) => spec.required)
+            .map(([role, spec]) => [role, spec.dtypes])
+        : [],
+    [descriptor],
+  );
+  const optionalRoles = useMemo<[string, string[]][]>(
+    () =>
+      descriptor
+        ? Object.entries(descriptor.roles)
+            .filter(([, spec]) => !spec.required)
+            .map(([role, spec]) => [role, spec.dtypes])
+        : [],
+    [descriptor],
+  );
 
   const columnMapping = useMemo(
     () => (config.column_mapping || {}) as Record<string, string | string[]>,
@@ -534,46 +261,34 @@ const AdvancedVizBuilder: React.FC = () => {
     return detectEmbeddingMode(schema);
   }, [selectedKind, schema]);
 
-  // Auto-suggest mappings on kind change. For embedding live-compute mode,
-  // sample_id is the only required column binding; compute_method is a scalar
-  // config field that defaults to "pca".
+  // Auto-suggest mappings on kind change, pre-filling each required role with
+  // its best-named candidate from the backend's ranked role_candidates. For
+  // embedding live-compute mode, sample_id is the only required column binding;
+  // compute_method is a scalar config field that defaults to "pca".
   useEffect(() => {
     if (!selectedKind || !schema) return;
     if (Object.keys(columnMapping).length > 0) return;
 
-    const suggest: Record<string, string> = {};
-    // Same hyphen/dot normalization as unmetReason — see comment there.
-    const normalize = (s: string) =>
-      s.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-    const normalizedToOriginal = Object.keys(schema).reduce<Record<string, string>>(
-      (acc, c) => {
-        acc[normalize(c)] = c;
-        return acc;
-      },
-      {},
-    );
+    const candidates = scoreMap.get(selectedKind)?.role_candidates ?? {};
     const liveEmbeddingSuggest =
       selectedKind === 'embedding' && embeddingMode === 'live';
     const rolesToSuggest = liveEmbeddingSuggest
-      ? { sample_id: REQUIRED_ROLES.embedding.sample_id }
-      : REQUIRED_ROLES[selectedKind];
-    for (const role of Object.keys(rolesToSuggest)) {
-      const aliases = (ROLE_ALIASES[role] || [role]).map(normalize);
-      for (const alias of aliases) {
-        if (normalizedToOriginal[alias]) {
-          suggest[role] = normalizedToOriginal[alias];
-          break;
-        }
-      }
+      ? requiredRoles.filter(([role]) => role === 'sample_id')
+      : requiredRoles;
+
+    const suggest: Record<string, string> = {};
+    for (const [role] of rolesToSuggest) {
+      const best = candidates[role]?.[0];
+      if (best) suggest[role] = best;
     }
     if (liveEmbeddingSuggest) {
       // Default the compute method to PCA; user can change in the dropdown.
-      (suggest as Record<string, string>).compute_method = 'pca';
+      suggest.compute_method = 'pca';
     }
     if (Object.keys(suggest).length > 0) {
       patchConfig({ column_mapping: { ...columnMapping, ...suggest } });
     }
-  }, [selectedKind, schema, columnMapping, patchConfig, embeddingMode]);
+  }, [selectedKind, schema, columnMapping, patchConfig, embeddingMode, requiredRoles, scoreMap]);
 
   const setKind = (kind: AdvancedVizKind | null) => {
     patchConfig({ viz_kind: kind || undefined, column_mapping: {} });
@@ -593,29 +308,44 @@ const AdvancedVizBuilder: React.FC = () => {
   // Celery task derives them), so only sample_id is required from the DC.
   const liveEmbedding = selectedKind === 'embedding' && embeddingMode === 'live';
 
+  // Tolerant validation. A missing required role or a wholly-incompatible
+  // dtype is a blocking error; a castable-but-inexact dtype (e.g. Int for a
+  // Float role) is a non-blocking warning the renderer can coerce. Save is
+  // gated on errors only — warnings let the user proceed.
   const validation = useMemo(() => {
-    if (!selectedKind || !schema) return { errors: [], ok: false };
+    if (!selectedKind || !schema) return { errors: [], warnings: [], ok: false };
     const errors: string[] = [];
-    const required = liveEmbedding
-      ? { sample_id: REQUIRED_ROLES.embedding.sample_id }
-      : REQUIRED_ROLES[selectedKind];
-    for (const [role, accepted] of Object.entries(required)) {
+    const warnings: string[] = [];
+    const checkBinding = (role: string, accepted: string[], optional: boolean) => {
       const val = columnMapping[role];
+      const prefix = optional ? 'Optional column' : 'Column';
       if (!val) {
-        errors.push(`Required role "${role}" is not bound`);
-        continue;
+        if (!optional) errors.push(`Required role "${role}" is not bound`);
+        return;
       }
       const cols = Array.isArray(val) ? val : [val];
       for (const col of cols) {
         const dtype = schema[col];
         if (!dtype) {
-          errors.push(`Column "${col}" (role "${role}") is not in the DC`);
-        } else if (!accepted.includes(dtype)) {
+          errors.push(`${prefix} "${col}" (role "${role}") is not in the DC`);
+          continue;
+        }
+        const match = dtypeMatch(dtype, accepted);
+        if (match === 'none') {
           errors.push(
-            `Column "${col}" (role "${role}") has dtype ${dtype}; expected one of ${accepted.join(', ')}`,
+            `${prefix} "${col}" (role "${role}") has dtype ${dtype}; expected one of ${accepted.join(', ')}`,
+          );
+        } else if (match === 'castable') {
+          warnings.push(
+            `${prefix} "${col}" (role "${role}") is ${dtype}; it will be coerced to ${accepted.join('/')}.`,
           );
         }
       }
+    };
+    for (const [role, accepted] of requiredRoles) {
+      // In embedding live-compute mode the renderer derives dim_1/dim_2.
+      if (liveEmbedding && (role === 'dim_1' || role === 'dim_2')) continue;
+      checkBinding(role, accepted, false);
     }
     // Sunburst: rank_cols must have at least 2 columns.
     if (selectedKind === 'sunburst') {
@@ -624,27 +354,14 @@ const AdvancedVizBuilder: React.FC = () => {
         errors.push('Sunburst needs at least 2 rank columns');
       }
     }
-    const optional = OPTIONAL_ROLES[selectedKind];
-    for (const [role, accepted] of Object.entries(optional)) {
-      const val = columnMapping[role];
-      if (!val) continue;
-      const cols = Array.isArray(val) ? val : [val];
-      for (const col of cols) {
-        const dtype = schema[col];
-        if (!dtype) {
-          errors.push(`Optional column "${col}" (role "${role}") is not in the DC`);
-        } else if (!accepted.includes(dtype)) {
-          errors.push(
-            `Optional column "${col}" (role "${role}") has dtype ${dtype}; expected one of ${accepted.join(', ')}`,
-          );
-        }
-      }
+    for (const [role, accepted] of optionalRoles) {
+      checkBinding(role, accepted, true);
     }
     if (liveEmbedding && !columnMapping.compute_method) {
       errors.push('Pick a compute method (PCA / UMAP / t-SNE / PCoA)');
     }
-    return { errors, ok: errors.length === 0 };
-  }, [selectedKind, schema, columnMapping, liveEmbedding]);
+    return { errors, warnings, ok: errors.length === 0 };
+  }, [selectedKind, schema, columnMapping, liveEmbedding, requiredRoles, optionalRoles]);
 
   const setSaveError = useBuilderStore((s) => s.setSaveError);
   useEffect(() => {
@@ -659,11 +376,20 @@ const AdvancedVizBuilder: React.FC = () => {
     setSaveError(validation.ok ? null : validation.errors.join(' • '));
   }, [selectedKind, schema, schemaError, validation, setSaveError]);
 
+  // Dropdown options for a role: dtype-exact columns first, then castable ones
+  // (flagged), so the tolerant binding can still offer an Int column for a
+  // Float role without hiding it.
   const columnOptions = (accepted: string[]): { value: string; label: string }[] => {
     if (!schema) return [];
-    return Object.entries(schema)
-      .filter(([, dtype]) => accepted.includes(dtype))
-      .map(([name, dtype]) => ({ value: name, label: `${name} : ${dtype}` }));
+    const exact: { value: string; label: string }[] = [];
+    const castable: { value: string; label: string }[] = [];
+    for (const [name, dtype] of Object.entries(schema)) {
+      const match = dtypeMatch(dtype, accepted);
+      if (match === 'exact') exact.push({ value: name, label: `${name} : ${dtype}` });
+      else if (match === 'castable')
+        castable.push({ value: name, label: `${name} : ${dtype} (castable)` });
+    }
+    return [...exact, ...castable];
   };
 
   const allColumnOptions = (): { value: string; label: string }[] => {
@@ -684,55 +410,52 @@ const AdvancedVizBuilder: React.FC = () => {
     );
   }, [kinds, search]);
 
-  // Split into kinds the bound DC can satisfy vs. the rest. When no schema
-  // is loaded yet (no DC picked), treat everything as available so the user
-  // sees the full picker.
-  const { availableKinds, unavailableKinds } = useMemo(() => {
-    if (!schema) return { availableKinds: matchedKinds, unavailableKinds: [] };
-    const ok: typeof matchedKinds = [];
-    const blocked: typeof matchedKinds = [];
-    for (const k of matchedKinds) {
-      (unmetReason(k.viz_kind, schema, dcConfigType) ? blocked : ok).push(k);
-    }
-    return { availableKinds: ok, unavailableKinds: blocked };
-  }, [matchedKinds, schema, dcConfigType]);
+  // Rank every kind by the backend fit score. Nothing is hidden or disabled —
+  // strong matches surface under "Recommended", the rest under "Other
+  // visualisations", all fully selectable ("suggest but tolerate"). Until
+  // scores arrive (no DC bound / still loading) we show one flat list.
+  type RankedKind = { k: AdvancedVizKindDescriptor; suggestion?: VizKindSuggestion };
+  const { recommendedKinds, otherKinds } = useMemo(() => {
+    const decorated: RankedKind[] = matchedKinds.map((k) => ({
+      k,
+      suggestion: scoreMap.get(k.viz_kind),
+    }));
+    const scoreOf = (d: RankedKind) => d.suggestion?.score ?? -1;
+    decorated.sort((a, b) => scoreOf(b) - scoreOf(a) || a.k.label.localeCompare(b.k.label));
+    if (suggestions == null) return { recommendedKinds: [], otherKinds: decorated };
+    const rec = decorated.filter((d) => (d.suggestion?.score ?? 0) >= RECOMMENDED_SCORE);
+    const rest = decorated.filter((d) => (d.suggestion?.score ?? 0) < RECOMMENDED_SCORE);
+    return { recommendedKinds: rec, otherKinds: rest };
+  }, [matchedKinds, scoreMap, suggestions]);
 
-  /** Render a titled grid of kind tiles. `dim=true` is used for the
-   *  unavailable accordion (greyed-out + tooltip with unmet reason). */
+  /** Render a titled grid of kind tiles with a fit-score badge. Tiles are
+   *  always selectable; a tooltip surfaces which roles are missing/weak. */
   const renderKindSection = (
     title: string | null,
-    items: AdvancedVizKindDescriptor[],
-    dim: boolean,
-    subtitle?: string,
+    items: RankedKind[],
   ): React.ReactNode => {
     if (items.length === 0) return null;
     return (
       <Stack gap={6}>
-        {title ? (
-          <Group gap="xs" align="baseline">
-            <Text fw={600} size="sm">{title}</Text>
-            {subtitle ? (
-              <Text size="xs" c="dimmed">{subtitle}</Text>
-            ) : null}
-          </Group>
-        ) : null}
+        {title ? <Text fw={600} size="sm">{title}</Text> : null}
         <SimpleGrid cols={{ base: 1, sm: 2, md: 3, lg: 4 }} spacing="sm">
-          {items.map((k) => {
+          {items.map(({ k, suggestion }) => {
             const isSelected = selectedKind === k.viz_kind;
-            const reason = dim ? unmetReason(k.viz_kind, schema, dcConfigType) : null;
-            const disabled = !!reason;
+            const fitPct = suggestion ? Math.round(suggestion.score * 100) : null;
+            const gaps: string[] = [];
+            if (suggestion?.unmet_roles?.length)
+              gaps.push(`missing: ${suggestion.unmet_roles.join(', ')}`);
+            if (suggestion?.weak_roles?.length)
+              gaps.push(`weak match: ${suggestion.weak_roles.join(', ')}`);
+            const tooltip = gaps.length ? gaps.join(' · ') : null;
             const tile = (
               <Paper
                 withBorder
                 p="sm"
                 radius="md"
-                onClick={() => {
-                  if (disabled) return;
-                  setKind(k.viz_kind);
-                }}
+                onClick={() => setKind(k.viz_kind)}
                 style={{
-                  cursor: disabled ? 'not-allowed' : 'pointer',
-                  opacity: dim ? 0.5 : 1,
+                  cursor: 'pointer',
                   borderColor: isSelected ? 'var(--mantine-color-pink-6)' : undefined,
                   background: isSelected ? 'var(--mantine-color-pink-0)' : undefined,
                   transition: 'transform 120ms ease, box-shadow 120ms ease',
@@ -740,9 +463,20 @@ const AdvancedVizBuilder: React.FC = () => {
                 }}
               >
                 <Stack gap={6}>
-                  <Group gap={6} wrap="nowrap">
-                    <Icon icon={k.icon} width={18} height={18} />
-                    <Text fw={600} size="sm" lineClamp={1}>{k.label}</Text>
+                  <Group gap={6} wrap="nowrap" justify="space-between">
+                    <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+                      <Icon icon={k.icon} width={18} height={18} />
+                      <Text fw={600} size="sm" lineClamp={1}>{k.label}</Text>
+                    </Group>
+                    {fitPct != null ? (
+                      <Badge
+                        size="xs"
+                        variant="light"
+                        color={fitPct >= RECOMMENDED_SCORE * 100 ? 'teal' : 'gray'}
+                      >
+                        {fitPct}% fit
+                      </Badge>
+                    ) : null}
                   </Group>
                   <Text size="xs" c="dimmed" lineClamp={3}>{k.description}</Text>
                   {isSelected ? <Badge size="xs" color="pink">selected</Badge> : null}
@@ -751,8 +485,8 @@ const AdvancedVizBuilder: React.FC = () => {
             );
             return (
               <div key={k.viz_kind}>
-                {disabled && reason ? (
-                  <Tooltip label={reason} multiline w={260} withinPortal>
+                {tooltip ? (
+                  <Tooltip label={tooltip} multiline w={260} withinPortal>
                     {tile}
                   </Tooltip>
                 ) : (
@@ -770,9 +504,9 @@ const AdvancedVizBuilder: React.FC = () => {
     <Stack gap="md">
       <Title order={4}>Advanced visualisation</Title>
       <Text size="sm" c="dimmed">
-        Pick a viz kind, then bind each required role to a column from the chosen
-        data collection. The picker shows kinds compatible with this DC; expand
-        "other kinds" below to see ones that need a different schema.
+        Each visualization is ranked by how well it fits this data collection.
+        The recommended ones are the strongest matches — but you can pick any
+        kind and bind the columns yourself.
       </Text>
 
       {kindsError ? (
@@ -789,27 +523,14 @@ const AdvancedVizBuilder: React.FC = () => {
         style={{ maxWidth: 320 }}
       />
 
-      {/* Single "Visualisations" section — kinds previously split into
-          "Statistical tools" (manhattan / ancombc / da_barplot / enrichment)
-          are now folded in. The backend `category: "tool"` field is kept on
-          the metadata payload for future per-family grouping but no longer
-          drives picker layout. */}
-      {renderKindSection('Visualisations', availableKinds, false)}
-
-      {unavailableKinds.length > 0 ? (
-        <Accordion variant="contained" defaultValue={null}>
-          <Accordion.Item value="unavailable">
-            <Accordion.Control>
-              <Text size="sm" c="dimmed">
-                {unavailableKinds.length} other kinds need different data — show them anyway
-              </Text>
-            </Accordion.Control>
-            <Accordion.Panel>
-              {renderKindSection(null, unavailableKinds, true)}
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
-      ) : null}
+      {renderKindSection(
+        recommendedKinds.length ? 'Recommended for this data collection' : null,
+        recommendedKinds,
+      )}
+      {renderKindSection(
+        recommendedKinds.length ? 'Other visualisations' : 'Visualisations',
+        otherKinds,
+      )}
 
       {selectedKind ? (
         <Paper withBorder p="md" radius="md">
@@ -830,7 +551,7 @@ const AdvancedVizBuilder: React.FC = () => {
                     </Table.Tr>
                   </Table.Thead>
                   <Table.Tbody>
-                    {Object.entries(REQUIRED_ROLES[selectedKind])
+                    {requiredRoles
                       .filter(
                         ([role]) =>
                           !liveEmbedding || (role !== 'dim_1' && role !== 'dim_2'),
@@ -849,7 +570,7 @@ const AdvancedVizBuilder: React.FC = () => {
                         <Table.Td>required</Table.Td>
                       </Table.Tr>
                     ) : null}
-                    {Object.entries(OPTIONAL_ROLES[selectedKind]).map(([role, accepted]) => (
+                    {optionalRoles.map(([role, accepted]) => (
                       <Table.Tr key={`opt-${role}`}>
                         <Table.Td>{role}</Table.Td>
                         <Table.Td>{accepted.join(' / ')}</Table.Td>
@@ -918,7 +639,7 @@ const AdvancedVizBuilder: React.FC = () => {
                     />
                   </>
                 ) : null}
-                {Object.entries(REQUIRED_ROLES[selectedKind])
+                {requiredRoles
                   .filter(
                     // Skip dim_1/dim_2 when running embedding live — the
                     // Celery task derives them.
@@ -942,7 +663,7 @@ const AdvancedVizBuilder: React.FC = () => {
                     nothingFoundMessage="No column with a compatible dtype"
                   />
                 ))}
-                {Object.entries(OPTIONAL_ROLES[selectedKind]).map(([role, accepted]) => (
+                {optionalRoles.map(([role, accepted]) => (
                   <Select
                     key={role}
                     label={`${role} (optional, ${accepted.join('/')})`}
@@ -965,6 +686,17 @@ const AdvancedVizBuilder: React.FC = () => {
                       {validation.errors.map((e) => (
                         <li key={e}>
                           <Text size="xs">{e}</Text>
+                        </li>
+                      ))}
+                    </ul>
+                  </Alert>
+                ) : null}
+                {validation.warnings.length > 0 ? (
+                  <Alert color="yellow" variant="light" title="Heads up — dtype coercion">
+                    <ul style={{ margin: 0, paddingLeft: 16 }}>
+                      {validation.warnings.map((w) => (
+                        <li key={w}>
+                          <Text size="xs">{w}</Text>
                         </li>
                       ))}
                     </ul>

--- a/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
+++ b/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
@@ -79,6 +79,25 @@ function dtypeMatch(actual: string, accepted: string[]): DtypeMatch {
   return 'none';
 }
 
+// Colour scheme shared by the bindings table + tooltip so required/optional
+// reads consistently. Required uses a warm accent, optional stays muted.
+const REQUIRED_COLOR = 'red';
+const OPTIONAL_COLOR = 'gray';
+
+/** Friendly one-word category for a role's accepted polars dtypes, so the
+ *  bindings overview reads "text"/"number" instead of "String / Utf8". */
+function simplifyDtypes(dtypes: string[]): string {
+  if (dtypes.length === 0) return 'any';
+  const allIn = (arr: string[]) => dtypes.every((d) => arr.includes(d));
+  const some = (arr: string[]) => dtypes.some((d) => arr.includes(d));
+  if (allIn(STRING_LIKE)) return 'text';
+  if (allIn(NUMERIC_FLOAT)) return 'decimal';
+  if (allIn(NUMERIC_INT)) return 'integer';
+  if (allIn(NUMERIC_ANY)) return 'number';
+  if (some(STRING_LIKE) && some(NUMERIC_ANY)) return 'text / number';
+  return dtypes.join(' / ');
+}
+
 /** Live-compute embedding gate — wide feature-matrix DCs (sample_id + many
  *  numeric features) should make Embedding available so the renderer can
  *  dispatch a Celery PCA/UMAP/t-SNE/PCoA task. Without this, embedding_features
@@ -110,6 +129,84 @@ function detectEmbeddingMode(
     NUMERIC_ANY.includes(d),
   ).length;
   return numericCount >= EMBEDDING_LIVE_MIN_NUMERIC ? 'live' : null;
+}
+
+/** Compact binding label: just the role name, with an info icon whose rich
+ *  tooltip carries required/optional, accepted dtypes and the role description.
+ *  Keeps each binding row scannable instead of a verbose inline label. */
+function roleBindingLabel(
+  role: string,
+  dtypes: string[],
+  description: string,
+  required: boolean,
+): React.ReactNode {
+  return (
+    <Text
+      span
+      size="sm"
+      fw={500}
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+    >
+      {role}
+      {required ? (
+        <Text span size="xs" c={REQUIRED_COLOR}>
+          *
+        </Text>
+      ) : null}
+      <Tooltip
+        withinPortal
+        multiline
+        w={260}
+        label={
+          <Stack gap={2}>
+            <Text size="xs" fw={600} c={required ? REQUIRED_COLOR : OPTIONAL_COLOR}>
+              {required ? 'Required' : 'Optional'}
+            </Text>
+            {description ? <Text size="xs">{description}</Text> : null}
+            <Text size="xs" c="dimmed">
+              {dtypes.length ? `Accepts: ${dtypes.join(', ')}` : 'Accepts: any column'}
+            </Text>
+          </Stack>
+        }
+      >
+        <Text span c="dimmed" style={{ display: 'inline-flex', cursor: 'help' }}>
+          <Icon icon="mdi:information-outline" width={14} height={14} />
+        </Text>
+      </Tooltip>
+    </Text>
+  );
+}
+
+/** One row of the "Bindings overview" table: role name + a colour-coded
+ *  required/optional badge, a simplified type, and the role description. */
+function exampleInputRow(
+  role: string,
+  typeLabel: string,
+  description: string,
+  required: boolean,
+): React.ReactNode {
+  return (
+    <Table.Tr key={`${required ? 'req' : 'opt'}-${role}`}>
+      {/* Role + Type never wrap, so they always fit their content; Description
+          is the only wrapping column and absorbs the remaining width. */}
+      <Table.Td style={{ whiteSpace: 'nowrap', width: '1%' }}>
+        <Group gap={6} wrap="nowrap">
+          <Text size="xs" fw={500}>
+            {role}
+          </Text>
+          <Badge size="xs" variant="light" color={required ? REQUIRED_COLOR : OPTIONAL_COLOR}>
+            {required ? 'required' : 'optional'}
+          </Badge>
+        </Group>
+      </Table.Td>
+      <Table.Td style={{ whiteSpace: 'nowrap', width: '1%' }}>{typeLabel}</Table.Td>
+      <Table.Td>
+        <Text size="xs" c="dimmed">
+          {description || '—'}
+        </Text>
+      </Table.Td>
+    </Table.Tr>
+  );
 }
 
 const AdvancedVizBuilder: React.FC = () => {
@@ -204,22 +301,23 @@ const AdvancedVizBuilder: React.FC = () => {
     [suggestions],
   );
   const descriptor = selectedKind ? (kindMap.get(selectedKind) ?? null) : null;
-  // [role, acceptedDtypes][] for the selected kind, split required vs optional.
-  const requiredRoles = useMemo<[string, string[]][]>(
+  // [role, acceptedDtypes, description][] for the selected kind, split required
+  // vs optional. Description feeds each binding's rich tooltip.
+  const requiredRoles = useMemo<[string, string[], string][]>(
     () =>
       descriptor
         ? Object.entries(descriptor.roles)
             .filter(([, spec]) => spec.required)
-            .map(([role, spec]) => [role, spec.dtypes])
+            .map(([role, spec]) => [role, spec.dtypes, spec.description ?? ''])
         : [],
     [descriptor],
   );
-  const optionalRoles = useMemo<[string, string[]][]>(
+  const optionalRoles = useMemo<[string, string[], string][]>(
     () =>
       descriptor
         ? Object.entries(descriptor.roles)
             .filter(([, spec]) => !spec.required)
-            .map(([role, spec]) => [role, spec.dtypes])
+            .map(([role, spec]) => [role, spec.dtypes, spec.description ?? ''])
         : [],
     [descriptor],
   );
@@ -241,6 +339,12 @@ const AdvancedVizBuilder: React.FC = () => {
     for (const [k, v] of Object.entries(persistedConfig)) {
       if (k === 'rank_cols' && Array.isArray(v)) {
         recovered.ranks = v as string[];
+      } else if (k === 'step_cols' && Array.isArray(v)) {
+        recovered.steps = v as string[];
+      } else if (k === 'index_column' && typeof v === 'string') {
+        recovered.index = v;
+      } else if ((k === 'value_columns' || k === 'row_annotation_cols') && Array.isArray(v)) {
+        recovered[k] = v as string[];
       } else if (k === 'compute_method' && typeof v === 'string') {
         recovered.compute_method = v;
       } else if (k.endsWith('_col') && typeof v === 'string') {
@@ -352,6 +456,13 @@ const AdvancedVizBuilder: React.FC = () => {
       const ranks = columnMapping.ranks;
       if (!Array.isArray(ranks) || ranks.length < 2) {
         errors.push('Sunburst needs at least 2 rank columns');
+      }
+    }
+    // Sankey: step_cols must have at least 2 ordered categorical columns.
+    if (selectedKind === 'sankey') {
+      const steps = columnMapping.steps;
+      if (!Array.isArray(steps) || steps.length < 2) {
+        errors.push('Sankey needs at least 2 step columns');
       }
     }
     for (const [role, accepted] of optionalRoles) {
@@ -538,16 +649,16 @@ const AdvancedVizBuilder: React.FC = () => {
             <Text fw={600}>Column bindings</Text>
             <Paper withBorder p="xs" radius="sm">
               <Stack gap={4}>
-                <Text size="xs" fw={500}>Example input columns</Text>
+                <Text size="xs" fw={500}>Bindings overview</Text>
                 <Text size="xs" c="dimmed">
-                  Your data collection needs at least these columns (any accepted dtype works).
+                  The roles this visualization binds. Hover a binding below for full details.
                 </Text>
-                <Table withTableBorder withColumnBorders striped fz="xs">
+                <Table withTableBorder withColumnBorders striped fz="xs" layout="auto">
                   <Table.Thead>
                     <Table.Tr>
-                      <Table.Th>Role</Table.Th>
-                      <Table.Th>Accepted dtypes</Table.Th>
-                      <Table.Th>Required?</Table.Th>
+                      <Table.Th style={{ whiteSpace: 'nowrap', width: '1%' }}>Role</Table.Th>
+                      <Table.Th style={{ whiteSpace: 'nowrap', width: '1%' }}>Type</Table.Th>
+                      <Table.Th>Description</Table.Th>
                     </Table.Tr>
                   </Table.Thead>
                   <Table.Tbody>
@@ -556,27 +667,36 @@ const AdvancedVizBuilder: React.FC = () => {
                         ([role]) =>
                           !liveEmbedding || (role !== 'dim_1' && role !== 'dim_2'),
                       )
-                      .map(([role, accepted]) => (
-                      <Table.Tr key={`req-${role}`}>
-                        <Table.Td>{role}</Table.Td>
-                        <Table.Td>{accepted.join(' / ')}</Table.Td>
-                        <Table.Td>required</Table.Td>
-                      </Table.Tr>
-                    ))}
-                    {liveEmbedding ? (
-                      <Table.Tr key="req-compute_method">
-                        <Table.Td>compute_method</Table.Td>
-                        <Table.Td>pca / umap / tsne / pcoa</Table.Td>
-                        <Table.Td>required</Table.Td>
-                      </Table.Tr>
-                    ) : null}
-                    {optionalRoles.map(([role, accepted]) => (
-                      <Table.Tr key={`opt-${role}`}>
-                        <Table.Td>{role}</Table.Td>
-                        <Table.Td>{accepted.join(' / ')}</Table.Td>
-                        <Table.Td>optional</Table.Td>
-                      </Table.Tr>
-                    ))}
+                      .map(([role, accepted, description]) =>
+                        exampleInputRow(role, simplifyDtypes(accepted), description, true),
+                      )}
+                    {selectedKind === 'sunburst'
+                      ? exampleInputRow(
+                          'ranks',
+                          'any (≥2, ordered)',
+                          'Hierarchy columns from root to leaf.',
+                          true,
+                        )
+                      : null}
+                    {selectedKind === 'sankey'
+                      ? exampleInputRow(
+                          'step columns',
+                          'any (≥2, ordered)',
+                          'Ordered categorical levels the flow passes through.',
+                          true,
+                        )
+                      : null}
+                    {liveEmbedding
+                      ? exampleInputRow(
+                          'compute_method',
+                          'choice',
+                          'Dimensionality reduction: pca / umap / tsne / pcoa.',
+                          true,
+                        )
+                      : null}
+                    {optionalRoles.map(([role, accepted, description]) =>
+                      exampleInputRow(role, simplifyDtypes(accepted), description, false),
+                    )}
                   </Table.Tbody>
                 </Table>
               </Stack>
@@ -597,7 +717,12 @@ const AdvancedVizBuilder: React.FC = () => {
                     the kind supports a list binding. */}
                 {selectedKind === 'sunburst' ? (
                   <MultiSelect
-                    label="ranks (required, hierarchy root→leaf)"
+                    label={roleBindingLabel(
+                      'ranks',
+                      [],
+                      'Hierarchy columns from root to leaf — pick at least 2, in order.',
+                      true,
+                    )}
                     placeholder="Pick rank columns in order"
                     value={
                       Array.isArray(columnMapping.ranks)
@@ -609,6 +734,73 @@ const AdvancedVizBuilder: React.FC = () => {
                     searchable
                     clearable
                   />
+                ) : null}
+                {/* Sankey has no single <role>_col schema — it binds an ordered
+                    list of categorical columns (step_cols). Without this block
+                    the kind was selectable but unbindable, so the renderer
+                    failed with "≥2 step columns required". */}
+                {selectedKind === 'sankey' ? (
+                  <MultiSelect
+                    label={roleBindingLabel(
+                      'step columns',
+                      [],
+                      'Ordered categorical levels the flow passes through (e.g. sample → lineage → clade). Pick at least 2, in order.',
+                      true,
+                    )}
+                    placeholder="Pick step columns in order"
+                    value={
+                      Array.isArray(columnMapping.steps)
+                        ? (columnMapping.steps as string[])
+                        : []
+                    }
+                    onChange={(v) => setRole('steps', v)}
+                    data={allColumnOptions()}
+                    searchable
+                    clearable
+                  />
+                ) : null}
+                {/* ComplexHeatmap: beyond the index row-id, let the user choose
+                    which numeric columns form the matrix (excluding the rest)
+                    and which categorical columns annotate the rows. */}
+                {selectedKind === 'complex_heatmap' ? (
+                  <>
+                    <MultiSelect
+                      label={roleBindingLabel(
+                        'value columns',
+                        NUMERIC_ANY,
+                        'Numeric columns that form the heatmap matrix. Leave empty to use every numeric column; pick a subset to exclude the rest.',
+                        false,
+                      )}
+                      placeholder="All numeric columns (pick to restrict / exclude)"
+                      value={
+                        Array.isArray(columnMapping.value_columns)
+                          ? (columnMapping.value_columns as string[])
+                          : []
+                      }
+                      onChange={(v) => setRole('value_columns', v)}
+                      data={columnOptions(NUMERIC_ANY)}
+                      searchable
+                      clearable
+                    />
+                    <MultiSelect
+                      label={roleBindingLabel(
+                        'row annotation columns',
+                        STRING_LIKE,
+                        'Categorical columns drawn as a colour strip beside the rows (e.g. Kingdom / taxonomy level). Excluded from the matrix.',
+                        false,
+                      )}
+                      placeholder="Pick categorical columns to annotate rows"
+                      value={
+                        Array.isArray(columnMapping.row_annotation_cols)
+                          ? (columnMapping.row_annotation_cols as string[])
+                          : []
+                      }
+                      onChange={(v) => setRole('row_annotation_cols', v)}
+                      data={columnOptions(STRING_LIKE)}
+                      searchable
+                      clearable
+                    />
+                  </>
                 ) : null}
                 {/* Embedding live-compute mode: surface compute_method Select
                     in place of dim_1/dim_2 pickers. Renderer dispatches the
@@ -646,10 +838,10 @@ const AdvancedVizBuilder: React.FC = () => {
                     ([role]) =>
                       !liveEmbedding || (role !== 'dim_1' && role !== 'dim_2'),
                   )
-                  .map(([role, accepted]) => (
+                  .map(([role, accepted, description]) => (
                   <Select
                     key={role}
-                    label={`${role} (required, ${accepted.join('/')})`}
+                    label={roleBindingLabel(role, accepted, description, true)}
                     placeholder="Pick a column"
                     value={
                       typeof columnMapping[role] === 'string'
@@ -663,10 +855,10 @@ const AdvancedVizBuilder: React.FC = () => {
                     nothingFoundMessage="No column with a compatible dtype"
                   />
                 ))}
-                {optionalRoles.map(([role, accepted]) => (
+                {optionalRoles.map(([role, accepted, description]) => (
                   <Select
                     key={role}
-                    label={`${role} (optional, ${accepted.join('/')})`}
+                    label={roleBindingLabel(role, accepted, description, false)}
                     placeholder="Pick a column"
                     value={
                       typeof columnMapping[role] === 'string'

--- a/depictio/viewer/src/builder/advanced_viz/configBlob.ts
+++ b/depictio/viewer/src/builder/advanced_viz/configBlob.ts
@@ -7,9 +7,9 @@
  * one path serialises a new role differently from the other.
  *
  * Mirrors depictio/models/components/advanced_viz/configs.py: most roles
- * serialise as `<role>_col`; sunburst's hierarchical `ranks` is list-typed
- * (→ `rank_cols`); embedding's `compute_method` is a scalar pick
- * (pca/umap/tsne/pcoa), not a column reference.
+ * serialise as `<role>_col`; sunburst's hierarchical `ranks` and sankey's
+ * ordered `steps` are list-typed (→ `rank_cols` / `step_cols`); embedding's
+ * `compute_method` is a scalar pick (pca/umap/tsne/pcoa), not a column reference.
  */
 export function buildAdvancedVizConfigBlob(
   vizKind: string | undefined,
@@ -19,6 +19,16 @@ export function buildAdvancedVizConfigBlob(
   for (const [role, value] of Object.entries(columnMapping)) {
     if (vizKind === 'sunburst' && role === 'ranks') {
       blob.rank_cols = value;
+    } else if (vizKind === 'sankey' && role === 'steps') {
+      blob.step_cols = value;
+    } else if (vizKind === 'complex_heatmap' && role === 'index') {
+      // ComplexHeatmapConfig's row-id field is `index_column`, NOT the generic
+      // `<role>_col` — emitting `index_col` would be dropped and the compute
+      // task would fall back to its "sample_id" default and fail the select.
+      blob.index_column = value;
+    } else if (role === 'value_columns' || role === 'row_annotation_cols') {
+      // List-typed config fields whose key already matches the model field.
+      blob[role] = value;
     } else if (role === 'compute_method') {
       blob.compute_method = value;
     } else {

--- a/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
+++ b/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
@@ -46,7 +46,6 @@ import {
   createDataCollectionFromUpload,
   createMultiQCDataCollection,
   checkMultiQCUniformity,
-  suggestFromColumns,
   fetchVizSuggestions,
 } from 'depictio-react-core';
 import type {
@@ -54,7 +53,6 @@ import type {
   PreviewResult,
   MultiQCReportSummary,
   DCLink,
-  SuggestFromColumnsResponse,
   VizSuggestionsResponse,
 } from 'depictio-react-core';
 import LinksSection from './LinksSection';
@@ -1015,12 +1013,6 @@ const CreateDataCollectionModal: React.FC<{
   // (DCTableCoordinatesConfig). Auto-flips on when detection succeeds; can be
   // toggled manually for non-delimited formats where we can't peek the header.
   const [coordsConfirmed, setCoordsConfirmed] = useState(false);
-  // Suggestion engine match for the parsed header — producers (DESeq2,
-  // mosdepth, Bracken, …) fingerprinted on column names alone. When a
-  // match lands, the coordinates fallback gets demoted and a passive
-  // "looks like X" Alert takes its place. See
-  // POST /datacollections/suggest-from-columns.
-  const [suggestions, setSuggestions] = useState<SuggestFromColumnsResponse | null>(null);
 
   // MultiQC folder dropzone — owned by the modal so close-and-reopen clears it.
   const multiqcDropzone = useFolderDropzone({
@@ -1092,55 +1084,13 @@ const CreateDataCollectionModal: React.FC<{
     [csvColumns],
   );
 
-  // Call the suggestion engine whenever the parsed header changes. The
-  // backend matches known producer fingerprints on column names alone —
-  // no dtype inference needed — so this works as soon as we have the
-  // CSV/TSV header. AbortController prevents a slow earlier response from
-  // stomping a newer one if the user thrashes the separator field.
-  // Failures are silent: missing suggestions just falls back to the
-  // coordinates toggle.
-  useEffect(() => {
-    if (!csvColumns.length) {
-      setSuggestions(null);
-      return;
-    }
-    const controller = new AbortController();
-    suggestFromColumns(csvColumns, controller.signal)
-      .then(setSuggestions)
-      .catch((err) => {
-        if (err?.name !== 'AbortError') setSuggestions(null);
-      });
-    return () => controller.abort();
-  }, [csvColumns]);
-
-  // When a producer fingerprint matches, the coordinates fallback is
-  // demoted. Coords stays available as an explicit alternative only when
-  // nothing else is detected (or when the header is unreadable, e.g.
-  // Parquet).
-  const hasVizMatch = Boolean(suggestions && suggestions.producers.length > 0);
-
-  // Auto-confirm coords on lat/lon header detection — UNLESS the producer
-  // engine matched, in which case we don't want to ship lat/lon metadata
-  // on, say, a DESeq2 results table whose columns happened to fuzzy-match.
-  // Both branches are gated by per-file refs so:
-  //   - a user who toggles the switch off doesn't have it flipped back on
-  //   - a user who manually picked lat/lon doesn't see them wiped on every
-  //     re-render after the producer match resolves (the reset fires once
-  //     per file, then stays out of the way).
+  // Auto-confirm coords on lat/lon header detection. Gated by a per-file ref
+  // so a user who toggles the switch off doesn't have it flipped back on by
+  // this effect (the auto-fill fires once per file, then stays out of the way).
   const autoConfirmedForFileRef = useRef<File | null>(null);
-  const vizResetForFileRef = useRef<File | null>(null);
   useEffect(() => {
     if (!file) {
       autoConfirmedForFileRef.current = null;
-      vizResetForFileRef.current = null;
-      return;
-    }
-    if (hasVizMatch) {
-      if (vizResetForFileRef.current === file) return;
-      vizResetForFileRef.current = file;
-      setCoordsConfirmed(false);
-      setLatColumn(null);
-      setLonColumn(null);
       return;
     }
     if (!coordsGuess) return;
@@ -1149,7 +1099,7 @@ const CreateDataCollectionModal: React.FC<{
     setLatColumn(coordsGuess.latColumn);
     setLonColumn(coordsGuess.lonColumn);
     setCoordsConfirmed(true);
-  }, [file, coordsGuess, hasVizMatch]);
+  }, [file, coordsGuess]);
 
   // Reset everything when the modal closes — otherwise re-opening shows stale
   // state from the previous attempt.
@@ -1171,7 +1121,6 @@ const CreateDataCollectionModal: React.FC<{
       setLonColumn(null);
       setCoordsConfirmed(false);
       setParsingHeader(false);
-      setSuggestions(null);
       multiqcDropzone.clear();
       tableDropzone.clear();
     }
@@ -1456,40 +1405,7 @@ const CreateDataCollectionModal: React.FC<{
                   tableDropzone.clear();
                 }}
               />
-              {file && hasVizMatch && suggestions && (
-                <Alert
-                  color="violet"
-                  variant="light"
-                  icon={<Icon icon="mdi:auto-fix" width={18} />}
-                  title="Looks like a known tool output"
-                >
-                  <Stack gap={4}>
-                    {suggestions.producers.slice(0, 2).map((p) => (
-                      <Text size="sm" key={p.name}>
-                        <Text span fw={600}>
-                          {p.tool}
-                        </Text>
-                        {' — '}
-                        {p.description}
-                        {p.feeds_viz.length > 0 && (
-                          <>
-                            {' '}
-                            <Text span c="dimmed" size="xs">
-                              (feeds: {p.feeds_viz.join(', ')})
-                            </Text>
-                          </>
-                        )}
-                      </Text>
-                    ))}
-                    <Text size="xs" c="dimmed">
-                      Detected from the column header — no action needed. The
-                      hint is saved with the data collection so the component
-                      builder can pre-fill bindings.
-                    </Text>
-                  </Stack>
-                </Alert>
-              )}
-              {file && !hasVizMatch && (
+              {file && (
                 <Paper p="sm" withBorder radius="sm" bg="var(--mantine-color-default-hover)">
                   <Stack gap="xs">
                     <Switch
@@ -2470,10 +2386,9 @@ const DataCollectionViewer: React.FC<{
   const isCoordTable = dcHasCoordinates(dc);
   const isAggregate = isTable && (metatype || '').toLowerCase() !== 'metadata';
 
-  // Detected producer / viz-kind suggestions for this DC. Mirrors the
-  // modal's passive "Looks like a known tool output" badge — surfaced in
-  // the viewer so users can discover the affinity post-creation.
-  // Only tables make sense to fingerprint; MultiQC has its own viewer.
+  // Ranked viz-kind fit scores for this DC — surfaced in the viewer as
+  // "compatible advanced visualizations" chips so users discover the affinity
+  // post-creation. Only tables are scored; MultiQC has its own viewer.
   const [vizSuggestions, setVizSuggestions] =
     useState<VizSuggestionsResponse | null>(null);
   useEffect(() => {
@@ -2493,8 +2408,9 @@ const DataCollectionViewer: React.FC<{
       cancelled = true;
     };
   }, [dcId, isTable]);
-  const detectedProducer = vizSuggestions?.producers?.[0] ?? null;
-  const detectedVizKinds = vizSuggestions?.viz_kinds ?? [];
+  // Only surface strong matches as "compatible" chips — mirrors the builder's
+  // recommended threshold (RECOMMENDED_SCORE in schemas.py).
+  const detectedVizKinds = (vizSuggestions?.viz_kinds ?? []).filter((v) => v.score >= 0.8);
 
   return (
     <Paper withBorder radius="md" p="lg">
@@ -2539,40 +2455,8 @@ const DataCollectionViewer: React.FC<{
               COORDINATES
             </Badge>
           )}
-          {detectedProducer && (
-            <Badge
-              color="violet"
-              variant="light"
-              size="sm"
-              radius="sm"
-              leftSection={<Icon icon="mdi:auto-fix" width={12} />}
-              title={detectedProducer.description}
-            >
-              {detectedProducer.tool.toUpperCase()}
-            </Badge>
-          )}
         </Group>
-        {detectedProducer && (
-          <Alert
-            color="violet"
-            variant="light"
-            icon={<Icon icon="mdi:auto-fix" width={18} />}
-            title={`Detected as ${detectedProducer.tool}`}
-          >
-            <Stack gap={4}>
-              <Text size="sm">{detectedProducer.description}</Text>
-              {detectedProducer.feeds_viz.length > 0 && (
-                <Text size="xs" c="dimmed">
-                  Feeds advanced viz:{' '}
-                  <Text span fw={600}>
-                    {detectedProducer.feeds_viz.join(', ')}
-                  </Text>
-                </Text>
-              )}
-            </Stack>
-          </Alert>
-        )}
-        {!detectedProducer && detectedVizKinds.length > 0 && (
+        {detectedVizKinds.length > 0 && (
           <Alert
             color="violet"
             variant="light"

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -496,6 +496,8 @@ export type AdvancedVizKind =
 export interface RoleDtypeSpec {
   required: boolean;
   dtypes: string[];
+  /** Short human description of the role, shown in the builder's binding tooltip. */
+  description: string;
 }
 
 export interface AdvancedVizKindDescriptor {

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -490,12 +490,23 @@ export type AdvancedVizKind =
   | 'coverage_track'
   | 'sankey';
 
+/** Accepted dtypes for one role, plus whether the role is required. Sourced
+ *  from the backend canonical schema so the builder never duplicates the
+ *  dtype tables in TS. */
+export interface RoleDtypeSpec {
+  required: boolean;
+  dtypes: string[];
+}
+
 export interface AdvancedVizKindDescriptor {
   viz_kind: AdvancedVizKind;
   label: string;
   description: string;
   icon: string;
   required_roles: string[];
+  /** Per-role accepted dtypes (required + optional), keyed by role name.
+   *  Drives the builder's binding dropdowns + dtype validation. */
+  roles: Record<string, RoleDtypeSpec>;
   /** "plot" for pure visualisations, "tool" for statistical methods that
    *  compute then plot (GSEA, GWAS, ANCOM-BC, DA barplot per contrast). */
   category: 'plot' | 'tool';
@@ -519,35 +530,29 @@ export async function fetchPolarsSchema(dcId: string): Promise<Record<string, st
   return res.json();
 }
 
-export interface ProducerSuggestion {
-  name: string;
-  confidence: number;
-  tool: string;
-  description: string;
-  feeds_viz: string[];
-}
-
+/** One viz kind scored against a DC schema by the backend suggestion engine.
+ *  `score` is a graded 0-1 fit (dtype compatibility × column-name similarity).
+ *  `role_candidates` lists dtype-compatible columns per required role, ranked
+ *  best-first, for pre-filling bindings. `unmet_roles` / `weak_roles` drive the
+ *  builder's inline guidance. */
 export interface VizKindSuggestion {
   viz_kind: string;
-  confidence: number;
+  score: number;
   role_candidates: Record<string, string[]>;
-}
-
-export interface SuggestFromColumnsResponse {
-  producers: ProducerSuggestion[];
+  unmet_roles: string[];
+  weak_roles: string[];
 }
 
 export interface VizSuggestionsResponse {
   data_collection_id: string;
   schema: Record<string, string>;
   viz_kinds: VizKindSuggestion[];
-  producers: ProducerSuggestion[];
 }
 
-/** Full producer + viz-kind suggestions for an existing DC. Reads the DC's
- *  inferred polars schema server-side, then runs the same suggestion
- *  engine as the modal — but with dtypes available, so the viz_kinds list
- *  is populated too. */
+/** Ranked viz-kind suggestions for an existing DC. Reads the DC's inferred
+ *  polars schema server-side and runs the graded scoring engine, returning
+ *  every kind scored (best-first) so the builder can present a "suggest but
+ *  tolerate" picker. */
 export async function fetchVizSuggestions(
   dcId: string,
 ): Promise<VizSuggestionsResponse> {
@@ -556,29 +561,6 @@ export async function fetchVizSuggestions(
     { headers: authHeaders() },
   );
   if (!res.ok) throw new Error(`Failed to fetch viz suggestions: ${res.status}`);
-  return res.json();
-}
-
-/** Run the producer suggestion engine on a bare column list (no DC required).
- *  Used by the DC-creation modal to decide whether to surface a passive
- *  "looks like X" hint vs. the coordinates fallback toggle. Producers are
- *  matched on column names alone — dtype info isn't available until the
- *  file is parsed server-side.
- *
- *  `signal` lets callers abort superseded requests (e.g. the user editing
- *  the CSV separator quickly enough to dispatch two fetches back-to-back).
- *  Without it the slower response can stomp the newer state. */
-export async function suggestFromColumns(
-  columns: string[],
-  signal?: AbortSignal,
-): Promise<SuggestFromColumnsResponse> {
-  const res = await fetch(`${API_BASE}/datacollections/suggest-from-columns`, {
-    method: 'POST',
-    headers: authHeaders(),
-    body: JSON.stringify({ columns }),
-    signal,
-  });
-  if (!res.ok) throw new Error(`Failed to fetch suggestions: ${res.status}`);
   return res.json();
 }
 

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -175,7 +175,6 @@ export {
   fetchAdvancedVizKinds,
   fetchAdvancedVizData,
   fetchPolarsSchema,
-  suggestFromColumns,
   fetchVizSuggestions,
   fetchPhylogenyNewick,
   dispatchComputeEmbedding,
@@ -187,8 +186,7 @@ export {
 } from './api';
 export type {
   TableMutationResult,
-  ProducerSuggestion,
-  SuggestFromColumnsResponse,
+  RoleDtypeSpec,
   VizKindSuggestion,
   VizSuggestionsResponse,
 } from './api';


### PR DESCRIPTION
Reworks the advanced-viz suggestion engine into a graded, tolerant model and the builder into a "suggest but tolerate" binding flow, and removes the dead column-fingerprint ("producers") code left behind by the backend retirement.

## Suggestion model (backend)
- `suggest_viz_kinds` now ranks **every** viz kind by a graded 0-1 score blending fuzzy column-name similarity (stdlib `difflib`) and dtype compatibility tiers (exact > castable Int→Float / Categorical→String), plus optional-role nudges and structural gates (heatmap matrix, sankey/upset counts, DC type) — nothing is filtered out by default. Short (1-2 char) aliases no longer match by substring (fixed `qq`/`embedding` scoring ~1.0 on generic numeric tables).
- `VizSuggestion` exposes `score` + ranked `role_candidates` + `unmet_roles` / `weak_roles`.
- `validate_binding` tags castable dtype mismatches as warnings, not errors.
- `/viz-suggestions` returns the ranked list (no `producers`); `/advanced_viz/kinds` now exposes per-role accepted dtypes **and descriptions**; `/suggest-from-columns` removed.

## Builder (frontend)
- Single source of truth: the builder consumes backend scores + per-role dtypes/descriptions, dropping the duplicated `REQUIRED_ROLES`/`ROLE_ALIASES`/`unmetReason` tables.
- Picker ranks kinds into **Recommended** + **Other visualisations** (nothing hidden/disabled), with fit-score badges; bindings pre-fill from `role_candidates`; validation is tolerant (castable dtype = warning).
- Each binding shows just its name + a colour-coded required/optional marker and a rich tooltip (description + accepted dtypes). "Bindings overview" table: Role / simplified Type / Description, content-sized columns.
- **Sankey**: adds the `step_cols` binding (was unbindable → "≥2 step columns required").
- **ComplexHeatmap**: fixes the `index` role serialising to `index_col` instead of the model's `index_column` (binding was dropped → compute fell back to `sample_id` → polars select failure); adds value-column (matrix subset / exclude) and row-annotation bindings.
- Removes the producer chips / `producers` field+types and `suggestFromColumns`.
- Renames the "GWAS Manhattan (tool)" label to "Manhattan plot".

## Verification
- Python: ruff + `ty` clean on changed modules; `pytest` advanced-viz suites green (graded-engine + regression tests).
- Viewer: Vite compiles clean; API checks confirm the ranked `/viz-suggestions` shape (score/role_candidates, no producers) and per-role descriptions live.