### PR TITLE
perf(deltatables): column projection for figures/cards + Delta schema cache

### DIFF
--- a/depictio/api/v1/celery_tasks.py
+++ b/depictio/api/v1/celery_tasks.py
@@ -78,11 +78,33 @@ def build_figure_preview(payload: dict) -> dict:
             "size_bytes": dc_config.get("size_bytes", 0),
         }
 
+    visu_type = metadata.get("visu_type", "scatter")
+    dict_kwargs = metadata.get("dict_kwargs") or {}
+    mode = metadata.get("mode", "ui")
+    code_content = metadata.get("code_content", "")
+    selection_enabled = bool(metadata.get("selection_enabled", False))
+    selection_column = metadata.get("selection_column")
+
+    # Column projection (#7): in UI mode the figure spec tells us exactly which
+    # columns Plotly Express will read, so load only those — the loader folds in
+    # filter columns and schema-guards the set. Code mode can reference any
+    # column via arbitrary user code, so it always loads the full frame.
+    select_columns: list[str] | None = None
+    if mode != "code":
+        from depictio.api.v1.services.figure.figure_builder import referenced_columns
+
+        cols = referenced_columns(visu_type, dict_kwargs)
+        if cols is not None:
+            if selection_enabled and selection_column:
+                cols = cols | {selection_column}
+            select_columns = sorted(cols)
+
     started = time.monotonic()
     df = load_deltatable_lite(
         workflow_id=ObjectId(str(wf_id)) if not isinstance(wf_id, ObjectId) else wf_id,
         data_collection_id=str(dc_id),
         metadata=filter_metadata or None,
+        select_columns=select_columns,
         init_data=init_data,
     )
     load_ms = int((time.monotonic() - started) * 1000)
@@ -93,13 +115,6 @@ def build_figure_preview(payload: dict) -> dict:
         create_figure_from_data,
         process_code_mode_figure,
     )
-
-    visu_type = metadata.get("visu_type", "scatter")
-    dict_kwargs = metadata.get("dict_kwargs") or {}
-    mode = metadata.get("mode", "ui")
-    code_content = metadata.get("code_content", "")
-    selection_enabled = bool(metadata.get("selection_enabled", False))
-    selection_column = metadata.get("selection_column")
 
     build_started = time.monotonic()
     code_error: str | None = None

--- a/depictio/api/v1/deltatables_utils.py
+++ b/depictio/api/v1/deltatables_utils.py
@@ -19,6 +19,15 @@ ENABLE_CACHING = True  # Global toggle for caching system
 USE_LOCAL_FILES = os.getenv("DEPICTIO_USE_LOCAL_FILES", "false").lower() == "true"
 DELTA_CACHE_DIR = os.getenv("DEPICTIO_DELTA_CACHE_DIR", "/app/cache/delta_cache")
 
+# Delta schema cache (#12). ``collect_schema()`` reads the Delta log; on the hot
+# render path (a card grid re-computing on every filter change, or a projected
+# figure load) that's a repeated round-trip for a schema that only changes when
+# ingest bumps the aggregation version. Cache the column names per
+# (data_collection_id, aggregation_version) so a new ingest naturally
+# invalidates the entry — the same discriminator the dataframe cache keys use.
+_DELTA_SCHEMA_CACHE: dict[tuple[str, str], frozenset[str]] = {}
+_DELTA_SCHEMA_CACHE_MAX = 512  # bounded; the version salt churns keys over time
+
 
 def get_local_cache_path(s3_path: str) -> str:
     """
@@ -601,28 +610,105 @@ def _create_delta_scan(file_id: str, dc_type: str | None = None) -> pl.LazyFrame
     return pl.scan_delta(file_id, storage_options=polars_s3_config)
 
 
-def _apply_scan_options(
+def _get_cached_schema(
     delta_scan: pl.LazyFrame,
+    data_collection_id_str: str,
+    version_salt: str | int | None,
+) -> frozenset[str] | None:
+    """Return a DC's Delta column names, cached per (collection, version) (#12).
+
+    On cache miss, reads the lazy schema once (a Delta-log round-trip, no data)
+    and memoizes it. Returns ``None`` if the schema can't be read, so callers
+    fall back to their pre-cache behaviour (no projection / no filter pruning).
+    """
+    cache_key = (data_collection_id_str, str(version_salt))
+    cached = _DELTA_SCHEMA_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        names = frozenset(delta_scan.collect_schema().names())
+    except Exception as e:
+        logger.debug(f"_get_cached_schema: schema read failed for {data_collection_id_str}: {e}")
+        return None
+    # Simple bound: a schema is cheap to re-read, so clearing on overflow is
+    # fine and avoids tracking per-entry recency.
+    if len(_DELTA_SCHEMA_CACHE) >= _DELTA_SCHEMA_CACHE_MAX:
+        _DELTA_SCHEMA_CACHE.clear()
+    _DELTA_SCHEMA_CACHE[cache_key] = names
+    return names
+
+
+def _filter_columns(metadata: list[dict] | None) -> set[str]:
+    """Column names referenced by a filter metadata list.
+
+    Mirrors the column extraction used by ``apply_runtime_filters`` and the
+    large-path filter pruning: a filter component carries its column either at
+    the top level or under a nested ``metadata`` dict.
+    """
+    cols: set[str] = set()
+    for component in metadata or []:
+        if not isinstance(component, dict):
+            continue
+        nested = component.get("metadata") if isinstance(component.get("metadata"), dict) else None
+        col = component.get("column_name") or (nested.get("column_name") if nested else None)
+        if col:
+            cols.add(col)
+    return cols
+
+
+def _effective_projection(
     select_columns: list[str] | None,
-    limit_rows: int | None,
+    metadata: list[dict] | None,
+    load_for_options: bool,
+) -> list[str] | None:
+    """Resolve the column set a projected load must actually scan (#7).
+
+    Returns ``None`` (full load) when no projection was requested, preserving
+    today's behaviour for every caller that doesn't opt in.
+
+    When a projection *is* requested, the columns the pending filters reference
+    are folded in: projection happens at scan level *before* filtering, and
+    ``apply_runtime_filters`` silently skips a filter whose column is missing —
+    so dropping a filter column would quietly change results, not just error.
+    Folding filter columns into the returned set also means the cache key
+    (derived from this list) reflects the exact columns of the cached frame, so
+    two requests sharing a projection but filtering on different columns can't
+    collide on the same base entry.
+    """
+    if not select_columns:
+        return None
+    cols = set(select_columns)
+    if metadata and not load_for_options:
+        cols |= _filter_columns(metadata)
+    return sorted(cols)
+
+
+def _project_scan(
+    delta_scan: pl.LazyFrame,
+    effective_cols: list[str] | None,
+    data_collection_id_str: str,
+    version_salt: str | int | None,
 ) -> pl.LazyFrame:
+    """Apply scan-level column projection, intersected with the real schema.
+
+    ``effective_cols`` already unions the requested columns with the columns
+    the pending filters reference (see ``_effective_projection``). Columns not
+    on this DC's schema are dropped here rather than passed to ``.select`` —
+    which would raise ``ColumnNotFoundError`` at ``collect`` — mirroring the
+    cross-DC filter pruning the large path already does. Projection therefore
+    never changes which rows or columns a load would otherwise return; it only
+    avoids reading columns nothing needs.
     """
-    Apply column projection and row limit to a LazyFrame scan.
-
-    Args:
-        delta_scan: Polars LazyFrame to modify.
-        select_columns: Optional list of columns to select.
-        limit_rows: Optional row limit.
-
-    Returns:
-        Modified LazyFrame with projections/limits applied.
-    """
-    if select_columns:
-        delta_scan = delta_scan.select(select_columns)
-
-    if limit_rows:
-        delta_scan = delta_scan.limit(limit_rows)
-
+    if not effective_cols:
+        return delta_scan
+    schema_names = _get_cached_schema(delta_scan, data_collection_id_str, version_salt)
+    projection = (
+        [c for c in effective_cols if c in schema_names]
+        if schema_names is not None
+        else effective_cols
+    )
+    if projection:
+        delta_scan = delta_scan.select(projection)
     return delta_scan
 
 
@@ -875,6 +961,7 @@ def _load_large_dataframe(
     load_for_options: bool,
     limit_rows: int | None,
     size_bytes: int,
+    version_salt: str | int | None = None,
 ) -> pl.DataFrame:
     """
     Load a large DataFrame using lazy evaluation with filters applied at scan time.
@@ -886,6 +973,7 @@ def _load_large_dataframe(
         load_for_options: If True, skip filtering.
         limit_rows: Optional row limit.
         size_bytes: Size for logging.
+        version_salt: Aggregation version for the schema cache key (#12).
 
     Returns:
         Loaded DataFrame.
@@ -899,10 +987,8 @@ def _load_large_dataframe(
         # appends the translated sample_id filter, so we can safely drop the
         # untranslated habitat filter here instead of failing the whole load
         # with a polars ColumnNotFoundError.
-        try:
-            available_cols = set(delta_scan.collect_schema().names())
-        except Exception:
-            available_cols = None
+        schema_names = _get_cached_schema(delta_scan, data_collection_id_str, version_salt)
+        available_cols = set(schema_names) if schema_names is not None else None
 
         usable_metadata = metadata
         if available_cols is not None:
@@ -1054,6 +1140,13 @@ def load_deltatable_lite(
             "See get_result_dc_for_workflow() in depictio/dash/utils.py."
         )
 
+    # Resolve the effective projection once, up front (no I/O): the requested
+    # columns plus any columns the pending filters reference. Used for the
+    # cache key, the cache lookups, and the scan so they all agree on the exact
+    # column set of the (cached) frame. ``None`` when no projection was asked
+    # for, which keeps every non-opted-in caller on today's full-load path.
+    effective_cols = _effective_projection(select_columns, metadata, load_for_options)
+
     # CACHING DISABLED PATH - load directly from storage
     if not ENABLE_CACHING:
         file_id = _get_delta_location(data_collection_id_str, workflow_id_str, init_data, TOKEN)
@@ -1069,7 +1162,9 @@ def load_deltatable_lite(
             )
             dc_type = _get_dc_type_from_db(data_collection_id_obj)
         delta_scan = _create_delta_scan(file_id, dc_type)
-        delta_scan = _apply_scan_options(delta_scan, select_columns, limit_rows)
+        delta_scan = _project_scan(delta_scan, effective_cols, data_collection_id_str, None)
+        if limit_rows:
+            delta_scan = delta_scan.limit(limit_rows)
         df = delta_scan.collect()
         return _finalize_dataframe(df, metadata, load_for_options, None)
 
@@ -1089,7 +1184,7 @@ def load_deltatable_lite(
         workflow_id_str,
         data_collection_id_str,
         load_for_preview,
-        select_columns,
+        effective_cols,
         metadata,
         load_for_options,
         version_salt=version_salt,
@@ -1102,7 +1197,7 @@ def load_deltatable_lite(
         filter_hash,
         metadata,
         load_for_options,
-        select_columns,
+        effective_cols,
         limit_rows,
     )
     if cached_df is not None:
@@ -1115,7 +1210,7 @@ def load_deltatable_lite(
         filter_hash,
         metadata,
         load_for_options,
-        select_columns,
+        effective_cols,
         limit_rows,
     )
     if cached_df is not None:
@@ -1140,9 +1235,8 @@ def load_deltatable_lite(
     file_id = _get_delta_location(data_collection_id_str, workflow_id_str, init_data, TOKEN)
     delta_scan = _create_delta_scan(file_id, dc_type)
 
-    # Apply column projection at scan level
-    if select_columns:
-        delta_scan = delta_scan.select(select_columns)
+    # Apply column projection at scan level (schema-guarded; see _project_scan)
+    delta_scan = _project_scan(delta_scan, effective_cols, data_collection_id_str, version_salt)
 
     # ADAPTIVE LOADING STRATEGY
     if size_bytes == -1 or size_bytes <= MEMORY_THRESHOLD_BYTES:
@@ -1169,6 +1263,7 @@ def load_deltatable_lite(
             load_for_options,
             limit_rows,
             size_bytes,
+            version_salt,
         )
 
     # Final cleanup (drop aggregation column)

--- a/depictio/api/v1/deltatables_utils.py
+++ b/depictio/api/v1/deltatables_utils.py
@@ -698,14 +698,18 @@ def _project_scan(
     cross-DC filter pruning the large path already does. Projection therefore
     never changes which rows or columns a load would otherwise return; it only
     avoids reading columns nothing needs.
+
+    If the schema can't be read (``_get_cached_schema`` returns ``None``), we
+    skip projection entirely and load the full frame — passing an unverified
+    ``effective_cols`` to ``.select`` could include a column absent from this DC
+    (e.g. a cross-DC filter column) and turn a transient schema-read failure
+    into a hard ``ColumnNotFoundError`` at ``collect``.
     """
     if not effective_cols:
         return delta_scan
     schema_names = _get_cached_schema(delta_scan, data_collection_id_str, version_salt)
     projection = (
-        [c for c in effective_cols if c in schema_names]
-        if schema_names is not None
-        else effective_cols
+        [c for c in effective_cols if c in schema_names] if schema_names is not None else None
     )
     if projection:
         delta_scan = delta_scan.select(projection)

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -1605,6 +1605,43 @@ def bulk_compute_cards(
         specs_cache[dc_id_str] = flat
         return flat
 
+    def _card_cache_key(wf_id: Any, dc_id: Any) -> tuple:
+        """``(wf_id, dc_id, filter signature)`` — the dedupe key for a card's
+        Delta load. Cards sharing it share one loaded frame (via ``df_cache``),
+        so a projected load must carry the union of their columns."""
+        card_filters = _resolved_filters_for(str(dc_id))
+        filter_sig = tuple(
+            sorted(
+                (
+                    str(fm.get("column_name")),
+                    str(fm.get("interactive_component_type")),
+                    repr(fm.get("value")),
+                )
+                for fm in card_filters
+            )
+        )
+        return (str(wf_id), str(dc_id), filter_sig)
+
+    # Column projection (#7) pre-pass: the slow Delta load is shared across
+    # every card with the same (wf_id, dc_id, filter) signature, so the
+    # projected load must carry the union of all sibling cards' referenced
+    # columns — otherwise a sibling reusing the cached frame would find its
+    # column missing and report null. The loader folds in filter columns and
+    # schema-guards the set; over-inclusion only costs a little extra I/O.
+    needed_cols_by_key: dict[tuple, set[str]] = {}
+    for card in cards:
+        wf_id = card.get("wf_id")
+        dc_id = card.get("dc_id")
+        column = card.get("column_name")
+        aggregation = card.get("aggregation")
+        if not (wf_id and dc_id and column and aggregation):
+            continue
+        key_cols = needed_cols_by_key.setdefault(_card_cache_key(wf_id, dc_id), set())
+        key_cols.add(column)
+        breakdown_col = card.get("breakdown_col")
+        if breakdown_col:
+            key_cols.add(breakdown_col)
+
     for card in cards:
         idx = str(card.get("index"))
         wf_id = card.get("wf_id")
@@ -1673,24 +1710,16 @@ def bulk_compute_cards(
         # Cache key includes the filter signature so two cards on the same DC
         # with different (link-resolved) filter sets don't collide.
         card_filters = _resolved_filters_for(str(dc_id))
-        filter_sig = tuple(
-            sorted(
-                (
-                    str(fm.get("column_name")),
-                    str(fm.get("interactive_component_type")),
-                    repr(fm.get("value")),
-                )
-                for fm in card_filters
-            )
-        )
-        cache_key = (str(wf_id), str(dc_id), filter_sig)
+        cache_key = _card_cache_key(wf_id, dc_id)
         df = df_cache.get(cache_key)
         if df is None:
             try:
+                project_cols = sorted(needed_cols_by_key.get(cache_key, set())) or None
                 df = load_deltatable_lite(
                     workflow_id=ObjectId(str(wf_id)) if not isinstance(wf_id, ObjectId) else wf_id,
                     data_collection_id=str(dc_id),
                     metadata=card_filters if card_filters else None,
+                    select_columns=project_cols,
                     init_data=init_data,
                 )
                 logger.debug(

--- a/depictio/api/v1/services/figure/figure_builder.py
+++ b/depictio/api/v1/services/figure/figure_builder.py
@@ -26,6 +26,81 @@ _POINT_PLOT_TYPES = frozenset(
     {"scatter", "scatter_3d", "scatter_ternary", "scatter_polar", "strip"}
 )
 
+# Plotly Express keyword args whose value is a single DataFrame column name.
+_PX_COLUMN_PARAMS: frozenset[str] = frozenset(
+    {
+        "x", "y", "z", "color", "size", "symbol", "line_dash", "line_group",
+        "pattern_shape", "hover_name", "names", "values", "facet_col", "facet_row",
+        "animation_frame", "animation_group", "base", "r", "theta", "a", "b", "c",
+        "error_x", "error_y", "error_z",
+    }
+)  # fmt: skip
+
+# Plotly Express keyword args whose value is a list (or ``{col: bool}`` dict) of
+# column names.
+_PX_COLUMN_LIST_PARAMS: frozenset[str] = frozenset({"hover_data", "custom_data", "dimensions"})
+
+# Visualisations that read the whole frame (or a column set we can't reliably
+# enumerate from dict_kwargs): projecting them risks dropping needed columns, so
+# signal a full load instead.
+_WHOLE_FRAME_VISU: frozenset[str] = frozenset(
+    {
+        "heatmap", "scatter_matrix", "parallel_coordinates",
+        "parallel_categories", "imshow", "scatter_geo", "choropleth",
+    }
+)  # fmt: skip
+
+
+def referenced_columns(visu_type: str, dict_kwargs: dict) -> set[str] | None:
+    """Columns a UI-mode figure references, for scan-level column projection (#7).
+
+    Returns the set of column names the Plotly Express call will read from the
+    DataFrame, so the loader can project the Delta scan to just those columns
+    (it folds in any filter columns and schema-guards the result). Returns
+    ``None`` whenever projection is unsafe — a whole-frame visualisation
+    (heatmap, scatter_matrix, …), a column list we can't parse, or a non-dict
+    spec — so the caller falls back to a full load. Missing a referenced column
+    would silently break the figure, so this errs toward ``None`` on any
+    uncertainty.
+
+    Code-mode figures must never be projected via this helper — arbitrary user
+    code can reference any column — so callers gate on ``mode != "code"``.
+    """
+    import json
+
+    if not isinstance(dict_kwargs, dict):
+        return None
+    if (visu_type or "").lower() in _WHOLE_FRAME_VISU:
+        return None
+
+    cols: set[str] = set()
+    for key, value in dict_kwargs.items():
+        if value is None or value == "" or value == []:
+            continue
+        if key in _PX_COLUMN_PARAMS:
+            # error_x/y/z may be a dict config carrying no column — only a bare
+            # string names a column.
+            if isinstance(value, str):
+                cols.add(value)
+        elif key in _PX_COLUMN_LIST_PARAMS:
+            parsed = value
+            if isinstance(parsed, str):
+                try:
+                    parsed = json.loads(parsed)
+                except (json.JSONDecodeError, ValueError):
+                    # Opaque string we can't decompose into column names — don't
+                    # risk projecting away a column it might reference.
+                    return None
+            if isinstance(parsed, dict):
+                cols.update(k for k in parsed if isinstance(k, str))
+            elif isinstance(parsed, (list, tuple)):
+                cols.update(v for v in parsed if isinstance(v, str))
+            else:
+                return None
+        # Unknown keys are Plotly styling params (templates, colour maps, …)
+        # that take literal values, not column names — safe to ignore.
+    return cols or None
+
 
 def process_code_mode_figure(
     code_content: str,

--- a/depictio/tests/api/v1/test_column_projection.py
+++ b/depictio/tests/api/v1/test_column_projection.py
@@ -204,6 +204,18 @@ class TestProjectScanAndSchemaCache:
         assert _get_cached_schema(bad, "dcX", "v1") is None
         assert ("dcX", "v1") not in dtu._DELTA_SCHEMA_CACHE
 
+    def test_unreadable_schema_skips_projection_instead_of_selecting(self):
+        # When the schema can't be read, _project_scan must NOT pass the
+        # (unverified) requested columns to .select — an absent column (e.g. a
+        # cross-DC filter column) would raise ColumnNotFoundError at collect,
+        # turning a transient schema-read failure into a hard render failure.
+        # Safe fallback: load the full frame, leaving the scan untouched.
+        bad = MagicMock()
+        bad.collect_schema.side_effect = RuntimeError("boom")
+        out = _project_scan(bad, ["individual_id", "x"], "dcX", "v1")
+        assert out is bad
+        bad.select.assert_not_called()
+
     def test_schema_cache_is_bounded(self, monkeypatch):
         monkeypatch.setattr(dtu, "_DELTA_SCHEMA_CACHE_MAX", 2)
         for i in range(3):

--- a/depictio/tests/api/v1/test_column_projection.py
+++ b/depictio/tests/api/v1/test_column_projection.py
@@ -120,6 +120,44 @@ class TestEffectiveProjection:
         assert _effective_projection(["x", "y"], [{"column_name": "x"}], False) == ["x", "y"]
 
 
+class TestCrossDcLinkProjection:
+    """Projection must not break cross-DC linked filters.
+
+    A cross-DC link turns a filter on a *source* DC into a synthetic filter on
+    the *target* DC's join column (see ``_resolve_link_filters`` ->
+    ``extend_filters_via_links``). That join column is typically NOT one of the
+    figure's plotted columns, and may not even exist in the target DC's schema.
+    Projection must therefore (a) fold the link filter's column into the scan so
+    the filter actually applies, and (b) schema-guard it so a column absent from
+    the target never reaches ``.select`` and raises ColumnNotFoundError.
+
+    Neither perf PR touches the link-resolution code itself; this guards the one
+    way projection could regress cross-DC filtering.
+    """
+
+    def setup_method(self):
+        dtu._DELTA_SCHEMA_CACHE.clear()
+
+    def test_link_filter_column_folded_into_projection(self):
+        # Figure plots {x, y}; the link injects a filter on the join column
+        # "individual_id" (a non-plotted column). It must survive projection,
+        # else the cross-DC filter would silently no-op.
+        figure_cols = ["x", "y"]
+        link_filter_metadata = [{"column_name": "individual_id"}]
+        proj = _effective_projection(figure_cols, link_filter_metadata, False)
+        assert "individual_id" in proj
+        assert proj == ["individual_id", "x", "y"]
+
+    def test_link_filter_column_absent_from_target_is_dropped_not_crashed(self):
+        # If the link's join column doesn't exist on the target DC's real schema,
+        # _project_scan drops it instead of passing it to .select (which would
+        # raise ColumnNotFoundError at collect). The load still succeeds.
+        target_scan = pl.LazyFrame({"x": [1, 2], "y": [3, 4]})  # no individual_id
+        out = _project_scan(target_scan, ["individual_id", "x", "y"], "dc_target", "v1")
+        assert out.collect_schema().names() == ["x", "y"]
+        assert out.collect().height == 2
+
+
 class TestProjectScanAndSchemaCache:
     """`_project_scan` is schema-guarded; `_get_cached_schema` memoizes columns."""
 

--- a/depictio/tests/api/v1/test_column_projection.py
+++ b/depictio/tests/api/v1/test_column_projection.py
@@ -1,0 +1,173 @@
+"""Tests for column projection (#7) and the Delta schema cache (#12).
+
+Covers the safety-critical pure logic introduced for scan-level column
+projection: extracting the columns a figure references, folding filter columns
+into the effective projection (so filtering never silently drops a column), and
+the schema-guarded scan projection backed by a per-(collection, version) cache.
+"""
+
+from unittest.mock import MagicMock
+
+import polars as pl
+
+from depictio.api.v1 import deltatables_utils as dtu
+from depictio.api.v1.deltatables_utils import (
+    _effective_projection,
+    _filter_columns,
+    _get_cached_schema,
+    _project_scan,
+)
+from depictio.api.v1.services.figure.figure_builder import referenced_columns
+
+
+class TestReferencedColumns:
+    """`referenced_columns` extracts exactly the columns a UI figure reads."""
+
+    def test_scalar_params(self):
+        assert referenced_columns("scatter", {"x": "a", "y": "b", "color": "c"}) == {"a", "b", "c"}
+
+    def test_size_and_facets(self):
+        cols = referenced_columns("scatter", {"x": "a", "y": "b", "size": "s", "facet_col": "f"})
+        assert cols == {"a", "b", "s", "f"}
+
+    def test_hover_data_json_list(self):
+        cols = referenced_columns("bar", {"x": "a", "y": "b", "hover_data": '["h1", "h2"]'})
+        assert cols == {"a", "b", "h1", "h2"}
+
+    def test_custom_data_native_list(self):
+        cols = referenced_columns("scatter", {"x": "a", "y": "b", "custom_data": ["id"]})
+        assert cols == {"a", "b", "id"}
+
+    def test_hover_data_dict_keys_are_columns(self):
+        cols = referenced_columns("scatter", {"x": "a", "hover_data": {"h": True}})
+        assert cols == {"a", "h"}
+
+    def test_ignores_styling_and_empty_values(self):
+        cols = referenced_columns(
+            "scatter",
+            {
+                "x": "a",
+                "y": "b",
+                "color": "",  # empty → not a column
+                "size": None,  # null → skipped
+                "template": "mantine_light",  # styling literal
+                "opacity": 0.5,  # styling literal
+            },
+        )
+        assert cols == {"a", "b"}
+
+    def test_heatmap_returns_none(self):
+        # Heatmap consumes the whole frame (+ _col_annotations_json) → full load.
+        assert referenced_columns("heatmap", {"x": "a"}) is None
+
+    def test_whole_frame_visu_types_return_none(self):
+        for visu in ("scatter_matrix", "parallel_coordinates", "parallel_categories", "imshow"):
+            assert referenced_columns(visu, {"x": "a"}) is None
+
+    def test_unparseable_list_param_returns_none(self):
+        # An opaque string we can't decompose into column names → bail to a full
+        # load rather than risk projecting away a referenced column.
+        assert referenced_columns("scatter", {"x": "a", "hover_data": "not json"}) is None
+
+    def test_empty_or_styling_only_spec_returns_none(self):
+        assert referenced_columns("scatter", {}) is None
+        assert referenced_columns("scatter", {"template": "mantine_dark"}) is None
+
+    def test_non_dict_spec_returns_none(self):
+        assert referenced_columns("scatter", None) is None  # type: ignore[arg-type]
+
+
+class TestFilterColumns:
+    """`_filter_columns` pulls column names from a filter metadata list."""
+
+    def test_top_level_column(self):
+        assert _filter_columns([{"column_name": "f1", "value": 1}]) == {"f1"}
+
+    def test_nested_metadata_column(self):
+        assert _filter_columns([{"metadata": {"column_name": "f2"}, "value": 1}]) == {"f2"}
+
+    def test_mixed_and_missing_and_non_dict(self):
+        md = [
+            {"column_name": "f1"},
+            {"metadata": {"column_name": "f2"}},
+            {"value": 1},  # no column
+            "garbage",  # non-dict entry tolerated
+        ]
+        assert _filter_columns(md) == {"f1", "f2"}
+
+    def test_none_metadata(self):
+        assert _filter_columns(None) == set()
+
+
+class TestEffectiveProjection:
+    """`_effective_projection` folds filter columns into the requested set."""
+
+    def test_none_when_no_projection_requested(self):
+        assert _effective_projection(None, [{"column_name": "f"}], False) is None
+        assert _effective_projection([], None, False) is None
+
+    def test_unions_filter_columns_sorted(self):
+        assert _effective_projection(["y", "x"], [{"column_name": "f"}], False) == ["f", "x", "y"]
+
+    def test_skips_filters_when_loading_for_options(self):
+        # load_for_options bypasses filtering, so filter columns aren't needed.
+        assert _effective_projection(["x", "y"], [{"column_name": "f"}], True) == ["x", "y"]
+
+    def test_no_metadata_just_sorts(self):
+        assert _effective_projection(["b", "a"], None, False) == ["a", "b"]
+
+    def test_deduplicates_overlapping_filter_and_figure_columns(self):
+        assert _effective_projection(["x", "y"], [{"column_name": "x"}], False) == ["x", "y"]
+
+
+class TestProjectScanAndSchemaCache:
+    """`_project_scan` is schema-guarded; `_get_cached_schema` memoizes columns."""
+
+    def setup_method(self):
+        dtu._DELTA_SCHEMA_CACHE.clear()
+
+    @staticmethod
+    def _lf() -> pl.LazyFrame:
+        return pl.LazyFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+
+    def test_no_projection_returns_scan_unchanged(self):
+        out = _project_scan(self._lf(), None, "dc1", "v1")
+        assert out.collect_schema().names() == ["a", "b", "c"]
+
+    def test_projects_to_requested_columns(self):
+        out = _project_scan(self._lf(), ["a", "b"], "dc1", "v1")
+        assert out.collect_schema().names() == ["a", "b"]
+
+    def test_drops_columns_absent_from_schema_without_crashing(self):
+        # A requested column not present on the DC (e.g. a cross-DC filter
+        # column) must be dropped, not passed to .select (which would raise at
+        # collect). The load must still succeed.
+        out = _project_scan(self._lf(), ["a", "zzz"], "dc1", "v1")
+        assert out.collect_schema().names() == ["a"]
+        assert out.collect().height == 2
+
+    def test_schema_cache_populated_and_reused(self):
+        assert ("dc1", "v1") not in dtu._DELTA_SCHEMA_CACHE
+        names = _get_cached_schema(self._lf(), "dc1", "v1")
+        assert names == frozenset({"a", "b", "c"})
+        assert dtu._DELTA_SCHEMA_CACHE[("dc1", "v1")] == frozenset({"a", "b", "c"})
+
+    def test_schema_cache_keyed_on_version(self):
+        _get_cached_schema(self._lf(), "dc1", "v1")
+        lf2 = pl.LazyFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
+        names_v2 = _get_cached_schema(lf2, "dc1", "v2")
+        assert "d" in names_v2
+        # The v1 entry is untouched under its own key.
+        assert dtu._DELTA_SCHEMA_CACHE[("dc1", "v1")] == frozenset({"a", "b", "c"})
+
+    def test_schema_read_failure_returns_none_and_is_not_cached(self):
+        bad = MagicMock()
+        bad.collect_schema.side_effect = RuntimeError("boom")
+        assert _get_cached_schema(bad, "dcX", "v1") is None
+        assert ("dcX", "v1") not in dtu._DELTA_SCHEMA_CACHE
+
+    def test_schema_cache_is_bounded(self, monkeypatch):
+        monkeypatch.setattr(dtu, "_DELTA_SCHEMA_CACHE_MAX", 2)
+        for i in range(3):
+            _get_cached_schema(self._lf(), f"dc{i}", "v")
+        assert len(dtu._DELTA_SCHEMA_CACHE) <= 2


### PR DESCRIPTION
## Why

Phase-2 follow-up to the Gb-dataframe audit (#810): the next two highest value-per-risk items — **#7 column projection** and **#12 Delta schema caching**. On wide tables a figure or card reads a handful of columns but the loader pulled every column; and `collect_schema()` hit the Delta log on every hot render.

Branched off `main` independently of #810. Both touch overlapping files (`figure_builder.py`, `routes.py`, `celery_tasks.py`, `deltatables_utils.py`), so whichever merges second may need a small rebase.

## #7 — scan-level column projection

Figure (`build_figure_preview`) and card (`bulk_compute_cards`) loads now read only the columns they use. **Correctness is preserved by construction:**

- `load_deltatable_lite` resolves an **effective projection = requested columns ∪ the columns the pending filters reference**. Projection runs at scan level *before* filtering, and `apply_runtime_filters` **silently skips** a filter whose column is missing — so folding filter columns in is what keeps filtered results identical, not just crash-free. This also retroactively fixes a **latent filter-drop bug** in `compute_coverage_track`, which projected without unioning filter columns.
- The effective set drives the **cache key, cache lookups, and the scan**, so a projected base frame is self-consistent and can't collide with a differently filtered request on the same DC.
- `_project_scan` **intersects the requested columns with the real schema**, dropping absent (e.g. cross-DC filter) columns rather than passing them to `.select` and crashing at `collect` — mirroring the large path's existing filter pruning.
- `referenced_columns` extracts the column set from a UI figure's `dict_kwargs` and returns **`None` (→ full load)** for code mode, whole-frame visualisations (heatmap, scatter_matrix, parallel_*, imshow, …), or any spec it can't enumerate with certainty. Errs toward `None` on any uncertainty — a dropped column would silently break the figure.
- Cards share one cached frame per `(wf, dc, filter)` key, so a **pre-pass unions every sibling card's columns** before loading; the selection column is folded into figure projections.

## #12 — Delta schema cache

`collect_schema()` reads the Delta log on every hot render (a card grid re-computing on each filter change, or a projected load). Cached per `(data_collection_id, aggregation_version)` so a new ingest naturally invalidates the entry — the same discriminator the dataframe cache keys use. Used by both the projection guard and the large-path filter pruning. This is what keeps #7 from introducing a per-render schema round-trip.

## Tests

Adds `test_column_projection.py` covering `referenced_columns` (scalar/list/JSON params, heatmap & whole-frame → `None`, unparseable → `None`, styling ignored), `_filter_columns`, `_effective_projection` (filter-column union, `load_for_options` skip, dedup), `_project_scan` (schema-guard drops absent columns without crashing), and the schema cache (population, version keying, read-failure → `None`, bounded). Removes the now-unused `_apply_scan_options`.

## Validation

`ruff format` + `ruff check` clean across all five files; `py_compile` clean. `ty` / `pre-commit` / `pytest` aren't runnable in the authoring environment (no deps installed) — relying on CI; the unit tests are written correct-by-construction and no `ty` non-import diagnostics fall in the changed lines.