### PR TITLE
fix(api): list dashboards in any public project for anonymous users

### DIFF
--- a/depictio/api/v1/endpoints/dashboards_endpoints/core_functions.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/core_functions.py
@@ -188,14 +188,13 @@ def load_dashboards_from_db(owner, admin_mode=False, user=None, include_child_ta
                     )
                 )
             else:
-                # Anonymous users can only access admin-owned public projects
-                # (reference/demo projects), not user-created public projects
+                # Anonymous users can access dashboards in any public project,
+                # consistent with how projects are listed (_async_get_all_projects).
+                # The dashboard-level filter below still restricts results to
+                # public dashboards, so private dashboards do not leak.
                 accessible_projects = list(
                     projects_collection.find(
-                        {
-                            "is_public": True,
-                            "permissions.owners.is_admin": True,
-                        },
+                        {"is_public": True},
                         {"_id": 1},
                     )
                 )

--- a/depictio/tests/api/v1/test_unauthenticated_mode.py
+++ b/depictio/tests/api/v1/test_unauthenticated_mode.py
@@ -617,3 +617,83 @@ class TestInitializationProcess:
                                 await run_initialization()
 
                                 mock_create_anon.assert_not_called()
+
+
+class TestAnonymousDashboardListing:
+    """Regression tests for anonymous-user dashboard listing in public mode.
+
+    Anonymous users must see dashboards in *any* public project, consistent
+    with how projects are listed, while private dashboards must not leak.
+    """
+
+    def _make_anonymous_user(self):
+        user = MagicMock()
+        user.is_anonymous = True
+        user.is_admin = False
+        return user
+
+    def test_anonymous_sees_dashboards_in_non_admin_public_project(self):
+        """Public dashboards in a non-admin-owned public project must be listed."""
+        from bson import ObjectId
+
+        from depictio.api.v1.endpoints.dashboards_endpoints import core_functions
+
+        owner_id = ObjectId()
+        project_id = ObjectId()
+
+        mock_settings = MagicMock()
+        mock_settings.auth.is_single_user_mode = False
+
+        projects_coll = MagicMock()
+        # Non-admin-owned public project returned by the project visibility query.
+        projects_coll.find.return_value = [{"_id": project_id}]
+
+        dashboards_coll = MagicMock()
+        dashboards_coll.find.return_value = [
+            {
+                "_id": ObjectId(),
+                "dashboard_id": "dash-1",
+                "title": "Public Dashboard",
+                "project_id": project_id,
+                "is_public": True,
+            }
+        ]
+
+        with patch.object(core_functions, "projects_collection", projects_coll):
+            with patch.object(core_functions, "dashboards_collection", dashboards_coll):
+                with patch("depictio.api.v1.configs.config.settings", mock_settings):
+                    result = core_functions.load_dashboards_from_db(
+                        owner=str(owner_id),
+                        user=self._make_anonymous_user(),
+                    )
+
+        assert result["success"] is True
+        assert len(result["dashboards"]) == 1
+        assert result["dashboards"][0]["dashboard_id"] == "dash-1"
+
+    def test_anonymous_project_query_has_no_admin_owner_filter(self):
+        """The anonymous project-visibility query must not require an admin owner."""
+        from bson import ObjectId
+
+        from depictio.api.v1.endpoints.dashboards_endpoints import core_functions
+
+        mock_settings = MagicMock()
+        mock_settings.auth.is_single_user_mode = False
+
+        projects_coll = MagicMock()
+        projects_coll.find.return_value = []
+
+        dashboards_coll = MagicMock()
+        dashboards_coll.find.return_value = []
+
+        with patch.object(core_functions, "projects_collection", projects_coll):
+            with patch.object(core_functions, "dashboards_collection", dashboards_coll):
+                with patch("depictio.api.v1.configs.config.settings", mock_settings):
+                    core_functions.load_dashboards_from_db(
+                        owner=str(ObjectId()),
+                        user=self._make_anonymous_user(),
+                    )
+
+        project_query = projects_coll.find.call_args[0][0]
+        assert project_query == {"is_public": True}
+        assert "permissions.owners.is_admin" not in project_query


### PR DESCRIPTION
## Problem

In public / unauthenticated (anonymous) mode, users could see **all public projects** but **none of their dashboards** — e.g. the default/reference dashboards never showed up even though their projects did.

## Root cause

The two listings filtered the same data inconsistently for anonymous users:

- **Projects** (`_async_get_all_projects`, `projects_endpoints/utils.py`) match on `{"is_public": True}`.
- **Dashboards** (`load_dashboards_from_db`, `dashboards_endpoints/core_functions.py`) additionally required `{"permissions.owners.is_admin": True}` when selecting accessible projects.

So any public project whose owner is **not** an admin (e.g. created/imported by a regular user) passed the project filter but had its dashboards filtered out — exactly the reported symptom.

## Fix (short-term)

Align dashboard visibility with project visibility by matching only on `{"is_public": True}`. The existing dashboard-level filter still limits results to public dashboards (or those owned by the user), so private dashboards do not leak.

This is the **short-term** resolution. Note that public/demo sessions are supposed to be **temporary users** (who already see public dashboards correctly); this PR fixes the **anonymous fallback** path that the deployment was resolving to. The deeper architectural follow-up — ensuring public sessions always use temporary users and removing the special `is_anonymous` branch as anonymous is phased out — is tracked in **#884**.

## Tests

Added `TestAnonymousDashboardListing` regression tests covering:
- an anonymous user now receives a public dashboard in a **non-admin-owned** public project, and
- the project-visibility query shape no longer carries the admin-owner predicate.

`ruff format`, `ruff check`, and `ty check` pass on the changed files.

## Follow-up

- #884 — Phase out the anonymous-user fallback in dashboard listing; rely on temporary users in public mode.