### PR TITLE
fix(quickstart): make viewer conf.d tmpfs writable by the nginx user

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -181,7 +181,18 @@ services:
       - /tmp
       - /var/cache/nginx
       - /var/run
-      - /etc/nginx/conf.d
+    volumes:
+      # conf.d must be writable by the non-root nginx user (uid 101) so the
+      # entrypoint can render default.conf.template via envsubst at startup.
+      # A bare `tmpfs:` short-form mount lands root-owned 0755, so uid 101
+      # fails the entrypoint's writability check ("conf.d is not writable")
+      # and nginx starts with no server block → HTTP 000. The long-form mount
+      # sets an explicit world-writable (sticky) mode. With read_only root,
+      # this tmpfs is the only way to give the entrypoint a writable conf.d.
+      - type: tmpfs
+        target: /etc/nginx/conf.d
+        tmpfs:
+          mode: 1777
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]
     deploy:


### PR DESCRIPTION
## Problem

The `v1.0.1-b4` quick-start smoke test still fails with the viewer returning HTTP 000 on `:5080`, on **both** amd64 and arm64. PR #818 added the `/etc/nginx/conf.d` tmpfs, which fixed the earlier `read_only`-blocked failure — but exposed the next layer:

```
20-envsubst-on-templates.sh: ERROR: /etc/nginx/templates exists, but /etc/nginx/conf.d is not writable
```

The viewer image is `nginx-unprivileged` (uid 101). A bare short-form `tmpfs:` mount lands **root-owned 0755**, so uid 101 fails the entrypoint's writability check. envsubst is skipped, no `default.conf` is rendered, nginx starts with no server block → connection refused → HTTP 000.

Runtime envsubst can't be avoided: the template substitutes `${NGINX_LOCAL_RESOLVERS}` (auto-detected per environment) and `${DEPICTIO_API_UPSTREAM}` (overridden in k8s), so the config genuinely must render at container start.

## Fix

Mount `/etc/nginx/conf.d` via the **long-form** tmpfs syntax with an explicit world-writable sticky mode (`1777`), so the entrypoint can render the config as uid 101. The other scratch tmpfs mounts (`/tmp`, `/var/cache/nginx`, `/var/run`) are pre-owned by uid 101 in the base image and stay on the short form.

## Verification

The quick-start smoke test (boots the prod compose with no `.env`, polls the viewer on `:5080`) will gate this on both arches.