### PR TITLE
ci: restore docs-repo notify on release (regenerate OpenAPI reference)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -412,3 +412,41 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose -f "$RUNNER_TEMP/quickstart/docker-compose.yaml" down -v || true
+
+  # Tell depictio-docs a new version shipped so it regenerates the OpenAPI
+  # reference + opens a docs-update PR (listener: depictio-docs
+  # .github/workflows/update-on-release.yaml, on repository_dispatch:new-release).
+  # This restores the notify step that lived in the old multi-arch-build.yaml /
+  # amd64-build.yaml pipelines before they were consolidated into this file.
+  # Gated to real tag pushes only (not PRs or manual workflow_dispatch validation
+  # runs) and gated behind a green smoke test, so docs only hears about a
+  # release whose images actually boot.
+  notify-docs:
+    name: Notify docs repository
+    needs: smoke-test
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag + prerelease
+        id: rel
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"            # e.g. v1.0.1 or v1.0.1-b7
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          # Betas (…-b<N>) are prereleases; bare semver tags are stable.
+          case "$TAG" in
+            *-b*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
+            *)    echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Notify docs repository
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GHCR_PAT }}
+          repository: depictio/depictio-docs
+          event-type: new-release
+          client-payload: |
+            {
+              "version": "${{ steps.rel.outputs.tag }}",
+              "release_url": "https://github.com/${{ github.repository }}/releases/tag/${{ steps.rel.outputs.tag }}",
+              "prerelease": "${{ steps.rel.outputs.prerelease }}"
+            }


### PR DESCRIPTION
## Problem

The step that notified **depictio-docs** on each release was lost. It used to live in the old image pipelines — `multi-arch-build.yaml` (stable, `prerelease:false`) and `amd64-build.yaml` (beta, `prerelease:true`) — each ending with:

```yaml
- uses: peter-evans/repository-dispatch@v3
  with:
    token: ${{ secrets.GHCR_PAT }}
    repository: depictio/depictio-docs
    event-type: new-release
    client-payload: { version, release_url, prerelease }
```

Both pipelines were deleted when image builds were consolidated into `build-images.yaml` (#770), and the notify was **never carried over**. The docs repo's `update-on-release.yaml` still listens on `repository_dispatch: types: [new-release]` (it pulls the released image, extracts the OpenAPI spec, and opens a docs-update PR) — but it has sat idle since the consolidation. **1.0.0 and the 1.0.1 GA both shipped without a docs refresh.** (Triggered v1.0.1 manually as a one-off catch-up.)

## Fix

Add a single final `notify-docs` job that:
- `needs: smoke-test` — only notifies for a release whose images actually boot,
- is gated to **real tag pushes** (`github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')`) — not PRs or manual `workflow_dispatch` validation runs,
- derives `prerelease` from the `-b` suffix,
- fires **once** per release (vs 3× if bolted onto the per-image `merge` matrix).

## Note

Uses the existing `GHCR_PAT` secret (same one the old pipelines used and that this workflow already uses for registry login).