### PR TITLE
fix(cards): populate categorical `unique_values` sample (fixes Columns Description panel)

### DIFF
--- a/depictio/api/v1/endpoints/deltatables_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/deltatables_endpoints/utils.py
@@ -13,6 +13,10 @@ from depictio.api.v1.db import files_collection
 from depictio.api.v1.s3 import s3_client
 from depictio.api.v1.utils import numpy_to_python
 
+# Cap on how many distinct categorical values we sample into ``specs`` for the
+# card-builder preview. Kept small so specs stay compact in Mongo.
+_UNIQUE_VALUES_PREVIEW_CAP = 20
+
 
 def get_s3_folder_size(bucket_name, prefix):
     """
@@ -413,6 +417,25 @@ def precompute_columns_specs(
             if value is None:
                 continue
             tmp_dict["specs"][str(method_name)] = numpy_to_python(value)
+
+        # Categorical columns: record a small, frequency-ordered sample of the
+        # actual distinct values so the React card-builder preview can show real
+        # category names in top-N / concentration strips instead of placeholder
+        # "Bucket N" labels. The saved card recomputes the true distribution from
+        # live data via bulk_compute_cards(); this only makes the design-time
+        # preview representative. Capped to keep specs compact.
+        if normalized_type in ("object", "bool", "category") or normalized_type.startswith(
+            "string"
+        ):
+            try:
+                value_counts = aggregated_df[column].value_counts(dropna=True)
+                unique_values = [
+                    str(v) for v in value_counts.index.tolist()[:_UNIQUE_VALUES_PREVIEW_CAP]
+                ]
+                if unique_values:
+                    tmp_dict["specs"]["unique_values"] = unique_values
+            except Exception as exc:  # never let preview metadata abort an upsert
+                logger.debug(f"unique_values sample failed for column {column!r}: {exc}")
 
         results.append(tmp_dict)
 

--- a/depictio/api/v1/endpoints/deltatables_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/deltatables_endpoints/utils.py
@@ -428,9 +428,13 @@ def precompute_columns_specs(
             "string"
         ):
             try:
-                value_counts = aggregated_df[column].value_counts(dropna=True)
+                value_counts = (
+                    lf.select(pl.col(column).drop_nulls().value_counts(sort=True))
+                    .unnest(column)
+                    .collect()
+                )
                 unique_values = [
-                    str(v) for v in value_counts.index.tolist()[:_UNIQUE_VALUES_PREVIEW_CAP]
+                    str(v) for v in value_counts[column].to_list()[:_UNIQUE_VALUES_PREVIEW_CAP]
                 ]
                 if unique_values:
                     tmp_dict["specs"]["unique_values"] = unique_values

--- a/depictio/tests/api/v1/test_precompute_columns_specs.py
+++ b/depictio/tests/api/v1/test_precompute_columns_specs.py
@@ -374,6 +374,23 @@ def test_pangolin_lineages_shape_does_not_raise() -> None:
     assert by_name["qc_status"]["specs"]["mode"] in ("pass", "fail")
 
 
+def test_unique_values_recorded_for_categorical() -> None:
+    """Categorical columns carry a frequency-ordered ``unique_values`` sample so
+    the card-builder preview shows real names instead of "Bucket N" labels."""
+    df = pl.DataFrame({"variety": ["Setosa", "Setosa", "Versicolor", "Virginica"]})
+    [spec] = precompute_columns_specs(df, _AGG_FUNCTIONS, _dc_data())
+    uv = spec["specs"]["unique_values"]
+    assert uv[0] == "Setosa"  # most frequent first
+    assert set(uv) == {"Setosa", "Versicolor", "Virginica"}
+
+
+def test_unique_values_capped() -> None:
+    """High-cardinality columns only keep a capped sample to keep specs compact."""
+    df = pl.DataFrame({"id": [f"v{i}" for i in range(50)]})
+    [spec] = precompute_columns_specs(df, _AGG_FUNCTIONS, _dc_data())
+    assert len(spec["specs"]["unique_values"]) == 20
+
+
 # --------------------------------------------------------------------------
 # Degradation rather than aborting the upsert
 # --------------------------------------------------------------------------

--- a/depictio/tests/api/v1/test_precompute_columns_specs.py
+++ b/depictio/tests/api/v1/test_precompute_columns_specs.py
@@ -156,6 +156,10 @@ def _assert_specs_equivalent(new: list[dict], ref: list[dict]) -> None:
     the lazy implementation returns null and skips the key. Both read as
     "no value" downstream, and NaN is turned into null on serialisation anyway
     (``sanitize_for_json``).
+
+    ``unique_values`` is allowlisted as a known extra: it is a deliberate
+    addition (categorical columns only, see ``test_unique_values_*``) that the
+    pandas reference never computed, not accidental drift from the rewrite.
     """
     assert [c["name"] for c in new] == [c["name"] for c in ref]
     for got, want in zip(new, ref):
@@ -173,9 +177,8 @@ def _assert_specs_equivalent(new: list[dict], ref: list[dict]) -> None:
                 )
             else:
                 assert actual == expected, f"{want['name']}.{method}"
-        assert set(got["specs"]) <= set(want["specs"]), (
-            f"{want['name']}: unexpected extra specs {set(got['specs']) - set(want['specs'])}"
-        )
+        extra = set(got["specs"]) - set(want["specs"]) - {"unique_values"}
+        assert not extra, f"{want['name']}: unexpected extra specs {extra}"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In the React card builder, picking a categorical column (e.g. `variety` in the iris seed project) and choosing a multi-metric **cardinality** style — **Top-N bars** (`top_n`) or **Concentration** (`concentration`) — made the live preview show placeholder labels **"Bucket 1 / 2 / 3"** instead of the real category names (Setosa / Versicolor / Virginica).

## Root cause

The preview is already designed to render real category names pulled from the breakdown column's *precomputed* specs, falling back to `Bucket N` only when those names are missing:

- `depictio/viewer/src/builder/card/CardPreview.tsx` — `buildBreakdownPreview()` reads `breakdownSpecs['unique_values']`; when absent it synthesises `Bucket ${i+1}` labels.
- `depictio/api/v1/endpoints/deltatables_endpoints/utils.py` — `precompute_columns_specs()` only computed `count` / `mode` / `nunique` for categorical columns and **never populated `unique_values`**, so the preview always hit the fallback.

The **saved** card was always correct — `bulk_compute_cards()` computes the real top-N breakdown from live data. This bug was **preview-only**, but it made the builder look broken.

## Fix

In `precompute_columns_specs()`, for categorical columns (`object` / `bool` / `category` / `string`), record a **frequency-ordered, capped (20)** sample of the actual distinct values on `specs['unique_values']`. `DeltaTableColumn.specs` is a free-form `dict`, so no schema change is needed. The computation is wrapped in `try/except` so it can never abort a Delta-table upsert.

No frontend change is required — the preview already consumes `unique_values`.

## Tests

Added regression tests in `depictio/tests/api/v1/test_precompute_columns_specs.py`:
- `test_unique_values_recorded_for_categorical` — names are recorded, most-frequent first.
- `test_unique_values_capped` — high-cardinality columns keep at most 20.

---

## Update — rebase (2026-08-24) + retarget

This PR sat since June while `CardPreview.tsx`/`precompute_columns_specs.py` were reworked underneath it (a real `/deltatables/breakdown` endpoint now backs the card preview's top_n/concentration strips instead of static `specs`). **The original "Bucket 1/2/3" card-preview bug described above no longer exists on `main` — it was independently fixed via that endpoint.**

However, rebasing surfaced that `specs['unique_values']` is *still* a real, live gap: `depictio/viewer/src/builder/shared/ColumnsDescription.tsx` (the "Data Collection — Columns description" panel, `summarizeSpecs()`) reads exactly this field to show a `e.g. Setosa, Versicolor, Virginica` sample next to each categorical column, and it's silently blank today because nothing populates it. This PR now targets *that* gap instead — title/description updated accordingly.

Rebasing also surfaced that the original implementation never actually worked against polars (pandas-style `.value_counts(dropna=True)` / `.index.tolist()` on a polars `Series`/`LazyFrame`), so `unique_values` silently stayed unset even for its original target. Fixed in a follow-up commit:
- `value_counts()` on current polars (1.42.1) takes `sort=`, not `dropna=`, and returns a 2-column `DataFrame`, not something with `.index` — switched to `.drop_nulls().value_counts(sort=True)`.
- The direct-subscript form (`aggregated_df[column]`) doesn't work when the input is a `pl.LazyFrame` (only `DataFrame` supports it) — switched to `lf.select(pl.col(column)...).unnest(column).collect()`, matching the function's "never materialise except where necessary" contract and keeping `test_lazyframe_and_dataframe_agree` green for this branch too.
- `test_matches_pandas_reference`'s strict parity guard now allowlists `unique_values` as a deliberate addition (the old pandas reference never computed it) rather than flagging it as drift.

Verified: 37/37 tests in the target module pass, plus the broader `deltatable`/`card`/`precompute`-scoped suite (173 tests) with no regressions. `ruff format`/`ruff check` clean.

## Type of change
- [x] Bugfix

## How was this tested?
- `pytest depictio/tests/api/v1/test_precompute_columns_specs.py` → 37 passed.
- `pytest depictio/tests/api/v1/ -k "deltatable or card or precompute"` → 173 passed, 0 regressions.
- `ruff format` + `ruff check` clean on both changed files.

## Checklist
- [x] Code follows project style (`ruff` pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed
