### PR TITLE
ci(quickstart): poll the viewer in smoke test instead of one eager curl

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -309,7 +309,14 @@ jobs:
 
           echo "Asserting published endpoints..."
           curl -fsS http://localhost:8058/health >/dev/null && echo "API /health: OK"
-          code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5080/)"
+          # The viewer starts only after the backend is healthy, so nginx may not
+          # be listening yet — poll (tolerating connection-refused) until it serves.
+          code=000
+          for i in $(seq 1 30); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5080/ || echo 000)"
+            [ "$code" = "200" ] && break
+            sleep 3
+          done
           echo "viewer / -> HTTP $code"
           [ "$code" = "200" ] || { echo "::error::viewer not serving on 5080"; exit 1; }
           echo "Quick start booted cleanly with no .env on ${{ matrix.arch }}."


### PR DESCRIPTION
## What the 1.0.1-b2 smoke run showed

The whole stack now boots cleanly (validates the mongo `cap_add` fix from #816):

```
Container mongo Healthy · minio Healthy · redis Healthy
Container depictio-backend Healthy · viewer Started · worker Started
[1] backend: healthy
API /health: OK
##[error]Process completed with exit code 7
```

The failure is a **smoke-test timing bug**, not the app: right after the backend health loop, the step curled `http://localhost:5080` **once, immediately**. The viewer only starts *after* the backend is healthy (`depends_on`), so nginx wasn't listening yet → `curl` exits 7 (connection refused) → `set -e` aborts before the `== 200` check.

## Fix

Poll `:5080` with retries (tolerating connection-refused) until it serves `200`, the same way the backend is waited on:

```bash
code=000
for i in $(seq 1 30); do
  code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5080/ || echo 000)"
  [ "$code" = "200" ] && break
  sleep 3
done
[ "$code" = "200" ] || { echo "::error::viewer not serving on 5080"; exit 1; }
```

The `|| echo 000` keeps a transient connection-refused from tripping `set -e`. With this, the boot step proceeds to the sanity checks (status/version, openapi, 6 containers) and the seeding verification (admin user + iris dashboard), which never got to run before.

## Note

Product side is fine — `1.0.1-b2` images are built, multi-arch, and the stack boots. This only fixes the test gate. Validated on the next release's smoke run.