### PR TITLE
fix(nf-core): let the release monitor open its draft PR (persist-credentials)

### DIFF
--- a/.github/workflows/nfcore-release-monitor.yaml
+++ b/.github/workflows/nfcore-release-monitor.yaml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          # avoid clashing with create-pull-request's own push token
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Follow-up to #827. The monitor's draft-PR step failed with `Duplicate header: Authorization` (HTTP 400): `actions/checkout` persists a git credential that collides with the token `peter-evans/create-pull-request` uses. `persist-credentials: false` fixes it.