### PR TITLE
fix(quickstart): let mongo start under cap_drop:[ALL]

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,7 +44,11 @@ services:
     # Not published to the host to avoid exposing the DB.
     volumes:
       - mongo_data:/data/db
+    # The stock mongo image starts as root and drops to the `mongodb` user
+    # (chown the data dir + gosu). cap_drop:[ALL] removes the capabilities that
+    # needs, so add back only those — keeping a minimal, hardened cap set.
     cap_drop: [ALL]
+    cap_add: [CHOWN, SETGID, SETUID, DAC_OVERRIDE]
     security_opt: ["no-new-privileges:true"]
     deploy:
       resources:


### PR DESCRIPTION
## Problem

The quick-start smoke test (added in #815) ran for the first time on the `1.0.1-b1` release build and caught a **real latent bug** — the bundled `mongo` can't boot:

```
mongo | chown: changing ownership of '/proc/1/fd/1': Operation not permitted
mongo | error: failed switching to 'mongodb': operation not permitted
dependency failed to start: container mongo is unhealthy
```

The stock `mongo` image starts as **root**, then drops to the `mongodb` user (chown the data dir + `gosu`). The pre-existing `cap_drop: [ALL]` strips `CAP_CHOWN` / `CAP_SETUID` / `CAP_SETGID`, so the privilege-drop fails, mongo goes unhealthy, and `docker compose up` aborts. This affects the **real quick-start**, not just CI — it was simply never booted end-to-end before the smoke test existed. Both amd64 and arm64 failed identically.

(depictio's own images run non-root from the start, so `cap_drop: [ALL]` is correct for them. `redis` came up Healthy and `minio` runs as root without dropping, so only `mongo` needs this.)

## Fix

Keep `cap_drop: [ALL]` as the baseline; add back only the four capabilities the entrypoint needs:

```yaml
cap_drop: [ALL]
cap_add: [CHOWN, SETGID, SETUID, DAC_OVERRIDE]
```

- `CHOWN` + `DAC_OVERRIDE` → `chown -R mongodb /data/db`
- `SETUID` + `SETGID` → `gosu mongodb`

This lets mongo run its **standard** entrypoint (so it works the same for fresh *and* existing volumes, no `user:`/uid coupling), while staying hardened with a minimal cap set. `no-new-privileges` is unaffected — gosu *drops* privileges, which it permits.

## Validation

Will be confirmed by the smoke test on the next release build (it boots the published compose with no `.env` and asserts mongo healthy → API → seeding). The dev compose already runs mongo fine under `cap_drop: [ALL]` because it sets `user:` instead — a different but equivalent escape hatch.