### PR TITLE
feat(cli): auto-trigger ingestion from Nextflow via nextflow.config

### DIFF
--- a/depictio/cli/README.md
+++ b/depictio/cli/README.md
@@ -65,6 +65,81 @@ depictio-cli data process \
   --project-config-path path/to/project_config.yaml
 ```
 
+## Automatic triggering from Nextflow
+
+Instead of running `depictio-cli run` by hand after a pipeline finishes, you can
+have a **Nextflow pipeline trigger ingestion itself** on successful completion.
+
+The mechanism is a small `nextflow.config` snippet
+([`configs/nextflow/depictio.config`](configs/nextflow/depictio.config)) that
+hooks into `workflow.onComplete` and shells out to `depictio-cli run`. All the
+logic (template/nf-core resolution, ingestion, dashboards) stays in the CLI — the
+snippet is just a thin, best-effort trigger that never fails the pipeline.
+
+### Quick start (nf-core pipeline)
+
+```bash
+# Token kept out of CLI.yaml, injected at runtime (handy for CI/clusters)
+export DEPICTIO_CLI_TOKEN="eyJhbGciOiJI...<JWT>"
+export DEPICTIO_CLI_API_BASE_URL="http://localhost:8058"   # optional
+
+nextflow run nf-core/rnaseq -r 3.18.0 -profile docker \
+  --outdir results/ -c /path/to/depictio.config
+```
+
+On success the trigger runs (manifest forwarded so the CLI resolves the bundled
+`nf-core/rnaseq/3.18.0` template automatically):
+
+```bash
+depictio-cli run --data-root results/ \
+  --nextflow-manifest nf-core/rnaseq/3.18.0 \
+  --CLI-config-path ~/.depictio/CLI.yaml
+```
+
+To make it permanent, add `includeConfig 'depictio.config'` to your
+`nextflow.config` instead of passing `-c`.
+
+### Custom (non-nf-core) pipelines
+
+There is no bundled template, so provide a Depictio project config and let the
+snippet pass it through:
+
+```groovy
+params.depictio_project_config = '/path/to/depictio_project.yaml'
+```
+
+The trigger exports `DEPICTIO_DATA_ROOT` (= `--outdir`) into the CLI environment,
+so the project config can reference the output directory as
+`{DEPICTIO_DATA_ROOT}` in `parent_runs_location`.
+
+### Authentication via environment variables
+
+`depictio-cli` now reads these env vars, so a `CLI.yaml` can be committed without
+secrets:
+
+| Variable | Overrides |
+|----------|-----------|
+| `DEPICTIO_CLI_TOKEN` | `user.token.access_token` in the CLI config |
+| `DEPICTIO_CLI_API_BASE_URL` | `api_base_url` in the CLI config |
+| `DEPICTIO_CLI_CONFIG_PATH` | path of the CLI config to load (when left at default) |
+
+### Snippet parameters
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `depictio_enabled` | `true` | Enable/disable the trigger |
+| `depictio_cli_config` | `~/.depictio/CLI.yaml` | CLI config path |
+| `depictio_data_root` | `params.outdir` | Directory to ingest |
+| `depictio_template` | _none_ | Explicit depictio template id |
+| `depictio_project_config` | _none_ | Path to a `depictio_project.yaml` |
+| `depictio_cli_executable` | `depictio-cli` | CLI command name/path |
+
+> **Requirement:** `depictio-cli` must be installed and on the `PATH` of the
+> Nextflow head job.
+
+A runnable end-to-end example lives in
+[`configs/nextflow/example/`](configs/nextflow/example/).
+
 ## Development
 
 ### Package Structure

--- a/depictio/cli/cli/commands/run.py
+++ b/depictio/cli/cli/commands/run.py
@@ -81,6 +81,18 @@ def register_run_command(app: typer.Typer):
             "--skip-dashboard-import",
             help="Skip automatic dashboard import from template.",
         ),
+        nextflow_manifest: Annotated[
+            str | None,
+            typer.Option(
+                "--nextflow-manifest",
+                help=(
+                    "Nextflow manifest as '<name>/<version>' (e.g. 'nf-core/rnaseq/3.18.0'). "
+                    "When neither --template nor --project-config-path is given, the CLI "
+                    "auto-resolves a bundled depictio template matching this manifest. "
+                    "Intended for automated triggering from a Nextflow pipeline."
+                ),
+            ),
+        ] = None,
         # Existing options
         workflow_name: Annotated[
             str | None,
@@ -159,6 +171,28 @@ def register_run_command(app: typer.Typer):
             depictio-cli run --template nf-core/ampliseq/2.16.0 --data-root /path/to/data
         """
         rich_print_command_usage("run")
+
+        # Auto-resolve a bundled template from a Nextflow manifest. Lets pipeline
+        # triggers (the nextflow.config snippet) forward the raw manifest and let
+        # the CLI decide the mode — explicit --template/--project-config-path win.
+        if nextflow_manifest and not template and not project_config_path:
+            from depictio.cli.cli.utils.templates import locate_template
+
+            try:
+                locate_template(nextflow_manifest)
+            except FileNotFoundError:
+                rich_print_checked_statement(
+                    f"No bundled depictio template matches Nextflow manifest "
+                    f"'{nextflow_manifest}'. Provide --project-config-path with a depictio "
+                    f"project YAML for this pipeline (or --template for a known one).",
+                    "error",
+                )
+                raise typer.Exit(code=1)
+            template = nextflow_manifest
+            rich_print_checked_statement(
+                f"Resolved Nextflow manifest '{nextflow_manifest}' to bundled template.",
+                "success",
+            )
 
         # Validate template/project-config-path mutual exclusivity
         if template and project_config_path:

--- a/depictio/cli/cli/utils/common.py
+++ b/depictio/cli/cli/utils/common.py
@@ -77,6 +77,37 @@ def validate_depictio_cli_config(depictio_cli_config: dict) -> CLIConfig:
     return config
 
 
+# CLI config paths considered "default" — only these are overridden by
+# DEPICTIO_CLI_CONFIG_PATH so an explicit --CLI-config-path is never clobbered.
+_DEFAULT_CLI_CONFIG_PATHS = ("~/.depictio/cli.yaml", "~/.depictio/CLI.yaml")
+
+
+def _apply_env_overrides(config: dict) -> dict:
+    """Apply environment-variable overrides to a loaded CLI config dict.
+
+    Lets a ``CLI.yaml`` be committed **without secrets** and have the token (and
+    optionally the API URL) injected at runtime — the mechanism that makes
+    automated triggering (e.g. from a Nextflow pipeline in CI/cluster) practical.
+
+    Recognised variables:
+      - ``DEPICTIO_CLI_TOKEN``        → ``user.token.access_token``
+      - ``DEPICTIO_CLI_API_BASE_URL`` → ``api_base_url``
+
+    (``DEPICTIO_CLI_CONFIG_PATH`` is handled in :func:`load_depictio_config`
+    since it selects the file to load before this runs.)
+    """
+    token = os.environ.get("DEPICTIO_CLI_TOKEN")
+    if token:
+        user = config.setdefault("user", {})
+        user.setdefault("token", {})["access_token"] = token
+
+    api_base_url = os.environ.get("DEPICTIO_CLI_API_BASE_URL")
+    if api_base_url:
+        config["api_base_url"] = api_base_url
+
+    return config
+
+
 @validate_call(validate_return=True)
 def load_depictio_config(yaml_config_path: str = "~/.depictio/cli.yaml") -> CLIConfig:
     """
@@ -84,7 +115,13 @@ def load_depictio_config(yaml_config_path: str = "~/.depictio/cli.yaml") -> CLIC
     """
     try:
         rich_print_checked_statement("Loading Depictio configuration...", "loading")
+        # DEPICTIO_CLI_CONFIG_PATH overrides the path only when the caller left it
+        # at a default — an explicit --CLI-config-path always wins.
+        env_path = os.environ.get("DEPICTIO_CLI_CONFIG_PATH")
+        if env_path and yaml_config_path in _DEFAULT_CLI_CONFIG_PATHS:
+            yaml_config_path = env_path
         config = get_config(os.path.expanduser(yaml_config_path))
+        config = _apply_env_overrides(config)
         config = validate_depictio_cli_config(config)
         return config
     except FileNotFoundError:

--- a/depictio/cli/configs/nextflow/depictio.config
+++ b/depictio/cli/configs/nextflow/depictio.config
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------
+// depictio.config — automatic Depictio ingestion after a Nextflow run
+// ---------------------------------------------------------------------------
+//
+// Drop-in config snippet that triggers `depictio-cli run` when a pipeline
+// finishes successfully, so pipeline outputs are scanned, ingested into
+// Delta Lake / S3 and turned into a Depictio dashboard — with no manual step.
+//
+// All real logic (template/nf-core resolution, ingestion, dashboards) lives in
+// depictio-cli. This snippet is intentionally a thin trigger.
+//
+// Usage (one-off):
+//     nextflow run <pipeline> --outdir results/ -c depictio.config
+//
+// Usage (permanent, in your nextflow.config):
+//     includeConfig 'depictio.config'
+//
+// Requirements:
+//   * `depictio-cli` installed and on the PATH of the Nextflow head job.
+//   * A CLI config file (default ~/.depictio/CLI.yaml). The token may be kept
+//     out of that file and injected at runtime via DEPICTIO_CLI_TOKEN
+//     (and DEPICTIO_CLI_API_BASE_URL), which is convenient for CI/clusters.
+//
+// Parameters (override with --param or in your config):
+//   depictio_enabled         enable/disable the trigger          (default: true)
+//   depictio_cli_config      path to CLI.yaml                    (default: ~/.depictio/CLI.yaml,
+//                                                                 or $DEPICTIO_CLI_CONFIG_PATH)
+//   depictio_data_root       directory to ingest                 (default: params.outdir)
+//   depictio_template        explicit depictio template id       (optional)
+//   depictio_project_config  path to a depictio_project.yaml     (optional, for custom pipelines)
+//   depictio_cli_executable  CLI command name/path               (default: depictio-cli)
+//
+// Mode resolution is delegated to depictio-cli:
+//   * --project-config-path or --template (if given) take precedence;
+//   * otherwise the Nextflow manifest (name/version) lets the CLI auto-resolve
+//     a bundled nf-core template (e.g. nf-core/rnaseq/3.18.0).
+// ---------------------------------------------------------------------------
+
+// Defensive defaults: never clobber a value the user already set (include order
+// and `-c` precedence are unpredictable, so we only fill in when unset).
+params.depictio_enabled        = params.containsKey('depictio_enabled') ? params.depictio_enabled : true
+params.depictio_cli_config     = params.depictio_cli_config     ?: (System.getenv('DEPICTIO_CLI_CONFIG_PATH') ?: "${System.getProperty('user.home')}/.depictio/CLI.yaml")
+params.depictio_data_root      = params.depictio_data_root      ?: null
+params.depictio_template       = params.depictio_template       ?: null
+params.depictio_project_config = params.depictio_project_config ?: null
+params.depictio_cli_executable = params.depictio_cli_executable ?: 'depictio-cli'
+
+workflow.onComplete {
+    if (!params.depictio_enabled) {
+        return
+    }
+    if (!workflow.success) {
+        log.warn "[depictio] pipeline did not complete successfully — skipping ingestion"
+        return
+    }
+
+    def dataRoot = params.depictio_data_root ?: params.outdir
+    if (!dataRoot) {
+        log.warn "[depictio] no --outdir / params.depictio_data_root set — skipping ingestion"
+        return
+    }
+
+    def cmd = [params.depictio_cli_executable.toString(), 'run',
+               '--data-root', dataRoot.toString(),
+               '--CLI-config-path', params.depictio_cli_config.toString()]
+
+    if (params.depictio_project_config) {
+        cmd += ['--project-config-path', params.depictio_project_config.toString()]
+    } else if (params.depictio_template) {
+        cmd += ['--template', params.depictio_template.toString()]
+    }
+
+    // Forward the raw Nextflow manifest; the CLI decides whether a bundled
+    // template matches it (ignored when a project config / template is given).
+    if (workflow.manifest?.name) {
+        def manifestVersion = workflow.manifest.version ?: 'latest'
+        cmd += ['--nextflow-manifest', "${workflow.manifest.name}/${manifestVersion}".toString()]
+    }
+
+    log.info "[depictio] triggering ingestion: ${cmd.join(' ')}"
+    try {
+        def pb = new ProcessBuilder(cmd).redirectErrorStream(true)
+        // Expose the data root so generic project YAMLs can reference it as
+        // {DEPICTIO_DATA_ROOT} in parent_runs_location.
+        pb.environment().put('DEPICTIO_DATA_ROOT', dataRoot.toString())
+        def proc = pb.start()
+        proc.inputStream.eachLine { line -> log.info "[depictio] ${line}" }
+        proc.waitFor()
+        if (proc.exitValue() != 0) {
+            log.warn "[depictio] ingestion exited with code ${proc.exitValue()} " +
+                     "(pipeline result is unaffected)"
+        } else {
+            log.info "[depictio] ingestion completed"
+        }
+    } catch (Exception e) {
+        log.warn "[depictio] could not run '${params.depictio_cli_executable}': " +
+                 "${e.message} (is depictio-cli installed and on PATH?)"
+    }
+}

--- a/depictio/cli/configs/nextflow/example/README.md
+++ b/depictio/cli/configs/nextflow/example/README.md
@@ -1,0 +1,63 @@
+# Depictio Nextflow trigger — minimal example
+
+This directory shows how to make a Nextflow pipeline **automatically ingest its
+outputs into Depictio** when it finishes, using the shared
+[`depictio.config`](../depictio.config) snippet (`workflow.onComplete`).
+
+Files:
+
+| File | Purpose |
+|------|---------|
+| `main.nf` | Trivial pipeline that writes `measurements.tsv` to `--outdir`. |
+| `nextflow.config` | Loads `../depictio.config` and points it at a generic project config. |
+| `depictio_project.yaml` | Generic Depictio project config (uses `{DEPICTIO_DATA_ROOT}`). |
+
+## Prerequisites
+
+* `nextflow` and `depictio-cli` installed and on your `PATH`.
+* A Depictio CLI config. Keep the token out of the file and inject it at runtime:
+
+  ```bash
+  export DEPICTIO_CLI_TOKEN="eyJhbGciOiJI...<JWT>"
+  export DEPICTIO_CLI_API_BASE_URL="http://localhost:8058"   # optional override
+  ```
+
+## Run it
+
+```bash
+cd depictio/cli/configs/nextflow/example
+nextflow run main.nf --outdir results/
+```
+
+On success you should see, after `Pipeline completed successfully`:
+
+```
+[depictio] triggering ingestion: depictio-cli run --data-root results/ ... --nextflow-manifest depictio/nextflow-trigger-example/0.1.0
+[depictio] ✓ ...
+[depictio] ingestion completed
+```
+
+If `depictio-cli` is not installed or ingestion fails, the pipeline still
+finishes **green** — the trigger is best-effort and only logs a warning.
+
+## Try it without a running Depictio server
+
+To see the resolved `depictio-cli` invocation without performing any ingestion,
+run the CLI directly in dry-run mode:
+
+```bash
+depictio-cli run --data-root results/ \
+  --project-config-path depictio_project.yaml \
+  --dry-run
+```
+
+## nf-core pipelines
+
+For an nf-core pipeline you do **not** need `depictio_project.yaml`: drop the
+`params.depictio_project_config` line and the trigger will forward the pipeline's
+manifest (e.g. `nf-core/rnaseq/3.18.0`) so depictio-cli auto-resolves the bundled
+template:
+
+```bash
+nextflow run nf-core/rnaseq -r 3.18.0 -profile docker --outdir results/ -c ../depictio.config
+```

--- a/depictio/cli/configs/nextflow/example/depictio_project.yaml
+++ b/depictio/cli/configs/nextflow/example/depictio_project.yaml
@@ -1,0 +1,35 @@
+# Minimal generic Depictio project config for the demo pipeline (main.nf).
+#
+# data_location.locations uses the {DEPICTIO_DATA_ROOT} placeholder, which the
+# trigger (depictio.config) exports into the depictio-cli environment as the
+# pipeline's --outdir. This is how a custom (non-nf-core) pipeline wires its
+# output directory into Depictio without hardcoding an absolute path.
+
+name: "Nextflow Trigger Example"
+
+workflows:
+  - name: "nextflow-trigger-example"
+    engine:
+      name: "nextflow"
+    description: "Demo pipeline exercising the Depictio onComplete trigger"
+    data_location:
+      structure: "flat"
+      locations:
+        - "{DEPICTIO_DATA_ROOT}"
+    data_collections:
+      - data_collection_tag: "measurements"
+        description: "Demo measurements table written by the pipeline"
+        config:
+          type: "Table"
+          scan:
+            # Recursive (not single) so the file is located under the run's
+            # data_location regardless of the CLI's working directory.
+            mode: "recursive"
+            scan_parameters:
+              regex_config:
+                pattern: "measurements\\.tsv$"
+          dc_specific_properties:
+            format: "TSV"
+            polars_kwargs:
+              separator: "\t"
+              has_header: true

--- a/depictio/cli/configs/nextflow/example/main.nf
+++ b/depictio/cli/configs/nextflow/example/main.nf
@@ -1,0 +1,26 @@
+#!/usr/bin/env nextflow
+
+// Minimal demo pipeline used to exercise the Depictio trigger (depictio.config)
+// without depending on a real nf-core pipeline. It writes a tiny TSV table into
+// the publish directory, which the generic depictio_project.yaml then ingests.
+
+nextflow.enable.dsl = 2
+
+process WRITE_TABLE {
+    publishDir "${params.outdir}", mode: 'copy'
+
+    output:
+    path 'measurements.tsv'
+
+    script:
+    """
+    printf 'sample\\tcondition\\tvalue\\n' > measurements.tsv
+    printf 'A\\tctrl\\t1.2\\n'            >> measurements.tsv
+    printf 'B\\tctrl\\t0.9\\n'            >> measurements.tsv
+    printf 'C\\ttreated\\t2.4\\n'         >> measurements.tsv
+    """
+}
+
+workflow {
+    WRITE_TABLE()
+}

--- a/depictio/cli/configs/nextflow/example/nextflow.config
+++ b/depictio/cli/configs/nextflow/example/nextflow.config
@@ -1,0 +1,20 @@
+// Example nextflow.config wiring the Depictio trigger into a custom pipeline.
+//
+// Load the shared trigger first so its defaults are in place, then override the
+// bits specific to this demo (output dir + the depictio project config to use).
+
+includeConfig '../depictio.config'
+
+params.outdir = 'results'
+
+// This demo pipeline is NOT an nf-core pipeline, so there is no bundled depictio
+// template — we point the trigger at a generic depictio project config instead.
+// (For an nf-core pipeline you would omit this and let the manifest auto-resolve
+// a bundled template.)
+params.depictio_project_config = "${projectDir}/depictio_project.yaml"
+
+manifest {
+    name        = 'depictio/nextflow-trigger-example'
+    version     = '0.1.0'
+    description = 'Demo pipeline exercising the Depictio onComplete trigger'
+}

--- a/depictio/tests/cli/commands/test_run.py
+++ b/depictio/tests/cli/commands/test_run.py
@@ -1,0 +1,75 @@
+"""
+Tests for the `run` command's Nextflow manifest resolution (--nextflow-manifest).
+
+These exercise only the early resolution branch, which runs before any server or
+S3 interaction, so no network/mocking of the full pipeline is needed.
+"""
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from depictio.cli.cli.commands.run import register_run_command
+
+
+@pytest.fixture
+def run_app():
+    """A minimal Typer app exposing just the `run` command."""
+    app = typer.Typer()
+    register_run_command(app)
+    return app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestNextflowManifestResolution:
+    """Tests for auto-resolving a bundled template from a Nextflow manifest."""
+
+    def test_unknown_manifest_errors(self, run_app, runner):
+        """An unknown manifest (no bundled template) exits with a clear error."""
+        result = runner.invoke(
+            run_app,
+            ["--nextflow-manifest", "acme/not-a-real-pipeline/9.9.9"],
+        )
+        assert result.exit_code == 1
+        assert "No bundled depictio template" in result.output
+
+    def test_known_manifest_resolves_to_template(self, run_app, runner):
+        """A known nf-core manifest resolves to a template.
+
+        Resolution succeeds (template is set), so the next guard — '--data-root is
+        required when using --template' — fires instead of the 'no template' error.
+        """
+        result = runner.invoke(
+            run_app,
+            ["--nextflow-manifest", "nf-core/ampliseq/2.16.0"],
+        )
+        assert result.exit_code == 1
+        assert "No bundled depictio template" not in result.output
+        assert "data-root is required" in result.output
+
+    def test_explicit_project_config_takes_precedence(self, run_app, runner, tmp_path):
+        """An explicit --project-config-path wins; the manifest is not resolved."""
+        project_yaml = tmp_path / "depictio_project.yaml"
+        project_yaml.write_text("name: dummy\n")
+        result = runner.invoke(
+            run_app,
+            [
+                "--nextflow-manifest",
+                "acme/not-a-real-pipeline/9.9.9",
+                "--project-config-path",
+                str(project_yaml),
+                "--dry-run",
+                "--skip-server-check",
+                "--skip-s3-check",
+                "--skip-sync",
+                "--skip-scan",
+                "--skip-process",
+                "--skip-join",
+            ],
+        )
+        # The unknown-manifest error must NOT fire because project config wins.
+        assert "No bundled depictio template" not in result.output

--- a/depictio/tests/cli/utils/test_common.py
+++ b/depictio/tests/cli/utils/test_common.py
@@ -7,6 +7,7 @@ from typer import Exit
 
 # Remove this line as we already import datetime later
 from depictio.cli.cli.utils.common import (
+    _apply_env_overrides,
     format_timestamp,
     generate_api_headers,
     load_depictio_config,
@@ -197,3 +198,95 @@ class TestCommon:
 
                 with pytest.raises(Exit):
                     load_depictio_config()
+
+    class TestApplyEnvOverrides:
+        """Tests for _apply_env_overrides (env-var auth for automation)"""
+
+        def test_no_env_returns_unchanged(self, sample_cli_config, monkeypatch):
+            """Without env vars the config dict is returned untouched."""
+            monkeypatch.delenv("DEPICTIO_CLI_TOKEN", raising=False)
+            monkeypatch.delenv("DEPICTIO_CLI_API_BASE_URL", raising=False)
+            original_token = sample_cli_config["user"]["token"]["access_token"]
+            original_url = sample_cli_config["api_base_url"]
+
+            result = _apply_env_overrides(sample_cli_config)
+
+            assert result is sample_cli_config
+            assert result["user"]["token"]["access_token"] == original_token
+            assert result["api_base_url"] == original_url
+
+        def test_token_override(self, sample_cli_config, monkeypatch):
+            """DEPICTIO_CLI_TOKEN overrides the access token."""
+            monkeypatch.setenv("DEPICTIO_CLI_TOKEN", "env-injected-token")
+            monkeypatch.delenv("DEPICTIO_CLI_API_BASE_URL", raising=False)
+
+            result = _apply_env_overrides(sample_cli_config)
+
+            assert result["user"]["token"]["access_token"] == "env-injected-token"
+
+        def test_api_base_url_override(self, sample_cli_config, monkeypatch):
+            """DEPICTIO_CLI_API_BASE_URL overrides the API base URL."""
+            monkeypatch.delenv("DEPICTIO_CLI_TOKEN", raising=False)
+            monkeypatch.setenv("DEPICTIO_CLI_API_BASE_URL", "https://env.depictio.dev")
+
+            result = _apply_env_overrides(sample_cli_config)
+
+            assert result["api_base_url"] == "https://env.depictio.dev"
+
+        def test_token_override_creates_missing_keys(self, monkeypatch):
+            """Token injection works even when user/token keys are absent."""
+            monkeypatch.setenv("DEPICTIO_CLI_TOKEN", "env-injected-token")
+
+            result = _apply_env_overrides({})
+
+            assert result["user"]["token"]["access_token"] == "env-injected-token"
+
+        def test_config_path_env_used_when_default(self, sample_cli_config, monkeypatch):
+            """DEPICTIO_CLI_CONFIG_PATH is honoured when the caller left the default."""
+            monkeypatch.setenv("DEPICTIO_CLI_CONFIG_PATH", "/custom/path/CLI.yaml")
+            monkeypatch.delenv("DEPICTIO_CLI_TOKEN", raising=False)
+            monkeypatch.delenv("DEPICTIO_CLI_API_BASE_URL", raising=False)
+
+            with (
+                patch("depictio.cli.cli.utils.common.get_config") as mock_get_config,
+                patch(
+                    "depictio.cli.cli.utils.common.validate_depictio_cli_config"
+                ) as mock_validate,
+                patch("depictio.cli.cli.utils.common.rich_print_checked_statement"),
+                patch("os.path.expanduser", side_effect=lambda p: p),
+            ):
+                mock_get_config.return_value = sample_cli_config
+                mock_validate.return_value = CLIConfig(
+                    api_base_url=sample_cli_config["api_base_url"],
+                    user=sample_cli_config["user"],
+                    s3_storage=sample_cli_config["s3_storage"],
+                )
+
+                load_depictio_config("~/.depictio/CLI.yaml")
+
+                mock_get_config.assert_called_once_with("/custom/path/CLI.yaml")
+
+        def test_explicit_config_path_not_overridden(self, sample_cli_config, monkeypatch):
+            """An explicit --CLI-config-path is never clobbered by the env var."""
+            monkeypatch.setenv("DEPICTIO_CLI_CONFIG_PATH", "/custom/path/CLI.yaml")
+            monkeypatch.delenv("DEPICTIO_CLI_TOKEN", raising=False)
+            monkeypatch.delenv("DEPICTIO_CLI_API_BASE_URL", raising=False)
+
+            with (
+                patch("depictio.cli.cli.utils.common.get_config") as mock_get_config,
+                patch(
+                    "depictio.cli.cli.utils.common.validate_depictio_cli_config"
+                ) as mock_validate,
+                patch("depictio.cli.cli.utils.common.rich_print_checked_statement"),
+                patch("os.path.expanduser", side_effect=lambda p: p),
+            ):
+                mock_get_config.return_value = sample_cli_config
+                mock_validate.return_value = CLIConfig(
+                    api_base_url=sample_cli_config["api_base_url"],
+                    user=sample_cli_config["user"],
+                    s3_storage=sample_cli_config["s3_storage"],
+                )
+
+                load_depictio_config("/explicit/user/path.yaml")
+
+                mock_get_config.assert_called_once_with("/explicit/user/path.yaml")


### PR DESCRIPTION
## Why

Today Depictio is **pull-based**: after a Nextflow pipeline finishes, someone runs `depictio-cli run` by hand to scan the outputs, ingest into Delta Lake/S3 and import dashboards. This PR lets a pipeline **trigger that ingestion itself** on successful completion — for both nf-core pipelines (manifest auto-resolves a bundled template) and custom pipelines (user-provided project config).

Two gaps were in the way and are addressed here:
1. The CLI only read the token from `CLI.yaml` — no env-var auth, awkward for CI/clusters.
2. Nothing bridged "pipeline finished" → "run the CLI".

## Approach — maximal reuse of `depictio-cli`

All decision logic stays in the CLI; the Nextflow side is a thin, best-effort relay.

**CLI enhancements (shared core)**
- `common.py`: env-var auth overrides so a `CLI.yaml` can be committed **without secrets** —
  `DEPICTIO_CLI_TOKEN`, `DEPICTIO_CLI_API_BASE_URL`, `DEPICTIO_CLI_CONFIG_PATH` (the path override only applies when the caller left the default, so an explicit `--CLI-config-path` always wins).
- `run.py`: new `--nextflow-manifest "<name>/<version>"` flag. When neither `--template` nor `--project-config-path` is given, the CLI auto-resolves a bundled template (reusing `locate_template`); otherwise it prints a clear "provide `--project-config-path`" message.

**Nextflow trigger**
- `configs/nextflow/depictio.config`: a `workflow.onComplete` snippet that shells out to `depictio-cli run`. Best-effort (a failed/absent ingestion never fails the pipeline), drains the subprocess output via `ProcessBuilder`, and exports `DEPICTIO_DATA_ROOT` so custom project configs can reference the output dir.
- `configs/nextflow/example/`: a runnable end-to-end example (minimal pipeline + config + project YAML + README).

**Docs & tests**
- "Automatic triggering from Nextflow" section in the CLI README.
- Unit tests for the env overrides and the manifest resolution (unknown → error; known → resolves).

## Usage

```bash
export DEPICTIO_CLI_TOKEN="eyJ...<JWT>"
# nf-core: manifest auto-resolves the bundled template
nextflow run nf-core/rnaseq -r 3.18.0 -profile docker --outdir results/ -c depictio.config
# → depictio-cli run --data-root results/ --nextflow-manifest nf-core/rnaseq/3.18.0 --CLI-config-path ~/.depictio/CLI.yaml
```

For custom pipelines, set `params.depictio_project_config = '/path/depictio_project.yaml'`.

## Verification
- `ruff format` / `ruff check` / `pre-commit` on changed files: pass.
- `ty check`: no new diagnostics (the 2 remaining in `run.py` pre-exist on `main`).
- CLI smoke test: known manifest resolves to a bundled template; unknown manifest errors clearly.
- Example `depictio_project.yaml` validated against the `Project` model.
- New + existing CLI unit tests pass (129 in the CLI suite).

## Out of scope / future work
A native Nextflow plugin (`nf-depictio`, JVM/Groovy via the Nextflow plugin registry) is deferred. It would call the same `depictio-cli run`, so these CLI enhancements would carry over unchanged.

https://claude.ai/code/session_01HomL49XajA3x5VQn8j3qW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HomL49XajA3x5VQn8j3qW3)_