### PR TITLE
feat(nf-core): run recipes against the megatest + one draft PR per pipeline

### DIFF
--- a/.github/workflows/nfcore-release-monitor.yaml
+++ b/.github/workflows/nfcore-release-monitor.yaml
@@ -3,14 +3,14 @@ name: nf-core release monitor
 # Weekly check: has nf-core shipped a newer version for any pipeline we template
 # under depictio/projects/nf-core/? If so, list that release's AWS megatest
 # results and report which of our recipe source paths no longer resolve, then
-# open a concise draft PR carrying the drift report.
+# open one concise draft PR per pipeline carrying its drift report.
 on:
   schedule:
     - cron: "0 6 * * 1" # Mondays 06:00 UTC
   workflow_dispatch:
     inputs:
       force_report_pipeline:
-        description: "Run the drift report for this pipeline even if no update is detected (dry-run)."
+        description: "Report this pipeline even if no update is detected (dry-run)."
         required: false
         default: ""
 
@@ -19,12 +19,68 @@ permissions:
   pull-requests: write
 
 jobs:
-  monitor:
+  # Detect which templated pipelines have a newer nf-core release and emit them
+  # as a matrix so the report job can fan out one draft PR per pipeline.
+  check:
     runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+      has_updates: ${{ steps.detect.outputs.has_updates }}
     steps:
       - uses: actions/checkout@v6
         with:
           # avoid clashing with create-pull-request's own push token
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies
+        run: |
+          uv venv --python 3.12.9 venv
+          source venv/bin/activate
+          uv pip install packaging # all `check` needs (no recipe imports)
+
+      - name: Detect new nf-core releases
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE_PIPELINE: ${{ github.event.inputs.force_report_pipeline }}
+        run: |
+          source venv/bin/activate
+          python scripts/nfcore_monitor.py check --json > updates.json
+          {
+            echo "## nf-core release check"
+            echo '```'
+            python scripts/nfcore_monitor.py check
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # One matrix entry per pipeline with an update (+ an optional forced one).
+          include=$(jq -c '[.[] | select(.update_available) | {pipeline, version: .remote}]' updates.json)
+          if [ -n "$FORCE_PIPELINE" ]; then
+            include=$(jq -c --arg p "$FORCE_PIPELINE" '. + [{pipeline: $p, version: "forced"}]' <<<"$include")
+          fi
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+          [ "$(jq 'length' <<<"$include")" -gt 0 ] && echo "has_updates=1" >> "$GITHUB_OUTPUT" || echo "has_updates=0" >> "$GITHUB_OUTPUT"
+
+  # One leg per pipeline: build its drift report and open its own draft PR.
+  report:
+    needs: check
+    if: needs.check.outputs.has_updates == '1'
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.check.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
           persist-credentials: false
 
       - name: Install uv
@@ -46,56 +102,26 @@ jobs:
           uv pip uninstall -y polars polars-runtime-32 2>/dev/null || true
           uv pip install --force-reinstall "polars-lts-cpu[numpy,pandas,pyarrow,excel,deltalake]==1.19.0"
 
-      - name: Check for new nf-core releases
-        id: check
+      - name: Generate megatest drift report
+        id: gen
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          source venv/bin/activate
-          python scripts/nfcore_monitor.py check --json > updates.json
-          {
-            echo "## nf-core release check"
-            echo '```'
-            python scripts/nfcore_monitor.py check
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Generate megatest drift reports
-        id: report
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FORCE_PIPELINE: ${{ github.event.inputs.force_report_pipeline }}
         run: |
           source venv/bin/activate
           mkdir -p .nfcore-monitor
-          # Pipelines with a newer release ("<pipeline> <remote-version>" per line)...
-          jq -r '.[] | select(.update_available) | "\(.pipeline) \(.remote)"' updates.json > to_report.txt
-          # ...plus an optional forced dry-run pipeline.
-          if [ -n "$FORCE_PIPELINE" ]; then echo "$FORCE_PIPELINE forced" >> to_report.txt; fi
-
-          has=0
-          body=pr_body.md
-          echo "## nf-core megatest drift reports" > "$body"
-          while read -r pipeline version; do
-            [ -n "$pipeline" ] || continue
-            out=".nfcore-monitor/${pipeline}-${version}.md"
-            if python scripts/nfcore_monitor.py report --pipeline "$pipeline" --out "$out"; then
-              { echo; cat "$out"; } >> "$body"
-              cat "$out" >> "$GITHUB_STEP_SUMMARY"
-              has=1
-            fi
-          done < to_report.txt
-          echo "has_updates=$has" >> "$GITHUB_OUTPUT"
+          out=".nfcore-monitor/${{ matrix.pipeline }}-${{ matrix.version }}.md"
+          python scripts/nfcore_monitor.py report --pipeline "${{ matrix.pipeline }}" --out "$out"
+          cat "$out" >> "$GITHUB_STEP_SUMMARY"
+          echo "report_file=$out" >> "$GITHUB_OUTPUT"
 
       - name: Open draft PR with drift report
-        if: steps.report.outputs.has_updates == '1'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: nfcore-monitor/updates
+          branch: nfcore-monitor/${{ matrix.pipeline }}-${{ matrix.version }}
           draft: true
-          add-paths: .nfcore-monitor/*.md
-          commit-message: "chore(nf-core): megatest drift report for new release(s)"
-          title: "chore(nf-core): new nf-core release(s) — megatest drift report"
+          add-paths: ${{ steps.gen.outputs.report_file }}
+          commit-message: "chore(nf-core): ${{ matrix.pipeline }} ${{ matrix.version }} megatest drift report"
+          title: "chore(nf-core): ${{ matrix.pipeline }} ${{ matrix.version }} — megatest drift report"
           labels: nf-core
-          body-path: pr_body.md
+          body-path: ${{ steps.gen.outputs.report_file }}


### PR DESCRIPTION
Follow-up to #827. Makes the monitor do the real validation, not just path checks, and splits output per pipeline.

**1. Actually run the recipes against the new megatest** (the point of the tool). `report` now validates a template in three layers:
1. source-path existence — which recipe inputs moved/renamed;
2. **recipe execution** — download each file-based recipe's inputs and run `transform()` + assert `EXPECTED_SCHEMA` (reuses `depictio.recipes.execute_recipe`); catches column/content changes, not just missing files. `dc_ref`/canonical recipes (read upstream DCs, not megatest files) are skipped;
3. `depictio dev catalog validate` static gate.

`--no-exec` keeps the fast path-only check; `--max-file-mb` bounds downloads.

**2. One draft PR per pipeline.** A `check` job emits pipelines-with-updates as a dynamic matrix; a `report` job fans out one leg → one report + one draft PR per pipeline on `nfcore-monitor/<pipeline>-<version>`.

Verified live against the ampliseq 2.16.0 megatest: `alpha_rarefaction` (24.5k×4), `taxonomy_composition` (270×7) and `ancombc_results` (96×11, 5-slice join) all execute and pass; canonical recipes skip; all 8 source paths resolve.

The earlier single-PR drift report #829 can be closed.