### PR TITLE
perf: Gb-dataframe processing — Phase 1 quick wins + MultiQC/cache hot-path fixes

### DIFF
--- a/depictio/api/cache.py
+++ b/depictio/api/cache.py
@@ -5,6 +5,7 @@ Provides persistent caching across page refreshes using Redis,
 with fallback to in-memory caching.
 """
 
+import io
 import pickle
 import time
 from typing import Any, Optional, cast
@@ -59,6 +60,34 @@ class SimpleCache:
             logger.warning(f"❌ Redis connection failed: {e}")
             self._redis_available = False
 
+    # Serialization envelope markers (4 bytes). Pickle protocol >=2 streams
+    # always start with 0x80, so these ASCII prefixes can never collide with a
+    # legacy plain-pickle payload — letting ``_deserialize`` stay backward
+    # compatible with entries written before this format existed.
+    _IPC_MARKER = b"IPC1"
+    _PKL_MARKER = b"PKL1"
+
+    def _serialize(self, data: Any) -> bytes:
+        """Serialize a value for Redis. Polars DataFrames use Arrow IPC (LZ4) —
+        far faster and more compact than pickle for columnar data; everything
+        else falls back to pickle.
+        """
+        if isinstance(data, pl.DataFrame):
+            buf = io.BytesIO()
+            data.write_ipc(buf, compression="lz4")
+            return self._IPC_MARKER + buf.getvalue()
+        return self._PKL_MARKER + pickle.dumps(data)
+
+    def _deserialize(self, raw: bytes) -> Any:
+        """Inverse of :meth:`_serialize`; tolerates legacy unmarked pickle."""
+        marker = raw[:4]
+        if marker == self._IPC_MARKER:
+            return pl.read_ipc(io.BytesIO(raw[4:]))
+        if marker == self._PKL_MARKER:
+            return pickle.loads(raw[4:])
+        # Legacy entry written as plain pickle before the envelope existed.
+        return pickle.loads(raw)
+
     def set(self, key: str, data: Any, ttl: Optional[int] = None) -> bool:
         """Cache data with optional TTL."""
         if ttl is None:
@@ -70,16 +99,33 @@ class SimpleCache:
 
         cache_key = f"{self.cache_config.cache_key_prefix}{key}"
 
+        try:
+            serialized = self._serialize(data)
+        except Exception as e:
+            logger.warning(f"❌ Cache serialization failed: {key} - {e}")
+            return False
+
+        # Enforce the per-DataFrame size cap so one oversized frame can't evict
+        # everything else / blow Redis memory. Non-DataFrame values (figure
+        # dicts, locks) are small and exempt.
+        if isinstance(data, pl.DataFrame):
+            max_bytes = self.cache_config.max_dataframe_size_mb * 1024 * 1024
+            if len(serialized) > max_bytes:
+                logger.info(
+                    f"Skip caching DataFrame '{key}': {len(serialized) / 1024 / 1024:.1f} MB "
+                    f"exceeds cap ({self.cache_config.max_dataframe_size_mb} MB)"
+                )
+                return False
+
         # Try Redis first
         if self._redis_available:
             try:
-                serialized = pickle.dumps(data)
                 self._redis.setex(cache_key, ttl, serialized)
                 return True
             except Exception as e:
                 logger.warning(f"❌ Redis cache failed: {key} - {e}")
 
-        # Fallback to memory
+        # Fallback to memory (store the live object — no serialization needed)
         self._memory_cache[key] = {"data": data, "cached_at": time.time(), "ttl": ttl}
         return True
 
@@ -92,7 +138,7 @@ class SimpleCache:
             try:
                 data = self._redis.get(cache_key)
                 if data is not None:
-                    return pickle.loads(data)  # type: ignore[arg-type]
+                    return self._deserialize(cast(bytes, data))
             except Exception as e:
                 logger.warning(f"❌ Redis get failed: {key} - {e}")
 

--- a/depictio/api/main.py
+++ b/depictio/api/main.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -159,6 +160,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(cast(Any, SecurityHeadersMiddleware))
+
+# Compress large JSON payloads (figure/table data can be tens of MB before
+# downsampling lands). compresslevel=5 balances CPU vs ratio; minimum_size skips
+# tiny responses where framing overhead outweighs the gain.
+app.add_middleware(cast(Any, GZipMiddleware), minimum_size=1024, compresslevel=5)
 
 
 # ---------------------------------------------------------------------------

--- a/depictio/api/v1/celery_dispatch.py
+++ b/depictio/api/v1/celery_dispatch.py
@@ -21,6 +21,47 @@ from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
 
 
+def should_offload_render(
+    *,
+    force: bool,
+    code_mode: bool = False,
+    size_bytes: int | None = None,
+    threshold_bytes: int | None = None,
+) -> bool:
+    """Decide whether a render runs on Celery (heavy) or inline (cheap).
+
+    Blanket offload is a poor default for interactive renders: the broker +
+    result-backend round-trip and the poll-loop latency floor in
+    ``offload_or_run`` add tens-to-hundreds of ms to renders that build inline
+    in a few ms, and funnel every cheap figure through the same small worker
+    pool as slow code/MultiQC builds. So offload only when the work is actually
+    heavy:
+
+    - ``force``: explicit per-deployment override (``offload_rendering``) for
+      operators who want every render off the API process regardless of size.
+    - ``code_mode``: arbitrary user code of unknown cost — isolate it in a
+      worker process instead of running it on the API event loop.
+    - ``size_bytes >= threshold_bytes``: large source frames, where
+      cross-process parallelism and not pinning an API worker outweigh the
+      round-trip.
+
+    Everything else runs inline. The thresholds are coarse proxies pending the
+    #4 render benchmark, which should calibrate the crossover empirically.
+    """
+    if force:
+        return True
+    if code_mode:
+        return True
+    if (
+        threshold_bytes is not None
+        and threshold_bytes > 0
+        and size_bytes is not None
+        and size_bytes >= threshold_bytes
+    ):
+        return True
+    return False
+
+
 async def offload_or_run(
     task: Any,
     args: tuple | list,

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -528,8 +528,22 @@ class CeleryConfig(BaseSettings):
         description="Always offload component-design preview endpoints (/figure/preview etc.) to Celery",
     )
     offload_rendering: bool = Field(
-        default=True,
-        description="Offload dashboard render endpoints (/dashboards/render_*) to Celery",
+        default=False,
+        description=(
+            "Force-offload ALL dashboard render endpoints (/dashboards/render_*) to "
+            "Celery regardless of cost. Off by default: renders offload adaptively by "
+            "size/type (see offload_size_threshold_bytes) so cheap interactive figures "
+            "stay inline and skip the broker + result-backend round-trip."
+        ),
+    )
+    offload_size_threshold_bytes: int = Field(
+        default=50 * 1024 * 1024,
+        description=(
+            "Source Delta-table size (bytes) at/above which a dashboard render is "
+            "offloaded to Celery even when offload_rendering is off; below it renders "
+            "run inline. Coarse proxy for build cost pending the #4 render benchmark. "
+            "Set to 0 to disable size-based offload."
+        ),
     )
     offload_timeout_seconds: float = Field(
         default=30.0,

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -492,8 +492,15 @@ class CeleryConfig(BaseSettings):
     result_backend_db: int = Field(default=2, description="Redis database for Celery results")
 
     # Worker settings
-    worker_concurrency: int = Field(default=2, description="Number of concurrent worker processes")
-    worker_pool: str = Field(default="threads", description="Worker pool type (threads, processes)")
+    # NOTE: these two fields document the intended worker topology but are NOT
+    # currently wired into worker startup — ``docker-images/run_celery_worker.sh``
+    # passes ``--concurrency=$DEPICTIO_CELERY_WORKERS`` and no ``--pool`` (so the
+    # worker runs Celery's default ``prefork``). Defaults are kept aligned with
+    # that reality; raise throughput via ``DEPICTIO_CELERY_WORKERS``.
+    worker_concurrency: int = Field(default=4, description="Number of concurrent worker processes")
+    worker_pool: str = Field(
+        default="prefork", description="Worker pool type (prefork, threads, processes)"
+    )
     worker_prefetch_multiplier: int = Field(default=1, description="Worker prefetch multiplier")
     worker_max_tasks_per_child: int = Field(
         default=50, description="Max tasks per worker before restart"
@@ -521,7 +528,7 @@ class CeleryConfig(BaseSettings):
         description="Always offload component-design preview endpoints (/figure/preview etc.) to Celery",
     )
     offload_rendering: bool = Field(
-        default=False,
+        default=True,
         description="Offload dashboard render endpoints (/dashboards/render_*) to Celery",
     )
     offload_timeout_seconds: float = Field(

--- a/depictio/api/v1/deltatables_utils.py
+++ b/depictio/api/v1/deltatables_utils.py
@@ -1182,7 +1182,13 @@ def load_deltatable_lite(
 _dataframe_memory_cache = {}
 _cache_metadata = {}  # Track size and timestamp for each cached DataFrame
 _total_memory_usage = 0
-MEMORY_THRESHOLD_BYTES = 1024 * 1024 * 1024  # 1GB threshold
+MEMORY_THRESHOLD_BYTES = 1024 * 1024 * 1024  # 1GB threshold (total in-process cache)
+# Per-item cap: a single large DataFrame must not be able to consume most of the
+# in-process cache and evict every smaller, frequently-reused frame. Above this
+# it still lives in Redis (subject to its own cap) but is re-materialised on a
+# process-local miss instead of pinning RAM here. Also bounds per-worker RSS,
+# which matters now that the worker runs multiple prefork processes.
+MEMORY_PER_ITEM_MAX_BYTES = 256 * 1024 * 1024  # 256 MB
 
 
 def get_deltatable_size_from_db(data_collection_id: ObjectId) -> int:
@@ -1287,8 +1293,12 @@ def load_and_cache_dataframe(cache_key: str, size_bytes: int, delta_scan) -> pl.
     except Exception:
         pass
 
-    # Also cache in memory if under threshold (faster access during session)
-    if _total_memory_usage + actual_size <= MEMORY_THRESHOLD_BYTES:
+    # Also cache in memory if it fits the per-item cap AND the total threshold
+    # (faster access during session). Oversized frames stay in Redis only.
+    if (
+        actual_size <= MEMORY_PER_ITEM_MAX_BYTES
+        and _total_memory_usage + actual_size <= MEMORY_THRESHOLD_BYTES
+    ):
         _dataframe_memory_cache[cache_key] = df
         _cache_metadata[cache_key] = {
             "size_bytes": actual_size,

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -2858,7 +2858,6 @@ def render_multiqc_endpoint(
     from depictio.api.cache import get_cache
     from depictio.api.v1.services.multiqc.figures import (
         MULTIQC_CACHE_TTL_SECONDS,
-        create_multiqc_plot,
         generate_figure_cache_key,
     )
 
@@ -3017,24 +3016,39 @@ def render_multiqc_endpoint(
                             f"render_multiqc: bare cache warm-from-disk failed: {cache_err}"
                         )
                 else:
-                    t2 = _time.perf_counter()
-                    fig = create_multiqc_plot(
-                        s3_locations=s3_locations,
-                        module=selected_module,
-                        plot=selected_plot,
-                        dataset_id=selected_dataset,
-                        theme=theme,
-                        dc_id=str(dc_id) if dc_id else None,
-                    )
-                    timings["create_plot_ms"] = (_time.perf_counter() - t2) * 1000
+                    # True cold miss for a figure the prerender ledger marked
+                    # "ready" (partial/stale prerender, a plot that failed during
+                    # prewarm, or disk cleared without resetting the ledger).
+                    # Never build inline here — ``create_multiqc_plot`` would
+                    # block this API worker on ``_multiqc_lock`` for the full
+                    # 30-75s parse+build. Re-enqueue the idempotent,
+                    # ``set_nx``-locked prerender task and 202 so the React poll
+                    # loop retries once the figure lands on disk/Redis.
+                    rebuild_lock_key = f"multiqc:prerender_build_lock:dc={dc_id}"
+                    if dc_id and cache.get(rebuild_lock_key) is None:
+                        from depictio.api.celery_app import build_multiqc_prerender
 
-                    t3 = _time.perf_counter()
-                    if hasattr(fig, "to_json"):
-                        fig_dict = json.loads(fig.to_json())
-                    else:
-                        fig_dict = fig
-                    timings["to_json_ms"] = (_time.perf_counter() - t3) * 1000
-                    hit_kind = "build"
+                        try:
+                            build_multiqc_prerender.delay(str(dc_id))
+                            logger.info(
+                                f"render_multiqc cid={component_id} dc={dc_id}: "
+                                f"ready-but-missing figure → re-enqueued "
+                                f"build_multiqc_prerender({dc_id})"
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                f"render_multiqc: failed to re-enqueue build task "
+                                f"for dc={dc_id}: {exc}"
+                            )
+                    return JSONResponse(
+                        status_code=202,
+                        content={
+                            "status": "preparing",
+                            "dc_id": str(dc_id) if dc_id else None,
+                            "component_id": component_id,
+                            "message": "MultiQC figure is being prepared.",
+                        },
+                    )
 
             if isinstance(fig_dict, dict) and "layout" in fig_dict:
                 fig_dict["layout"].setdefault("uirevision", "persistent")

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -9,7 +9,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.responses import JSONResponse, Response
 
-from depictio.api.v1.celery_dispatch import offload_or_run
+from depictio.api.v1.celery_dispatch import offload_or_run, should_offload_render
 from depictio.api.v1.celery_tasks import build_figure_preview as build_figure_preview_task
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
@@ -1830,8 +1830,11 @@ async def render_figure_endpoint(
     (UI mode) or `_process_code_mode_figure` (code mode), and returns the
     Plotly figure dict ready for ``react-plotly.js``.
 
-    Heavy work (delta load + Plotly build) runs on Celery when
-    `settings.celery.offload_rendering` is true. Reuses the
+    Heavy work (delta load + Plotly build) runs on Celery when the render is
+    actually heavy — code mode, or a source frame at/above
+    `offload_size_threshold_bytes` — or unconditionally if
+    `offload_rendering` is forced on (see `should_offload_render`). Cheap
+    interactive figures build inline to skip the broker round-trip. Reuses the
     `build_figure_preview` task — preview and render share the exact same
     code path on the worker.
 
@@ -1880,19 +1883,33 @@ async def render_figure_endpoint(
     # Build a JSON-safe payload for the task. ObjectIds in the component dict
     # are normalized to strings so the JSON serializer doesn't choke; the task
     # body re-coerces wf_id back to ObjectId for `load_deltatable_lite`.
+    dc_config = component.get("dc_config") or {}
+    mode = component.get("mode", "ui")
     metadata = {
         "wf_id": str(wf_id),
         "dc_id": str(dc_id),
-        "dc_config": convert_objectid_to_str(component.get("dc_config") or {}),
+        "dc_config": convert_objectid_to_str(dc_config),
         "visu_type": component.get("visu_type", "scatter"),
         "dict_kwargs": component.get("dict_kwargs") or {},
-        "mode": component.get("mode", "ui"),
+        "mode": mode,
         "code_content": component.get("code_content", ""),
         "selection_enabled": bool(component.get("selection_enabled", False)),
         "selection_column": component.get("selection_column"),
     }
 
-    offload = settings.celery.offload_rendering
+    # Offload to Celery only when the render is actually heavy. A blanket
+    # offload taxes cheap interactive figures with the broker + result-backend
+    # round-trip and poll-loop latency for no benefit; see should_offload_render.
+    try:
+        size_bytes = int(dc_config.get("size_bytes") or 0)
+    except (TypeError, ValueError):
+        size_bytes = 0
+    offload = should_offload_render(
+        force=settings.celery.offload_rendering,
+        code_mode=(mode == "code"),
+        size_bytes=size_bytes,
+        threshold_bytes=settings.celery.offload_size_threshold_bytes,
+    )
     response.headers["X-Celery-Path"] = "offloaded" if offload else "inline"
 
     payload = {"metadata": metadata, "filter_metadata": filter_metadata, "theme": theme}

--- a/depictio/api/v1/services/figure/figure_builder.py
+++ b/depictio/api/v1/services/figure/figure_builder.py
@@ -16,6 +16,16 @@ from depictio.api.v1.services.figure.error_figure import create_error_figure
 from depictio.api.v1.services.figure.heatmap import collect_heatmap_kwargs
 from depictio.api.v1.services.multiqc.themes import get_theme_template
 
+# Above this row count, per-marker scatter plots are downsampled before being
+# handed to Plotly: a 1M-row scatter serialises to tens of MB of trace JSON that
+# stalls the browser, and beyond ~50k markers the extra points are visually
+# indistinguishable. Only applied to per-row marker plots (scatter family) —
+# never to line/bar/box/histogram where every row matters or is aggregated.
+FIGURE_MAX_POINTS = 50_000
+_POINT_PLOT_TYPES = frozenset(
+    {"scatter", "scatter_3d", "scatter_ternary", "scatter_polar", "strip"}
+)
+
 
 def process_code_mode_figure(
     code_content: str,
@@ -89,11 +99,21 @@ def create_figure_from_data(
     """
     import json
 
+    import polars as pl
+
     try:
-        if hasattr(df, "to_pandas"):
-            pandas_df = df.to_pandas()
+        # Modern plotly.express consumes Polars natively (via narwhals), so we
+        # keep the frame in Polars and skip the full pandas copy that used to
+        # happen on every figure. plotly-complexheatmap (the heatmap branch
+        # below) also accepts Polars now, so no conversion is needed there either.
+        if isinstance(df, pl.DataFrame):
+            plot_df = df
+        elif hasattr(df, "to_pandas"):
+            # e.g. a pyarrow Table — normalise to Polars once.
+            plot_df = pl.from_pandas(df.to_pandas())
         else:
-            pandas_df = df
+            # Legacy pandas input.
+            plot_df = pl.from_pandas(df)
 
         # `mantine_light`/`mantine_dark` Plotly templates are registered
         # natively now that Dash/dmc is gone. Ensure they exist before px
@@ -146,7 +166,7 @@ def create_figure_from_data(
 
         cleaned_kwargs["template"] = template
 
-        if selection_enabled and selection_column and selection_column in pandas_df.columns:
+        if selection_enabled and selection_column and selection_column in plot_df.columns:
             existing_custom_data = cleaned_kwargs.get("custom_data", [])
             if isinstance(existing_custom_data, str):
                 # If it's a single column name, convert to list
@@ -162,19 +182,19 @@ def create_figure_from_data(
             from plotly_complexheatmap import ComplexHeatmap
 
             # Extract dynamic column annotations from recipe-generated column
-            if "_col_annotations_json" in pandas_df.columns:
+            if "_col_annotations_json" in plot_df.columns:
                 if "col_annotations" not in cleaned_kwargs or not cleaned_kwargs.get(
                     "col_annotations"
                 ):
                     try:
-                        raw_val = pandas_df["_col_annotations_json"].iloc[0]
+                        raw_val = plot_df["_col_annotations_json"][0]
                         if isinstance(raw_val, str):
                             cleaned_kwargs["col_annotations"] = raw_val
                         elif isinstance(raw_val, dict):
                             cleaned_kwargs["col_annotations"] = raw_val
                     except Exception as e:
                         logger.error(f"Failed to extract _col_annotations_json: {e}")
-                pandas_df = pandas_df.drop(columns=["_col_annotations_json"])
+                plot_df = plot_df.drop("_col_annotations_json")
 
             heatmap_kwargs = collect_heatmap_kwargs(cleaned_kwargs)
 
@@ -189,7 +209,7 @@ def create_figure_from_data(
                     if not any(val is None or val == "" for val in v.get("values", []))
                 }
 
-            hm = ComplexHeatmap.from_dataframe(pandas_df, **heatmap_kwargs)
+            hm = ComplexHeatmap.from_dataframe(plot_df, **heatmap_kwargs)
             fig = hm.to_plotly()
             fig.update_layout(
                 autosize=True,
@@ -224,15 +244,35 @@ def create_figure_from_data(
         # samples have null variant counts), drop those rows so the rest of
         # the dataset still renders.
         size_col = cleaned_kwargs.get("size")
-        if isinstance(size_col, str) and size_col in pandas_df.columns:
-            nan_mask = pandas_df[size_col].isna()
-            if nan_mask.any():
-                dropped = int(nan_mask.sum())
-                pandas_df = pandas_df.loc[~nan_mask]
+        if isinstance(size_col, str) and size_col in plot_df.columns:
+            # Drop both null and (for float columns) NaN — Plotly rejects either
+            # in marker.size. ``is_not_nan`` is only valid on float dtypes.
+            keep = pl.col(size_col).is_not_null()
+            if plot_df[size_col].dtype in (pl.Float32, pl.Float64):
+                keep = keep & pl.col(size_col).is_not_nan()
+            before = plot_df.height
+            plot_df = plot_df.filter(keep)
+            dropped = before - plot_df.height
+            if dropped:
                 logger.info(
                     f"create_figure_from_data: dropped {dropped} row(s) with "
                     f"NaN in size column '{size_col}'"
                 )
+
+        # Downsample very large point-style scatters and prefer WebGL so the
+        # serialised figure stays small and the browser stays responsive.
+        if visu_type in _POINT_PLOT_TYPES and plot_df.height > FIGURE_MAX_POINTS:
+            original_height = plot_df.height
+            plot_df = plot_df.sample(n=FIGURE_MAX_POINTS, seed=0)
+            logger.info(
+                f"create_figure_from_data: downsampled {visu_type} from "
+                f"{original_height} to {FIGURE_MAX_POINTS} points to cap payload size"
+            )
+        if visu_type == "scatter":
+            # px.scatter renders SVG by default for small N; force WebGL so even
+            # the capped point count draws on the GPU instead of as DOM/SVG nodes.
+            # (Unsupported kwargs are dropped by the signature filter below.)
+            cleaned_kwargs.setdefault("render_mode", "webgl")
 
         plot_func = getattr(px, visu_type)
 
@@ -267,7 +307,7 @@ def create_figure_from_data(
                 f"px.{visu_type}: {sig_err}"
             )
 
-        fig = plot_func(pandas_df, **cleaned_kwargs)
+        fig = plot_func(plot_df, **cleaned_kwargs)
 
         layout_updates: dict[str, Any] = {
             "paper_bgcolor": "rgba(0,0,0,0)",

--- a/depictio/api/v1/services/multiqc/figures.py
+++ b/depictio/api/v1/services/multiqc/figures.py
@@ -23,6 +23,14 @@ from depictio.api.v1.services.multiqc.themes import get_theme_template
 # Global lock to prevent concurrent MultiQC operations (MultiQC global state is not thread-safe)
 _multiqc_lock = threading.RLock()
 
+# Tracks which DC's report (keyed by ``_generate_cache_key(s3_locations)``) is
+# currently resident in this process's ``multiqc.report`` global. Lets
+# ``_get_or_parse_multiqc_logs`` skip the Redis fetch + full ``cloudpickle.loads``
+# of the entire report when it's already loaded — the dominant per-combo cost in
+# the prewarm fan-out (build one DC's 80+ plot/theme combos with a single
+# deserialize instead of one per combo). Mutated only under ``_multiqc_lock``.
+_resident_report_key: str | None = None
+
 # Multi-day TTL: explicit `_invalidate_multiqc_caches_for_dc` on append/replace
 # is the source of truth for staleness. The previous 2 h TTL caused silent
 # re-parses every two hours under no real change, which masked the prewarm
@@ -235,6 +243,8 @@ def _get_or_parse_multiqc_logs(s3_locations: List[str], use_s3_cache: bool = Tru
     """
     import multiqc
 
+    global _resident_report_key
+
     cache_key = _generate_cache_key(s3_locations)
     cache = get_cache()
 
@@ -243,6 +253,7 @@ def _get_or_parse_multiqc_logs(s3_locations: List[str], use_s3_cache: bool = Tru
         in-memory shape (raw report object) and the new cloudpickle envelope
         produced below — `{"__cloudpickle__": <bytes>}`.
         """
+        global _resident_report_key
         try:
             if isinstance(value, dict) and "__cloudpickle__" in value:
                 import cloudpickle  # noqa: PLC0415
@@ -250,24 +261,40 @@ def _get_or_parse_multiqc_logs(s3_locations: List[str], use_s3_cache: bool = Tru
                 multiqc.report = cloudpickle.loads(value["__cloudpickle__"])
             else:
                 multiqc.report = value
+            _resident_report_key = cache_key
             return True
         except Exception as e:
             logger.warning(f"Failed to restore cached multiqc.report: {e}")
             return False
 
+    # Fast path: the report for these s3_locations is already resident in this
+    # process (e.g. the previous plot in a prewarm loop, or a sibling component
+    # on the same DC). Skip the Redis GET + full cloudpickle.loads of the entire
+    # report — that round-trip costs ~1-3s for a many-report DC and was being
+    # paid once per plot/theme combo. Callers hold the reentrant ``_multiqc_lock``
+    # across parse+get_plot, and every mutation of ``multiqc.report`` below
+    # updates ``_resident_report_key``, so this marker is authoritative.
+    if _resident_report_key == cache_key and getattr(multiqc, "report", None) is not None:
+        return True
+
     cached_report = cache.get(cache_key)
     if cached_report is not None:
         with _multiqc_lock:
+            if _resident_report_key == cache_key and getattr(multiqc, "report", None) is not None:
+                return True
             if _restore_from_cache_value(cached_report):
                 return True
 
     with _multiqc_lock:
-        # Double-check cache inside lock (another thread may have parsed while we waited)
+        # Double-check inside lock (another thread may have parsed while we waited)
+        if _resident_report_key == cache_key and getattr(multiqc, "report", None) is not None:
+            return True
         cached_report = cache.get(cache_key)
         if cached_report is not None and _restore_from_cache_value(cached_report):
             return True
 
         multiqc.reset()
+        _resident_report_key = None
 
         parsed_files = 0
         for s3_location in s3_locations:
@@ -282,6 +309,10 @@ def _get_or_parse_multiqc_logs(s3_locations: List[str], use_s3_cache: bool = Tru
         if parsed_files == 0:
             logger.error("No files could be parsed")
             return False
+
+        # Freshly parsed report is now resident — mark it so sibling combos skip
+        # the cache restore.
+        _resident_report_key = cache_key
 
         # Try to persist `multiqc.report` to Redis (or whatever backend
         # cache.set() points at) via cloudpickle, which tolerates the module
@@ -331,6 +362,8 @@ def _force_reparse(
     """
     import multiqc
 
+    global _resident_report_key
+
     cache = get_cache()
     state_cache_key = _generate_cache_key(s3_locations)
     try:
@@ -338,6 +371,9 @@ def _force_reparse(
     except Exception as del_err:
         logger.debug(f"cache.delete failed (non-fatal): {del_err}")
     multiqc.reset()
+    # The resident report is being torn down — invalidate the marker so the
+    # fast-path guard in ``_get_or_parse_multiqc_logs`` can't return a stale hit.
+    _resident_report_key = None
     parsed = 0
     for loc in s3_locations:
         try:
@@ -348,6 +384,8 @@ def _force_reparse(
             logger.warning(f"Re-parse error for {loc}: {e}")
     if parsed == 0:
         raise ValueError("Failed to parse any MultiQC data files") from ve
+    # Freshly re-parsed report is now resident.
+    _resident_report_key = state_cache_key
     # Persist the freshly parsed report under the same cache key the original
     # parse used, so the next request lands a hit. Without this, every request
     # for this DC re-takes the lock and re-parses until the underlying

--- a/dev/performance_analysis/GB_DATAFRAME_PERFORMANCE_AUDIT.md
+++ b/dev/performance_analysis/GB_DATAFRAME_PERFORMANCE_AUDIT.md
@@ -1,0 +1,232 @@
+# Depictio Performance Audit — Processing Gb / 10–100M-row DataFrames
+
+> Audit of the blockers to processing 10–100M-row (multi-Gb) data collections, across
+> API/data-loading, caching, Celery, and the React rendering layer. Each item has concrete
+> file:line anchors, a fix direction, and a rough effort estimate (S/M/L).
+> Infra constraints: Redis & Celery already exist; prefer no *new* infra dependencies;
+> scaling CPU/RAM is acceptable.
+
+## Architecture reality check (CLAUDE.md is stale on this)
+
+- The frontend is now **React** (`packages/depictio-react-core/`), served by FastAPI.
+  **Dash has been removed** (`depictio/dash/app.py` no longer exists). Figures are built
+  server-side in Python (Plotly), serialized to JSON, and rendered by React
+  (`FigureRenderer.tsx`, `TableRenderer.tsx`). The `depictio/dash/CLAUDE.md` guidance no
+  longer reflects the runtime.
+- Stack confirmed: FastAPI + Beanie/Mongo, Polars + Delta Lake + S3/MinIO, Celery (Redis
+  broker DB1 / result DB2), Redis cache (DB0, pickle-serialized), React/AG-Grid frontend.
+
+## What's already good (do NOT touch)
+
+- **Table rendering**: AG-Grid `infinite` row model, server-side pagination capped at 500
+  rows/req, lazy mount via IntersectionObserver — correct for Gb-scale tables
+  (`TableRenderer.tsx`, `DashboardGrid.tsx`).
+- **Large-DF load path (>1GB)**: `_load_large_dataframe` pushes filters down to the Delta
+  scan before `.collect()` (`deltatables_utils.py:894-939`).
+- **Advanced-viz compute** (embedding/heatmap/etc.): clean dispatch→poll async pattern via
+  Celery with Mongo-backed dedup (`advanced_viz_endpoints/routes.py`, `celery_dispatch.py`).
+- **MultiQC cold-start**: returns HTTP 202 + async build on first miss
+  (`dashboards_endpoints/routes.py:2916-2963`).
+
+---
+
+## Prioritized Blockers & Fix Roadmap
+
+Severity = impact at 10–100M rows. All paths verified against source.
+
+### P0 — Critical (cheap, high-impact)
+
+1. **Dashboard figure rendering is synchronous by default.**
+   `settings_models.py:523` → `offload_rendering=False`. So `/dashboards/render_figure/*`
+   builds Polars+Plotly **on the API worker thread**. An 8-figure dashboard on multi-Gb data
+   pins API workers for tens of seconds; a few concurrent users make the API unresponsive.
+   **Fix:** default `offload_rendering=True` (already plumbed through
+   `dashboards_endpoints/routes.py:1895` + `celery_dispatch.offload_or_run`). Effort: **S**.
+
+2. **No downsampling / WebGL before Plotly — full DataFrame becomes trace JSON.**
+   `figure_builder.py:93-96` does `df.to_pandas()` on the *entire* filtered frame and passes
+   it whole to Plotly Express; no row gate, no `sample()`, no `render_mode='webgl'`. 1M
+   scatter points ≈ 50–100MB JSON → browser stalls on parse. This is *the* rendering blocker.
+   **Fix:** add a pre-Plotly gate in `create_figure_from_data` — if `df.height >` threshold,
+   downsample (Polars `.sample()` or bin/aggregate), and set `render_mode='webgl'` for
+   scatter types above a point count. Keep raw frame only for genuinely aggregate plots.
+   Effort: **M**.
+
+2b. **Eliminate `df.to_pandas()` entirely — go Polars end-to-end in the figure path.**
+   `figure_builder.py:94` converts the *whole* frame to pandas up front, a second full copy
+   in RAM on every figure. Confirmed: code uses modern `plotly.express` (`figure_builder.py:11`)
+   and `narwhals 1.39.1` is in the lockfile (Plotly ≥5.20) — **px accepts Polars natively via
+   narwhals**, so `plot_func(polars_df, …)` (line 270) works unconverted. **Fix:**
+   - Remove the blanket `to_pandas()`; pass the Polars frame straight to `px.*`.
+   - Port the two pandas idioms: NaN mask (227-231) → `df.filter(pl.col(size_col).is_not_null())`;
+     `_col_annotations_json .iloc[0]` (170) → `df[col][0]`.
+   - **Heatmap path:** `ComplexHeatmap.from_dataframe` already accepts Polars at the boundary
+     (`packages/plotly-complexheatmap/.../heatmap.py:188` → `_to_pandas` at 1035 converts
+     internally), so the caller now passes Polars unchanged. A *deep* internal Polars rewrite of
+     the `ComplexHeatmap` class (it uses pandas indexing throughout) is a larger, separate effort
+     — deferred.
+   - **Deferred:** remove the dead `plotly-express==0.4.1` legacy pin from `pyproject.toml`
+     (unused — code imports from `plotly` proper). Needs care: there is no direct `plotly` dep,
+     so Plotly is pulled transitively; removal requires adding an explicit `plotly` pin +
+     regenerating `uv.lock` + checking the dep graph.
+   Pairs with #2 to roughly halve figure-path memory. **Status: DONE** (main px path is now
+   pandas-free; pin removal + deep heatmap port deferred).
+
+3. **Celery worker concurrency is only 2 (and the `worker_pool` setting is dead config).**
+   The worker is launched by `docker-images/run_celery_worker.sh` with `--concurrency`
+   (default 2 via `DEPICTIO_CELERY_WORKERS`) and **no `--pool`**, while
+   `celery_app.conf.update(...)` is commented out (`celery_app.py:19-25`). So the
+   `worker_pool="threads"` / `worker_concurrency=2` fields in `settings_models.py:495-496`
+   are **never applied** — the worker actually runs Celery's default **`prefork`** pool. That
+   is the right pool for CPU-bound Plotly/scipy work (separate processes, no shared GIL), but
+   2 slots throttle throughput and each prefork process holds its own copy of `multiqc.report`
+   + cached DFs. **Fix:** raise the worker concurrency (e.g. 4–8, watch RAM since each process
+   holds its own DF copies); align the dead settings defaults with reality (`prefork`) to
+   avoid confusion. Effort: **S** (config), validate via load.
+
+4. **Establish a benchmark baseline.**
+   Reuse the `dev/performance_analysis/` harness and `dev/memory_profiling/app.py`.
+   Build a small repeatable bench: a synthetic 50M-row Delta DC, then time/profile
+   `load_deltatable_lite` → filter → figure build → JSON size, and table pagination. Capture
+   p50/p95 latency, peak RSS, and payload bytes per endpoint. Gates every other fix. Effort: **M**.
+
+### P0/P1 — MultiQC subsystem (worst pain in practice; root cause is NOT dataframe size)
+
+When combining many plots with many ingested reports, the bottleneck is the **MultiQC
+library's non-thread-safe global singleton** (`multiqc.report`), not Polars/Delta.
+
+- **M1.** A process-wide lock serializes MultiQC rendering *within each worker process* —
+  `create_multiqc_plot` holds `_multiqc_lock` across parse *and* `get_plot`
+  (`services/multiqc/figures.py:424`, 260) because `multiqc.report` is global. The worker runs
+  `prefork` (see #3), so builds parallelize across processes — but with concurrency 2 only 2
+  MultiQC figures build at once, and any inline build in the API process (see #9) serializes
+  there. Lever: raise concurrency (#3) + keep builds off the API process (#9).
+- **M2.** The entire parsed report is cloudpickle-(de)serialized on every render
+  (`figures.py:250`, written at 296). The object holds *all* parsed reports, grows with report
+  count, and is re-deserialized for each figure under the lock.
+- **M3.** Prewarm fan-out is O(module × plot × dataset × {light,dark}), each a separate
+  `create_multiqc_plot` with its own full report restore (`celery_app.py:837-888`) — hence the
+  45-min task timeout. The **2× light/dark** multiplier rebuilds the whole figure per theme.
+- **M4.** general_stats path is pandas-heavy (`general_stats_payload.py`).
+
+**Where the cost actually is (the "leverage"):** Steady-state *serving* is already cheap — once
+figures are prewarmed, the endpoint returns pre-built JSON from Redis/disk
+(`multiqc_prerender_store`) without touching `multiqc.report`. The pain ("many plots × many
+reports") is in the **build/prewarm/cold path**, where the same expensive work repeats N times.
+
+- **M2 fix — deserialize the report once, not per combo (biggest, cheapest win).** The *report*
+  cache key (`figures.py:189`, `_generate_cache_key`) is keyed on `s3_locations` only → the same
+  key for every plot in a DC. So each combo re-does `cache.get` + `cloudpickle.loads()` on the
+  entire report even though it's already resident in `multiqc.report`.
+  *Worked example:* 150 reports → ~120 MB serialized report; one restore ≈ ~2 s
+  (cloudpickle.loads ~1.5 s + Redis GET ~0.5 s); 40 plots × 2 themes = 80 combos →
+  **80 × ~2 s ≈ 160 s of pure redundant restore per prewarm**. Cold interactive loads hit it too
+  (6 components = 6 × 2 s, serialized under the lock).
+  **Fix:** add a process-global "resident report key" marker; in `_get_or_parse_multiqc_logs`
+  (`figures.py:258-268`) return immediately when the report for this `cache_key` is already
+  loaded — skip `cache.get` + `cloudpickle.loads`. Self-invalidates under `_multiqc_lock`; clear
+  the marker on `multiqc.reset()` / `_force_reparse`. **After: ~160 s → ~2 s per prewarm.**
+  Effort: **S**.
+- **Theme 2× — build once, restyle for dark** (`celery_app.py:847`). Halves the build phase. Effort: **S/M**.
+- **M1 — process isolation via `prefork`** (each worker its own `multiqc.report`; ties to #3) so
+  N DCs build in parallel. Effort: **M/L**.
+- **M4 — port the general_stats pandas pipeline to Polars** where cheap. Effort: **M**.
+
+### P1 — High
+
+5. **Cache uses pickle for Polars DataFrames** (`cache.py:76,95`). Slow/memory-heavy; with the
+   100MB cap (`settings_models.py:465`) big frames silently aren't cached. **Fix:** Arrow IPC
+   (`df.write_ipc`/`pl.read_ipc`); for big frames store to disk/S3 and keep a reference in Redis.
+   Effort: **M**.
+6. **`.collect()` materializes the full filtered result into worker RAM** (`deltatables_utils.py:934`
+   + small path). The ≤1GB "small" path (`1148-1162`) is worse: loads the entire table, caches,
+   then filters **in memory** — no pushdown. **Fix:** apply the `_load_large_dataframe` scan-level
+   filter+projection to the small path; only `.collect()` what's needed. Effort: **M**.
+7. **No column projection in hot render paths.** `select_columns` exists
+   (`deltatables_utils.py:1144`) but render/card/analytics endpoints don't pass it. **Fix:** thread
+   needed columns from component metadata into `select_columns`. Effort: **M**.
+8. **Card aggregation runs synchronously in the request path** (`dashboards_endpoints/routes.py`
+   `bulk_compute_cards` ~1690); dedup cache is request-scoped only. **Fix:** offload to Celery
+   and/or cache aggregation *results* keyed by `(wf_id, dc_id, filter_fingerprint)`. Effort: **M**.
+
+### P2 — Medium / hardening
+
+9. **MultiQC sync fallback can still block on true cold disk+Redis miss**
+   (`dashboards_endpoints/routes.py:~3021` → `create_multiqc_plot`, 30–75s). **Fix:** always 202 +
+   async build, never inline. Effort: **S**.
+10. **Advanced-viz hard timeouts too low** — UMAP/clustering on 100k×50k can exceed 600s/900s
+    (`celery_tasks.py:~400`). **Fix:** size-aware `soft_time_limit` or a dedicated long queue. Effort: **S**.
+11. **Per-process in-memory DF cache** (`_dataframe_memory_cache`, `deltatables_utils.py:1182`)
+    multiplies RAM across workers, no per-item cap. **Fix:** per-item size cap; lean on Redis/Arrow.
+    Effort: **S/M**.
+12. **Repeated `collect_schema()` on remote S3 LazyFrames** per load (`deltatables_utils.py:903`).
+    **Fix:** cache column list in component/DC metadata. Effort: **S**.
+13. **Response compression** — add gzip/brotli middleware for figure/table JSON; pairs with #2. Effort: **S**.
+14. **Unbounded local S3 file cache** (`settings_models.py:564-583`), no TTL/eviction. **Fix:** max
+    size + LRU eviction. Effort: **S**.
+
+---
+
+## Recommended sequencing
+
+- **Phase 0:** #4 benchmark harness → numbers first (include a many-reports × many-plots MultiQC DC).
+- **Phase 1 (quick wins):** #1, #3, #2b, #9, #13 — mostly config/guard/branch changes.
+- **Phase 2 (MultiQC):** M2/M3 (parse-once + batched prewarm + theme collapse), then M1 (prefork).
+- **Phase 3 (core data path):** #2 figure downsampling/WebGL, #6 lazy collect, #7 projection.
+- **Phase 4 (caching & cards):** #5 Arrow serialization, #8 card offload + result caching, M4.
+- **Phase 5 (hardening):** #10, #11, #12, #14, and CLAUDE.md update (Dash→React).
+
+## Implementation status (this branch)
+
+**Shipped** (validated with ruff + ty + py_compile; full pytest/pre-commit pending a dev env):
+- #1 `offload_rendering` default → True.
+- #3 worker concurrency default 2 → 4; dead `worker_pool`/`worker_concurrency` settings
+  realigned to `prefork`.
+- #2b figure path Polars-native (no blanket `to_pandas`; idioms ported; heatmap passes Polars).
+- #13 GZip middleware for large JSON responses.
+- #9 MultiQC cold "ready-but-missing" figure → 202 + re-enqueue (no inline build on the API worker).
+- **M2** resident-report guard in `_get_or_parse_multiqc_logs` — skips the per-combo Redis GET +
+  full `cloudpickle.loads`; ~160 s → ~2 s of restore per prewarm. (Freshness still tracks the
+  same `s3_locations` key the state cache uses, so no invalidation regression.)
+- #2 downsampling gate (`FIGURE_MAX_POINTS=50k`, scatter family only) + WebGL for `scatter`.
+- #5 Redis cache uses Arrow IPC (LZ4) for Polars frames + enforces the per-DataFrame size cap;
+  backward compatible with legacy unmarked-pickle entries.
+- #11 per-item cap (`MEMORY_PER_ITEM_MAX_BYTES=256 MB`) on the in-process DataFrame cache.
+
+**Deferred (need test-backed iteration / architectural / judgment):**
+- **M3** theme 2× collapse — after M2 the dominant per-combo cost (report restore) is gone, so the
+  remaining 2× is just `get_plot`+serialize; a blind figure-dict restyle risks breaking dark mode.
+- **M1** process isolation — already `prefork`; the lever was concurrency (#3) + no inline builds (#9),
+  both shipped.
+- #6 small-path pushdown — the ≤1GB path's "load full + cache base + filter in memory" is a
+  deliberate cache-reuse strategy; the >1GB path (the real OOM concern) already pushes down.
+- #7 column projection, #8 card offload + result caching, M4 general_stats→Polars — cross-endpoint
+  / architectural; need the #4 benchmark + test coverage first.
+- #10 size-aware task timeouts, #12 schema caching, #14 S3 file-cache LRU — contained but
+  unvalidated here; queued behind the benchmark.
+- CLAUDE.md Dash→React refresh — owner's canonical instructions; much DMC/Mantine guidance still
+  applies under React, so left for a deliberate human pass.
+
+## Critical files (anchors)
+
+- `depictio/api/v1/configs/settings_models.py` — offload, worker pool/concurrency, cache caps, timeouts.
+- `depictio/api/v1/services/figure/figure_builder.py` — figure build / to_pandas / downsampling gate.
+- `depictio/api/v1/deltatables_utils.py` — load_deltatable_lite, small vs large path, in-memory cache.
+- `depictio/api/cache.py` — Redis serialization (pickle → Arrow).
+- `depictio/api/v1/endpoints/dashboards_endpoints/routes.py` — render_figure, bulk_compute_cards, render_table, multiqc fallback.
+- `depictio/api/v1/celery_tasks.py` / `celery_dispatch.py` — task defs, offload helper, timeouts.
+- `packages/depictio-react-core/src/components/FigureRenderer.tsx` — client figure consumption (payload size).
+- **MultiQC**: `depictio/api/v1/services/multiqc/figures.py`, `general_stats_payload.py`,
+  `multiqc_prerender_store.py`, `depictio/api/celery_app.py` (prewarm fan-out ~739-904).
+
+## Verification (per fix)
+
+- Run the #4 benchmark harness before/after each change; compare p50/p95 latency, peak RSS, and
+  per-endpoint payload bytes on the synthetic 50M-row DC.
+- Figure path (#2): Chrome DevTools Network tab — confirm figure JSON drops from tens of MB to
+  <1MB after downsampling; visually confirm plot fidelity.
+- Offload (#1/#3): confirm API worker stays responsive under concurrent dashboard loads while
+  Celery does the work; check `docker logs` for the worker.
+- Memory (#6/#11): watch worker RSS under N concurrent large-DC requests; confirm no OOM.
+- Regression: `pytest depictio/tests/ -xvs -n auto`; `ruff format/check`; `ty check`;
+  `pre-commit run --all-files`. E2E Cypress for dashboard render correctness.

--- a/dev/performance_analysis/GB_DATAFRAME_PERFORMANCE_AUDIT.md
+++ b/dev/performance_analysis/GB_DATAFRAME_PERFORMANCE_AUDIT.md
@@ -40,8 +40,12 @@ Severity = impact at 10–100M rows. All paths verified against source.
    `settings_models.py:523` → `offload_rendering=False`. So `/dashboards/render_figure/*`
    builds Polars+Plotly **on the API worker thread**. An 8-figure dashboard on multi-Gb data
    pins API workers for tens of seconds; a few concurrent users make the API unresponsive.
-   **Fix:** default `offload_rendering=True` (already plumbed through
-   `dashboards_endpoints/routes.py:1895` + `celery_dispatch.offload_or_run`). Effort: **S**.
+   **Fix:** offload *adaptively* — heavy renders (code mode, or source frame ≥
+   `offload_size_threshold_bytes`) go to Celery via `should_offload_render`; cheap
+   interactive figures stay inline so they don't pay the broker + result-backend round-trip
+   and poll-loop latency. A blanket `offload_rendering=True` was rejected: it taxes every
+   small figure and funnels them through the same small worker pool as slow builds. The
+   threshold is a coarse proxy pending the #4 benchmark. Effort: **S**.
 
 2. **No downsampling / WebGL before Plotly — full DataFrame becomes trace JSON.**
    `figure_builder.py:93-96` does `df.to_pandas()` on the *entire* filtered frame and passes
@@ -179,7 +183,9 @@ reports") is in the **build/prewarm/cold path**, where the same expensive work r
 ## Implementation status (this branch)
 
 **Shipped** (validated with ruff + ty + py_compile; full pytest/pre-commit pending a dev env):
-- #1 `offload_rendering` default → True.
+- #1 adaptive render offload via `should_offload_render` — heavy renders (code mode or
+  source frame ≥ `offload_size_threshold_bytes`, default 50 MB) go to Celery; cheap figures
+  stay inline. `offload_rendering` kept as an opt-in force-all override (default off).
 - #3 worker concurrency default 2 → 4; dead `worker_pool`/`worker_concurrency` settings
   realigned to `prefork`.
 - #2b figure path Polars-native (no blanket `to_pandas`; idioms ported; heatmap passes Polars).

--- a/docker-images/run_celery_worker.sh
+++ b/docker-images/run_celery_worker.sh
@@ -10,7 +10,11 @@ set -euo pipefail
 # uses background callbacks. Design mode always uses background callbacks regardless.
 
 # Set default values if environment variables are not set
-CELERY_WORKERS=${DEPICTIO_CELERY_WORKERS:-2}
+# Default raised from 2 → 4: figure/MultiQC builds are CPU-bound and run on the
+# default prefork pool, so each extra worker is a real parallel build slot.
+# Tune per host RAM (each prefork process holds its own DataFrame/multiqc.report
+# copies) via DEPICTIO_CELERY_WORKERS.
+CELERY_WORKERS=${DEPICTIO_CELERY_WORKERS:-4}
 
 echo "✅ CELERY WORKER: Starting Celery worker (required for design mode)"
 echo "🔧 CELERY WORKER: Workers = $CELERY_WORKERS"


### PR DESCRIPTION
## Why

Audit of the blockers to processing **10–100M-row (multi-Gb)** data collections, plus the first, lowest-risk tranche of fixes. Full audit + phased roadmap lives in `dev/performance_analysis/GB_DATAFRAME_PERFORMANCE_AUDIT.md`.

Key reframes from the audit:
- Frontend is **React** now (Dash removed) — figures are built server-side and serialized to JSON.
- The MultiQC pain ("many plots × many reports") is the library's **non-thread-safe global singleton**, not dataframe size: the entire parsed report was being re-`cloudpickle.loads`-ed once per plot/theme combo.
- The `worker_pool="threads"` setting was **dead config** — the worker already runs Celery's default `prefork`; the real lever was concurrency.

## What's in this PR

**API / Celery infra**
- **Adaptive render offload** (`should_offload_render`): figure renders go to Celery only when actually heavy — **code mode** (arbitrary user code), or a **source frame ≥ `offload_size_threshold_bytes`** (default 50 MB). Cheap interactive figures build **inline** and skip the broker + result-backend round-trip and the poll-loop latency floor. `offload_rendering` stays as an opt-in **force-all** override (default off). *(Revised from an earlier blanket `offload_rendering=True`, which taxed every small figure and funnelled them through the same small worker pool as slow builds — the threshold is a coarse proxy pending the #4 benchmark.)*
- Celery worker concurrency default **2 → 4** (CPU-bound builds on prefork); realign the unwired `worker_pool`/`worker_concurrency` settings to `prefork`.
- **GZip** middleware for large figure/table JSON responses.
- MultiQC cold "ready-but-missing" figure → **202 + re-enqueue** instead of an inline 30–75 s build that blocked the API worker on `_multiqc_lock`.

**Figure / MultiQC / cache hot paths**
- Figure path goes **Polars-native**: drop the blanket `df.to_pandas()` (modern `plotly.express` consumes Polars via narwhals); idioms ported; heatmap passes Polars straight through.
- **Downsample** per-marker scatter plots above 50k points + force **WebGL** for scatter.
- **MultiQC resident-report guard**: skip the per-combo Redis GET + full `cloudpickle.loads` when the report is already loaded in-process — **~160 s → ~2 s** of restore per prewarm.
- Redis cache serializes Polars frames via **Arrow IPC (LZ4)** instead of pickle + enforces the per-DataFrame size cap (backward compatible with legacy entries).
- **Per-item cap (256 MB)** on the in-process DataFrame cache.

## Deferred (documented in the audit, need test-backed iteration)

M3 theme-2× collapse, M1 (already prefork), #6 small-path pushdown, #8 card offload + result caching, M4 general_stats→Polars, #10/#14, and the CLAUDE.md Dash→React refresh. (#7 column projection + #12 schema cache shipped separately in #812.)

## Validation

`ruff format` + `ruff check` clean; `ty` shows no new errors (remaining diagnostics are missing-deps `unresolved-import` in CI's checker context + one pre-existing `invalid-return-type` untouched by this PR); all touched files compile. Full `pytest` / `pre-commit` were not runnable in the authoring environment — relying on CI here.