### PR TITLE
refactor(viewer): drop default-thumbnail placeholder, fall back to icon

### DIFF
--- a/depictio/viewer/src/dashboards/DashboardCard.tsx
+++ b/depictio/viewer/src/dashboards/DashboardCard.tsx
@@ -24,7 +24,6 @@ import MultiTabPreview from './MultiTabPreview';
 import DashboardActionsMenu from './DashboardActionsMenu';
 import {
   coerceString,
-  DEFAULT_THUMBNAIL_URL,
   formatLastSaved,
   isImagePath,
   resolveAssetUrl,
@@ -57,17 +56,41 @@ const SingleThumbnail: React.FC<{
   dashboard: DashboardListEntry;
   theme: 'light' | 'dark';
 }> = ({ dashboard, theme }) => {
-  // Fallback chain: real screenshot → shared default thumbnail → icon
-  // (last resort if the default asset itself fails to load).
-  const [fallback, setFallback] = useState<'none' | 'default' | 'icon'>('none');
+  // No real screenshot yet (freshly created dashboard, or capture failed) →
+  // fall straight back to the dashboard's own colored icon. No generic
+  // placeholder image in between.
+  const [fallback, setFallback] = useState<'none' | 'icon'>('none');
   const icon = coerceString(dashboard.icon, 'mdi:view-dashboard');
   const color = coerceString(dashboard.icon_color, 'orange');
 
   if (fallback === 'icon') {
+    // When the dashboard's "icon" is actually an image logo, show that logo as
+    // the thumbnail rather than the generic dashboard glyph. Previously this
+    // branch swapped any image path for `mdi:view-dashboard`, so a logo'd
+    // dashboard with no screenshot fell back to the default placeholder even
+    // though a perfectly good logo was available — render the logo instead.
+    if (isImagePath(icon)) {
+      return (
+        <Center h="100%" w="100%" bg="var(--mantine-color-default-hover)">
+          <img
+            src={resolveAssetUrl(icon)}
+            alt={dashboard.title || dashboard.dashboard_id}
+            loading="lazy"
+            decoding="async"
+            style={{
+              maxWidth: '60%',
+              maxHeight: '60%',
+              objectFit: 'contain',
+              display: 'block',
+            }}
+          />
+        </Center>
+      );
+    }
     return (
       <Center h="100%" w="100%" bg="var(--mantine-color-default-hover)">
         <ThemeIcon size={64} variant="light" color={color} radius="md">
-          <Icon icon={isImagePath(icon) ? 'mdi:view-dashboard' : icon} width={36} />
+          <Icon icon={icon} width={36} />
         </ThemeIcon>
       </Center>
     );
@@ -75,15 +98,11 @@ const SingleThumbnail: React.FC<{
   return (
     <img
       key={`${theme}-${dashboard.last_saved_ts ?? ''}-${fallback}`}
-      src={
-        fallback === 'default'
-          ? DEFAULT_THUMBNAIL_URL
-          : screenshotUrl(dashboard.dashboard_id, theme, dashboard.last_saved_ts)
-      }
+      src={screenshotUrl(dashboard.dashboard_id, theme, dashboard.last_saved_ts)}
       alt={dashboard.title || dashboard.dashboard_id}
       loading="lazy"
       decoding="async"
-      onError={() => setFallback(fallback === 'none' ? 'default' : 'icon')}
+      onError={() => setFallback('icon')}
       style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
     />
   );
@@ -151,9 +170,10 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     theme,
     dashboard.last_saved_ts,
   );
-  // Same fallback chain as SingleThumbnail for the hover-popover preview:
-  // real screenshot → default thumbnail → no popover image at all.
-  const [popoverFallback, setPopoverFallback] = useState<'none' | 'default' | 'hidden'>('none');
+  // Hover-popover preview only makes sense with a real screenshot — when the
+  // card itself is showing the icon fallback there's nothing to enlarge, so we
+  // just suppress the popover image rather than blow up a placeholder.
+  const [popoverFallback, setPopoverFallback] = useState<'none' | 'hidden'>('none');
 
   return (
     <Card
@@ -248,19 +268,11 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
                     <AspectRatio ratio={16 / 10}>
                       <img
                         key={`${thumbnailSrc}-${popoverFallback}`}
-                        src={
-                          popoverFallback === 'default'
-                            ? DEFAULT_THUMBNAIL_URL
-                            : thumbnailSrc
-                        }
+                        src={thumbnailSrc}
                         alt=""
                         loading="lazy"
                         decoding="async"
-                        onError={() =>
-                          setPopoverFallback(
-                            popoverFallback === 'none' ? 'default' : 'hidden',
-                          )
-                        }
+                        onError={() => setPopoverFallback('hidden')}
                         style={{
                           width: '100%',
                           height: '100%',

--- a/depictio/viewer/src/dashboards/MultiTabPreview.tsx
+++ b/depictio/viewer/src/dashboards/MultiTabPreview.tsx
@@ -14,7 +14,7 @@ import { Icon } from '@iconify/react';
 
 import type { DashboardListEntry } from 'depictio-react-core';
 import { dashboardHref, dashboardLinkClickHandler } from './lib/dashboardLinks';
-import { DEFAULT_THUMBNAIL_URL } from './lib/format';
+import { isImagePath, resolveAssetUrl } from './lib/format';
 
 interface MultiTabPreviewProps {
   parent: DashboardListEntry;
@@ -59,10 +59,30 @@ const SlideImage: React.FC<{
   theme: 'light' | 'dark';
   iconSize: number;
 }> = ({ slide, theme, iconSize }) => {
-  // Fallback chain: real screenshot → shared default thumbnail → icon
-  // (last resort if the default asset itself fails to load).
-  const [fallback, setFallback] = useState<'none' | 'default' | 'icon'>('none');
+  // No real screenshot yet → fall straight back to the tab's colored icon.
+  // No generic placeholder image in between.
+  const [fallback, setFallback] = useState<'none' | 'icon'>('none');
   if (fallback === 'icon') {
+    // An image-logo `icon` can't be rendered as an Iconify glyph — show the
+    // logo image itself instead of an empty/broken ThemeIcon.
+    if (isImagePath(slide.icon)) {
+      return (
+        <Center h="100%" w="100%" bg="var(--mantine-color-default-hover)">
+          <img
+            src={resolveAssetUrl(slide.icon)}
+            alt={slide.title}
+            loading="lazy"
+            decoding="async"
+            style={{
+              maxWidth: '60%',
+              maxHeight: '60%',
+              objectFit: 'contain',
+              display: 'block',
+            }}
+          />
+        </Center>
+      );
+    }
     return (
       <Center h="100%" w="100%" bg="var(--mantine-color-default-hover)">
         <ThemeIcon size={iconSize} variant="light" color={slide.color} radius="md">
@@ -75,15 +95,11 @@ const SlideImage: React.FC<{
   return (
     <img
       key={`${theme}-${slide.version ?? ''}-${fallback}`}
-      src={
-        fallback === 'default'
-          ? DEFAULT_THUMBNAIL_URL
-          : `/static/screenshots/${slide.id}_${theme}.png${versionQuery}`
-      }
+      src={`/static/screenshots/${slide.id}_${theme}.png${versionQuery}`}
       alt={slide.title}
       loading="lazy"
       decoding="async"
-      onError={() => setFallback(fallback === 'none' ? 'default' : 'icon')}
+      onError={() => setFallback('icon')}
       style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
     />
   );

--- a/depictio/viewer/src/dashboards/lib/format.ts
+++ b/depictio/viewer/src/dashboards/lib/format.ts
@@ -35,12 +35,6 @@ export function formatLastSaved(raw: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-/** Generic placeholder shown when a dashboard has no screenshot yet (e.g. a
- *  freshly created dashboard before the first auto-screenshot run). Shipped
- *  with the backend image and served by the FastAPI /assets StaticFiles
- *  mount; both the vite dev proxy and the prod nginx forward /assets/. */
-export const DEFAULT_THUMBNAIL_URL = '/assets/images/backgrounds/default_thumbnail.png';
-
 export function screenshotUrl(
   dashboardId: string,
   theme: 'light' | 'dark',

--- a/dev/regenerate_dashboard_thumbnails.py
+++ b/dev/regenerate_dashboard_thumbnails.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Regenerate dashboard thumbnails on a live Depictio deployment.
+
+Drives the backend's ``/depictio/api/v1/utils/screenshot-react-dual/{id}``
+endpoint (Playwright in the Celery workers) for every dashboard returned by
+``/dashboards/list_all``, capturing both light and dark themes in one call.
+
+Auth: pass a long-lived admin bearer token via ``--token-file`` (one line).
+On an EMBL K8s deployment you can mint one from the backend pod's per-admin
+config, e.g.::
+
+    NS=datasci-depictio-project-demo-dev
+    POD=$(kubectl -n $NS get pods -o name | grep -m1 depictio-backend | sed 's|pod/||')
+    kubectl -n $NS exec $POD -c depictio-backend -- python3 -c \
+      "import yaml;print(yaml.safe_load(open('/app/depictio/.depictio/thomas.weber_config.yaml'))['user']['token']['access_token'])" \
+      > /tmp/devdemo_admin_token
+
+Example::
+
+    python dev/regenerate_dashboard_thumbnails.py \
+        --host dev.api.demo.depictio.embl.org \
+        --token-file /tmp/devdemo_admin_token \
+        --concurrency 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def _api_get(host: str, path: str, token: str, timeout: float) -> dict | list:
+    req = urllib.request.Request(
+        f"https://{host}{path}", headers={"Authorization": f"Bearer {token}"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def list_targets(host: str, token: str, include_private: bool) -> list[dict]:
+    docs = _api_get(
+        host,
+        "/depictio/api/v1/dashboards/list_all?include_child_tabs=true",
+        token,
+        timeout=30,
+    )
+    if not isinstance(docs, list):
+        raise SystemExit(f"Unexpected list_all payload: {type(docs)}")
+    if not include_private:
+        docs = [d for d in docs if d.get("is_public")]
+    return docs
+
+
+def regenerate_one(host: str, token: str, dashboard_id: str, timeout: float) -> dict:
+    """Call the dual-theme screenshot endpoint for one dashboard.
+
+    The endpoint blocks until the Celery task finishes (server-side timeout
+    ~180s), so the client timeout is set a little higher.
+    """
+    started = time.monotonic()
+    try:
+        result = _api_get(
+            host,
+            f"/depictio/api/v1/utils/screenshot-react-dual/{dashboard_id}",
+            token,
+            timeout=timeout,
+        )
+        return {
+            "id": dashboard_id,
+            "ok": True,
+            "status": (result or {}).get("status", "?"),
+            "elapsed": time.monotonic() - started,
+        }
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:200]
+        return {
+            "id": dashboard_id,
+            "ok": False,
+            "status": f"HTTP {exc.code}: {body}",
+            "elapsed": time.monotonic() - started,
+        }
+    except Exception as exc:  # noqa: BLE001 — surface every failure mode in the report
+        return {
+            "id": dashboard_id,
+            "ok": False,
+            "status": f"{type(exc).__name__}: {exc}",
+            "elapsed": time.monotonic() - started,
+        }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="dev.api.demo.depictio.embl.org", help="API hostname (no scheme)")
+    ap.add_argument("--token-file", default="/tmp/devdemo_admin_token", help="File holding the admin bearer token")
+    ap.add_argument("--concurrency", type=int, default=3, help="Parallel in-flight requests (keep near worker count)")
+    ap.add_argument("--timeout", type=float, default=210.0, help="Per-request client timeout in seconds")
+    ap.add_argument("--include-private", action="store_true", help="Also regenerate non-public dashboards")
+    ap.add_argument("--only", nargs="*", default=None, help="Restrict to these dashboard ids")
+    ap.add_argument("--dry-run", action="store_true", help="List targets and exit without regenerating")
+    args = ap.parse_args()
+
+    token = open(args.token_file).read().strip()
+    if not token:
+        raise SystemExit(f"Empty token in {args.token_file}")
+
+    me = _api_get(args.host, "/depictio/api/v1/auth/me", token, timeout=10)
+    print(f"[auth] {me.get('email')}  is_admin={me.get('is_admin')}  host={args.host}")
+
+    docs = list_targets(args.host, token, args.include_private)
+    if args.only:
+        wanted = set(args.only)
+        docs = [d for d in docs if d.get("dashboard_id") in wanted]
+
+    print(f"[targets] {len(docs)} dashboards  (include_private={args.include_private}, concurrency={args.concurrency})")
+    for d in docs:
+        print(f"   - {d.get('dashboard_id')}  pub={int(bool(d.get('is_public')))}  {d.get('title')!r}")
+    if args.dry_run:
+        print("[dry-run] no screenshots generated")
+        return 0
+
+    results: list[dict] = []
+    done = 0
+    total = len(docs)
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        futures = {
+            pool.submit(regenerate_one, args.host, token, d["dashboard_id"], args.timeout): d
+            for d in docs
+        }
+        for fut in as_completed(futures):
+            d = futures[fut]
+            r = fut.result()
+            results.append(r)
+            done += 1
+            mark = "✓" if r["ok"] else "✗"
+            print(
+                f"[{done:>2}/{total}] {mark} {r['id']}  {r['status']:<28} "
+                f"{r['elapsed']:5.1f}s  {d.get('title')!r}",
+                flush=True,
+            )
+
+    ok = [r for r in results if r["ok"]]
+    bad = [r for r in results if not r["ok"]]
+    print(f"\n[summary] {len(ok)}/{total} regenerated, {len(bad)} failed")
+    for r in bad:
+        print(f"   FAILED {r['id']}: {r['status']}")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Dashboards with no screenshot yet (freshly created, or capture failed) now fall straight back to their own colored icon — or the logo image when the icon is an image path — instead of a generic placeholder PNG.

## Changes
- Remove `DEFAULT_THUMBNAIL_URL` from `lib/format.ts`.
- `DashboardCard.tsx` / `MultiTabPreview.tsx`: fallback chain `screenshot → icon/logo`, dropping the intermediate `default` step (card thumbnail + hover-popover preview).
- Add `dev/regenerate_dashboard_thumbnails.py` to backfill thumbnails.

## Test
- pre-commit clean.