### PR TITLE
feat(cli): auto-detect a workflow run and compose a dashboard (pluggable, nf-core + Snakemake)

### DIFF
--- a/depictio/cli/cli/commands/run.py
+++ b/depictio/cli/cli/commands/run.py
@@ -160,6 +160,66 @@ def register_run_command(app: typer.Typer):
         """
         rich_print_command_usage("run")
 
+        # Step 0a: Auto-detect from a Nextflow run directory.
+        # `depictio run --data-root X` (no --template / --project-config-path) reads
+        # the run's pipeline_info/ to identify the pipeline+version, picks a matching
+        # template, and pre-fills --var from params.json. With no matching template it
+        # auto-composes a dashboard from the catalog-recognised module outputs.
+        autodetect_info = None
+        autodetect_dashboard_path: Path | None = None
+        if template is None and not project_config_path and data_root and Path(data_root).is_dir():
+            from depictio.cli.cli.utils.templates import detect_template_from_run_dir
+
+            detected_template, autodetect_info = detect_template_from_run_dir(data_root)
+            if autodetect_info is not None:
+                rich_print_checked_statement(
+                    f"Detected {autodetect_info.pipeline_name or 'unknown pipeline'} "
+                    f"{autodetect_info.pipeline_version or ''} "
+                    f"(Nextflow {autodetect_info.nextflow_version or '?'}, "
+                    f"{len(autodetect_info.tools_executed)} tool(s))".strip(),
+                    "info",
+                )
+            if detected_template:
+                template = detected_template
+                rich_print_checked_statement(f"Auto-selected template: {template}", "info")
+                # Pre-fill template variables from run params (never override user --var).
+                provided_keys = {v.split("=", 1)[0] for v in var if "=" in v}
+                param_to_var = {"input": "SAMPLESHEET_FILE", "metadata": "METADATA_FILE"}
+                for param_key, var_key in param_to_var.items():
+                    value = autodetect_info.params.get(param_key) if autodetect_info else None
+                    if value and var_key not in provided_keys:
+                        var = list(var) + [f"{var_key}={value}"]
+                        rich_print_checked_statement(
+                            f"Pre-filled {var_key} from run params", "info"
+                        )
+            elif autodetect_info is not None:
+                # No template → auto-compose a dashboard from the catalog.
+                from depictio.models.components.advanced_viz.compose import (
+                    build_dashboard_from_run_dir,
+                )
+
+                composed = build_dashboard_from_run_dir(data_root, info=autodetect_info)
+                if composed.components:
+                    autodetect_dashboard_path = (
+                        Path(data_root) / "depictio_dashboard.generated.yaml"
+                    )
+                    autodetect_dashboard_path.write_text(composed.to_yaml(), encoding="utf-8")
+                    rich_print_checked_statement(
+                        f"Auto-composed dashboard with {len(composed.components)} component(s) → "
+                        f"{autodetect_dashboard_path}",
+                        "success",
+                    )
+                    rich_print_checked_statement(
+                        "No template matched: review the generated dashboard, then ingest its "
+                        "data collections (template or --project-config-path) before importing it.",
+                        "info",
+                    )
+                else:
+                    rich_print_checked_statement(
+                        "No template matched and no catalogued module outputs were recognised.",
+                        "warning",
+                    )
+
         # Validate template/project-config-path mutual exclusivity
         if template and project_config_path:
             rich_print_checked_statement(
@@ -232,6 +292,20 @@ def register_run_command(app: typer.Typer):
                     f"Template '{template_metadata.template_id}' loaded successfully",
                     "success",
                 )
+
+                # Persist Nextflow provenance on each workflow's config when the
+                # template was auto-detected from a real run directory.
+                if autodetect_info is not None:
+                    provenance = {
+                        "engine_name": "nextflow",
+                        "pipeline_version": autodetect_info.pipeline_version,
+                        "nextflow_version": autodetect_info.nextflow_version,
+                        "tools_executed": sorted(autodetect_info.tools_executed),
+                        "workflow_parameters": autodetect_info.params or None,
+                    }
+                    provenance = {k: v for k, v in provenance.items() if v}
+                    for wf in resolved_config.get("workflows", []):
+                        wf.setdefault("config", {}).update(provenance)
 
                 template_resolved_config = resolved_config
 

--- a/depictio/cli/cli/commands/run.py
+++ b/depictio/cli/cli/commands/run.py
@@ -183,8 +183,14 @@ def register_run_command(app: typer.Typer):
                 template = detected_template
                 rich_print_checked_statement(f"Auto-selected template: {template}", "info")
                 # Pre-fill template variables from run params (never override user --var).
+                # Mapping is per engine (param name → template variable).
                 provided_keys = {v.split("=", 1)[0] for v in var if "=" in v}
-                param_to_var = {"input": "SAMPLESHEET_FILE", "metadata": "METADATA_FILE"}
+                param_to_var_by_engine = {
+                    "nextflow": {"input": "SAMPLESHEET_FILE", "metadata": "METADATA_FILE"},
+                    "snakemake": {"samples": "SAMPLESHEET_FILE", "metadata": "METADATA_FILE"},
+                }
+                engine = autodetect_info.engine if autodetect_info else None
+                param_to_var = param_to_var_by_engine.get(engine or "", {})
                 for param_key, var_key in param_to_var.items():
                     value = autodetect_info.params.get(param_key) if autodetect_info else None
                     if value and var_key not in provided_keys:
@@ -293,13 +299,17 @@ def register_run_command(app: typer.Typer):
                     "success",
                 )
 
-                # Persist Nextflow provenance on each workflow's config when the
-                # template was auto-detected from a real run directory.
+                # Persist workflow-run provenance on each workflow's config when the
+                # template was auto-detected from a real run directory (any engine).
                 if autodetect_info is not None:
                     provenance = {
-                        "engine_name": "nextflow",
+                        "engine_name": autodetect_info.engine,
                         "pipeline_version": autodetect_info.pipeline_version,
-                        "nextflow_version": autodetect_info.nextflow_version,
+                        "nextflow_version": (
+                            autodetect_info.engine_version
+                            if autodetect_info.engine == "nextflow"
+                            else None
+                        ),
                         "tools_executed": sorted(autodetect_info.tools_executed),
                         "workflow_parameters": autodetect_info.params or None,
                     }

--- a/depictio/cli/cli/utils/templates.py
+++ b/depictio/cli/cli/utils/templates.py
@@ -125,17 +125,18 @@ def _list_pipeline_versions(pipeline_name: str) -> list[str]:
 
 
 def detect_template_from_run_dir(run_dir: str | Path) -> tuple[str | None, Any]:
-    """Detect the template matching a Nextflow run directory.
+    """Detect the template matching a workflow run directory (any engine).
 
-    Reads the run's ``pipeline_info/`` provenance, then resolves a template id:
-    the exact ``<pipeline>/<version>`` if present, otherwise the closest available
+    Reads the run's provenance via the engine-agnostic registry
+    (``read_run_info`` — nf-core, Snakemake, …), then resolves a template id: the
+    exact ``<pipeline>/<version>`` if present, otherwise the closest available
     version of the same pipeline (with a warning). Returns ``(template_id, info)``
     where ``template_id`` is ``None`` when no template matches (caller falls back
-    to catalog auto-composition) and ``info`` is the ``NextflowRunInfo`` (or None).
+    to catalog auto-composition) and ``info`` is the ``WorkflowRunInfo`` (or None).
     """
-    from depictio.models.models.nextflow import read_nextflow_run_info
+    from depictio.models.models.run_info import read_run_info
 
-    info = read_nextflow_run_info(run_dir)
+    info = read_run_info(run_dir)
     if info is None or not info.pipeline_name:
         return None, info
 

--- a/depictio/cli/cli/utils/templates.py
+++ b/depictio/cli/cli/utils/templates.py
@@ -103,6 +103,65 @@ def _list_available_templates(package_root: Path) -> list[str]:
     return sorted(templates)
 
 
+def _version_key(version: str) -> tuple:
+    """Sortable key for a version dir name (numeric components, then the raw tail)."""
+    parts = re.findall(r"\d+", version)
+    return (tuple(int(p) for p in parts), version)
+
+
+def _list_pipeline_versions(pipeline_name: str) -> list[str]:
+    """Version folder names available for a pipeline (e.g. ['2.14.0', '2.16.0'])."""
+    package_root = Path(__file__).resolve().parents[4]
+    pipeline_dir = package_root / "depictio" / "projects" / pipeline_name
+    if not pipeline_dir.is_dir():
+        return []
+    versions: list[str] = []
+    for child in pipeline_dir.iterdir():
+        if not child.is_dir():
+            continue
+        if (child / "template.yaml").is_file() or (child / "project.yaml").is_file():
+            versions.append(child.name)
+    return sorted(versions, key=_version_key)
+
+
+def detect_template_from_run_dir(run_dir: str | Path) -> tuple[str | None, Any]:
+    """Detect the template matching a Nextflow run directory.
+
+    Reads the run's ``pipeline_info/`` provenance, then resolves a template id:
+    the exact ``<pipeline>/<version>`` if present, otherwise the closest available
+    version of the same pipeline (with a warning). Returns ``(template_id, info)``
+    where ``template_id`` is ``None`` when no template matches (caller falls back
+    to catalog auto-composition) and ``info`` is the ``NextflowRunInfo`` (or None).
+    """
+    from depictio.models.models.nextflow import read_nextflow_run_info
+
+    info = read_nextflow_run_info(run_dir)
+    if info is None or not info.pipeline_name:
+        return None, info
+
+    # 1. Exact match on either version spelling (with / without leading "v").
+    for template_id in info.template_ids():
+        try:
+            locate_template(template_id)
+            return template_id, info
+        except FileNotFoundError:
+            continue
+
+    # 2. Closest available version of the same pipeline.
+    available = _list_pipeline_versions(info.pipeline_name)
+    if not available:
+        return None, info
+
+    target = (info.pipeline_version or "").lstrip("v")
+    not_newer = [v for v in available if _version_key(v) <= _version_key(target)] if target else []
+    chosen = not_newer[-1] if not_newer else available[-1]
+    logger.warning(
+        f"No exact template for {info.pipeline_name} {target or '?'}; "
+        f"using closest available version {chosen}."
+    )
+    return f"{info.pipeline_name}/{chosen}", info
+
+
 def substitute_template_variables(config: Any, variables: dict[str, str]) -> Any:
     """Recursively substitute {VAR_NAME} placeholders in config dict/list/str.
 

--- a/depictio/models/components/advanced_viz/catalog.py
+++ b/depictio/models/components/advanced_viz/catalog.py
@@ -550,6 +550,7 @@ def match_run_dir(
     run_dir: str | Path,
     entries: tuple[CatalogEntry, ...] | None = None,
     confirm_with_versions: bool = False,
+    executed_tools: set[str] | None = None,
 ) -> list[CatalogMatch]:
     """Walk ``run_dir`` and return every module output the catalog recognises.
 
@@ -557,13 +558,20 @@ def match_run_dir(
     (pipeline-agnostic). NOTE: exposed via `depictio catalog match`/`compose`
     and intended as the scan-time recogniser; not yet wired into live ingestion.
 
-    With ``confirm_with_versions=True`` and a ``software_versions.yml`` present,
-    matches are restricted to tools the run actually executed — a second signal
-    on top of filename matching (no file present → no restriction, non-breaking).
+    Restriction to the tools a run actually executed (a second signal on top of
+    filename matching) can come from two sources, in order of precedence:
+    ``executed_tools`` (passed explicitly — engine-agnostic, e.g. from a
+    ``WorkflowRunInfo``), else ``confirm_with_versions=True`` which reads the
+    nf-core ``software_versions.yml``. Empty/absent → no restriction (non-breaking).
     """
     run_dir = Path(run_dir)
     entries = entries if entries is not None else load_catalog_entries()
-    executed = read_software_versions(run_dir) if confirm_with_versions else set()
+    if executed_tools is not None:
+        executed = {t.lower() for t in executed_tools}
+    elif confirm_with_versions:
+        executed = read_software_versions(run_dir)
+    else:
+        executed = set()
     matches: list[CatalogMatch] = []
     for entry in entries:
         if executed and entry.id.lower() not in executed:

--- a/depictio/models/components/advanced_viz/compose.py
+++ b/depictio/models/components/advanced_viz/compose.py
@@ -1,0 +1,262 @@
+"""Compose a dashboard from a scanned run directory (the catalog → dashboard step).
+
+Turns the catalog's run recognition (``match_run_dir``) into an actual
+``DashboardDataLite``: each recognised tool output contributes its ``renders_as``
+entries, mapped to the matching lite component, and laid out on an 8-column grid.
+
+Pure + offline by contract: like ``catalog.py`` this module **never imports a
+recipe** ``.py``. It only maps ``Render`` → lite component and places tiles; the
+recipe → data-collection resolution lives in the CLI. Advanced-viz tiles are
+emitted as ``use: <tool>/<render-or-output>`` references and expanded by
+``AdvancedVizLiteComponent`` (role → ``<role>_col`` config) at validation time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from depictio.models.components.advanced_viz.catalog import (
+    CatalogEntry,
+    CatalogOutput,
+    Render,
+    load_catalog_entries,
+    match_run_dir,
+)
+
+if TYPE_CHECKING:
+    from depictio.models.models.dashboards import DashboardDataLite
+    from depictio.models.models.nextflow import NextflowRunInfo
+
+# 8-column grid (matches the real nf-core dashboards, e.g. ampliseq base.yaml).
+GRID_WIDTH = 8
+
+# Tile size (w, h) per component type on the 8-column grid.
+_TILE_SIZE: dict[str, tuple[int, int]] = {
+    "card": (2, 2),
+    "advanced_viz": (8, 8),
+    "figure": (8, 8),
+    "table": (8, 6),
+    "multiqc": (8, 5),
+    "text": (8, 1),
+}
+
+# polars dtype name (as the catalog declares it) → depictio column_type.
+_DTYPE_TO_COLUMN_TYPE: dict[str, str] = {
+    "String": "object",
+    "Utf8": "object",
+    "Categorical": "category",
+    "Boolean": "bool",
+    "Date": "datetime",
+    "Datetime": "datetime",
+    "Time": "datetime",
+    "Int8": "int64",
+    "Int16": "int64",
+    "Int32": "int64",
+    "Int64": "int64",
+    "UInt8": "int64",
+    "UInt16": "int64",
+    "UInt32": "int64",
+    "UInt64": "int64",
+    "Float32": "float64",
+    "Float64": "float64",
+}
+
+
+class _LayoutPacker:
+    """Left-to-right grid packer: wraps to a new row when a tile overflows."""
+
+    def __init__(self, width: int = GRID_WIDTH) -> None:
+        self._width = width
+        self._x = 0
+        self._y = 0
+        self._row_h = 0
+
+    def place(self, component_type: str) -> dict[str, int]:
+        w, h = _TILE_SIZE.get(component_type, (8, 6))
+        if self._x + w > self._width:
+            self._x = 0
+            self._y += self._row_h
+            self._row_h = 0
+        layout = {"x": self._x, "y": self._y, "w": w, "h": h}
+        self._x += w
+        self._row_h = max(self._row_h, h)
+        return layout
+
+
+def _short_output_id(tool_id: str, output_id: str) -> str:
+    """``mosdepth`` + ``mosdepth_genome_coverage`` → ``genome_coverage``."""
+    return output_id.removeprefix(f"{tool_id}_")
+
+
+def _tile_title(output: CatalogOutput) -> str:
+    """A short human title from the output description (first sentence)."""
+    if output.description:
+        return output.description.split(".")[0].strip()
+    return output.id
+
+
+def render_to_component_dict(
+    render: Render,
+    entry: CatalogEntry,
+    output: CatalogOutput,
+    *,
+    workflow_tag: str,
+    data_collection_tag: str,
+    index: int,
+) -> dict[str, Any] | None:
+    """Map one catalog ``Render`` to a lite-component dict (no layout), or None to skip.
+
+    Returns ``None`` for render targets that can't be grounded from the catalog
+    alone (today: ``multiqc`` lacks a ``selected_plot``; non-tabular targets like
+    jbrowse/image/map/text are not emitted from a run scan yet).
+    """
+    common: dict[str, Any] = {
+        "workflow_tag": workflow_tag,
+        "data_collection_tag": data_collection_tag,
+        "tag": f"{output.id}-{render.component}-{index}",
+        "title": _tile_title(output),
+    }
+
+    if render.component == "advanced_viz":
+        short = render.id or _short_output_id(entry.id, output.id)
+        comp: dict[str, Any] = {
+            "component_type": "advanced_viz",
+            "use": f"{entry.id}/{short}",
+            **common,
+        }
+        if not render.id and render.kind is not None:
+            # Output-id reference can render several kinds → disambiguate.
+            comp["viz_kind"] = render.kind
+        return comp
+
+    if render.component == "figure":
+        comp = {"component_type": "figure", **common}
+        if render.code:
+            comp["mode"] = "code"
+            comp["code_content"] = render.code
+            comp["visu_type"] = render.visu_type or "scatter"
+        else:
+            comp["mode"] = "ui"
+            comp["visu_type"] = render.visu_type or "scatter"
+            if render.dict_kwargs:
+                comp["dict_kwargs"] = dict(render.dict_kwargs)
+        return comp
+
+    if render.component == "card":
+        comp = {
+            "component_type": "card",
+            "aggregation": render.aggregation,
+            "column_name": render.column,
+            **common,
+        }
+        if render.aggregations:
+            comp["aggregations"] = list(render.aggregations)
+        if render.secondary_layout:
+            comp["secondary_layout"] = render.secondary_layout
+        if render.breakdown_col:
+            comp["breakdown_col"] = render.breakdown_col
+        if render.top_n_count:
+            comp["top_n_count"] = render.top_n_count
+        if render.coverage_max is not None:
+            comp["coverage_max"] = render.coverage_max
+        if render.filter_expr:
+            comp["filter_expr"] = render.filter_expr
+        if render.column and (dtype := output.columns.get(render.column)):
+            if column_type := _DTYPE_TO_COLUMN_TYPE.get(dtype):
+                comp["column_type"] = column_type
+        return comp
+
+    if render.component == "table":
+        return {"component_type": "table", **common}
+
+    # multiqc (no selected_plot) + non-tabular targets: skip for now.
+    return None
+
+
+def _build_lite_component(comp: dict[str, Any]):
+    """Instantiate the typed lite component so validation errors surface here."""
+    from depictio.models.components.advanced_viz.component import AdvancedVizLiteComponent
+    from depictio.models.components.lite import (
+        CardLiteComponent,
+        FigureLiteComponent,
+        TableLiteComponent,
+    )
+
+    builders = {
+        "advanced_viz": AdvancedVizLiteComponent,
+        "figure": FigureLiteComponent,
+        "card": CardLiteComponent,
+        "table": TableLiteComponent,
+    }
+    return builders[comp["component_type"]](**comp)
+
+
+def build_dashboard_from_run_dir(
+    run_dir: str | Path,
+    *,
+    info: NextflowRunInfo | None = None,
+    workflow_tag: str = "",
+    project_tag: str | None = None,
+    title: str | None = None,
+    confirm_with_versions: bool = True,
+    entries: tuple[CatalogEntry, ...] | None = None,
+) -> DashboardDataLite:
+    """Compose a ``DashboardDataLite`` from the catalog outputs present in ``run_dir``.
+
+    ``info`` (Nextflow provenance) drives the title and ``workflow_tag`` when not
+    given explicitly. ``confirm_with_versions`` scopes recognition to the tools the
+    run actually executed (``software_versions.yml``) when present.
+    """
+    from depictio.models.models.dashboards import DashboardDataLite
+
+    run_dir = Path(run_dir)
+    entries = entries if entries is not None else load_catalog_entries()
+
+    if not workflow_tag and info is not None and info.pipeline_name:
+        workflow_tag = info.pipeline_name
+
+    matches = match_run_dir(run_dir, entries, confirm_with_versions=confirm_with_versions)
+    present: set[tuple[str, str]] = {(m.tool_id, m.output_id) for m in matches}
+
+    entry_by_id = {e.id: e for e in entries}
+    packer = _LayoutPacker()
+    components: list = []
+
+    for tool_id in sorted({t for t, _ in present}):
+        entry = entry_by_id[tool_id]
+        for output in entry.outputs:
+            if (tool_id, output.id) not in present:
+                continue
+            for index, render in enumerate(output.renders_as):
+                comp = render_to_component_dict(
+                    render,
+                    entry,
+                    output,
+                    workflow_tag=workflow_tag,
+                    data_collection_tag=output.id,
+                    index=index,
+                )
+                if comp is None:
+                    continue
+                comp["layout"] = packer.place(comp["component_type"])
+                components.append(_build_lite_component(comp))
+
+    if title is None:
+        if info is not None and info.pipeline_name:
+            version = f" {info.pipeline_version}" if info.pipeline_version else ""
+            title = f"{info.short_name or info.pipeline_name}{version}"
+        else:
+            title = run_dir.name
+
+    subtitle = ""
+    if info is not None and info.pipeline_name:
+        subtitle = f"Auto-composed from {info.pipeline_name} run"
+
+    return DashboardDataLite(
+        title=title,
+        subtitle=subtitle,
+        project_tag=project_tag,
+        workflow_system="nf-core",
+        components=components,
+    )

--- a/depictio/models/components/advanced_viz/compose.py
+++ b/depictio/models/components/advanced_viz/compose.py
@@ -26,7 +26,7 @@ from depictio.models.components.advanced_viz.catalog import (
 
 if TYPE_CHECKING:
     from depictio.models.models.dashboards import DashboardDataLite
-    from depictio.models.models.nextflow import NextflowRunInfo
+    from depictio.models.models.run_info import WorkflowRunInfo
 
 # 8-column grid (matches the real nf-core dashboards, e.g. ampliseq base.yaml).
 GRID_WIDTH = 8
@@ -195,7 +195,7 @@ def _build_lite_component(comp: dict[str, Any]):
 def build_dashboard_from_run_dir(
     run_dir: str | Path,
     *,
-    info: NextflowRunInfo | None = None,
+    info: WorkflowRunInfo | None = None,
     workflow_tag: str = "",
     project_tag: str | None = None,
     title: str | None = None,
@@ -204,9 +204,11 @@ def build_dashboard_from_run_dir(
 ) -> DashboardDataLite:
     """Compose a ``DashboardDataLite`` from the catalog outputs present in ``run_dir``.
 
-    ``info`` (Nextflow provenance) drives the title and ``workflow_tag`` when not
-    given explicitly. ``confirm_with_versions`` scopes recognition to the tools the
-    run actually executed (``software_versions.yml``) when present.
+    Engine-agnostic: ``info`` (any ``WorkflowRunInfo`` — Nextflow, Snakemake, …)
+    drives the title and ``workflow_tag`` when not given explicitly, and scopes
+    recognition to the tools the run executed (``info.tools_executed``). With no
+    ``info``, ``confirm_with_versions`` falls back to the nf-core
+    ``software_versions.yml`` when present.
     """
     from depictio.models.models.dashboards import DashboardDataLite
 
@@ -216,7 +218,13 @@ def build_dashboard_from_run_dir(
     if not workflow_tag and info is not None and info.pipeline_name:
         workflow_tag = info.pipeline_name
 
-    matches = match_run_dir(run_dir, entries, confirm_with_versions=confirm_with_versions)
+    executed_tools = info.tools_executed if info is not None and info.tools_executed else None
+    matches = match_run_dir(
+        run_dir,
+        entries,
+        confirm_with_versions=confirm_with_versions,
+        executed_tools=executed_tools,
+    )
     present: set[tuple[str, str]] = {(m.tool_id, m.output_id) for m in matches}
 
     entry_by_id = {e.id: e for e in entries}
@@ -257,6 +265,6 @@ def build_dashboard_from_run_dir(
         title=title,
         subtitle=subtitle,
         project_tag=project_tag,
-        workflow_system="nf-core",
+        workflow_system=(info.engine if info is not None and info.engine else None),
         components=components,
     )

--- a/depictio/models/models/nextflow.py
+++ b/depictio/models/models/nextflow.py
@@ -1,0 +1,196 @@
+"""Read a Nextflow / nf-core run's provenance from its ``pipeline_info/`` artefacts.
+
+Pure + offline (mirrors ``catalog.read_software_versions``): given a run directory,
+extract the pipeline identity, version, Nextflow version, run parameters and the
+set of executed tools, plus the paths of the standard execution reports. Used to:
+
+  - detect which template (if any) matches a run (``detect_template_from_run_dir``),
+  - enrich a generated dashboard (title / workflow_tag / version),
+  - persist provenance per run (``WorkflowConfig``).
+
+Source priority (formats grounded on real nf-core runs):
+  1. ``pipeline_info/nf_core_*_software_mqc_versions.yml`` — its ``Workflow:``
+     section gives ``nf-core/<pipeline>: <version>`` **and** ``Nextflow: <version>``
+     in one file; the other sections are the executed tools.
+  2. fallback ``software_versions.yml`` (executed tools only).
+  3. ``pipeline_info/params_*.json`` (or ``nf-params.json``) — the run parameters.
+  4. fallback manifest in ``nextflow.config`` (only present when pointing at a
+     pipeline checkout, not a results dir).
+
+Tolerant by design: a missing ``pipeline_info/`` (e.g. a curated run subset) yields
+``None`` rather than an error, so callers fall back to filename-based recognition.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Default Nextflow execution-trace columns (parsed in a later increment).
+_MANIFEST_RE = {
+    "name": re.compile(r"""name\s*=\s*['"]([^'"]+)['"]"""),
+    "version": re.compile(r"""version\s*=\s*['"]([^'"]+)['"]"""),
+    "homePage": re.compile(r"""homePage\s*=\s*['"]([^'"]+)['"]"""),
+}
+
+
+class NextflowRunInfo(BaseModel):
+    """Provenance extracted from a Nextflow/nf-core run directory."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pipeline_name: str | None = None  # e.g. "nf-core/ampliseq"
+    pipeline_version: str | None = None  # e.g. "2.16.0" (leading "v" stripped)
+    nextflow_version: str | None = None  # runtime Nextflow version, e.g. "24.04.4"
+    run_name: str | None = None
+    homepage: str | None = None
+    params: dict = Field(default_factory=dict)
+    tools_executed: set[str] = Field(default_factory=set)
+
+    # Artefact paths kept for reference / later provenance parsing.
+    software_versions_path: str | None = None
+    params_json_path: str | None = None
+    execution_report_path: str | None = None
+    execution_trace_path: str | None = None
+    pipeline_dag_path: str | None = None
+
+    @property
+    def short_name(self) -> str | None:
+        """Pipeline name without the catalog prefix (``nf-core/ampliseq`` → ``ampliseq``)."""
+        if self.pipeline_name and "/" in self.pipeline_name:
+            return self.pipeline_name.split("/", 1)[1]
+        return self.pipeline_name
+
+    def template_ids(self) -> list[str]:
+        """Candidate template ids to try, most specific first.
+
+        nf-core versions.yml may carry a leading ``v`` (``v3.16.0``) while template
+        folders are unprefixed (``2.16.0``), so both forms are offered.
+        """
+        if not (self.pipeline_name and self.pipeline_version):
+            return []
+        raw = self.pipeline_version
+        stripped = raw.lstrip("v")
+        versions = [raw] if raw == stripped else [stripped, raw]
+        return [f"{self.pipeline_name}/{v}" for v in versions]
+
+
+def _find_first(run_dir: Path, *globs: str) -> Path | None:
+    """First file matching any of ``globs`` (recursive), or None."""
+    for pattern in globs:
+        for path in sorted(run_dir.rglob(pattern)):
+            if path.is_file():
+                return path
+    return None
+
+
+def _parse_versions_yaml(path: Path, info: NextflowRunInfo) -> None:
+    """Fill identity / Nextflow version / tools from a *_software_mqc_versions.yml."""
+    import yaml
+
+    try:
+        data = yaml.safe_load(path.read_text()) or {}
+    except Exception:
+        return
+    if not isinstance(data, dict):
+        return
+    info.software_versions_path = str(path)
+    tools: set[str] = set()
+    for section, versions in data.items():
+        if not isinstance(versions, dict):
+            continue
+        if str(section).lower() == "workflow":
+            for key, value in versions.items():
+                if str(key).lower() == "nextflow":
+                    info.nextflow_version = str(value)
+                else:
+                    info.pipeline_name = str(key)
+                    info.pipeline_version = str(value).lstrip("v")
+        else:
+            tools.update(str(tool).lower() for tool in versions)
+    if tools:
+        info.tools_executed = tools
+
+
+def _parse_params_json(path: Path, info: NextflowRunInfo) -> None:
+    """Fill the run parameters from a params_*.json / nf-params.json."""
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        return
+    if isinstance(data, dict):
+        info.params = data
+        info.params_json_path = str(path)
+
+
+def _parse_manifest(run_dir: Path, info: NextflowRunInfo) -> None:
+    """Fallback identity from a ``nextflow.config`` manifest block (checkout only).
+
+    ``nextflowVersion`` is intentionally ignored — it is a constraint
+    (``!>=25.04.3``), not the runtime version.
+    """
+    config = _find_first(run_dir, "nextflow.config")
+    if config is None:
+        return
+    try:
+        text = config.read_text()
+    except Exception:
+        return
+    if (m := _MANIFEST_RE["name"].search(text)) and not info.pipeline_name:
+        info.pipeline_name = m.group(1)
+    if (m := _MANIFEST_RE["version"].search(text)) and not info.pipeline_version:
+        info.pipeline_version = m.group(1).lstrip("v")
+    if (m := _MANIFEST_RE["homePage"].search(text)) and not info.homepage:
+        info.homepage = m.group(1)
+
+
+def read_nextflow_run_info(run_dir: str | Path) -> NextflowRunInfo | None:
+    """Read a run's Nextflow provenance, or None if no artefact is recognised."""
+    run_dir = Path(run_dir)
+    if not run_dir.is_dir():
+        return None
+
+    info = NextflowRunInfo()
+
+    versions = _find_first(
+        run_dir, "nf_core_*_software_mqc_versions.yml", "*_software_mqc_versions.yml"
+    )
+    if versions is not None:
+        _parse_versions_yaml(versions, info)
+
+    if not info.tools_executed:
+        # Reuse the catalog's reader for the legacy per-process file.
+        from depictio.models.components.advanced_viz.catalog import read_software_versions
+
+        info.tools_executed = read_software_versions(run_dir)
+
+    params = _find_first(run_dir, "params_*.json", "nf-params.json", "nf_params.json")
+    if params is not None:
+        _parse_params_json(params, info)
+
+    if not info.pipeline_name:
+        _parse_manifest(run_dir, info)
+
+    for attr, pattern in (
+        ("execution_report_path", "execution_report*.html"),
+        ("execution_trace_path", "execution_trace*.txt"),
+        ("pipeline_dag_path", "pipeline_dag*"),
+    ):
+        match = _find_first(run_dir, pattern)
+        if match is not None:
+            setattr(info, attr, str(match))
+
+    has_signal = any(
+        (
+            info.pipeline_name,
+            info.nextflow_version,
+            info.tools_executed,
+            info.params,
+            info.execution_report_path,
+            info.execution_trace_path,
+        )
+    )
+    return info if has_signal else None

--- a/depictio/models/models/nextflow.py
+++ b/depictio/models/models/nextflow.py
@@ -1,12 +1,7 @@
-"""Read a Nextflow / nf-core run's provenance from its ``pipeline_info/`` artefacts.
+"""nf-core / Nextflow connector: read a run's provenance from ``pipeline_info/``.
 
-Pure + offline (mirrors ``catalog.read_software_versions``): given a run directory,
-extract the pipeline identity, version, Nextflow version, run parameters and the
-set of executed tools, plus the paths of the standard execution reports. Used to:
-
-  - detect which template (if any) matches a run (``detect_template_from_run_dir``),
-  - enrich a generated dashboard (title / workflow_tag / version),
-  - persist provenance per run (``WorkflowConfig``).
+Registers itself with the generic run-info registry (``run_info.py``) so callers
+go through ``read_run_info`` and never depend on this engine directly.
 
 Source priority (formats grounded on real nf-core runs):
   1. ``pipeline_info/nf_core_*_software_mqc_versions.yml`` — its ``Workflow:``
@@ -27,55 +22,13 @@ import json
 import re
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field
+from depictio.models.models.run_info import WorkflowRunInfo, register_run_info_reader
 
-# Default Nextflow execution-trace columns (parsed in a later increment).
 _MANIFEST_RE = {
     "name": re.compile(r"""name\s*=\s*['"]([^'"]+)['"]"""),
     "version": re.compile(r"""version\s*=\s*['"]([^'"]+)['"]"""),
     "homePage": re.compile(r"""homePage\s*=\s*['"]([^'"]+)['"]"""),
 }
-
-
-class NextflowRunInfo(BaseModel):
-    """Provenance extracted from a Nextflow/nf-core run directory."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    pipeline_name: str | None = None  # e.g. "nf-core/ampliseq"
-    pipeline_version: str | None = None  # e.g. "2.16.0" (leading "v" stripped)
-    nextflow_version: str | None = None  # runtime Nextflow version, e.g. "24.04.4"
-    run_name: str | None = None
-    homepage: str | None = None
-    params: dict = Field(default_factory=dict)
-    tools_executed: set[str] = Field(default_factory=set)
-
-    # Artefact paths kept for reference / later provenance parsing.
-    software_versions_path: str | None = None
-    params_json_path: str | None = None
-    execution_report_path: str | None = None
-    execution_trace_path: str | None = None
-    pipeline_dag_path: str | None = None
-
-    @property
-    def short_name(self) -> str | None:
-        """Pipeline name without the catalog prefix (``nf-core/ampliseq`` → ``ampliseq``)."""
-        if self.pipeline_name and "/" in self.pipeline_name:
-            return self.pipeline_name.split("/", 1)[1]
-        return self.pipeline_name
-
-    def template_ids(self) -> list[str]:
-        """Candidate template ids to try, most specific first.
-
-        nf-core versions.yml may carry a leading ``v`` (``v3.16.0``) while template
-        folders are unprefixed (``2.16.0``), so both forms are offered.
-        """
-        if not (self.pipeline_name and self.pipeline_version):
-            return []
-        raw = self.pipeline_version
-        stripped = raw.lstrip("v")
-        versions = [raw] if raw == stripped else [stripped, raw]
-        return [f"{self.pipeline_name}/{v}" for v in versions]
 
 
 def _find_first(run_dir: Path, *globs: str) -> Path | None:
@@ -87,7 +40,7 @@ def _find_first(run_dir: Path, *globs: str) -> Path | None:
     return None
 
 
-def _parse_versions_yaml(path: Path, info: NextflowRunInfo) -> None:
+def _parse_versions_yaml(path: Path, info: WorkflowRunInfo) -> None:
     """Fill identity / Nextflow version / tools from a *_software_mqc_versions.yml."""
     import yaml
 
@@ -105,7 +58,7 @@ def _parse_versions_yaml(path: Path, info: NextflowRunInfo) -> None:
         if str(section).lower() == "workflow":
             for key, value in versions.items():
                 if str(key).lower() == "nextflow":
-                    info.nextflow_version = str(value)
+                    info.engine_version = str(value)
                 else:
                     info.pipeline_name = str(key)
                     info.pipeline_version = str(value).lstrip("v")
@@ -115,7 +68,7 @@ def _parse_versions_yaml(path: Path, info: NextflowRunInfo) -> None:
         info.tools_executed = tools
 
 
-def _parse_params_json(path: Path, info: NextflowRunInfo) -> None:
+def _parse_params_json(path: Path, info: WorkflowRunInfo) -> None:
     """Fill the run parameters from a params_*.json / nf-params.json."""
     try:
         data = json.loads(path.read_text())
@@ -126,7 +79,7 @@ def _parse_params_json(path: Path, info: NextflowRunInfo) -> None:
         info.params_json_path = str(path)
 
 
-def _parse_manifest(run_dir: Path, info: NextflowRunInfo) -> None:
+def _parse_manifest(run_dir: Path, info: WorkflowRunInfo) -> None:
     """Fallback identity from a ``nextflow.config`` manifest block (checkout only).
 
     ``nextflowVersion`` is intentionally ignored — it is a constraint
@@ -147,13 +100,13 @@ def _parse_manifest(run_dir: Path, info: NextflowRunInfo) -> None:
         info.homepage = m.group(1)
 
 
-def read_nextflow_run_info(run_dir: str | Path) -> NextflowRunInfo | None:
-    """Read a run's Nextflow provenance, or None if no artefact is recognised."""
+def read_nextflow_run_info(run_dir: str | Path) -> WorkflowRunInfo | None:
+    """Read an nf-core/Nextflow run's provenance, or None if nothing recognised."""
     run_dir = Path(run_dir)
     if not run_dir.is_dir():
         return None
 
-    info = NextflowRunInfo()
+    info = WorkflowRunInfo(engine="nextflow")
 
     versions = _find_first(
         run_dir, "nf_core_*_software_mqc_versions.yml", "*_software_mqc_versions.yml"
@@ -186,7 +139,7 @@ def read_nextflow_run_info(run_dir: str | Path) -> NextflowRunInfo | None:
     has_signal = any(
         (
             info.pipeline_name,
-            info.nextflow_version,
+            info.engine_version,
             info.tools_executed,
             info.params,
             info.execution_report_path,
@@ -194,3 +147,16 @@ def read_nextflow_run_info(run_dir: str | Path) -> NextflowRunInfo | None:
         )
     )
     return info if has_signal else None
+
+
+class _NextflowReader:
+    """Connector entry for the run-info registry."""
+
+    name = "nextflow"
+    priority = 100  # most specific / self-describing → tried first
+
+    def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+        return read_nextflow_run_info(run_dir)
+
+
+register_run_info_reader(_NextflowReader())

--- a/depictio/models/models/run_info.py
+++ b/depictio/models/models/run_info.py
@@ -1,0 +1,143 @@
+"""Generic, pluggable workflow run-provenance layer.
+
+A run directory produced by *any* workflow engine (Nextflow/nf-core, Snakemake,
+Galaxy via RO-Crate, CWL, …) is described by a single engine-agnostic model,
+``WorkflowRunInfo``. Each engine ships a **connector** — a small reader that
+recognises its own artefacts and returns a ``WorkflowRunInfo`` (or ``None``).
+
+Connectors self-register via ``register_run_info_reader``; ``read_run_info``
+iterates them by descending priority and returns the first hit. Adding support
+for a new system is therefore: create a module with a reader, call
+``register_run_info_reader(...)`` at import time, and list the module in
+``_CONNECTOR_MODULES`` — **no change to any caller** (compose / run / templates).
+
+Pure + offline by contract (like ``catalog.read_software_versions``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WorkflowRunInfo(BaseModel):
+    """Engine-agnostic provenance for a single workflow run directory."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    engine: str | None = None  # "nextflow" | "snakemake" | "galaxy" | …
+    pipeline_name: str | None = None  # e.g. "nf-core/ampliseq" (may carry a catalog prefix)
+    pipeline_version: str | None = None  # e.g. "2.16.0" (leading "v" stripped)
+    engine_version: str | None = None  # runtime engine version, e.g. Nextflow "24.04.4"
+    run_name: str | None = None
+    homepage: str | None = None
+    params: dict = Field(default_factory=dict)
+    tools_executed: set[str] = Field(default_factory=set)
+
+    # Standard artefact paths kept for reference / later provenance parsing.
+    software_versions_path: str | None = None
+    params_json_path: str | None = None
+    execution_report_path: str | None = None
+    execution_trace_path: str | None = None
+    pipeline_dag_path: str | None = None
+
+    # Connector-specific metadata that doesn't fit the common schema.
+    extra: dict = Field(default_factory=dict)
+
+    @property
+    def short_name(self) -> str | None:
+        """Pipeline name without the catalog prefix (``nf-core/ampliseq`` → ``ampliseq``)."""
+        if self.pipeline_name and "/" in self.pipeline_name:
+            return self.pipeline_name.split("/", 1)[1]
+        return self.pipeline_name
+
+    def template_ids(self) -> list[str]:
+        """Candidate template ids to try, most specific first.
+
+        Versions may carry a leading ``v`` (``v3.16.0``) while template folders
+        are unprefixed (``2.16.0``), so both spellings are offered.
+        """
+        if not (self.pipeline_name and self.pipeline_version):
+            return []
+        raw = self.pipeline_version
+        stripped = raw.lstrip("v")
+        versions = [raw] if raw == stripped else [stripped, raw]
+        return [f"{self.pipeline_name}/{v}" for v in versions]
+
+
+@runtime_checkable
+class RunInfoReader(Protocol):
+    """A connector that recognises one engine's run artefacts.
+
+    ``read`` must be self-contained recognition: return ``None`` when the
+    directory is not a run of this engine, otherwise a populated
+    ``WorkflowRunInfo``. Higher ``priority`` readers are tried first.
+    """
+
+    name: str
+    priority: int
+
+    def read(self, run_dir: Path) -> WorkflowRunInfo | None: ...
+
+
+# Connector modules imported (once) to trigger their self-registration. Listing a
+# new module here is the only wiring needed to add an engine.
+_CONNECTOR_MODULES: tuple[str, ...] = (
+    "depictio.models.models.nextflow",
+    "depictio.models.models.snakemake",
+)
+
+_READERS: list[RunInfoReader] = []
+_LOADED = False
+
+
+def register_run_info_reader(reader: RunInfoReader) -> None:
+    """Register a connector (idempotent by ``name``); kept sorted by priority desc."""
+    global _READERS
+    _READERS = [r for r in _READERS if r.name != reader.name]
+    _READERS.append(reader)
+    _READERS.sort(key=lambda r: r.priority, reverse=True)
+
+
+def _ensure_readers_loaded() -> None:
+    """Import connector modules so they self-register (lazy, avoids import cycles)."""
+    global _LOADED
+    if _LOADED:
+        return
+    import importlib
+
+    for module in _CONNECTOR_MODULES:
+        try:
+            importlib.import_module(module)
+        except Exception:
+            # A broken/optional connector must not break detection for the others.
+            continue
+    _LOADED = True
+
+
+def registered_readers() -> list[RunInfoReader]:
+    """The connectors currently registered (priority order). Mainly for tests."""
+    _ensure_readers_loaded()
+    return list(_READERS)
+
+
+def read_run_info(run_dir: str | Path) -> WorkflowRunInfo | None:
+    """Detect the engine of ``run_dir`` and read its provenance, or ``None``.
+
+    Tries each registered connector by descending priority; the first one that
+    recognises the directory wins.
+    """
+    run_dir = Path(run_dir)
+    if not run_dir.is_dir():
+        return None
+    _ensure_readers_loaded()
+    for reader in _READERS:
+        try:
+            info = reader.read(run_dir)
+        except Exception:
+            continue
+        if info is not None:
+            return info
+    return None

--- a/depictio/models/models/snakemake.py
+++ b/depictio/models/models/snakemake.py
@@ -1,0 +1,101 @@
+"""Snakemake connector: read a run's provenance from its working directory.
+
+Reference template for additional connectors. Snakemake has no canonical
+self-describing manifest like nf-core's ``pipeline_info/`` (identity/version are
+best-effort), so recognition keys off the engine's footprint (``.snakemake/``,
+``Snakefile``, ``config.yaml``) and the dashboard composition (catalog file
+recognition) remains the primary driver.
+
+Registers itself with the generic run-info registry (``run_info.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from depictio.models.models.run_info import WorkflowRunInfo, register_run_info_reader
+
+# Files whose presence identifies a Snakemake working directory.
+_SNAKEFILES = ("Snakefile", "workflow/Snakefile")
+_CONFIGS = ("config.yaml", "config.yml", "config/config.yaml", "config/config.yml")
+
+
+def _looks_like_snakemake(run_dir: Path) -> bool:
+    if (run_dir / ".snakemake").is_dir():
+        return True
+    return any((run_dir / rel).is_file() for rel in (*_SNAKEFILES, *_CONFIGS))
+
+
+def _load_config(run_dir: Path) -> tuple[dict, Path | None]:
+    import yaml
+
+    for rel in _CONFIGS:
+        path = run_dir / rel
+        if path.is_file():
+            try:
+                data = yaml.safe_load(path.read_text()) or {}
+            except Exception:
+                return {}, path
+            return (data if isinstance(data, dict) else {}), path
+    return {}, None
+
+
+def _conda_tools(run_dir: Path) -> set[str]:
+    """Best-effort tool names from ``.snakemake/conda/*.yaml`` env definitions."""
+    import yaml
+
+    tools: set[str] = set()
+    conda_dir = run_dir / ".snakemake" / "conda"
+    if not conda_dir.is_dir():
+        return tools
+    for env in sorted(conda_dir.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(env.read_text()) or {}
+        except Exception:
+            continue
+        for dep in data.get("dependencies", []) if isinstance(data, dict) else []:
+            # dependencies are "tool=version" strings (or dicts like {pip: [...]}).
+            if isinstance(dep, str):
+                tools.add(dep.split("=", 1)[0].split("::")[-1].strip().lower())
+    return tools
+
+
+def read_snakemake_run_info(run_dir: str | Path) -> WorkflowRunInfo | None:
+    """Read a Snakemake run's provenance, or None if the dir isn't a Snakemake run."""
+    run_dir = Path(run_dir)
+    if not run_dir.is_dir() or not _looks_like_snakemake(run_dir):
+        return None
+
+    config, _ = _load_config(run_dir)
+    pipeline_name = None
+    for key in ("pipeline", "name", "workflow"):
+        value = config.get(key)
+        if isinstance(value, str) and value:
+            pipeline_name = value
+            break
+    if not pipeline_name:
+        pipeline_name = run_dir.name
+
+    version = config.get("version")
+    pipeline_version = str(version).lstrip("v") if version is not None else None
+
+    return WorkflowRunInfo(
+        engine="snakemake",
+        pipeline_name=pipeline_name,
+        pipeline_version=pipeline_version,
+        params=config,
+        tools_executed=_conda_tools(run_dir),
+    )
+
+
+class _SnakemakeReader:
+    """Connector entry for the run-info registry."""
+
+    name = "snakemake"
+    priority = 50  # below nf-core (less self-describing)
+
+    def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+        return read_snakemake_run_info(run_dir)
+
+
+register_run_info_reader(_SnakemakeReader())

--- a/depictio/models/models/workflows.py
+++ b/depictio/models/models/workflows.py
@@ -70,6 +70,13 @@ class WorkflowDataLocation(MongoModel):
 class WorkflowConfig(MongoModel):
     version: str | None = None
     workflow_parameters: dict | None = None
+    # Per-run Nextflow provenance (read from the run's pipeline_info/). Stored on
+    # the run-scoped WorkflowConfig so a workflow can aggregate runs of different
+    # pipeline versions without conflict.
+    engine_name: str | None = None
+    pipeline_version: str | None = None
+    nextflow_version: str | None = None
+    tools_executed: list[str] | None = None
 
 
 class WorkflowRunScan(BaseModel):

--- a/depictio/tests/cli/utils/test_template_detection.py
+++ b/depictio/tests/cli/utils/test_template_detection.py
@@ -1,0 +1,64 @@
+"""Tests for auto-detecting a template from a Nextflow run directory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from depictio.cli.cli.utils.templates import (
+    _list_pipeline_versions,
+    _version_key,
+    detect_template_from_run_dir,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _write_versions(run_dir: Path, pipeline: str, version: str) -> None:
+    pinfo = run_dir / "pipeline_info"
+    pinfo.mkdir(parents=True, exist_ok=True)
+    (pinfo / f"nf_core_{pipeline.split('/')[-1]}_software_mqc_versions.yml").write_text(
+        f"FASTQC:\n  fastqc: 0.12.1\nWorkflow:\n  {pipeline}: {version}\n  Nextflow: 24.04.4\n"
+    )
+    (pinfo / "params_x.json").write_text(json.dumps({"input": "samplesheet.csv"}))
+
+
+def test_version_key_orders_numerically():
+    assert _version_key("2.16.0") > _version_key("2.14.0")
+    assert _version_key("2.9.0") < _version_key("2.16.0")
+
+
+def test_lists_ampliseq_versions():
+    versions = _list_pipeline_versions("nf-core/ampliseq")
+    # The repo ships at least 2.14.0 and 2.16.0 template/project folders.
+    assert "2.16.0" in versions
+
+
+def test_exact_match_detected(tmp_path):
+    _write_versions(tmp_path, "nf-core/ampliseq", "2.16.0")
+    template_id, info = detect_template_from_run_dir(tmp_path)
+    assert template_id == "nf-core/ampliseq/2.16.0"
+    assert info is not None
+    assert info.params["input"] == "samplesheet.csv"
+
+
+def test_closest_version_fallback(tmp_path):
+    # A version with no exact template falls back to the closest available one.
+    _write_versions(tmp_path, "nf-core/ampliseq", "2.15.0")
+    template_id, info = detect_template_from_run_dir(tmp_path)
+    assert template_id is not None
+    assert template_id.startswith("nf-core/ampliseq/")
+    assert info is not None
+
+
+def test_unknown_pipeline_returns_none(tmp_path):
+    _write_versions(tmp_path, "nf-core/doesnotexist", "1.0.0")
+    template_id, info = detect_template_from_run_dir(tmp_path)
+    assert template_id is None
+    assert info is not None  # provenance still read
+
+
+def test_no_pipeline_info_returns_none(tmp_path):
+    template_id, info = detect_template_from_run_dir(tmp_path)
+    assert template_id is None
+    assert info is None

--- a/depictio/tests/models/test_compose_dashboard.py
+++ b/depictio/tests/models/test_compose_dashboard.py
@@ -1,0 +1,175 @@
+"""Tests for composing a DashboardDataLite from a scanned run directory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from depictio.models.components.advanced_viz.catalog import (
+    CatalogEntry,
+    CatalogFind,
+    CatalogOutput,
+    Render,
+)
+from depictio.models.components.advanced_viz.compose import (
+    GRID_WIDTH,
+    build_dashboard_from_run_dir,
+    render_to_component_dict,
+)
+from depictio.models.models.dashboards import DashboardDataLite
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VIRALRECON_RUN = REPO_ROOT / "depictio" / "projects" / "nf-core" / "viralrecon" / "3.0.0" / "run_1"
+
+
+def _entry(**kw) -> CatalogEntry:
+    base = {"id": "tool", "name": "tool", "outputs": []}
+    base.update(kw)
+    return CatalogEntry(**base)
+
+
+# ---------------------------------------------------------------------------
+# Unit: Render → lite component dict mapping
+# ---------------------------------------------------------------------------
+
+
+def test_advanced_viz_render_emits_use_reference():
+    render = Render(
+        id="volcano",
+        component="advanced_viz",
+        kind="volcano",
+        roles={"feature_id": "id", "effect_size": "lfc", "significance": "q"},
+    )
+    output = CatalogOutput(id="tool_diff", find=CatalogFind(filename="x.csv"), recipe="t/d.py")
+    entry = _entry(outputs=[output])
+    comp = render_to_component_dict(
+        render, entry, output, workflow_tag="nf-core/x", data_collection_tag="tool_diff", index=0
+    )
+    assert comp is not None
+    assert comp["component_type"] == "advanced_viz"
+    assert comp["use"] == "tool/volcano"  # render id preferred
+    assert comp["data_collection_tag"] == "tool_diff"
+
+
+def test_advanced_viz_without_render_id_uses_output_short_and_kind():
+    render = Render(component="advanced_viz", kind="qq", roles={"p_value": "pval"})
+    output = CatalogOutput(id="tool_diff", find=CatalogFind(filename="x.csv"), recipe="t/d.py")
+    entry = _entry(outputs=[output])
+    comp = render_to_component_dict(
+        render, entry, output, workflow_tag="", data_collection_tag="tool_diff", index=1
+    )
+    assert comp is not None
+    assert comp["use"] == "tool/diff"  # output id minus the "tool_" prefix
+    assert comp["viz_kind"] == "qq"
+
+
+def test_card_render_maps_fields_and_derives_column_type():
+    render = Render(component="card", column="coverage", aggregation="average")
+    output = CatalogOutput(
+        id="tool_cov",
+        find=CatalogFind(filename="x.tsv"),
+        columns={"coverage": "Float64"},
+    )
+    entry = _entry(outputs=[output])
+    comp = render_to_component_dict(
+        render, entry, output, workflow_tag="", data_collection_tag="tool_cov", index=0
+    )
+    assert comp is not None
+    assert comp["component_type"] == "card"
+    assert comp["column_name"] == "coverage"
+    assert comp["aggregation"] == "average"
+    assert comp["column_type"] == "float64"
+
+
+def test_figure_code_mode_render():
+    render = Render(component="figure", code="fig = px.box(df)")
+    output = CatalogOutput(id="tool_fig", find=CatalogFind(filename="x.tsv"))
+    entry = _entry(outputs=[output])
+    comp = render_to_component_dict(
+        render, entry, output, workflow_tag="", data_collection_tag="tool_fig", index=0
+    )
+    assert comp is not None
+    assert comp["mode"] == "code"
+    assert comp["code_content"] == "fig = px.box(df)"
+
+
+def test_multiqc_render_is_skipped():
+    render = Render(component="multiqc", section="fastqc")
+    output = CatalogOutput(id="tool_mqc", find=CatalogFind(filename="x"))
+    entry = _entry(outputs=[output])
+    comp = render_to_component_dict(
+        render, entry, output, workflow_tag="", data_collection_tag="tool_mqc", index=0
+    )
+    assert comp is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end on a real run directory
+# ---------------------------------------------------------------------------
+
+
+def _require_run():
+    if not VIRALRECON_RUN.is_dir():
+        pytest.skip("viralrecon run_1 fixture not present")
+
+
+def test_build_returns_nonempty_dashboard():
+    _require_run()
+    dash = build_dashboard_from_run_dir(VIRALRECON_RUN, confirm_with_versions=False)
+    assert isinstance(dash, DashboardDataLite)
+    assert dash.components, "expected catalog-recognised components"
+
+
+def test_advanced_viz_components_validate_and_expand_use():
+    _require_run()
+    dash = build_dashboard_from_run_dir(VIRALRECON_RUN, confirm_with_versions=False)
+    kinds = {
+        getattr(c, "viz_kind", None)
+        for c in dash.components
+        if getattr(c, "component_type", None) == "advanced_viz"
+    }
+    # mosdepth genome/amplicon coverage → coverage_track (use: expanded to config)
+    assert "coverage_track" in kinds
+    for comp in dash.components:
+        if getattr(comp, "component_type", None) == "advanced_viz":
+            assert comp.config is not None
+            assert comp.viz_kind == comp.config.viz_kind
+
+
+def test_layout_fits_grid():
+    _require_run()
+    dash = build_dashboard_from_run_dir(VIRALRECON_RUN, confirm_with_versions=False)
+    for comp in dash.components:
+        layout = getattr(comp, "layout", None)
+        assert layout is not None
+        assert layout["x"] + layout["w"] <= GRID_WIDTH
+
+
+def test_yaml_roundtrip_lite_only():
+    _require_run()
+    dash = build_dashboard_from_run_dir(VIRALRECON_RUN, confirm_with_versions=False)
+    # Lite → yaml → Lite must re-validate (do NOT go through to_full/from_full).
+    reparsed = DashboardDataLite.from_yaml(dash.to_yaml())
+    assert len(reparsed.components) == len(dash.components)
+
+
+# ---------------------------------------------------------------------------
+# Architectural guard: the compose module must stay recipe-free / offline
+# ---------------------------------------------------------------------------
+
+
+def test_compose_module_never_imports_recipes():
+    import ast
+
+    source = (
+        REPO_ROOT / "depictio" / "models" / "components" / "advanced_viz" / "compose.py"
+    ).read_text()
+    tree = ast.parse(source)
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+        elif isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+    assert not any(m == "depictio.recipes" or m.startswith("depictio.recipes.") for m in imported)

--- a/depictio/tests/models/test_nextflow_run_info.py
+++ b/depictio/tests/models/test_nextflow_run_info.py
@@ -1,0 +1,94 @@
+"""Tests for the Nextflow run-info reader (pipeline_info/ provenance)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from depictio.models.models.nextflow import NextflowRunInfo, read_nextflow_run_info
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _write_pipeline_info(run_dir: Path) -> None:
+    """Create a realistic nf-core pipeline_info/ under run_dir."""
+    pinfo = run_dir / "pipeline_info"
+    pinfo.mkdir(parents=True)
+    (pinfo / "nf_core_ampliseq_software_mqc_versions.yml").write_text(
+        "FASTQC:\n"
+        "  fastqc: 0.12.1\n"
+        "QIIME2:\n"
+        "  qiime2: 2024.5.0\n"
+        "Workflow:\n"
+        "  nf-core/ampliseq: 2.16.0\n"
+        "  Nextflow: 24.04.4\n"
+    )
+    (pinfo / "params_2026-06-09_10-00-00.json").write_text(
+        json.dumps({"input": "samplesheet.csv", "metadata": "meta.tsv", "outdir": "results"})
+    )
+    (pinfo / "execution_report_2026-06-09_10-00-00.html").write_text("<html></html>")
+    (pinfo / "execution_trace_2026-06-09_10-00-00.txt").write_text("task_id\thash\n")
+
+
+def test_reads_full_pipeline_info(tmp_path):
+    _write_pipeline_info(tmp_path)
+    info = read_nextflow_run_info(tmp_path)
+    assert info is not None
+    assert info.pipeline_name == "nf-core/ampliseq"
+    assert info.pipeline_version == "2.16.0"
+    assert info.nextflow_version == "24.04.4"
+    assert info.short_name == "ampliseq"
+    assert info.tools_executed == {"fastqc", "qiime2"}
+    assert info.params["input"] == "samplesheet.csv"
+    assert info.params["metadata"] == "meta.tsv"
+    assert info.execution_report_path is not None
+    assert info.execution_trace_path is not None
+
+
+def test_template_ids_offers_both_version_spellings():
+    info = NextflowRunInfo(pipeline_name="nf-core/rnaseq", pipeline_version="v3.16.0")
+    assert info.template_ids() == ["nf-core/rnaseq/3.16.0", "nf-core/rnaseq/v3.16.0"]
+    plain = NextflowRunInfo(pipeline_name="nf-core/ampliseq", pipeline_version="2.16.0")
+    assert plain.template_ids() == ["nf-core/ampliseq/2.16.0"]
+
+
+def test_strips_leading_v_from_version(tmp_path):
+    pinfo = tmp_path / "pipeline_info"
+    pinfo.mkdir()
+    (pinfo / "nf_core_rnaseq_software_mqc_versions.yml").write_text(
+        "Workflow:\n  nf-core/rnaseq: v3.16.0\n  Nextflow: 24.10.0\n"
+    )
+    info = read_nextflow_run_info(tmp_path)
+    assert info is not None
+    assert info.pipeline_version == "3.16.0"
+
+
+def test_missing_pipeline_info_degrades_gracefully(tmp_path):
+    # An empty run dir (no pipeline_info/) must not raise; returns None.
+    assert read_nextflow_run_info(tmp_path) is None
+
+
+def test_nonexistent_dir_returns_none():
+    assert read_nextflow_run_info("/no/such/path/xyz") is None
+
+
+def test_real_viralrecon_run_has_no_pipeline_info():
+    # The curated reference run dirs are subsets without pipeline_info/ — the
+    # reader must tolerate that (returns None or partial without exception).
+    run = REPO_ROOT / "depictio" / "projects" / "nf-core" / "viralrecon" / "3.0.0" / "run_1"
+    if not run.is_dir():
+        import pytest
+
+        pytest.skip("viralrecon run_1 fixture not present")
+    info = read_nextflow_run_info(run)
+    # No pipeline_info → no pipeline identity (None or partial without a name).
+    assert info is None or info.pipeline_name is None
+
+
+def test_software_versions_fallback_for_tools(tmp_path):
+    # Legacy software_versions.yml (no Workflow section) still yields tools.
+    (tmp_path / "software_versions.yml").write_text("FASTQC:\n  fastqc: 0.12.1\n")
+    info = read_nextflow_run_info(tmp_path)
+    assert info is not None
+    assert info.tools_executed == {"fastqc"}
+    assert info.pipeline_name is None

--- a/depictio/tests/models/test_nextflow_run_info.py
+++ b/depictio/tests/models/test_nextflow_run_info.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from depictio.models.models.nextflow import NextflowRunInfo, read_nextflow_run_info
+from depictio.models.models.nextflow import read_nextflow_run_info
+from depictio.models.models.run_info import WorkflowRunInfo
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -34,9 +35,10 @@ def test_reads_full_pipeline_info(tmp_path):
     _write_pipeline_info(tmp_path)
     info = read_nextflow_run_info(tmp_path)
     assert info is not None
+    assert info.engine == "nextflow"
     assert info.pipeline_name == "nf-core/ampliseq"
     assert info.pipeline_version == "2.16.0"
-    assert info.nextflow_version == "24.04.4"
+    assert info.engine_version == "24.04.4"
     assert info.short_name == "ampliseq"
     assert info.tools_executed == {"fastqc", "qiime2"}
     assert info.params["input"] == "samplesheet.csv"
@@ -46,9 +48,9 @@ def test_reads_full_pipeline_info(tmp_path):
 
 
 def test_template_ids_offers_both_version_spellings():
-    info = NextflowRunInfo(pipeline_name="nf-core/rnaseq", pipeline_version="v3.16.0")
+    info = WorkflowRunInfo(pipeline_name="nf-core/rnaseq", pipeline_version="v3.16.0")
     assert info.template_ids() == ["nf-core/rnaseq/3.16.0", "nf-core/rnaseq/v3.16.0"]
-    plain = NextflowRunInfo(pipeline_name="nf-core/ampliseq", pipeline_version="2.16.0")
+    plain = WorkflowRunInfo(pipeline_name="nf-core/ampliseq", pipeline_version="2.16.0")
     assert plain.template_ids() == ["nf-core/ampliseq/2.16.0"]
 
 

--- a/depictio/tests/models/test_run_info_dispatch.py
+++ b/depictio/tests/models/test_run_info_dispatch.py
@@ -1,0 +1,76 @@
+"""Tests for the pluggable run-info registry/dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from depictio.models.models.run_info import (
+    WorkflowRunInfo,
+    read_run_info,
+    register_run_info_reader,
+    registered_readers,
+)
+
+
+def test_nextflow_and_snakemake_connectors_registered():
+    names = {r.name for r in registered_readers()}
+    assert {"nextflow", "snakemake"} <= names
+
+
+def test_dispatch_detects_nextflow(tmp_path):
+    pinfo = tmp_path / "pipeline_info"
+    pinfo.mkdir()
+    (pinfo / "nf_core_ampliseq_software_mqc_versions.yml").write_text(
+        "Workflow:\n  nf-core/ampliseq: 2.16.0\n  Nextflow: 24.04.4\n"
+    )
+    info = read_run_info(tmp_path)
+    assert info is not None
+    assert info.engine == "nextflow"
+    assert info.pipeline_name == "nf-core/ampliseq"
+
+
+def test_dispatch_detects_snakemake(tmp_path):
+    (tmp_path / "Snakefile").write_text("rule all:\n    input: []\n")
+    (tmp_path / "config.yaml").write_text("pipeline: smk-wf\nversion: 0.1.0\n")
+    info = read_run_info(tmp_path)
+    assert info is not None
+    assert info.engine == "snakemake"
+    assert info.pipeline_name == "smk-wf"
+
+
+def test_nextflow_wins_over_snakemake_when_both_present(tmp_path):
+    # A dir carrying both footprints resolves to nf-core (higher priority).
+    pinfo = tmp_path / "pipeline_info"
+    pinfo.mkdir()
+    (pinfo / "nf_core_x_software_mqc_versions.yml").write_text(
+        "Workflow:\n  nf-core/x: 1.0.0\n  Nextflow: 24.0.0\n"
+    )
+    (tmp_path / "Snakefile").write_text("rule all:\n    input: []\n")
+    info = read_run_info(tmp_path)
+    assert info is not None
+    assert info.engine == "nextflow"
+
+
+def test_dispatch_returns_none_for_unknown(tmp_path):
+    (tmp_path / "data.txt").write_text("nothing recognisable")
+    assert read_run_info(tmp_path) is None
+
+
+def test_priority_ordering_and_idempotent_registration():
+    before = len(registered_readers())
+
+    class _Dummy:
+        name = "nextflow"  # same name → replaces, not duplicates
+        priority = 1
+
+        def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+            return None
+
+    register_run_info_reader(_Dummy())
+    assert len(registered_readers()) == before
+    # restore the real nextflow connector for other tests in the session
+    import importlib
+
+    import depictio.models.models.nextflow as nf
+
+    importlib.reload(nf)

--- a/depictio/tests/models/test_snakemake_run_info.py
+++ b/depictio/tests/models/test_snakemake_run_info.py
@@ -1,0 +1,59 @@
+"""Tests for the Snakemake run-info connector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from depictio.models.models.snakemake import read_snakemake_run_info
+
+
+def _write_snakemake(run_dir: Path, *, with_config: bool = True) -> None:
+    (run_dir / "Snakefile").write_text("rule all:\n    input: 'results/out.tsv'\n")
+    (run_dir / ".snakemake").mkdir()
+    conda = run_dir / ".snakemake" / "conda"
+    conda.mkdir()
+    (conda / "abc123.yaml").write_text(
+        "channels:\n  - bioconda\ndependencies:\n  - mosdepth=0.3.3\n  - samtools=1.17\n"
+    )
+    if with_config:
+        (run_dir / "config.yaml").write_text(
+            "pipeline: my-snake-wf\nversion: 1.2.0\nsamples: s.tsv\n"
+        )
+
+
+def test_reads_snakemake_run(tmp_path):
+    _write_snakemake(tmp_path)
+    info = read_snakemake_run_info(tmp_path)
+    assert info is not None
+    assert info.engine == "snakemake"
+    assert info.pipeline_name == "my-snake-wf"
+    assert info.pipeline_version == "1.2.0"
+    assert info.params["samples"] == "s.tsv"
+    assert {"mosdepth", "samtools"} <= info.tools_executed
+
+
+def test_pipeline_name_falls_back_to_dir(tmp_path):
+    run = tmp_path / "my_run"
+    run.mkdir()
+    _write_snakemake(run, with_config=False)
+    info = read_snakemake_run_info(run)
+    assert info is not None
+    assert info.pipeline_name == "my_run"
+    assert info.pipeline_version is None
+
+
+def test_recognised_by_snakefile_only(tmp_path):
+    (tmp_path / "workflow").mkdir()
+    (tmp_path / "workflow" / "Snakefile").write_text("rule all:\n    input: []\n")
+    info = read_snakemake_run_info(tmp_path)
+    assert info is not None
+    assert info.engine == "snakemake"
+
+
+def test_non_snakemake_dir_returns_none(tmp_path):
+    (tmp_path / "random.txt").write_text("hello")
+    assert read_snakemake_run_info(tmp_path) is None
+
+
+def test_nonexistent_dir_returns_none():
+    assert read_snakemake_run_info("/no/such/path/xyz") is None


### PR DESCRIPTION
## What

`depictio run --data-root <run_dir>` works without hand-picking a template: it reads the run's provenance, then either auto-selects a matching template (pre-filling `--var` from run params) or auto-composes a dashboard from the catalog-recognised module outputs. Provenance is persisted per run.

The provenance/identity layer is **engine-agnostic and pluggable**: dashboard composition was already engine-neutral (the catalog recognises files by name/glob), so adding a workflow system is just dropping a small connector that self-registers — `compose`/`run`/`templates` are untouched. Ships **nf-core/Nextflow** and **Snakemake** connectors; Galaxy (via RO-Crate) and others (CWL, WDL, …) plug in the same way later.

## Changes

- **`models/models/run_info.py`** (new): engine-agnostic `WorkflowRunInfo` + a connector registry (`RunInfoReader` protocol, `register_run_info_reader`, `read_run_info`). Free-form `extra` for connector-specific metadata.
- **`models/models/nextflow.py`**: nf-core/Nextflow connector — parses `pipeline_info/` (`*_software_mqc_versions.yml` `Workflow:` section, `params_*.json`, manifest fallback), returns `WorkflowRunInfo`, self-registers (priority 100).
- **`models/models/snakemake.py`** (new): Snakemake connector (`.snakemake/` / `Snakefile` / `config.yaml`; best-effort identity; conda-env tools), self-registers (priority 50).
- **`models/components/advanced_viz/compose.py`**: `build_dashboard_from_run_dir` takes any `WorkflowRunInfo`, scopes recognition via `info.tools_executed`, derives `workflow_system` from the engine. Maps each catalog `Render` → lite component (advanced_viz via `use:`, figure, card, table; multiqc skipped) on an 8-column grid. Pure/offline: never imports a recipe.
- **`models/components/advanced_viz/catalog.py`**: `match_run_dir` gains engine-agnostic `executed_tools` scoping.
- **`cli/utils/templates.py`**: `detect_template_from_run_dir` uses the registry dispatch.
- **`cli/commands/run.py`**: Step 0 auto-detection; provenance + param→var mapping keyed by engine.
- **`models/models/workflows.py`**: `WorkflowConfig` gains per-run provenance.

## Tests

Connector readers (nf-core on real `viralrecon/run_1` + synthetic `pipeline_info/`; Snakemake on synthetic dirs), registry dispatch/priority, template detection, and the composer (advanced-viz `use:` expansion, 8-column layout, YAML round-trip).

## Scope / follow-ups

- nf-core + Snakemake connectors land here. **Galaxy via RO-Crate** (`ro-crate-metadata.json`) and other engines (CWL, WDL, native Galaxy `.ga`) plug in via the registry — deferred.
- No-template DataCollection generation (`data_collections:` from `find`/`recipe`) and scan-time per-run provenance wiring are the next increment.