### PR TITLE
fix(advanced-viz): 500 on DC schema fetch + binding badge clipping

### DIFF
--- a/depictio/api/v1/endpoints/datacollections_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/datacollections_endpoints/utils.py
@@ -174,11 +174,18 @@ async def _get_data_collection_polars_schema(
 
     try:
         dt = DeltaTable(delta_location, storage_options=polars_s3_config)
+        # deltalake 1.x renamed ``Schema.to_pyarrow()`` to ``Schema.to_arrow()``.
+        # The pinned/deployed runtime is 1.6.0 (uses ``to_arrow``) but a dev venv
+        # may still be on 0.24.x (only ``to_pyarrow``), so accept either. Keep the
+        # read inside the guard so any future API drift surfaces as a clean 500
+        # instead of a raw AttributeError traceback.
+        schema = dt.schema()
+        to_arrow = getattr(schema, "to_arrow", None) or getattr(schema, "to_pyarrow")
+        arrow_schema = to_arrow()
     except Exception as exc:
-        logger.warning(f"polars_schema: cannot open delta at {delta_location}: {exc}")
-        raise HTTPException(status_code=500, detail="Unable to open Delta table.") from exc
+        logger.warning(f"polars_schema: cannot read delta schema at {delta_location}: {exc}")
+        raise HTTPException(status_code=500, detail="Unable to read Delta schema.") from exc
 
-    arrow_schema = dt.schema().to_pyarrow()
     # Stringify pyarrow dtypes into the polars naming convention expected by
     # validate_binding(): polars uses CamelCase ("Float64", "Int64", "Utf8"/"String").
     return {field.name: _pyarrow_to_polars_dtype_name(field.type) for field in arrow_schema}

--- a/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
+++ b/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
@@ -194,7 +194,12 @@ function exampleInputRow(
           <Text size="xs" fw={500}>
             {role}
           </Text>
-          <Badge size="xs" variant="light" color={required ? REQUIRED_COLOR : OPTIONAL_COLOR}>
+          <Badge
+            size="xs"
+            variant="light"
+            color={required ? REQUIRED_COLOR : OPTIONAL_COLOR}
+            style={{ flexShrink: 0 }}
+          >
             {required ? 'required' : 'optional'}
           </Badge>
         </Group>


### PR DESCRIPTION
## Summary
Two advanced-viz builder fixes (Epic #839 / 1.1.0).

### #851 — Error 500 on advanced viz
`GET /datacollections/polars_schema/{id}` returned **500 for every DC**, surfaced in the builder as *"Failed to load DC schema / Failed to fetch polars schema: 500"*. Confirmed via dev-demo pod logs:

```
File ".../datacollections_endpoints/utils.py", line 181, in _get_data_collection_polars_schema
    arrow_schema = dt.schema().to_pyarrow()
AttributeError: 'deltalake._internal.Schema' object has no attribute 'to_pyarrow'. Did you mean: 'to_arrow'?
```

`deltalake` 1.x (pinned `1.6.0`, since 0d08b3949) renamed `Schema.to_pyarrow()` → `to_arrow()`. The endpoint still called the old name. Fix resolves the method dynamically so it works on both the deployed 1.6.0 runtime and a lagging 0.24.x dev venv, and moves the read inside the existing `try/except` so future API drift returns a clean 500 instead of a raw traceback. Also clears a pre-existing `ty` `unresolved-attribute` error on that line.

### Binding badge clipping
In the builder's *Bindings overview* table the required/optional badges rendered as clipped circles (the `width:1%` nowrap Role cell squeezed the flex Badge below its label). Pinned with `flexShrink:0`.

## Test
- `ruff` + `ty` clean (ty error on line 181 now resolved); viewer `tsc --noEmit` clean.
- Verify against dev-demo: add an Advanced-viz component → DC schema loads, column dropdowns populate; badges show full "required"/"optional".

Fixes #851