### PR TITLE
feat(nf-core): run recipes against megatest + show result in auto-PR title

### DIFF
--- a/.github/workflows/nfcore-release-monitor.yaml
+++ b/.github/workflows/nfcore-release-monitor.yaml
@@ -110,9 +110,11 @@ jobs:
           source venv/bin/activate
           mkdir -p .nfcore-monitor
           out=".nfcore-monitor/${{ matrix.pipeline }}-${{ matrix.version }}.md"
-          python scripts/nfcore_monitor.py report --pipeline "${{ matrix.pipeline }}" --out "$out"
+          # stdout is the short status (✅ valid / ⚠️ N issue(s)) for the PR title
+          status=$(python scripts/nfcore_monitor.py report --pipeline "${{ matrix.pipeline }}" --out "$out")
           cat "$out" >> "$GITHUB_STEP_SUMMARY"
           echo "report_file=$out" >> "$GITHUB_OUTPUT"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
 
       - name: Open draft PR with drift report
         uses: peter-evans/create-pull-request@v6
@@ -121,7 +123,7 @@ jobs:
           branch: nfcore-monitor/${{ matrix.pipeline }}-${{ matrix.version }}
           draft: true
           add-paths: ${{ steps.gen.outputs.report_file }}
-          commit-message: "chore(nf-core): ${{ matrix.pipeline }} ${{ matrix.version }} megatest drift report"
-          title: "chore(nf-core): ${{ matrix.pipeline }} ${{ matrix.version }} — megatest drift report"
+          commit-message: "chore(nf-core): validate ${{ matrix.pipeline }} ${{ matrix.version }} against megatest"
+          title: "nf-core/${{ matrix.pipeline }} ${{ matrix.version }} — megatest: ${{ steps.gen.outputs.status }}"
           labels: nf-core
           body-path: ${{ steps.gen.outputs.report_file }}

--- a/depictio/tests/unit/test_nfcore_monitor.py
+++ b/depictio/tests/unit/test_nfcore_monitor.py
@@ -71,13 +71,39 @@ def test_build_drift_report_counts_missing_and_resolved(nfm: ModuleType) -> None
         ("ancombc", "lfc", "qiime2/ancombc/gone.csv", False),  # missing
         ("opt", "x", "qiime2/whatever/optional.csv", True),  # optional -> not missing
     ]
-    report, n_missing = nfm.build_drift_report(
+    report, n_problems = nfm.build_drift_report(
         "ampliseq", "2.16.0", "2.17.0", "ampliseq/results-abc/", source_paths, keys
     )
-    assert n_missing == 1
-    assert "Missing" in report and "qiime2/ancombc/gone.csv" in report
-    assert "Resolved (2)" in report  # the resolving one + the optional one
+    assert n_problems == 1
+    assert "qiime2/ancombc/gone.csv" in report
+    assert "2 resolved, 1 missing" in report
     assert "2.16.0 → 2.17.0" in report
+    assert "action needed" in report  # overall status reflects the missing path
+
+
+def test_build_drift_report_includes_recipe_and_catalog_layers(nfm: ModuleType) -> None:
+    keys = ["qiime2/barplot/level-2.csv"]
+    source_paths = [("taxonomy", "barplot", "qiime2/barplot/level-2.csv", False)]
+    recipe_results = [
+        nfm.RecipeCheck("taxonomy", "qiime2/x.py", "PASS", "10 rows × 3 cols"),
+        nfm.RecipeCheck("ancombc", "qiime2/y.py", "FAIL", "missing output column 'lfc'"),
+        nfm.RecipeCheck("sunburst", "qiime2/z.py", "SKIPPED", "consumes upstream DCs (dc_ref)"),
+    ]
+    report, n_problems = nfm.build_drift_report(
+        "ampliseq",
+        "2.16.0",
+        "2.17.0",
+        "ampliseq/results-abc/",
+        source_paths,
+        keys,
+        recipe_results,
+        ("PASS", "OK: 12 catalog tool(s) valid"),
+    )
+    # one recipe FAIL drives the problem count even though all paths resolve
+    assert n_problems == 1
+    assert "Recipe execution — 1 pass, 1 fail, 1 skipped" in report
+    assert "missing output column 'lfc'" in report
+    assert "Catalog validate — ✅ PASS" in report
 
 
 def test_check_updates_flags_newer_release(
@@ -91,6 +117,29 @@ def test_check_updates_flags_newer_release(
     assert by_pipeline["ampliseq"]["update_available"] is True
     # A failed (None) lookup must never report an update.
     assert by_pipeline["viralrecon"]["update_available"] is False
+
+
+def test_validate_one_recipe_skips_dc_ref_recipes(nfm: ModuleType, tmp_path: Path) -> None:
+    # A recipe consuming an upstream DC (dc_ref) reads no megatest file, so it is
+    # skipped before any download/execution — no network needed.
+    pytest.importorskip("depictio.recipes")  # needs the editable install (present in CI)
+    from types import SimpleNamespace
+
+    module = SimpleNamespace(SOURCES=[SimpleNamespace(dc_ref="variants_long", path=None)])
+    result = nfm._validate_one_recipe(
+        "upset",
+        "nf-core/viralrecon/upset.py",
+        module,
+        {},
+        {},
+        "viralrecon/results-x/",
+        {},
+        tmp_path,
+        "3.0.0",
+        50.0,
+    )
+    assert result.status == "SKIPPED"
+    assert "dc_ref" in result.detail
 
 
 def test_resolve_results_prefix_with_explicit_hash(nfm: ModuleType) -> None:

--- a/scripts/nfcore_monitor.py
+++ b/scripts/nfcore_monitor.py
@@ -598,20 +598,17 @@ def cmd_report(args: argparse.Namespace) -> int:
         recipe_results,
         catalog_result,
     )
+    status = "✅ valid" if n_problems == 0 else f"⚠️ {n_problems} issue(s)"
     if args.out:
         out = Path(args.out)
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(report)
         print(f"Report written to {out}", file=sys.stderr)
+        # The only stdout line: the short status, for the workflow to put in the PR title.
+        print(status)
     else:
         print(report)
-
-    print(
-        f"{'✗' if n_problems else '✓'} {n_problems} problem(s) found"
-        if n_problems
-        else "✓ no problems — template still valid for the new release",
-        file=sys.stderr,
-    )
+        print(f"\n{status}", file=sys.stderr)
     return 0
 
 

--- a/scripts/nfcore_monitor.py
+++ b/scripts/nfcore_monitor.py
@@ -12,10 +12,14 @@ This script does two things:
 
 * ``check``  — detect when a newer nf-core version exists for the pipelines we
   template (GitHub releases API vs. our pinned version dirs).
-* ``report`` — for a pipeline with an update, list that version's AWS megatest
-  results (anonymous S3) and report which recipe source paths no longer resolve.
-
-Path-resolution only: no file downloads, no recipe execution (those are phase-2).
+* ``report`` — for a pipeline with an update, validate the template against that
+  version's AWS megatest results (anonymous S3) in three layers:
+    1. source-path existence (which recipe inputs moved/renamed),
+    2. recipe execution — download each file-based recipe's inputs and actually
+       run ``transform()`` + assert ``EXPECTED_SCHEMA`` (catches column/content
+       changes, not just missing files); dc_ref/canonical recipes are skipped,
+    3. ``depictio dev catalog validate`` as a static module/recipe gate.
+  Pass ``--no-exec`` for the fast path-existence check only.
 
 Usage::
 
@@ -34,6 +38,7 @@ import urllib.parse
 import urllib.request
 from fnmatch import fnmatch
 from pathlib import Path
+from typing import Any, NamedTuple
 from xml.etree import ElementTree as ET
 
 from packaging.version import InvalidVersion, Version
@@ -194,21 +199,37 @@ def resolve_results_prefix(
     return max(candidates, key=lambda p: _prefix_last_modified(p, region))
 
 
-def list_keys(prefix: str, region: str = MEGATEST_REGION) -> list[str]:
-    """All object keys under ``prefix``, returned relative to it (paginated)."""
-    keys: list[str] = []
+def list_objects(prefix: str, region: str = MEGATEST_REGION) -> list[tuple[str, int]]:
+    """All objects under ``prefix`` as ``(key_relative_to_prefix, size)`` (paginated)."""
+    objects: list[tuple[str, int]] = []
     token: str | None = None
     while True:
         root = _s3_list(prefix, region=region, continuation_token=token)
         for contents in root.findall(f"{_S3_NS}Contents"):
             key_el = contents.find(f"{_S3_NS}Key")
+            size_el = contents.find(f"{_S3_NS}Size")
             if key_el is not None and key_el.text:
-                keys.append(key_el.text[len(prefix) :])
+                size = int(size_el.text) if size_el is not None and size_el.text else 0
+                objects.append((key_el.text[len(prefix) :], size))
         truncated = root.findtext(f"{_S3_NS}IsTruncated", "false") == "true"
         token = root.findtext(f"{_S3_NS}NextContinuationToken")
         if not truncated or not token:
             break
-    return keys
+    return objects
+
+
+def list_keys(prefix: str, region: str = MEGATEST_REGION) -> list[str]:
+    """All object keys under ``prefix``, returned relative to it (paginated)."""
+    return [key for key, _ in list_objects(prefix, region)]
+
+
+def download_object(prefix: str, rel_key: str, dest: Path, region: str = MEGATEST_REGION) -> None:
+    """Download one megatest object (``prefix`` + ``rel_key``) to ``dest``."""
+    url = f"https://{MEGATEST_BUCKET}.s3.{region}.amazonaws.com/" + urllib.parse.quote(
+        prefix + rel_key
+    )
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(_get(url))
 
 
 # ---------------------------------------------------------------------------
@@ -235,21 +256,20 @@ def substitute_vars(path: str, variables: dict[str, str]) -> str:
     return out
 
 
-def collect_recipe_source_paths(
-    template: dict, pipeline: str, version: str
-) -> list[tuple[str, str, str, bool]]:
-    """Extract ``(dc_tag, source_ref, resolved_path, optional)`` for every recipe.
-
-    Mirrors ``templates._check_dc_source_files``: load each transformed DC's
-    recipe, take its file-based ``SOURCES`` (skipping ``dc_ref`` joins), apply the
-    DC's ``source_overrides``, and substitute template variables.
-    """
-    from depictio.recipes import RecipeError, load_recipe
-
+def _template_vars(template: dict) -> dict[str, str]:
+    """The ``template.reference.vars`` map used to resolve recipe path tokens."""
     reference = (template.get("template", {}).get("reference", {}) or {}).get("vars", {}) or {}
-    variables = {k: str(v) for k, v in reference.items()}
+    return {k: str(v) for k, v in reference.items()}
 
-    entries: list[tuple[str, str, str, bool]] = []
+
+def _iter_recipe_dcs(template: dict, version: str):
+    """Yield ``(dc_tag, recipe_name, module_or_None, overrides, load_error)`` per recipe DC.
+
+    Loads each transformed data collection's recipe module (reused by both the
+    path-existence check and the recipe-execution check).
+    """
+    from depictio.recipes import load_recipe
+
     for workflow in template.get("workflows", []):
         for dc in workflow.get("data_collections", []):
             config = dc.get("config", {})
@@ -259,24 +279,158 @@ def collect_recipe_source_paths(
             recipe_name = transform.get("recipe")
             if not recipe_name:
                 continue
-            try:
-                module = load_recipe(recipe_name, version)
-            except (RecipeError, Exception) as exc:  # noqa: BLE001 - report, don't crash
-                print(f"  ! could not load recipe {recipe_name}: {exc}", file=sys.stderr)
-                continue
             overrides = {
                 ref: (so.get("path", "") if isinstance(so, dict) else so)
                 for ref, so in (transform.get("source_overrides") or {}).items()
             }
             tag = dc.get("data_collection_tag", "")
-            for src in module.SOURCES:
-                if src.dc_ref is not None:
-                    continue  # joined source, not a file path
-                raw = overrides.get(src.ref, src.path)
-                if not raw:
-                    continue
-                entries.append((tag, src.ref, substitute_vars(raw, variables), bool(src.optional)))
+            try:
+                module = load_recipe(recipe_name, version)
+            except Exception as exc:  # noqa: BLE001 - reported, never crashes the run
+                yield (tag, recipe_name, None, overrides, str(exc))
+            else:
+                yield (tag, recipe_name, module, overrides, None)
+
+
+def collect_recipe_source_paths(
+    template: dict, pipeline: str, version: str
+) -> list[tuple[str, str, str, bool]]:
+    """Extract ``(dc_tag, source_ref, resolved_path, optional)`` for every recipe.
+
+    Loads each transformed DC's recipe, takes its file-based ``SOURCES`` (skipping
+    ``dc_ref`` joins), applies the DC's ``source_overrides``, and substitutes
+    template variables.
+    """
+    variables = _template_vars(template)
+    entries: list[tuple[str, str, str, bool]] = []
+    for tag, recipe_name, module, overrides, load_error in _iter_recipe_dcs(template, version):
+        if load_error:
+            print(f"  ! could not load recipe {recipe_name}: {load_error}", file=sys.stderr)
+            continue
+        for src in module.SOURCES:
+            if src.dc_ref is not None:
+                continue  # joined source, not a file path
+            raw = overrides.get(src.ref, src.path)
+            if not raw:
+                continue
+            entries.append((tag, src.ref, substitute_vars(raw, variables), bool(src.optional)))
     return entries
+
+
+# ---------------------------------------------------------------------------
+# Recipe execution against the megatest (the deeper "do recipes still run?" layer)
+# ---------------------------------------------------------------------------
+class RecipeCheck(NamedTuple):
+    dc_tag: str
+    recipe: str
+    status: str  # "PASS" | "FAIL" | "SKIPPED"
+    detail: str
+
+
+def _validate_one_recipe(
+    dc_tag: str,
+    recipe_name: str,
+    module: Any,
+    overrides: dict[str, str],
+    variables: dict[str, str],
+    results_prefix: str,
+    sizes: dict[str, int],
+    workdir: Path,
+    version: str,
+    max_file_mb: float,
+) -> RecipeCheck:
+    """Download a file-based recipe's sources and actually run it (transform + schema).
+
+    Recipes that consume upstream DCs (``dc_ref``) don't read megatest files
+    directly, so they can't break from an nf-core layout change — skipped here.
+    """
+    from depictio.recipes import execute_recipe
+
+    sources = module.SOURCES
+    if any(s.dc_ref is not None for s in sources):
+        return RecipeCheck(dc_tag, recipe_name, "SKIPPED", "consumes upstream DCs (dc_ref)")
+
+    resolved_overrides: dict[str, str] = {}
+    for src in sources:
+        if src.glob_pattern is not None:
+            return RecipeCheck(dc_tag, recipe_name, "SKIPPED", "glob source not executed")
+        raw = overrides.get(src.ref, src.path)
+        if not raw:
+            return RecipeCheck(dc_tag, recipe_name, "SKIPPED", f"source '{src.ref}' has no path")
+        rel = substitute_vars(raw, variables)
+        if "{" in rel:
+            return RecipeCheck(dc_tag, recipe_name, "SKIPPED", f"unresolved var in {rel}")
+        if rel not in sizes:
+            return RecipeCheck(dc_tag, recipe_name, "FAIL", f"source file absent: {rel}")
+        if sizes[rel] > max_file_mb * 1_000_000:
+            return RecipeCheck(
+                dc_tag, recipe_name, "SKIPPED", f"{rel} too large ({sizes[rel] // 1_000_000}MB)"
+            )
+        download_object(results_prefix, rel, workdir / rel)
+        resolved_overrides[src.ref] = rel
+
+    try:
+        df = execute_recipe(
+            recipe_name, workdir, overrides=resolved_overrides, pipeline_version=version
+        )
+    except Exception as exc:  # noqa: BLE001 - the failure IS the signal we report
+        return RecipeCheck(dc_tag, recipe_name, "FAIL", f"{type(exc).__name__}: {exc}")
+    return RecipeCheck(dc_tag, recipe_name, "PASS", f"{df.height} rows × {df.width} cols")
+
+
+def validate_recipes(
+    template: dict,
+    pipeline: str,
+    version: str,
+    results_prefix: str,
+    objects: list[tuple[str, int]],
+    workdir: Path,
+    max_file_mb: float = 50.0,
+) -> list[RecipeCheck]:
+    """Run every file-based recipe of the template against the megatest results."""
+    variables = _template_vars(template)
+    sizes = dict(objects)
+    results: list[RecipeCheck] = []
+    for tag, recipe_name, module, overrides, load_error in _iter_recipe_dcs(template, version):
+        if load_error:
+            results.append(RecipeCheck(tag, recipe_name, "FAIL", f"import failed: {load_error}"))
+            continue
+        results.append(
+            _validate_one_recipe(
+                tag,
+                recipe_name,
+                module,
+                overrides,
+                variables,
+                results_prefix,
+                sizes,
+                workdir,
+                version,
+                max_file_mb,
+            )
+        )
+    return results
+
+
+def run_catalog_validate() -> tuple[str, str]:
+    """Run ``depictio dev catalog validate`` (static module/recipe gate).
+
+    Returns ``(status, detail)`` with status one of PASS/FAIL/SKIPPED.
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["depictio", "dev", "catalog", "validate"],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return ("SKIPPED", f"depictio CLI unavailable: {exc}")
+    tail = (proc.stdout + proc.stderr).strip().splitlines()
+    detail = tail[-1] if tail else ""
+    return ("PASS" if proc.returncode == 0 else "FAIL", detail)
 
 
 # ---------------------------------------------------------------------------
@@ -309,8 +463,16 @@ def build_drift_report(
     results_prefix: str,
     source_paths: list[tuple[str, str, str, bool]],
     keys: list[str],
+    recipe_results: list[RecipeCheck] | None = None,
+    catalog_result: tuple[str, str] | None = None,
 ) -> tuple[str, int]:
-    """Render a markdown drift report. Returns ``(markdown, n_missing)``."""
+    """Render a markdown drift report. Returns ``(markdown, n_problems)``.
+
+    Layer 1 (always): recipe source-path existence against the new megatest.
+    Layer 2 (when ``recipe_results`` given): the recipes actually run — load the
+    real files, run ``transform()`` and assert ``EXPECTED_SCHEMA``.
+    Layer 3 (when ``catalog_result`` given): static ``catalog validate`` gate.
+    """
     key_set = set(keys)
     resolved: list[tuple[str, str, str]] = []
     missing: list[tuple[str, str, str]] = []
@@ -320,32 +482,54 @@ def build_drift_report(
         else:
             missing.append((tag, ref, path))
 
+    failed_recipes = [r for r in (recipe_results or []) if r.status == "FAIL"]
+    catalog_failed = catalog_result is not None and catalog_result[0] == "FAIL"
+    n_problems = len(missing) + len(failed_recipes) + (1 if catalog_failed else 0)
+    overall = "❌ action needed" if n_problems else "✅ still valid"
+
     lines = [
         f"# nf-core/{pipeline} drift report — {local_version} → {new_version}",
         "",
-        f"Megatest: `s3://{MEGATEST_BUCKET}/{results_prefix}`",
-        f"Template: `nf-core/{pipeline}/{local_version}` — "
-        f"{len(source_paths)} recipe source paths checked, **{len(missing)} missing**.",
+        f"**{overall}** · Megatest: `s3://{MEGATEST_BUCKET}/{results_prefix}`",
         "",
     ]
-    if missing:
-        lines.append(f"## ❌ Missing — likely renamed/moved in {new_version} ({len(missing)})")
-        for tag, ref, path in missing:
-            lines.append(f"- `{tag}` ({ref}) → {path}")
-            hint = _nearest_prefix(path, keys)
-            if hint:
-                lines.append(f"  - _nearest existing prefix:_ `{hint}`")
-        lines.append("")
+
+    # Layer 2: recipe execution
+    if recipe_results is not None:
+        passed = [r for r in recipe_results if r.status == "PASS"]
+        skipped = [r for r in recipe_results if r.status == "SKIPPED"]
         lines.append(
-            "➡️ A maintainer should update the affected recipe / `source_overrides` "
-            f"paths when scaffolding the `{new_version}` template."
+            f"## Recipe execution — {len(passed)} pass, "
+            f"{len(failed_recipes)} fail, {len(skipped)} skipped"
         )
+        for r in failed_recipes:
+            lines.append(f"- ❌ `{r.dc_tag}` ({r.recipe}) — {r.detail}")
+        for r in passed:
+            lines.append(f"- ✅ `{r.dc_tag}` ({r.recipe}) — {r.detail}")
+        for r in skipped:
+            lines.append(f"- ⚪ `{r.dc_tag}` ({r.recipe}) — {r.detail}")
         lines.append("")
-    lines.append(f"## ✅ Resolved ({len(resolved)})")
-    for tag, ref, path in resolved:
-        lines.append(f"- `{tag}` ({ref}) → {path}")
+
+    # Layer 3: catalog validate
+    if catalog_result is not None:
+        icon = {"PASS": "✅", "FAIL": "❌", "SKIPPED": "⚪"}.get(catalog_result[0], "")
+        lines.append(f"## Catalog validate — {icon} {catalog_result[0]}")
+        if catalog_result[1]:
+            lines.append(f"- {catalog_result[1]}")
+        lines.append("")
+
+    # Layer 1: path existence
+    lines.append(
+        f"## Source paths — {len(resolved)} resolved, {len(missing)} missing "
+        f"(of {len(source_paths)})"
+    )
+    for tag, ref, path in missing:
+        lines.append(f"- ❌ `{tag}` ({ref}) → {path}")
+        hint = _nearest_prefix(path, keys)
+        if hint:
+            lines.append(f"  - _nearest existing prefix:_ `{hint}`")
     lines.append("")
-    return "\n".join(lines), len(missing)
+    return "\n".join(lines), n_problems
 
 
 # ---------------------------------------------------------------------------
@@ -377,15 +561,42 @@ def cmd_report(args: argparse.Namespace) -> int:
     print(f"→ nf-core/{pipeline}: {local} (local) → {new_version} (release)", file=sys.stderr)
     results_prefix = resolve_results_prefix(pipeline, args.results_hash)
     print(f"→ megatest results: {results_prefix}", file=sys.stderr)
-    keys = list_keys(results_prefix)
+    objects = list_objects(results_prefix)
+    keys = [k for k, _ in objects]
     print(f"→ listing s3://{MEGATEST_BUCKET}/{results_prefix}  ({len(keys)} keys)", file=sys.stderr)
 
     template = load_template(pipeline, local)
     source_paths = collect_recipe_source_paths(template, pipeline, local)
-    print(f"→ checking {len(source_paths)} recipe source paths", file=sys.stderr)
+    print(f"→ layer 1: checking {len(source_paths)} recipe source paths", file=sys.stderr)
 
-    report, n_missing = build_drift_report(
-        pipeline, local, new_version, results_prefix, source_paths, keys
+    recipe_results: list[RecipeCheck] | None = None
+    catalog_result: tuple[str, str] | None = None
+    if not args.no_exec:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            print("→ layer 2: running recipes against megatest data", file=sys.stderr)
+            recipe_results = validate_recipes(
+                template,
+                pipeline,
+                local,
+                results_prefix,
+                objects,
+                Path(tmp),
+                max_file_mb=args.max_file_mb,
+            )
+        print("→ layer 3: depictio dev catalog validate", file=sys.stderr)
+        catalog_result = run_catalog_validate()
+
+    report, n_problems = build_drift_report(
+        pipeline,
+        local,
+        new_version,
+        results_prefix,
+        source_paths,
+        keys,
+        recipe_results,
+        catalog_result,
     )
     if args.out:
         out = Path(args.out)
@@ -395,13 +606,12 @@ def cmd_report(args: argparse.Namespace) -> int:
     else:
         print(report)
 
-    if n_missing:
-        print(f"✗ {n_missing} of {len(source_paths)} paths no longer resolve", file=sys.stderr)
-    else:
-        print(
-            f"✓ {len(source_paths)} of {len(source_paths)} paths resolve — no drift",
-            file=sys.stderr,
-        )
+    print(
+        f"{'✗' if n_problems else '✓'} {n_problems} problem(s) found"
+        if n_problems
+        else "✓ no problems — template still valid for the new release",
+        file=sys.stderr,
+    )
     return 0
 
 
@@ -421,6 +631,17 @@ def main(argv: list[str] | None = None) -> int:
         "--results-hash", help="Pin a specific megatest results-<hash> (else newest is used)"
     )
     p_report.add_argument("--out", help="Write the markdown report to this file instead of stdout")
+    p_report.add_argument(
+        "--no-exec",
+        action="store_true",
+        help="Path-existence check only (skip recipe execution + catalog validate)",
+    )
+    p_report.add_argument(
+        "--max-file-mb",
+        type=float,
+        default=50.0,
+        help="Skip downloading/executing recipe sources larger than this (default 50)",
+    )
     p_report.set_defaults(func=cmd_report)
 
     args = parser.parse_args(argv)


### PR DESCRIPTION
Two things. **Note:** the recipe-execution layer described in #830 was merged before that commit landed, so it's re-submitted here.

**1. Actually run recipes against the megatest** (re-submit). `report` validates a template in three layers: source-path existence → download each file-based recipe's inputs and run `transform()` + assert `EXPECTED_SCHEMA` (reuses `depictio.recipes.execute_recipe`) → `depictio dev catalog validate`. `dc_ref`/canonical recipes are skipped. `--no-exec` / `--max-file-mb` flags.

**2. Validation result in the PR title.** `report` emits a short status on stdout (`✅ valid` / `⚠️ N issue(s)`); the workflow puts it in each per-pipeline draft-PR title, e.g. `nf-core/ampliseq 2.17.0 — megatest: ✅ valid` (replaces the generic "drift report" wording, e.g. on #832).

Verified live against the ampliseq 2.16.0 megatest: `alpha_rarefaction` (24.5k×4), `taxonomy_composition` (270×7), `ancombc_results` (96×11) execute and pass; canonical recipes skip; status line renders `✅ valid`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuDy8K2oGuKY1jXPt97B6c)_