### PR TITLE
fix(quickstart): drop read_only rootfs on viewer so nginx can render its config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -172,27 +172,17 @@ services:
       # Container now listens on 8080 (nginx-unprivileged / non-root); the
       # published host port is unchanged at 5080.
       - 5080:8080
-    # read_only root FS: nginx-unprivileged only needs writable scratch dirs,
-    # provided as tmpfs below (pid → /tmp, caches → /var/cache/nginx,
-    # runtime sockets → /var/run, and /etc/nginx/conf.d where the entrypoint
-    # renders default.conf.template via envsubst at startup).
-    read_only: true
-    tmpfs:
-      - /tmp
-      - /var/cache/nginx
-      - /var/run
-    volumes:
-      # conf.d must be writable by the non-root nginx user (uid 101) so the
-      # entrypoint can render default.conf.template via envsubst at startup.
-      # A bare `tmpfs:` short-form mount lands root-owned 0755, so uid 101
-      # fails the entrypoint's writability check ("conf.d is not writable")
-      # and nginx starts with no server block → HTTP 000. The long-form mount
-      # sets an explicit world-writable (sticky) mode. With read_only root,
-      # this tmpfs is the only way to give the entrypoint a writable conf.d.
-      - type: tmpfs
-        target: /etc/nginx/conf.d
-        tmpfs:
-          mode: 1777
+    # No read_only root FS here — unlike the backend/worker. The
+    # nginx-unprivileged entrypoint renders default.conf.template via envsubst
+    # into /etc/nginx/conf.d at startup (the API upstream + the DNS resolver
+    # are resolved at runtime), which needs a writable rootfs. The image owns
+    # conf.d as uid 101 so the render just works. This mirrors the production
+    # k8s viewer Deployment, which likewise does NOT set readOnlyRootFilesystem
+    # for exactly this reason. (A read_only root + a tmpfs overlay on conf.d
+    # was tried and fails: the overlay lands root-owned and uid 101 can't write
+    # it — "conf.d is not writable" — so nginx starts with no server block.)
+    # The container is still hardened: non-root uid 101, all caps dropped, no
+    # privilege escalation.
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]
     deploy:


### PR DESCRIPTION
## Problem

The quick-start smoke test still fails on `v1.0.1-b4` — viewer returns HTTP 000 on `:5080`, both amd64 and arm64. PR #818 (conf.d tmpfs) and PR #819 (`mode: 1777` on that tmpfs) each fixed one layer but the viewer still won't serve:

```
20-envsubst-on-templates.sh: ERROR: /etc/nginx/templates exists, but /etc/nginx/conf.d is not writable
```

Two compounding issues under `read_only: true`:
1. A `tmpfs` overlay on `/etc/nginx/conf.d` lands **root-owned**, replacing the image's uid-101-owned dir.
2. Compose's `tmpfs.mode: 1777` is parsed as **decimal** (→ `others=--x`), so it isn't world-writable anyway.

The non-root nginx user (uid 101) can't write conf.d → envsubst is skipped → nginx starts with no server block → HTTP 000.

## Root cause

The `nginx-unprivileged` entrypoint **must** render `default.conf.template` into conf.d at startup — the API upstream and DNS resolver are runtime values (`${DEPICTIO_API_UPSTREAM}`, `${NGINX_LOCAL_RESOLVERS}`), different in compose vs k8s — so it needs a **writable rootfs**. The image already owns conf.d as uid 101, so on a normal writable rootfs the render just works.

This is exactly how the **production k8s viewer Deployment** runs: `viewer.securityContext` in `values.yaml` does **not** set `readOnlyRootFilesystem`, for this same reason.

## Fix

Mirror the known-green k8s setup: drop `read_only: true` and the conf.d/scratch tmpfs overlays on the **viewer** service only. The container stays hardened — non-root uid 101, `cap_drop: [ALL]`, `no-new-privileges`. The backend and worker keep their read_only roots (their images render nothing at startup).

## Verification

The quick-start smoke test (boots the prod compose with no `.env`, polls `:5080`) gates this on both arches at release time.