### PR TITLE
fix(quickstart): give the viewer a writable /etc/nginx/conf.d

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -174,12 +174,14 @@ services:
       - 5080:8080
     # read_only root FS: nginx-unprivileged only needs writable scratch dirs,
     # provided as tmpfs below (pid → /tmp, caches → /var/cache/nginx,
-    # runtime sockets → /var/run).
+    # runtime sockets → /var/run, and /etc/nginx/conf.d where the entrypoint
+    # renders default.conf.template via envsubst at startup).
     read_only: true
     tmpfs:
       - /tmp
       - /var/cache/nginx
       - /var/run
+      - /etc/nginx/conf.d
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]
     deploy:


### PR DESCRIPTION
## What the 1.0.1-b3 smoke run showed

The mongo `cap_add` fix (#816) and the viewer-poll fix (#817) both worked — mongo/minio/redis/**backend** all go Healthy and the backend even **seeds the reference datasets successfully**. But the viewer never served on `:5080` (HTTP 000 for the full 90s poll). Its container logs showed nginx crash-looping:

```
20-envsubst-on-templates.sh: can't create /etc/nginx/conf.d/default.conf: Read-only file system
```

## Cause

The viewer image ships its nginx config as a **template** (`/etc/nginx/templates/default.conf.template`); the base image's entrypoint renders it into `/etc/nginx/conf.d/` at startup. The compose sets `read_only: true` with tmpfs for `/tmp`, `/var/cache/nginx`, `/var/run` — but **not** `/etc/nginx/conf.d`. So the render fails and nginx never starts. Same class of latent bug as the mongo caps one — the smoke test is the first thing to actually verify the viewer serves.

## Fix

Add `/etc/nginx/conf.d` to the viewer tmpfs. It's repopulated from the template on every boot, so an empty tmpfs there is exactly right and the read-only-rootfs hardening stays intact.

```yaml
tmpfs:
  - /tmp
  - /var/cache/nginx
  - /var/run
  - /etc/nginx/conf.d
```

## Status

This should be the last piece — backend already seeds fine, the other services are Healthy. Validated on the next release's smoke run (boot → viewer 200 → sanity checks → admin user + iris dashboard seeded).