### PR TITLE
fix(quickstart): zero-config `docker compose up -d` + multi-arch images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,38 @@
 # Depictio Docker Compose Configuration
-# Copy this file to .env and fill in real values.
+#
+# A .env file is OPTIONAL. The single-user quick start (`docker compose up -d`)
+# works with no .env at all. Copy this file to .env only when you need a multi-
+# user deployment or want to override the local defaults.
 # Full reference: https://depictio.github.io/depictio-docs/stable/installation/env-reference/
 
 # ── Application version ───────────────────────────────────────────────────────
-DEPICTIO_VERSION=latest
+# Leave unset to use the stable release pinned in docker-compose.yaml. Override
+# only to run a different build, e.g. `next` (bleeding edge off main) or a
+# specific tag like 1.0.0.
+# DEPICTIO_VERSION=next
 
-# ── Storage mode (compose profile) ────────────────────────────────────────────
-# `local-minio` starts the bundled MinIO container (default). To bring your own
-# external S3/MinIO instead, set this to `external-s3` (the bundled MinIO won't
-# start) and fill in your endpoint/credentials below.
-COMPOSE_PROFILES=local-minio
+# ── Auth mode ─────────────────────────────────────────────────────────────────
+# Default (unset) is single-user mode: no login, no secret enforcement — local
+# use only. Set to false for a multi-user deployment with login; the server then
+# REFUSES to boot until the MinIO and admin passwords below are strong.
+# DEPICTIO_AUTH_SINGLE_USER_MODE=false
 
-# ── Local MinIO storage (used when COMPOSE_PROFILES=local-minio) ──────────────
-# REQUIRED. Compose refuses to start with the placeholders below — generate
-# real secrets first, e.g.:
-#   openssl rand -base64 24   # for DEPICTIO_MINIO_ROOT_PASSWORD
-DEPICTIO_MINIO_ROOT_USER=depictio
-DEPICTIO_MINIO_ROOT_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
+# ── MinIO storage credentials ─────────────────────────────────────────────────
+# Optional in single-user mode (defaults: minio / minio123). REQUIRED for multi-
+# user mode — the defaults are rejected as weak. Generate a strong secret:
+#   openssl rand -base64 24
+# DEPICTIO_MINIO_ROOT_USER=depictio
+# DEPICTIO_MINIO_ROOT_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
 
-# ── First-boot admin (replaces legacy initial_users.yaml) ─────────────────────
-# REQUIRED on first start of a fresh database. The API pod refuses to boot
-# when no admin user exists in MongoDB AND these are unset. Subsequent
-# starts are no-ops, so password changes via the UI survive container
-# restarts and PVC wipes.
+# ── First-boot admin (multi-user mode) ────────────────────────────────────────
+# Used to seed the first admin on a fresh database. Not needed in single-user
+# mode. In multi-user mode, set these on first start; subsequent starts are
+# no-ops, so password changes via the UI survive restarts and PVC wipes.
 #
-# Password requirements: ≥16 characters, must not match any well-known
-# default (changeme, admin123, password, etc.).
-DEPICTIO_BOOTSTRAP_ADMIN_EMAIL=admin@example.com
-DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
+# Password requirements: ≥8 characters, must not match a well-known default
+# (changeme, admin123, password, etc.).
+# DEPICTIO_BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+# DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
 
 # ── Optional CI / Cypress fixture user ────────────────────────────────────────
 # Leave seed_test_user=false (the default) in any public-facing deployment.

--- a/.env.example
+++ b/.env.example
@@ -18,21 +18,21 @@
 # DEPICTIO_AUTH_SINGLE_USER_MODE=false
 
 # ── MinIO storage credentials ─────────────────────────────────────────────────
-# Optional in single-user mode (defaults: minio / minio123). REQUIRED for multi-
-# user mode — the defaults are rejected as weak. Generate a strong secret:
-#   openssl rand -base64 24
-# DEPICTIO_MINIO_ROOT_USER=depictio
-# DEPICTIO_MINIO_ROOT_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
+# The root single-user quick start IGNORES these — docker-compose.yaml already
+# defaults to minio/minio123. They apply when you copy this file to .env for a
+# multi-user deployment, the dev compose, or CI (docker-compose.dev.yaml requires
+# them). Multi-user mode rejects weak passwords (≥8 chars) — generate a strong
+# one:  openssl rand -base64 24
+DEPICTIO_MINIO_ROOT_USER=depictio
+DEPICTIO_MINIO_ROOT_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
 
-# ── First-boot admin (multi-user mode) ────────────────────────────────────────
-# Used to seed the first admin on a fresh database. Not needed in single-user
-# mode. In multi-user mode, set these on first start; subsequent starts are
-# no-ops, so password changes via the UI survive restarts and PVC wipes.
-#
-# Password requirements: ≥8 characters, must not match a well-known default
-# (changeme, admin123, password, etc.).
-# DEPICTIO_BOOTSTRAP_ADMIN_EMAIL=admin@example.com
-# DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
+# ── First-boot admin ──────────────────────────────────────────────────────────
+# Seeds the first admin on a fresh database. Not needed for the single-user quick
+# start (it auto-seeds a local admin). Required for multi-user mode; set on first
+# start — subsequent starts are no-ops, so UI password changes survive restarts
+# and PVC wipes. Password ≥8 chars, not a well-known default (changeme, etc.).
+DEPICTIO_BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
 
 # ── Optional CI / Cypress fixture user ────────────────────────────────────────
 # Leave seed_test_user=false (the default) in any public-facing deployment.

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -4,6 +4,11 @@ name: Build images (api / worker / viewer)
 # (see docker-images/Dockerfile.api / .worker / .viewer) on tag pushes
 # and validates them on PRs.
 #
+# Multi-arch: each image is built for linux/amd64 AND linux/arm64 on NATIVE
+# runners (no QEMU emulation), pushed by digest, then stitched into a single
+# multi-arch manifest by the `merge` job. amd64 builds at full speed on its own
+# runner and is never gated behind the arm64 build.
+#
 # Image namespaces: `depictio-api`, `depictio-worker`, `depictio-viewer`.
 
 on:
@@ -47,21 +52,22 @@ env:
 
 jobs:
   build:
-    name: Build ${{ matrix.image }}
-    runs-on: ubuntu-22.04
+    name: Build ${{ matrix.image.name }} (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image: depictio-api
-            dockerfile: docker-images/Dockerfile.api
-          - image: depictio-worker
-            dockerfile: docker-images/Dockerfile.worker
-          - image: depictio-viewer
-            dockerfile: docker-images/Dockerfile.viewer
+        image:
+          - { name: depictio-api, dockerfile: docker-images/Dockerfile.api }
+          - { name: depictio-worker, dockerfile: docker-images/Dockerfile.worker }
+          - { name: depictio-viewer, dockerfile: docker-images/Dockerfile.viewer }
+        platform:
+          # Native runners — no QEMU. amd64 ships independently of arm64.
+          - { name: linux/amd64, arch: amd64, runner: ubuntu-22.04 }
+          - { name: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
 
     steps:
       - name: Checkout repository
@@ -99,32 +105,109 @@ jobs:
           driver-opts: |
             image=moby/buildkit:latest
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract labels for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}
+
+      - name: Build ${{ matrix.image.name }} (${{ matrix.platform.arch }})
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.platform.name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta-vars.outputs.VERSION }}
+          # On push: emit a tag-less image and push by digest, so the two
+          # per-arch builds can be merged into one manifest later. On PRs:
+          # empty outputs → build-only validation (no load, no push).
+          outputs: ${{ steps.meta-vars.outputs.PUSH == 'true' && format('type=image,name={0}/{1}/{2},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.OWNER, matrix.image.name) || '' }}
+          # Per-image AND per-arch cache ref so api/worker/viewer and amd64/arm64
+          # builds never poison each other's layer cache. cache-to is push-gated
+          # because type=registry writes need GHCR auth (skipped on fork PRs).
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}:buildcache-${{ matrix.platform.arch }}
+          cache-to: ${{ steps.meta-vars.outputs.PUSH == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, env.OWNER, matrix.image.name, matrix.platform.arch) || '' }}
+
+      - name: Export digest
+        if: steps.meta-vars.outputs.PUSH == 'true'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: steps.meta-vars.outputs.PUSH == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.image }} manifest
+    needs: build
+    # Only the push path publishes — PRs stop at per-arch validation builds.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [depictio-api, depictio-worker, depictio-viewer]
+
+    steps:
+      - name: Determine version
+        id: meta-vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            GIT_TAG=${GITHUB_REF#refs/tags/}
+            echo "VERSION=${GIT_TAG#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.OWNER }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Extract metadata (tags) for Docker
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
-          # `next` is the moving pointer to the latest build off the
-          # default branch. Release tags get the explicit version tag.
+          # `next` is the moving pointer to the latest build; release tags also
+          # get their explicit version tag (e.g. 1.0.0).
           tags: |
             type=raw,value=${{ steps.meta-vars.outputs.VERSION }}
-            type=raw,value=next,enable=${{ steps.meta-vars.outputs.PUSH == 'true' }}
+            type=raw,value=next
 
-      - name: Build and push ${{ matrix.image }}
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: ${{ steps.meta-vars.outputs.PUSH == 'true' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-          build-args: |
-            VERSION=${{ steps.meta-vars.outputs.VERSION }}
-          # Per-image cache ref so the api/worker/viewer builds don't
-          # poison each other's layer cache (different base images, very
-          # different dep sets). cache-to is push-gated because
-          # type=registry writes need GHCR auth, which we skip on PRs
-          # (fork PRs wouldn't have the secret anyway).
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:buildcache
-          cache-to: ${{ steps.meta-vars.outputs.PUSH == 'true' && format('type=registry,ref={0}/{1}/{2}:buildcache,mode=max', env.REGISTRY, env.OWNER, matrix.image) || '' }}
+      - name: Create multi-arch manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}@sha256:%s ' *)
+
+      - name: Inspect merged image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ steps.meta-vars.outputs.VERSION }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -4,10 +4,12 @@ name: Build images (api / worker / viewer)
 # (see docker-images/Dockerfile.api / .worker / .viewer) on tag pushes
 # and validates them on PRs.
 #
-# Multi-arch: each image is built for linux/amd64 AND linux/arm64 on NATIVE
-# runners (no QEMU emulation), pushed by digest, then stitched into a single
-# multi-arch manifest by the `merge` job. amd64 builds at full speed on its own
-# runner and is never gated behind the arm64 build.
+# Architectures (resolved by the `setup` job):
+#   - PRs and beta/pre-release tags (1.0.0-b9, *-next): linux/amd64 only — fast.
+#   - Stable releases (pure X.Y.Z) and matching workflow_dispatch: linux/amd64
+#     AND linux/arm64, each built on a NATIVE runner (no QEMU emulation), pushed
+#     by digest, then stitched into one multi-arch manifest by the `merge` job.
+# arm64 is reserved for production releases so it never runs on every PR/commit.
 #
 # Image namespaces: `depictio-api`, `depictio-worker`, `depictio-viewer`.
 
@@ -51,8 +53,42 @@ env:
   OWNER: ${{ github.repository_owner }}
 
 jobs:
+  setup:
+    name: Resolve build platforms
+    runs-on: ubuntu-latest
+    outputs:
+      # JSON array of {name, arch, runner} — consumed by `build` and `smoke-test`.
+      platforms: ${{ steps.set.outputs.platforms }}
+    steps:
+      - name: Decide architectures
+        id: set
+        run: |
+          AMD='{"name":"linux/amd64","arch":"amd64","runner":"ubuntu-22.04"}'
+          ARM='{"name":"linux/arm64","arch":"arm64","runner":"ubuntu-24.04-arm"}'
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION=""
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            GIT_TAG=${GITHUB_REF#refs/tags/}
+            VERSION="${GIT_TAG#v}"
+          fi
+
+          # arm64 is reserved for STABLE production releases (pure X.Y.Z, no
+          # -bN / -next suffix). PRs and pre-release tags stay amd64-only so arm
+          # never builds on every PR/commit.
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "platforms=[$AMD,$ARM]" >> "$GITHUB_OUTPUT"
+            echo "Stable release '$VERSION' → amd64 + arm64"
+          else
+            echo "platforms=[$AMD]" >> "$GITHUB_OUTPUT"
+            echo "PR / pre-release '${VERSION:-PR}' → amd64 only"
+          fi
+
   build:
     name: Build ${{ matrix.image.name }} (${{ matrix.platform.arch }})
+    needs: setup
     runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
@@ -64,10 +100,8 @@ jobs:
           - { name: depictio-api, dockerfile: docker-images/Dockerfile.api }
           - { name: depictio-worker, dockerfile: docker-images/Dockerfile.worker }
           - { name: depictio-viewer, dockerfile: docker-images/Dockerfile.viewer }
-        platform:
-          # Native runners — no QEMU. amd64 ships independently of arm64.
-          - { name: linux/amd64, arch: amd64, runner: ubuntu-22.04 }
-          - { name: linux/arm64, arch: arm64, runner: ubuntu-24.04-arm }
+        # amd64 always; arm64 added only for stable releases (see `setup`).
+        platform: ${{ fromJSON(needs.setup.outputs.platforms) }}
 
     steps:
       - name: Checkout repository
@@ -217,7 +251,7 @@ jobs:
     # (no .env, no flags) — the exact thing a docs-following user runs. Runs on
     # both arches so the multi-arch images are validated end-to-end at runtime.
     name: Quick-start smoke test (${{ matrix.arch }})
-    needs: merge
+    needs: [setup, merge]
     if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -226,9 +260,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { arch: amd64, runner: ubuntu-22.04 }
-          - { arch: arm64, runner: ubuntu-24.04-arm }
+        # Same arches that were actually built+published (amd64, plus arm64 on
+        # stable releases) — so the arm64 smoke test only runs when arm64 exists.
+        include: ${{ fromJSON(needs.setup.outputs.platforms) }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -211,3 +211,88 @@ jobs:
         run: |
           docker buildx imagetools inspect \
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}:${{ steps.meta-vars.outputs.VERSION }}
+
+  smoke-test:
+    # Prove the published quick start actually boots from JUST the compose file
+    # (no .env, no flags) — the exact thing a docs-following user runs. Runs on
+    # both arches so the multi-arch images are validated end-to-end at runtime.
+    name: Quick-start smoke test (${{ matrix.arch }})
+    needs: merge
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: amd64, runner: ubuntu-22.04 }
+          - { arch: arm64, runner: ubuntu-24.04-arm }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Determine version
+        id: meta-vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            GIT_TAG=${GITHUB_REF#refs/tags/}
+            echo "VERSION=${GIT_TAG#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.OWNER }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Boot the quick start from docker-compose.yaml alone (no .env)
+        env:
+          # Pin to the images this run just built + merged, so the smoke test
+          # validates the exact release artifacts (works for betas too, whose
+          # compose pin still points at the previous stable).
+          DEPICTIO_VERSION: ${{ steps.meta-vars.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/quickstart"
+          mkdir -p "$work"
+          # Isolate exactly what a docs-following user has: the compose file,
+          # nothing else. No .env, no COMPOSE_PROFILES, no extra args.
+          cp docker-compose.yaml "$work/docker-compose.yaml"
+          cd "$work"
+          docker compose up -d
+
+          echo "::group::Wait for backend health"
+          ok=false
+          # First boot seeds the reference datasets, so allow a generous window.
+          for i in $(seq 1 90); do
+            status="$(docker inspect -f '{{ .State.Health.Status }}' depictio-backend 2>/dev/null || echo missing)"
+            echo "[$i] backend: $status"
+            case "$status" in
+              healthy) ok=true; break ;;
+              unhealthy) echo "backend reported unhealthy"; break ;;
+            esac
+            sleep 5
+          done
+          echo "::endgroup::"
+          $ok || { echo "::error::backend did not become healthy"; exit 1; }
+
+          echo "Asserting published endpoints..."
+          curl -fsS http://localhost:8058/health >/dev/null && echo "API /health: OK"
+          code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5080/)"
+          echo "viewer / -> HTTP $code"
+          [ "$code" = "200" ] || { echo "::error::viewer not serving on 5080"; exit 1; }
+          echo "Quick start booted cleanly with no .env on ${{ matrix.arch }}."
+
+      - name: Dump compose logs on failure
+        if: failure()
+        run: docker compose -f "$RUNNER_TEMP/quickstart/docker-compose.yaml" logs --no-color || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f "$RUNNER_TEMP/quickstart/docker-compose.yaml" down -v || true

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -328,6 +328,34 @@ jobs:
           echo "All six services running."
           echo "::endgroup::"
 
+      - name: Verify bootstrap admin + iris dashboard were seeded
+        run: |
+          set -euo pipefail
+          # Mongo is internal-only (not published to the host), so query it from
+          # inside the container. mongosh ships in the mongo image.
+          mq() { docker exec mongo mongosh --quiet --port 27018 depictioDB --eval "$1" 2>/dev/null | tr -dc '0-9'; }
+          # Non-anonymous admin = the single-user auto-seed (db_init) actually ran.
+          q_admin='db.users.countDocuments({is_admin:true, is_anonymous:{$ne:true}})'
+          # Match the iris reference dashboard case-insensitively (robust to the
+          # exact title wording).
+          q_dash='db.dashboards.countDocuments({title:/iris/i})'
+
+          echo "::group::Wait for first-boot seeding"
+          admins=0; dashes=0
+          for i in $(seq 1 24); do  # up to ~2 min after the API is healthy
+            admins="$(mq "$q_admin")"; admins="${admins:-0}"
+            dashes="$(mq "$q_dash")"; dashes="${dashes:-0}"
+            echo "[$i] admin users: $admins | iris dashboards: $dashes"
+            if [ "$admins" -ge 1 ] && [ "$dashes" -ge 1 ]; then break; fi
+            sleep 5
+          done
+          echo "::endgroup::"
+
+          [ "$admins" -ge 1 ] || { echo "::error::no non-anonymous admin user seeded — single-user bootstrap did not run"; exit 1; }
+          echo "Admin user created (single-user auto-seed works)."
+          [ "$dashes" -ge 1 ] || { echo "::error::no iris reference dashboard found in MongoDB"; exit 1; }
+          echo "Iris reference dashboard seeded and available."
+
       - name: Dump compose logs on failure
         if: failure()
         run: docker compose -f "$RUNNER_TEMP/quickstart/docker-compose.yaml" logs --no-color || true

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -5,11 +5,11 @@ name: Build images (api / worker / viewer)
 # and validates them on PRs.
 #
 # Architectures (resolved by the `setup` job):
-#   - PRs and beta/pre-release tags (1.0.0-b9, *-next): linux/amd64 only — fast.
-#   - Stable releases (pure X.Y.Z) and matching workflow_dispatch: linux/amd64
-#     AND linux/arm64, each built on a NATIVE runner (no QEMU emulation), pushed
-#     by digest, then stitched into one multi-arch manifest by the `merge` job.
-# arm64 is reserved for production releases so it never runs on every PR/commit.
+#   - PRs: linux/amd64 only — fast validation, no arm64 on every commit/PR.
+#   - Any published version (tag push, beta or stable, + workflow_dispatch):
+#     linux/amd64 AND linux/arm64, each built on a NATIVE runner (no QEMU
+#     emulation), pushed by digest, then stitched into one multi-arch manifest by
+#     the `merge` job. So every released version runs natively on Apple Silicon.
 #
 # Image namespaces: `depictio-api`, `depictio-worker`, `depictio-viewer`.
 
@@ -66,24 +66,15 @@ jobs:
           AMD='{"name":"linux/amd64","arch":"amd64","runner":"ubuntu-22.04"}'
           ARM='{"name":"linux/arm64","arch":"arm64","runner":"ubuntu-24.04-arm"}'
 
+          # PRs validate amd64 only — no arm64 on every PR/commit. Every
+          # published version (tag push, beta or stable, or workflow_dispatch)
+          # builds amd64 + arm64 so each release runs natively on Apple Silicon.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            VERSION=""
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
-          else
-            GIT_TAG=${GITHUB_REF#refs/tags/}
-            VERSION="${GIT_TAG#v}"
-          fi
-
-          # arm64 is reserved for STABLE production releases (pure X.Y.Z, no
-          # -bN / -next suffix). PRs and pre-release tags stay amd64-only so arm
-          # never builds on every PR/commit.
-          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "platforms=[$AMD,$ARM]" >> "$GITHUB_OUTPUT"
-            echo "Stable release '$VERSION' → amd64 + arm64"
-          else
             echo "platforms=[$AMD]" >> "$GITHUB_OUTPUT"
-            echo "PR / pre-release '${VERSION:-PR}' → amd64 only"
+            echo "PR → amd64 only"
+          else
+            echo "platforms=[$AMD,$ARM]" >> "$GITHUB_OUTPUT"
+            echo "Published build → amd64 + arm64"
           fi
 
   build:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -289,6 +289,45 @@ jobs:
           [ "$code" = "200" ] || { echo "::error::viewer not serving on 5080"; exit 1; }
           echo "Quick start booted cleanly with no .env on ${{ matrix.arch }}."
 
+      - name: Sanity checks (status, version, schema, containers)
+        env:
+          DEPICTIO_VERSION: ${{ steps.meta-vars.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+
+          echo "::group::API status + version"
+          # /depictio/api/v1/utils/status -> {"status": "online", "version": ...}
+          status_json="$(curl -fsS http://localhost:8058/depictio/api/v1/utils/status)"
+          echo "$status_json"
+          api_status="$(echo "$status_json" | jq -r '.status // "unknown"')"
+          api_version="$(echo "$status_json" | jq -r '.version // "unknown"')"
+          [ "$api_status" = "online" ] || { echo "::error::API status is '$api_status', expected 'online'"; exit 1; }
+          # The API reports the VERSION file verbatim; tolerate PEP 440 beta
+          # normalization (1.0.0-b9 -> 1.0.0b9) just in case.
+          want="$(echo "$DEPICTIO_VERSION" | tr -d '-')"
+          got="$(echo "$api_version" | tr -d '-')"
+          [ "$want" = "$got" ] || { echo "::error::API reports version '$api_version', expected '$DEPICTIO_VERSION' (the built image)"; exit 1; }
+          echo "API online and serving version $api_version (matches the built image)."
+          echo "::endgroup::"
+
+          echo "::group::FastAPI OpenAPI schema"
+          openapi_code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8058/openapi.json)"
+          [ "$openapi_code" = "200" ] || { echo "::error::/openapi.json -> HTTP $openapi_code"; exit 1; }
+          echo "/openapi.json: 200"
+          echo "::endgroup::"
+
+          echo "::group::All services running"
+          # The bundled MinIO must be up (the dropped profile / default creds) and
+          # the worker must be up (required for design mode) — assert no container
+          # exited or crash-looped.
+          for c in mongo redis minio depictio-backend depictio-viewer depictio-celery-worker; do
+            state="$(docker inspect -f '{{ .State.Status }}' "$c" 2>/dev/null || echo missing)"
+            echo "  $c: $state"
+            [ "$state" = "running" ] || { echo "::error::container '$c' is '$state', expected 'running'"; exit 1; }
+          done
+          echo "All six services running."
+          echo "::endgroup::"
+
       - name: Dump compose logs on failure
         if: failure()
         run: docker compose -f "$RUNNER_TEMP/quickstart/docker-compose.yaml" logs --no-color || true

--- a/bump-with-helm.sh
+++ b/bump-with-helm.sh
@@ -30,15 +30,27 @@ sed -i '' 's/^version: .*/version: "'"$(date +%Y%m%d)"'.1"/' helm-charts/depicti
 # Ensure uv.lock is up to date after pyproject.toml changes
 uv lock
 
+NEW_VERSION=$(cat VERSION)
+
+# Pin the public docker-compose.yaml to the released version on STABLE releases
+# only, so a fresh `docker compose up -d` (no .env) pulls the exact release.
+# Betas intentionally keep the previous stable pin — the quick start stays on
+# stable while beta images are published under their own version tags.
+PIN_COMPOSE=false
+if [[ "$NEW_VERSION" != *-b* ]]; then
+    sed -i '' -E "s#(ghcr\.io/depictio/depictio-[a-z]+:\\\$\{DEPICTIO_VERSION:-)[^}]*(\})#\1${NEW_VERSION}\2#g" docker-compose.yaml
+    PIN_COMPOSE=true
+fi
+
 # Add and amend commit if bump2version created one
 if git log -1 --pretty=%B | grep -q "Bump version"; then
     git add helm-charts/depictio/Chart.yaml uv.lock
+    [[ "$PIN_COMPOSE" == "true" ]] && git add docker-compose.yaml
     git commit --amend --no-edit
     # git push && git push --tags
 fi
 
 # Move the 'stable' tag for non-beta releases
-NEW_VERSION=$(cat VERSION)
 if [[ "$NEW_VERSION" != *-b* ]]; then
     echo "Stable release detected (v${NEW_VERSION}) — moving 'stable' tag"
     git tag -f stable "v${NEW_VERSION}"

--- a/depictio/api/v1/db_init.py
+++ b/depictio/api/v1/db_init.py
@@ -1,5 +1,6 @@
 import json
 import os
+import secrets
 from datetime import datetime, timezone
 from typing import Any
 
@@ -621,11 +622,25 @@ async def _bootstrap_admin_and_test_user() -> tuple[UserBeanie | None, dict | No
         admin_email = settings.bootstrap.admin_email.strip()
         admin_password = settings.bootstrap.admin_password.get_secret_value()
         if not admin_email or not admin_password:
-            raise RuntimeError(
-                "No admin user exists in MongoDB and DEPICTIO_BOOTSTRAP_ADMIN_EMAIL / "
-                "DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD are not set. Set both env vars (via a "
-                "Kubernetes Secret in production) so the first-boot admin can be created."
-            )
+            if settings.auth.is_single_user_mode:
+                # Single-user mode has no login UI — the anonymous auto-login
+                # session maps to this admin (see _get_anonymous_user_session).
+                # Seed a default local admin so the zero-config quick start needs
+                # no secrets. The password is random (never used to log in) and
+                # is never logged. Multi-user mode still fails fast below.
+                admin_email = admin_email or "admin@example.com"
+                admin_password = admin_password or secrets.token_urlsafe(32)
+                logger.info(
+                    "Single-user mode: seeding default local admin '%s' "
+                    "(no DEPICTIO_BOOTSTRAP_ADMIN_* set)",
+                    admin_email,
+                )
+            else:
+                raise RuntimeError(
+                    "No admin user exists in MongoDB and DEPICTIO_BOOTSTRAP_ADMIN_EMAIL / "
+                    "DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD are not set. Set both env vars (via a "
+                    "Kubernetes Secret in production) so the first-boot admin can be created."
+                )
 
         logger.info(
             "No admin user found in MongoDB — seeding bootstrap admin %s from "

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,24 +2,29 @@
 # DEPICTIO DOCKER COMPOSE - QUICK START
 # ============================================================================
 # This is the main docker-compose file for running Depictio with pre-built images.
-# MinIO (S3-compatible object storage) is bundled by default via the
-# `local-minio` profile, which .env activates (COMPOSE_PROFILES=local-minio).
+# MinIO (S3-compatible object storage) is bundled and starts by default — no
+# profile flag and no .env are required for the single-user quick start.
 #
-# QUICK START (no git clone required):
+# QUICK START (no git clone, no .env required):
 #   curl -LO https://raw.githubusercontent.com/depictio/depictio/main/docker-compose.yaml
-#   docker compose --profile local-minio up -d     # (or copy .env.example → .env)
-#   → http://localhost:5080
+#   docker compose up -d
+#   → http://localhost:5080   (single-user mode, no login)
 #
-# COMMANDS (with .env present — see CONFIGURATION below):
+# COMMANDS:
 #   Start:  docker compose up -d
 #   Stop:   docker compose down
 #   Logs:   docker compose logs -f
 #   Status: docker compose ps
 #
-# EXTERNAL S3 (advanced) — bring your own S3/MinIO, don't start the bundled one.
-# Override COMPOSE_PROFILES so the `local-minio` profile is off, and set your
-# S3 credentials/endpoint in .env:
-#   COMPOSE_PROFILES=external-s3 docker compose up -d
+# MULTI-USER / EXPOSED DEPLOYMENTS: the defaults below (minio/minio123) are for
+# local single-user use only. Set DEPICTIO_AUTH_SINGLE_USER_MODE=false and the
+# server refuses to boot until you provide strong DEPICTIO_MINIO_ROOT_PASSWORD
+# and DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD values — see .env.example.
+#
+# EXTERNAL S3 (advanced) — bring your own S3/MinIO instead of the bundled one:
+# set DEPICTIO_MINIO_* to your endpoint/credentials and
+# DEPICTIO_MINIO_EXTERNAL_SERVICE=true in .env (the bundled minio container can
+# be left stopped with `docker compose up -d --scale minio=0`).
 #
 # DEVELOPMENT:
 #   For local development with hot-reload, use docker-compose.dev.yaml instead.
@@ -77,19 +82,19 @@ services:
   minio:
     image: minio/minio:RELEASE.2025-01-20T14-49-07Z
     container_name: minio
-    # Bundled local object storage, gated behind the `local-minio` profile.
-    # `.env.example` ships COMPOSE_PROFILES=local-minio, so a plain
-    # `docker compose up -d` starts it (no flag needed). To bring your own
-    # external S3/MinIO instead, override the env var so this profile is off:
-    #   COMPOSE_PROFILES=external-s3 docker compose up -d
-    profiles: ["local-minio"]
+    # Bundled local object storage, started by default. For an external
+    # S3/MinIO instead, point DEPICTIO_MINIO_* at your endpoint and leave this
+    # container stopped (`docker compose up -d --scale minio=0`).
     # Internal-only: the backend/worker reach MinIO over the compose network.
     # Neither the S3 API nor the console is published to the host.
     volumes:
       - minio_data:/data
     environment:
-      MINIO_ROOT_USER: ${DEPICTIO_MINIO_ROOT_USER:?DEPICTIO_MINIO_ROOT_USER must be set in .env}
-      MINIO_ROOT_PASSWORD: ${DEPICTIO_MINIO_ROOT_PASSWORD:?DEPICTIO_MINIO_ROOT_PASSWORD must be set in .env (>=16 chars)}
+      # Local single-user defaults. Override with strong secrets for any
+      # multi-user / exposed deployment (the server enforces this — minio123 is
+      # rejected as weak when single-user mode is off).
+      MINIO_ROOT_USER: ${DEPICTIO_MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${DEPICTIO_MINIO_ROOT_PASSWORD:-minio123}
     command: server /data --console-address :9001
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]
@@ -106,7 +111,7 @@ services:
     restart: unless-stopped
 
   depictio-backend:
-    image: ghcr.io/depictio/depictio-api:${DEPICTIO_VERSION:-next}
+    image: ghcr.io/depictio/depictio-api:${DEPICTIO_VERSION:-1.0.0}
     container_name: depictio-backend
     ports:
       # Loopback-only: front this with a reverse proxy / TLS terminator for
@@ -130,8 +135,8 @@ services:
         required: false
     environment:
       DEPICTIO_AUTH_SINGLE_USER_MODE: "${DEPICTIO_AUTH_SINGLE_USER_MODE:-true}"
-      DEPICTIO_MINIO_ROOT_USER: "${DEPICTIO_MINIO_ROOT_USER:?DEPICTIO_MINIO_ROOT_USER must be set in .env}"
-      DEPICTIO_MINIO_ROOT_PASSWORD: "${DEPICTIO_MINIO_ROOT_PASSWORD:?DEPICTIO_MINIO_ROOT_PASSWORD must be set in .env (>=16 chars)}"
+      DEPICTIO_MINIO_ROOT_USER: "${DEPICTIO_MINIO_ROOT_USER:-minio}"
+      DEPICTIO_MINIO_ROOT_PASSWORD: "${DEPICTIO_MINIO_ROOT_PASSWORD:-minio123}"
       DEPICTIO_BOOTSTRAP_ADMIN_EMAIL: "${DEPICTIO_BOOTSTRAP_ADMIN_EMAIL:-}"
       DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD: "${DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD:-}"
       DEPICTIO_BOOTSTRAP_SEED_TEST_USER: "${DEPICTIO_BOOTSTRAP_SEED_TEST_USER:-false}"
@@ -150,14 +155,14 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      # required:false so external-S3 mode (local-minio profile off) starts
-      # the backend without waiting for — or pulling in — the minio service.
+      # required:false so external-S3 mode (minio scaled to 0) still starts the
+      # backend without waiting for the bundled minio service.
       minio:
         condition: service_healthy
         required: false
 
   depictio-viewer:
-    image: ghcr.io/depictio/depictio-viewer:${DEPICTIO_VERSION:-next}
+    image: ghcr.io/depictio/depictio-viewer:${DEPICTIO_VERSION:-1.0.0}
     container_name: depictio-viewer
     ports:
       # Container now listens on 8080 (nginx-unprivileged / non-root); the
@@ -192,7 +197,7 @@ services:
     container_name: depictio-celery-worker
     # Always enabled - required for design mode (stepper) to work
     # Dashboard editor will fail without Celery worker running
-    image: ghcr.io/depictio/depictio-worker:${DEPICTIO_VERSION:-next}
+    image: ghcr.io/depictio/depictio-worker:${DEPICTIO_VERSION:-1.0.0}
     volumes:
       - depictio_keys:/app/depictio/keys
     env_file:
@@ -201,8 +206,8 @@ services:
     environment:
       DEPICTIO_CONTEXT: "server"
       DEPICTIO_AUTH_SINGLE_USER_MODE: "${DEPICTIO_AUTH_SINGLE_USER_MODE:-true}"
-      DEPICTIO_MINIO_ROOT_USER: "${DEPICTIO_MINIO_ROOT_USER:?DEPICTIO_MINIO_ROOT_USER must be set in .env}"
-      DEPICTIO_MINIO_ROOT_PASSWORD: "${DEPICTIO_MINIO_ROOT_PASSWORD:?DEPICTIO_MINIO_ROOT_PASSWORD must be set in .env (>=16 chars)}"
+      DEPICTIO_MINIO_ROOT_USER: "${DEPICTIO_MINIO_ROOT_USER:-minio}"
+      DEPICTIO_MINIO_ROOT_PASSWORD: "${DEPICTIO_MINIO_ROOT_PASSWORD:-minio123}"
     command: ["/app/run_celery_worker.sh"]
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]


### PR DESCRIPTION
## Problem

A fresh user following the docs quick start (`curl` the compose file → `docker compose up -d`) **could not start Depictio**:

- **MinIO creds hard-required** — `${DEPICTIO_MINIO_ROOT_USER:?…}` / `${…_PASSWORD:?…}` made Docker Compose abort at interpolation, *before any container started*, even though single-user mode needs no secrets app-side:
  ```
  required variable DEPICTIO_MINIO_ROOT_USER is missing a value: DEPICTIO_MINIO_ROOT_USER must be set in .env
  ```
- **Bundled MinIO behind a profile** — `profiles: ["local-minio"]` meant a bare `docker compose up -d` (no `.env` setting `COMPOSE_PROFILES`) never started object storage.
- **Mutable / wrong image tag** — compose defaulted to `next` (bleeding edge), while `.env.example` referenced `latest`, a tag CI **never published** (404 on ghcr).
- **No arm64 images** — CI built `linux/amd64` only, so Apple Silicon Macs (and arm servers) got `no matching manifest for linux/arm64/v8`.

## Changes

- **`docker-compose.yaml`**
  - MinIO creds default to `minio` / `minio123` (single-user just works; multi-user still **fail-closes** because the app rejects `minio123` as weak when `DEPICTIO_AUTH_SINGLE_USER_MODE=false`).
  - Bundled MinIO starts by default (dropped the `local-minio` profile gate).
  - Images pinned to the released version: `${DEPICTIO_VERSION:-1.0.0}` — self-documenting, reproducible, still overridable.
- **`bump-with-helm.sh`** — on **stable** releases, rewrites the compose version pin to the new version and folds it into the bump commit. Betas keep the prior stable pin, so the public quick start always points at the latest stable.
- **`.env.example`** — `.env` is now optional; MinIO/admin creds commented and documented as multi-user-only; external-S3 guidance; fixed the stale "≥16" → "≥8" password note.
- **`build-images.yaml`** — multi-arch: build `linux/amd64` + `linux/arm64` on **native runners** (`ubuntu-22.04` / `ubuntu-24.04-arm`), push **by digest**, then merge into one multi-arch manifest per image. amd64 builds at full native speed, never gated behind arm64.

## Result

```bash
curl -LO https://raw.githubusercontent.com/depictio/depictio/main/docker-compose.yaml
docker compose up -d          # no .env, no flags, no DEPICTIO_VERSION
# → http://localhost:5080 (single-user)
```

## Notes / validation

- The multi-arch arm64 build uses the GitHub-hosted **`ubuntu-24.04-arm`** runner. This PR touches `build-images.yaml`, which is in that workflow's `paths` trigger, so opening the PR runs it in **PR mode** (build-only, both arches, no push) — self-validating the arm runner + arm64 Dockerfile builds. If unavailable, fall back to QEMU.
- Existing `1.0.0` images on ghcr are still amd64-only; publishing arm64 for `1.0.0` needs a `workflow_dispatch` rebuild (`version=1.0.0`) once this merges.

## Follow-ups (not in this PR)
- CI smoke-test job that boots the pinned compose with no `.env` and asserts `:5080` + `:8058/health`.
- Docs (`depictio-docs`) cleanup: external-S3 path points at a non-existent `docker-compose.no-minio.yaml`; reconcile the `latest`/version notes.