### PR TITLE
docs: switch Dash badge to React and fix broken tests workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## We rely on
 
 [![FastAPI](https://img.shields.io/badge/FastAPI-latest?style=flat-square&logo=fastapi&color=66C2B2)](https://fastapi.tiangolo.com/)
-[![React](https://img.shields.io/badge/React-latest?style=flat-square&logo=react&color=61DAFB)](https://react.dev/)
+[![React](https://img.shields.io/badge/React-latest?style=flat-square&logo=react&color=7DBEFF)](https://react.dev/)
 [![MongoDB](https://img.shields.io/badge/MongoDB-latest?style=flat-square&logo=mongodb&color=8FCA82)](https://www.mongodb.com/)
 [![MinIO](https://img.shields.io/badge/MinIO-latest?style=flat-square&logo=minio&color=E88A97)](https://min.io/)
 [![Pydantic](https://img.shields.io/badge/Pydantic-latest?style=flat-square&logo=pydantic&color=F18AAF)](https://pydantic-docs.helpmanual.io/)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## We rely on
 
 [![FastAPI](https://img.shields.io/badge/FastAPI-latest?style=flat-square&logo=fastapi&color=66C2B2)](https://fastapi.tiangolo.com/)
-[![React](https://img.shields.io/badge/React-latest?style=flat-square&logo=react&color=7DBEFF)](https://react.dev/)
+[![React](https://img.shields.io/badge/React-latest?style=flat-square&logo=react&logoColor=61DAFB&color=20232A)](https://react.dev/)
 [![MongoDB](https://img.shields.io/badge/MongoDB-latest?style=flat-square&logo=mongodb&color=8FCA82)](https://www.mongodb.com/)
 [![MinIO](https://img.shields.io/badge/MinIO-latest?style=flat-square&logo=minio&color=E88A97)](https://min.io/)
 [![Pydantic](https://img.shields.io/badge/Pydantic-latest?style=flat-square&logo=pydantic&color=F18AAF)](https://pydantic-docs.helpmanual.io/)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## We rely on
 
 [![FastAPI](https://img.shields.io/badge/FastAPI-latest?style=flat-square&logo=fastapi&color=66C2B2)](https://fastapi.tiangolo.com/)
-[![Dash](https://img.shields.io/badge/Dash-latest?style=flat-square&logo=plotly&color=7DBEFF)](https://dash.plotly.com/)
+[![React](https://img.shields.io/badge/React-latest?style=flat-square&logo=react&color=61DAFB)](https://react.dev/)
 [![MongoDB](https://img.shields.io/badge/MongoDB-latest?style=flat-square&logo=mongodb&color=8FCA82)](https://www.mongodb.com/)
 [![MinIO](https://img.shields.io/badge/MinIO-latest?style=flat-square&logo=minio&color=E88A97)](https://min.io/)
 [![Pydantic](https://img.shields.io/badge/Pydantic-latest?style=flat-square&logo=pydantic&color=F18AAF)](https://pydantic-docs.helpmanual.io/)
@@ -31,7 +31,7 @@
 ## Quality
 
 [![Ruff](https://img.shields.io/badge/code%20style-ruff-000000?style=flat-square&logo=python)](https://github.com/astral-sh/ruff)
-[![Test Status](https://img.shields.io/github/actions/workflow/status/depictio/depictio/deploy.yaml?label=tests&style=flat-square&logo=github-actions)](https://github.com/depictio/depictio/actions/workflows/deploy.yaml)
+[![Test Status](https://img.shields.io/github/actions/workflow/status/depictio/depictio/depictio-ci.yaml?label=tests&style=flat-square&logo=github-actions)](https://github.com/depictio/depictio/actions/workflows/depictio-ci.yaml)
 [![GitHub issues](https://img.shields.io/github/issues/depictio/depictio?style=flat-square&logo=github)](https://github.com/depictio/depictio/issues)
 
 ## Documentation


### PR DESCRIPTION
## Summary

- **Dash → React badge**: The "We rely on" section now advertises **React** (React's brand color `#61DAFB`, `logo=react`, linking to react.dev) instead of Dash, reflecting the dashboard frontend migration.
- **Fix broken tests badge**: The Test Status badge pointed at a workflow file named `deploy.yaml`, which **does not exist** in `.github/workflows/`. shields.io resolves these badges by workflow filename, so the missing file made it report the workflow as "not found". It now points at the actual CI workflow `depictio-ci.yaml` (both the badge image and its link).

## Notes

`depictio-ci.yaml` triggers on `push` to `main`, so the badge reflects default-branch status. If a different workflow should drive the badge, happy to adjust.

https://claude.ai/code/session_01EFDxSAuP87WYgrUXQMZUxU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFDxSAuP87WYgrUXQMZUxU)_