### PR TITLE
perf(docker): cache-friendly layer split in api/worker/viewer Dockerfiles

### DIFF
--- a/docker-images/Dockerfile.api
+++ b/docker-images/Dockerfile.api
@@ -29,10 +29,24 @@ ARG GID=1000
 RUN groupadd -g ${GID} depictio && \
     useradd -m -u ${UID} -g ${GID} -s /bin/bash depictio
 
-COPY --chown=depictio:depictio pyproject.toml uv.lock* VERSION ./
+# ---- Dependency layer (cached across code + version changes) ----
+# Install third-party deps + the editable in-tree packages WITHOUT the
+# depictio project itself (--no-install-project). This expensive layer is
+# keyed only on the lockfile + packages/, so editing application source — or
+# the per-release version churn in pyproject/VERSION — no longer reinstalls
+# every dependency. packages/ rarely changes, so it stays cached too.
+COPY --chown=depictio:depictio pyproject.toml uv.lock* ./
 COPY --chown=depictio:depictio packages ./packages/
-COPY --chown=depictio:depictio depictio ./depictio/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev \
+    || uv sync --no-install-project --no-dev
 
+# ---- Project layer (source + VERSION last) ----
+# Install the depictio project on top of the cached deps; cheap because every
+# dependency is already present. Copied last so source/version changes only
+# re-run this fast step, not the dependency install above.
+COPY --chown=depictio:depictio VERSION ./
+COPY --chown=depictio:depictio depictio ./depictio/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev || uv sync --no-dev
 

--- a/docker-images/Dockerfile.viewer
+++ b/docker-images/Dockerfile.viewer
@@ -15,12 +15,22 @@ WORKDIR /build
 
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
+# ---- Dependency layer (cached across viewer source changes) ----
+# Copy only the workspace manifests + lockfile so `pnpm install` is keyed on
+# dependencies, not source: a viewer code edit no longer reinstalls
+# node_modules — install only re-runs when a package.json or the lockfile
+# changes. node_modules is .dockerignored, so copying source afterwards can't
+# clobber the installed store.
 COPY pnpm-workspace.yaml pnpm-lock.yaml ./
-COPY packages ./packages/
-COPY depictio/viewer ./depictio/viewer/
-
+COPY packages/depictio-components/package.json ./packages/depictio-components/
+COPY packages/depictio-react-core/package.json ./packages/depictio-react-core/
+COPY depictio/viewer/package.json ./depictio/viewer/
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
+
+# ---- Source + build ----
+COPY packages ./packages/
+COPY depictio/viewer ./depictio/viewer/
 
 # Memory caps for typical 6 GB container limits: sourcemaps off (peak-mem
 # win, not shipped to users anyway), heap capped at 4 GB to leave cgroup

--- a/docker-images/Dockerfile.worker
+++ b/docker-images/Dockerfile.worker
@@ -61,12 +61,16 @@ ARG GID=1000
 RUN groupadd -g ${GID} depictio && \
     useradd -m -u ${UID} -g ${GID} -s /bin/bash depictio
 
-COPY --chown=depictio:depictio pyproject.toml uv.lock* VERSION ./
+# ---- Dependency layer (cached across code + version changes) ----
+# Deps + editable in-tree packages WITHOUT the depictio project itself
+# (--no-install-project), so a source edit or the per-release version churn in
+# pyproject/VERSION doesn't reinstall everything — see Dockerfile.api for the
+# full rationale.
+COPY --chown=depictio:depictio pyproject.toml uv.lock* ./
 COPY --chown=depictio:depictio packages ./packages/
-COPY --chown=depictio:depictio depictio ./depictio/
-
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev || uv sync --no-dev
+    uv sync --frozen --no-install-project --no-dev \
+    || uv sync --no-install-project --no-dev
 
 # Browser bundle target inside the image. We download into a BuildKit
 # cache mount and copy out — caches the chromium payload across rebuilds
@@ -80,13 +84,23 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 #
 # We also drop `--with-deps`: every shared library the shell needs is already
 # apt-installed above, and `--with-deps` would re-run apt over the same set.
+# Installed off the dependency layer (playwright is a dep), so the chromium
+# download only re-runs when deps change — not on source/version edits.
+# --no-sync runs from the already-synced env without pulling in the
+# not-yet-installed project (its source isn't copied until the layer below).
 ENV PLAYWRIGHT_BROWSERS_PATH=/usr/local/share/playwright-browsers
 RUN --mount=type=cache,target=/var/cache/playwright,sharing=locked \
     mkdir -p ${PLAYWRIGHT_BROWSERS_PATH} && \
     PLAYWRIGHT_BROWSERS_PATH=/var/cache/playwright \
-        uv run playwright install --only-shell && \
+        uv run --no-sync playwright install --only-shell && \
     cp -a /var/cache/playwright/. ${PLAYWRIGHT_BROWSERS_PATH}/ && \
     chmod -R 755 ${PLAYWRIGHT_BROWSERS_PATH}
+
+# ---- Project layer (source + VERSION last) ----
+COPY --chown=depictio:depictio VERSION ./
+COPY --chown=depictio:depictio depictio ./depictio/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev || uv sync --no-dev
 
 COPY --chown=depictio:depictio docker-images/run_celery_worker.sh /app/run_celery_worker.sh
 RUN chmod +x /app/run_celery_worker.sh


### PR DESCRIPTION
## Why

Follow-up to #821. The build-cache wiring (registry + `type=gha`) couldn't deliver real savings because the Dockerfiles copied **source and version files before** the dependency install — so `uv sync` / `pnpm install` was busted on every source change **and** every version bump (static `version` in `pyproject.toml` + `uv.lock` + `VERSION`).

## What

Reorder all three Dockerfiles into a **dependency layer** (lockfile + manifests only) and a **source/version layer copied last** — the standard cache-friendly pattern.

**`Dockerfile.api` / `Dockerfile.worker`**
- COPY `pyproject.toml` + `uv.lock` + `packages/`, then `uv sync --frozen --no-install-project --no-dev` — installs third-party deps + the editable in-tree packages (`plotly-upset`, `plotly-complexheatmap`) **without** the depictio project.
- COPY `VERSION` + `depictio/` source last, then a fast project-only `uv sync`.
- Worker only: the chromium bundle now installs off the dependency layer (`uv run --no-sync playwright install`), so the ~450 MB download re-runs only when deps change, not on source/version edits.

**`Dockerfile.viewer`**
- COPY only the workspace `package.json` manifests + `pnpm-lock.yaml` before `pnpm install --frozen-lockfile`, then the source. A viewer code edit no longer reinstalls `node_modules`. (`node_modules` is `.dockerignored`, so copying source afterwards can't clobber the installed store.)

## Effect

A code edit (the common PR case) and a version bump (every release) now reuse the cached dependency layers instead of reinstalling everything — which is what makes the registry/gha cache actually pay off on the tag-triggered release builds.

## Verification

Editing `docker-images/Dockerfile.*` self-triggers `build-images.yaml`'s PR path, which builds all three images (amd64, build-only) — that validates the reordered builds compile and `uv sync` / `pnpm install` resolve correctly with the split layers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01La2XqJWhamLRC8xzP3GxUB)_