### PR TITLE
fix(viewer): restore folder picker for MultiQC click-to-upload

### DIFF
--- a/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
+++ b/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
@@ -1557,8 +1557,16 @@ const CreateDataCollectionModal: React.FC<{
                 ref={multiqcDropzone.inputRef}
                 type="file"
                 multiple
-                accept=".parquet"
                 style={{ display: 'none' }}
+                // Click-to-pick must open a *folder* picker so the run-folder
+                // structure (<run>/multiqc_data/multiqc.parquet) reaches the
+                // hook via webkitRelativePath — parity with drag-drop. Without
+                // it, click-selected files carry no path and the upload silently
+                // does nothing (#847). `accept` is dropped because browsers
+                // ignore it for directory selection; the hook's
+                // filterFilename:'multiqc.parquet' does the real filtering.
+                // @ts-expect-error — webkitdirectory is non-standard but widely supported.
+                webkitdirectory=""
               />
             </div>
             {multiqcDropzone.error && (


### PR DESCRIPTION
## Summary
Carried-over 1.0.1 bug (Epic #839 / 1.1.0): MultiQC upload does nothing when you **click** the dropzone and select via the OS browser, while drag-drop works.

## Root cause
MultiQC ingestion groups files by run-folder structure (`<run>/multiqc_data/multiqc.parquet`); `useFolderDropzone` preserves that path via `webkitRelativePath`. Drag-drop traverses entries with `webkitGetAsEntry`, but the hidden `<input>` lost its `webkitdirectory` attribute in `f96503927`, so click-to-pick opened a flat **file** picker — selected files carried no relative path, the backend grouping found nothing, and the upload silently failed.

## Fix
Restore `webkitdirectory` on the MultiQC input so click opens a **folder** picker (the hook documents this contract; `filterFilename:'multiqc.parquet'` still filters). Dropped `accept=".parquet"` since browsers ignore it for directory selection. Single files remain uploadable via drag-drop.

## Test
- Viewer `tsc --noEmit` clean.
- Manual: Create-DC MultiQC flow → click dropzone → pick a run folder → files ingest with paths, name auto-fills, submit succeeds (parity with drag-drop).

Fixes #847