### PR TITLE
fix(devcontainer): reliable Codespaces setup + scoped reference seeding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,12 +30,16 @@
   "initializeCommand": ".devcontainer/pre_create_setup.sh",
   "postStartCommand": "bash /workspace/.devcontainer/fix_git_worktree.sh && bash /workspace/.devcontainer/scripts/forward-ports.sh",
   "postCreateCommand": "post_create_setup.sh", // script to run after the containers are started
-  // Port forwarding - ports are dynamically assigned based on branch name
-  // VS Code will auto-detect listening ports and prompt to forward them
+  // Port forwarding - ports are dynamically assigned based on branch name.
+  // forward-ports.sh (postStartCommand) creates socat listeners inside this
+  // container so Codespaces auto-detects them; the ranges below cover the
+  // bases allocated in allocate-ports.sh (viewer 5500+, minio console 9500+).
+  // The viewer opens in the browser automatically once it is forwarded.
   "portsAttributes": {
-    "5000-5200": {"label": "Dash Frontend", "onAutoForward": "notify"},
+    "5500-5700": {"label": "Depictio Viewer", "onAutoForward": "openBrowser"},
     "8000-8200": {"label": "FastAPI Backend", "onAutoForward": "notify"},
-    "9000-9200": {"label": "MinIO", "onAutoForward": "silent"},
+    "9000-9200": {"label": "MinIO API", "onAutoForward": "silent"},
+    "9500-9700": {"label": "MinIO Console", "onAutoForward": "silent"},
     "27000-27200": {"label": "MongoDB", "onAutoForward": "silent"},
     "6000-6200": {"label": "Redis", "onAutoForward": "silent"}
   },
@@ -54,6 +58,7 @@
     "DEPICTIO_MINIO_ENDPOINT_URL": "http://minio:9000",
     "DEPICTIO_LOGGING_VERBOSITY_LEVEL": "DEBUG",
     "DEV_MODE": "true",
+    "DEPICTIO_AUTH_SINGLE_USER_MODE": "true",
     "DEPICTIO_MONGODB_WIPE": "false"
   },
   "containerEnv": {
@@ -69,6 +74,7 @@
     "DEPICTIO_MINIO_ENDPOINT_URL": "http://minio:9000",
     "DEPICTIO_LOGGING_VERBOSITY_LEVEL": "DEBUG",
     "DEV_MODE": "true",
+    "DEPICTIO_AUTH_SINGLE_USER_MODE": "true",
     "DEPICTIO_MONGODB_WIPE": "false"
   },
 	"features": {

--- a/.devcontainer/docker-compose.devcontainer.yaml
+++ b/.devcontainer/docker-compose.devcontainer.yaml
@@ -70,12 +70,18 @@ services:
       - DEPICTIO_AUTH_SINGLE_USER_MODE=true
       - DEPICTIO_AUTH_PUBLIC_MODE=false
       - DEPICTIO_AUTH_UNAUTHENTICATED_MODE=false
+      # Seed only the lightweight iris reference project in Codespaces so the
+      # stack comes up fast. Set DEPICTIO_SEED_PROJECTS to a CSV (e.g.
+      # "iris,penguins") for more, or DEPICTIO_DISABLE_EXAMPLE_DASHBOARDS=true
+      # for none.
+      - DEPICTIO_SEED_PROJECTS=iris
 
   depictio-celery-worker:
     environment:
       - DEPICTIO_AUTH_SINGLE_USER_MODE=true
       - DEPICTIO_AUTH_PUBLIC_MODE=false
       - DEPICTIO_AUTH_UNAUTHENTICATED_MODE=false
+      - DEPICTIO_SEED_PROJECTS=iris
 
 volumes:
   claude-code-config:

--- a/.devcontainer/docker-compose.devcontainer.yaml
+++ b/.devcontainer/docker-compose.devcontainer.yaml
@@ -55,6 +55,28 @@ services:
       # Fix Docker API version mismatch in Codespaces
       - DOCKER_API_VERSION=1.43
 
+  # Force single-user auth mode for the devcontainer/Codespaces stack.
+  #
+  # docker-compose.dev.yaml declares DEPICTIO_AUTH_SINGLE_USER_MODE under the
+  # backend's `environment:` as "${DEPICTIO_AUTH_SINGLE_USER_MODE:-false}", and
+  # Compose's `environment:` ALWAYS overrides `env_file:` — so the `=true` in
+  # docker-compose/.env gets clobbered to `false` whenever that variable isn't
+  # present in the interpolation context (a git-ignored, init-generated .env /
+  # override that easily goes missing on Codespaces). This file is committed and
+  # loaded AFTER both dev.yaml and the generated override, so pinning the value
+  # here makes single-user mode deterministic regardless of that chain.
+  depictio-backend:
+    environment:
+      - DEPICTIO_AUTH_SINGLE_USER_MODE=true
+      - DEPICTIO_AUTH_PUBLIC_MODE=false
+      - DEPICTIO_AUTH_UNAUTHENTICATED_MODE=false
+
+  depictio-celery-worker:
+    environment:
+      - DEPICTIO_AUTH_SINGLE_USER_MODE=true
+      - DEPICTIO_AUTH_PUBLIC_MODE=false
+      - DEPICTIO_AUTH_UNAUTHENTICATED_MODE=false
+
 volumes:
   claude-code-config:
   uv-cache:

--- a/.devcontainer/post_create_setup.sh
+++ b/.devcontainer/post_create_setup.sh
@@ -91,14 +91,27 @@ fi
 
 echo "Waiting for services to become ready..."
 
-# Function to wait for a service using bash built-in TCP connection
+# Wait for a TCP service, but ONLY up to a bounded number of attempts.
+# Container creation must never hang forever on an unhealthy service
+# (e.g. a backend that failed to boot) — postCreateCommand blocking is what
+# leaves Codespaces stuck on the "Running postCreateCommand..." spinner.
+# On timeout we warn and continue; the service may still come up later, and
+# port forwarding / the rest of setup should not be held hostage by it.
 wait_for_service() {
     local host=$1
     local port=$2
     local service_name=$3
+    local max_attempts=${4:-30}   # ~60s at 2s/attempt
+    local attempt=0
 
     until timeout 1 bash -c "cat < /dev/null > /dev/tcp/${host}/${port}" 2>/dev/null; do
-        echo "⏳ Waiting for ${service_name}..."
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "⚠️  ${service_name} not ready after ${max_attempts} attempts — continuing without it."
+            echo "    (check 'docker logs ${host}' or 'docker compose ps' if it never comes up)"
+            return 1
+        fi
+        echo "⏳ Waiting for ${service_name}... (${attempt}/${max_attempts})"
         sleep 2
     done
     echo "✓ ${service_name} is ready"
@@ -119,7 +132,7 @@ wait_for_service depictio-backend 8058 "FastAPI backend"
 # Wait for the dev viewer (Vite HMR server)
 wait_for_service depictio-viewer-dev 5173 "Vite dev viewer"
 
-echo "All services are ready! Setting up development environment..."
+echo "Service readiness check complete. Setting up development environment..."
 
 # Install depictio in development mode with dev dependencies
 cd /workspace || exit

--- a/.devcontainer/scripts/allocate-ports.sh
+++ b/.devcontainer/scripts/allocate-ports.sh
@@ -116,7 +116,9 @@ else
 fi
 echo ""
 
-# Development auth settings (default: single-user mode for devcontainers)
+# Development auth settings: devcontainers default to single-user mode so the
+# stack is usable immediately without a login flow. Force it on unless the
+# caller has explicitly opted out by exporting DEPICTIO_AUTH_SINGLE_USER_MODE=false.
 DEPICTIO_AUTH_SINGLE_USER_MODE=${DEPICTIO_AUTH_SINGLE_USER_MODE:-true}
 
 # MinIO credentials: single source of truth is docker-compose/.env (committed).

--- a/.devcontainer/scripts/forward-ports.sh
+++ b/.devcontainer/scripts/forward-ports.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
-# Forward ports from sibling containers to the devcontainer
-# This makes them visible to VS Code's port auto-detection
+# Forward ports from sibling containers into the devcontainer (the compose
+# `app` service). This is what makes them visible to VS Code / Codespaces
+# automatic port forwarding.
+#
+# Why this is needed: depictio's services run as *sibling* containers
+# (docker-outside-of-docker) and publish to the HOST's 127.0.0.1. Codespaces
+# only auto-detects ports listening INSIDE the devcontainer, so we use socat
+# to create matching listeners here that proxy to the siblings over the
+# compose network (by service name).
+#
+# Why setsid/nohup: this script is invoked from postStartCommand via
+# `docker exec`. Plain `socat … &` children get SIGHUP'd when that exec
+# session closes, so the listeners vanish and nothing is left to forward.
+# `setsid nohup … & disown` detaches them into their own session so they
+# survive.
 
 if [ -f /workspace/.env.instance ]; then
     # shellcheck source=/dev/null
@@ -11,10 +24,13 @@ FASTAPI_PORT=${FASTAPI_PORT:-8058}
 MINIO_CONSOLE_PORT=${MINIO_CONSOLE_PORT:-9001}
 VIEWER_DEV_PORT=${VIEWER_DEV_PORT:-5173}
 
+LOG_DIR=/tmp/depictio-port-forward
+mkdir -p "$LOG_DIR"
+
 echo "🔌 Starting port forwarding..."
 echo "   Viewer (Vite HMR): $VIEWER_DEV_PORT -> depictio-viewer-dev:5173"
-echo "   FastAPI: $FASTAPI_PORT -> depictio-backend:8058"
-echo "   MinIO Console: $MINIO_CONSOLE_PORT -> minio:9001"
+echo "   FastAPI:           $FASTAPI_PORT -> depictio-backend:8058"
+echo "   MinIO Console:     $MINIO_CONSOLE_PORT -> minio:9001"
 
 # Check if socat is installed
 if ! command -v socat &> /dev/null; then
@@ -22,15 +38,35 @@ if ! command -v socat &> /dev/null; then
     sudo apt-get update -qq && sudo apt-get install -qq -y socat
 fi
 
-# Kill any existing socat processes
+# Kill any existing socat forwarders so re-runs are idempotent.
 pkill -f "socat.*TCP-LISTEN" 2>/dev/null || true
 
-# Start port forwarding in background
-socat TCP-LISTEN:"$VIEWER_DEV_PORT",fork,reuseaddr TCP:depictio-viewer-dev:5173 &
-socat TCP-LISTEN:"$FASTAPI_PORT",fork,reuseaddr TCP:depictio-backend:8058 &
-socat TCP-LISTEN:"$MINIO_CONSOLE_PORT",fork,reuseaddr TCP:minio:9001 &
+# Start a detached, self-restarting forwarder for one port.
+#   $1 local listen port, $2 target host, $3 target port
+start_forward() {
+    local listen_port=$1 target_host=$2 target_port=$3
+    local log="$LOG_DIR/${listen_port}.log"
+    # The `while true` keeps the proxy up if the target restarts; setsid +
+    # nohup + disown detach it from this exec session so it persists.
+    setsid nohup bash -c "
+        while true; do
+            socat TCP-LISTEN:${listen_port},fork,reuseaddr TCP:${target_host}:${target_port}
+            echo \"[\$(date)] socat ${listen_port} exited, restarting in 2s\" >> '${log}'
+            sleep 2
+        done
+    " >> "$log" 2>&1 &
+    disown
+}
 
-echo "✅ Port forwarding started!"
+start_forward "$VIEWER_DEV_PORT" depictio-viewer-dev 5173
+start_forward "$FASTAPI_PORT" depictio-backend 8058
+start_forward "$MINIO_CONSOLE_PORT" minio 9001
+
+# Give the listeners a moment to bind so Codespaces detects them on this pass.
+sleep 1
+
+echo "✅ Port forwarding started (logs in ${LOG_DIR})."
 echo ""
-echo "Ports should now appear in VS Code Ports panel."
-echo "If not, manually add: $VIEWER_DEV_PORT, $FASTAPI_PORT, $MINIO_CONSOLE_PORT"
+echo "Ports should now appear in the VS Code / Codespaces PORTS panel."
+echo "If not, run 'ports' to list them and add them manually:"
+echo "   $VIEWER_DEV_PORT, $FASTAPI_PORT, $MINIO_CONSOLE_PORT"

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -1039,6 +1039,17 @@ class Settings(BaseSettings):
         ),
     )
 
+    seed_projects: str = Field(
+        default="",
+        description=(
+            "Comma-separated allowlist of reference projects to seed on API "
+            "startup, e.g. 'iris' or 'iris,penguins'. Empty (the default) seeds "
+            "all of them. Ignored when DEPICTIO_DISABLE_EXAMPLE_DASHBOARDS is "
+            "true (that takes precedence and seeds nothing). Valid names: "
+            "iris, penguins, ampliseq, advanced_viz_showcase, viralrecon."
+        ),
+    )
+
     enable_dev_endpoints: bool = Field(
         default=False,
         description=(
@@ -1056,6 +1067,16 @@ class Settings(BaseSettings):
         case_sensitive=False,
         extra="ignore",  # Ignore extra fields in .env that aren't in the model
     )
+
+    @property
+    def seed_projects_filter(self) -> set[str] | None:
+        """Allowlist of reference projects to seed, or None to seed all.
+
+        Parses the ``DEPICTIO_SEED_PROJECTS`` CSV into a set. An empty/blank
+        value yields ``None``, which callers treat as "seed everything".
+        """
+        names = {name.strip() for name in self.seed_projects.split(",") if name.strip()}
+        return names or None
 
     @model_validator(mode="after")
     def _enforce_server_secrets(self) -> "Settings":

--- a/depictio/api/v1/db_init.py
+++ b/depictio/api/v1/db_init.py
@@ -173,11 +173,33 @@ async def create_initial_project_legacy(
         }
 
 
-async def create_initial_dashboards(admin_user: UserBeanie) -> list[dict | None]:
+def _dataset_of_dashboard(name: str) -> str:
+    """Map a reference dashboard name to its parent dataset (for seed filtering).
+
+    Dashboard names are consistently prefixed by their dataset, e.g.
+    ``ampliseq_multiqc`` → ``ampliseq``, ``advanced_viz_volcano`` →
+    ``advanced_viz_showcase``, ``viralrecon_variants`` → ``viralrecon``.
+    """
+    if name in ("iris", "penguins"):
+        return name
+    if name.startswith("ampliseq"):
+        return "ampliseq"
+    if name.startswith("advanced_viz"):
+        return "advanced_viz_showcase"
+    if name.startswith("viralrecon"):
+        return "viralrecon"
+    return name
+
+
+async def create_initial_dashboards(
+    admin_user: UserBeanie, only: set[str] | None = None
+) -> list[dict | None]:
     """Create all initial demo dashboards for reference datasets.
 
     Args:
         admin_user: Admin user to set as dashboard owner
+        only: Optional allowlist of dataset names (from DEPICTIO_SEED_PROJECTS).
+            ``None`` creates dashboards for all datasets.
 
     Returns:
         List of dashboard creation responses
@@ -339,6 +361,11 @@ async def create_initial_dashboards(admin_user: UserBeanie) -> list[dict | None]
             )
         ),
     ]
+
+    if only is not None:
+        dashboards_config = [
+            cfg for cfg in dashboards_config if _dataset_of_dashboard(str(cfg["name"])) in only
+        ]
 
     results = []
     for dashboard_config in dashboards_config:
@@ -785,11 +812,15 @@ async def initialize_db(wipe: bool = False) -> UserBeanie | None:
     if settings.disable_example_dashboards:
         logger.info("Skipping example dashboard seeding (DEPICTIO_DISABLE_EXAMPLE_DASHBOARDS=true)")
     else:
-        # Create all reference datasets (replaces hardcoded iris logic)
+        # Create all reference datasets (replaces hardcoded iris logic).
+        # DEPICTIO_SEED_PROJECTS optionally narrows this to an allowlist
+        # (e.g. "iris"); None seeds everything.
         from depictio.api.v1.db_init_reference_datasets import create_reference_datasets
 
+        seed_filter = settings.seed_projects_filter
+
         created_projects = await create_reference_datasets(
-            admin_user=admin_user, token_payload=token_payload
+            admin_user=admin_user, token_payload=token_payload, only=seed_filter
         )
 
         # Note: ampliseq-base shell project removed — only the extended (full) variant is loaded
@@ -809,8 +840,10 @@ async def initialize_db(wipe: bool = False) -> UserBeanie | None:
 
         logger.info(f"Created {len(created_projects)} reference datasets")
 
-        # Create dashboards for all reference datasets
-        dashboard_payloads = await create_initial_dashboards(admin_user=admin_user)
+        # Create dashboards for all reference datasets (same allowlist filter)
+        dashboard_payloads = await create_initial_dashboards(
+            admin_user=admin_user, only=seed_filter
+        )
         logger.info(f"Created {len([p for p in dashboard_payloads if p])} dashboards")
 
     logger.info("Database initialization completed successfully.")

--- a/depictio/api/v1/db_init_reference_datasets.py
+++ b/depictio/api/v1/db_init_reference_datasets.py
@@ -710,9 +710,17 @@ class ReferenceDatasetRegistry:
 
 
 async def create_reference_datasets(
-    admin_user: UserBeanie, token_payload: dict[str, Any]
+    admin_user: UserBeanie,
+    token_payload: dict[str, Any],
+    only: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Create all reference datasets (iris, penguins, ampliseq).
+
+    Args:
+        admin_user: Admin user set as project owner.
+        token_payload: Default admin token payload for authenticated creation.
+        only: Optional allowlist of dataset names to seed (from
+            ``DEPICTIO_SEED_PROJECTS``). ``None`` seeds all of them.
 
     Note: ampliseq dataset uses 16S rRNA microbiome data from nf-core/ampliseq.
     Data files are included under depictio/projects/nf-core/ampliseq/2.16.0/.
@@ -726,13 +734,32 @@ async def create_reference_datasets(
     # `resolve_template_for_init`. Run
     # `depictio/projects/nf-core/viralrecon/3.0.0/generate_seeds.sh` against a
     # local viralrecon run to populate `.db_seeds/` and the canonical TSVs.
-    for dataset_name in [
+    all_datasets = [
         "iris",
         "penguins",
         "ampliseq",
         "advanced_viz_showcase",
         "viralrecon",
-    ]:
+    ]
+
+    if only is not None:
+        unknown = only - set(all_datasets)
+        if unknown:
+            logger.warning(
+                "DEPICTIO_SEED_PROJECTS lists unknown project(s) %s — ignoring them. "
+                "Valid names: %s",
+                sorted(unknown),
+                ", ".join(all_datasets),
+            )
+        datasets_to_create = [name for name in all_datasets if name in only]
+        logger.info(
+            "DEPICTIO_SEED_PROJECTS set — seeding only: %s",
+            ", ".join(datasets_to_create) or "(none matched)",
+        )
+    else:
+        datasets_to_create = all_datasets
+
+    for dataset_name in datasets_to_create:
         logger.info(f"Creating reference dataset: {dataset_name}")
 
         try:

--- a/depictio/tests/api/v1/test_seed_projects_filter.py
+++ b/depictio/tests/api/v1/test_seed_projects_filter.py
@@ -1,0 +1,72 @@
+"""Tests for the reference-dataset seed allowlist (DEPICTIO_SEED_PROJECTS).
+
+Two seed controls exist on startup:
+
+* ``DEPICTIO_DISABLE_EXAMPLE_DASHBOARDS`` (bool) — skip *all* seeding.
+* ``DEPICTIO_SEED_PROJECTS`` (CSV) — seed *only* the named reference projects
+  (default empty = seed all). This file covers the parsing of that CSV into a
+  filter set and the name → dataset mapping used to gate dashboard creation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from depictio.api.v1.configs.settings_models import Settings
+from depictio.api.v1.db_init import _dataset_of_dashboard
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", None),
+        ("   ", None),
+        ("iris", {"iris"}),
+        ("iris,penguins", {"iris", "penguins"}),
+        (" iris , penguins ", {"iris", "penguins"}),
+        ("iris,,viralrecon,", {"iris", "viralrecon"}),
+    ],
+)
+def test_seed_projects_filter_parsing(monkeypatch, raw, expected):
+    # client context skips the server-secret enforcement validator.
+    monkeypatch.setenv("DEPICTIO_CONTEXT", "client")
+    monkeypatch.setenv("DEPICTIO_SEED_PROJECTS", raw)
+    assert Settings().seed_projects_filter == expected
+
+
+def test_seed_projects_default_is_all(monkeypatch):
+    monkeypatch.setenv("DEPICTIO_CONTEXT", "client")
+    monkeypatch.delenv("DEPICTIO_SEED_PROJECTS", raising=False)
+    settings = Settings()
+    assert settings.seed_projects == ""
+    assert settings.seed_projects_filter is None  # None => seed everything
+
+
+@pytest.mark.parametrize(
+    "dashboard_name,dataset",
+    [
+        ("iris", "iris"),
+        ("penguins", "penguins"),
+        ("ampliseq_multiqc", "ampliseq"),
+        ("ampliseq_phylogeny", "ampliseq"),
+        ("advanced_viz_volcano", "advanced_viz_showcase"),
+        ("advanced_viz_upset", "advanced_viz_showcase"),
+        ("viralrecon_variants", "viralrecon"),
+    ],
+)
+def test_dataset_of_dashboard_mapping(dashboard_name, dataset):
+    assert _dataset_of_dashboard(dashboard_name) == dataset
+
+
+def test_only_iris_keeps_only_iris_dashboards():
+    """A filter of {'iris'} should keep exactly the iris dashboard."""
+    names = [
+        "iris",
+        "penguins",
+        "ampliseq_multiqc",
+        "advanced_viz_volcano",
+        "viralrecon_variants",
+    ]
+    only = {"iris"}
+    kept = [n for n in names if _dataset_of_dashboard(n) in only]
+    assert kept == ["iris"]


### PR DESCRIPTION
## Summary

Fixes Codespaces devcontainer startup and adds a way to seed only specific reference projects.

## Changes

- **Port forwarding**: detach the `socat` bridges (`setsid`/`nohup`) so they survive `postStartCommand` — previously they were SIGHUP'd, leaving nothing for Codespaces to auto-detect. Fix `portsAttributes` ranges to match the allocated ports and auto-open the viewer in the browser.
- **postCreate hang**: bound the `wait_for_service` loops so a service that never comes up can't block container creation forever.
- **Single-user mode**: pin `DEPICTIO_AUTH_SINGLE_USER_MODE=true` on `depictio-backend`/`depictio-celery-worker` in the committed devcontainer compose file. The backend's `environment:` (default `false`) was overriding the `true` from `env_file`, so the mode depended on a fragile git-ignored interpolation chain.
- **Selective seeding**: new `DEPICTIO_SEED_PROJECTS` env var — a CSV allowlist of reference projects to seed (empty = all), complementing the existing `DEPICTIO_DISABLE_EXAMPLE_DASHBOARDS` kill switch. The devcontainer defaults to `iris` only for faster startup.

## Tests

- `test_seed_projects_filter.py`: CSV parsing, default-all, dashboard→dataset mapping, and the "only iris" case (15 cases, all pass).
- `ruff` clean; no new `ty` diagnostics.

---
_Generated by [Claude Code](https://claude.ai/code/session_011w3y5xn8JUbRZA1X1mDcRe)_