### PR TITLE
feat(api): grain-aware joins to prevent row explosion

### DIFF
--- a/depictio/api/v1/grain_aware_joins.py
+++ b/depictio/api/v1/grain_aware_joins.py
@@ -24,9 +24,11 @@ Example:
     True
 """
 
-from typing import Union
+from typing import Literal, Union
 
 import polars as pl
+
+JoinStrategy = Literal["inner", "left", "right", "full", "semi", "anti", "cross"]
 
 
 def is_unique_grain(df: pl.DataFrame, columns: Union[str, list[str]]) -> bool:
@@ -71,7 +73,7 @@ def grain_aware_join(
     df_base: pl.DataFrame,
     df_other: pl.DataFrame,
     on: Union[str, list[str]],
-    how: str = "left",
+    how: JoinStrategy = "left",
     aggregations: Union[dict[str, Union[str, pl.Expr]], None] = None,
 ) -> pl.DataFrame:
     """
@@ -136,6 +138,18 @@ def grain_aware_join(
             raise KeyError(f"Join column '{col}' not found in base DataFrame")
         if col not in df_other.columns:
             raise KeyError(f"Join column '{col}' not found in other DataFrame")
+
+    # Align join-column dtypes. Empty inputs produce Null-typed columns (and
+    # mismatched key types in general) that would otherwise raise a SchemaError
+    # on join; cast the Null/other side to its partner's dtype first.
+    for col in on_list:
+        base_dtype = df_base.schema[col]
+        other_dtype = df_other.schema[col]
+        if base_dtype != other_dtype:
+            if base_dtype == pl.Null:
+                df_base = df_base.with_columns(pl.col(col).cast(other_dtype))
+            else:
+                df_other = df_other.with_columns(pl.col(col).cast(base_dtype))
 
     # Check if df_other needs aggregation
     if is_unique_grain(df_other, on_list):
@@ -256,9 +270,10 @@ def _infer_aggregation(df: pl.DataFrame, column: str) -> pl.Expr:
     ]:
         return pl.col(column).mean().alias(f"{column}_mean")
 
-    # String/Categorical → list
+    # String/Categorical → list. Inside group_by().agg() the bare column already
+    # collects to a per-group list; an extra .implode() would double-wrap it.
     elif dtype in [pl.Utf8, pl.Categorical, pl.String]:
-        return pl.col(column).implode().alias(f"{column}_list")
+        return pl.col(column).alias(f"{column}_list")
 
     # Boolean → sum (count of True)
     elif dtype == pl.Boolean:
@@ -300,7 +315,7 @@ def _build_agg_expr(column: str, agg_type: str) -> pl.Expr:
         "std": lambda col: pl.col(col).std(),
         "var": lambda col: pl.col(col).var(),
         "count": lambda col: pl.col(col).count(),
-        "list": lambda col: pl.col(col).implode().alias(f"{col}_list"),
+        "list": lambda col: pl.col(col).alias(f"{col}_list"),
         "n_unique": lambda col: pl.col(col).n_unique(),
     }
 

--- a/depictio/api/v1/grain_aware_joins.py
+++ b/depictio/api/v1/grain_aware_joins.py
@@ -1,0 +1,322 @@
+"""
+Grain-aware join functionality using Polars.
+
+This module provides functions to join DataFrames while automatically handling
+different grain levels (row uniqueness) to prevent row explosion and ensure
+correct aggregation.
+
+Key principles:
+- Base DataFrame determines output grain (no explicit target_grain parameter)
+- Automatic aggregation when needed (type-based defaults)
+- Sensible defaults with configuration overrides
+- No row explosion (prevents accidental cartesian products)
+- Bidirectional: supports both aggregation (many→one) and broadcast (one→many)
+
+Example:
+    # Aggregate cells to samples (many → one)
+    >>> result = grain_aware_join(samples_df, cells_df, on='sample_id')
+    >>> len(result) == len(samples_df)  # Output has sample grain
+    True
+
+    # Broadcast samples to cells (one → many)
+    >>> result = grain_aware_join(cells_df, samples_df, on='sample_id')
+    >>> len(result) == len(cells_df)  # Output has cell grain
+    True
+"""
+
+from typing import Union
+
+import polars as pl
+
+
+def is_unique_grain(df: pl.DataFrame, columns: Union[str, list[str]]) -> bool:
+    """
+    Check if column(s) form a unique grain (no duplicate combinations).
+
+    A unique grain means each combination of values in the specified column(s)
+    appears at most once in the DataFrame.
+
+    Args:
+        df: DataFrame to check
+        columns: Column name(s) to check for uniqueness
+
+    Returns:
+        True if the column(s) form a unique grain, False otherwise
+
+    Examples:
+        >>> df = pl.DataFrame({'id': [1, 2, 3], 'value': [10, 20, 30]})
+        >>> is_unique_grain(df, 'id')
+        True
+
+        >>> df = pl.DataFrame({'id': [1, 1, 2], 'value': [10, 20, 30]})
+        >>> is_unique_grain(df, 'id')
+        False
+    """
+    # Handle empty DataFrame (vacuous truth)
+    if len(df) == 0:
+        return True
+
+    # Normalize to list
+    if isinstance(columns, str):
+        columns = [columns]
+
+    # Check if the number of unique combinations equals the number of rows
+    n_rows = len(df)
+    n_unique = df.select(columns).n_unique()
+
+    return n_rows == n_unique
+
+
+def grain_aware_join(
+    df_base: pl.DataFrame,
+    df_other: pl.DataFrame,
+    on: Union[str, list[str]],
+    how: str = "left",
+    aggregations: Union[dict[str, Union[str, pl.Expr]], None] = None,
+) -> pl.DataFrame:
+    """
+    Join DataFrames with automatic grain handling.
+
+    The base DataFrame determines the output grain. If df_other has a non-unique
+    join key (finer grain), it will be automatically aggregated to match the base
+    DataFrame's grain.
+
+    Args:
+        df_base: Base DataFrame (determines output grain)
+        df_other: Other DataFrame to join (may be aggregated if needed)
+        on: Column(s) to join on
+        how: Join type ('left', 'inner', 'outer', 'cross')
+        aggregations: Optional dict mapping column names to aggregation methods.
+                     Can be string names ('mean', 'sum', 'max', etc.) or Polars expressions.
+                     If not provided, uses type-based defaults:
+                     - Numeric: mean
+                     - String: list
+                     - Boolean: sum (count of True values)
+
+    Returns:
+        Joined DataFrame with base DataFrame's grain
+
+    Raises:
+        KeyError: If join column(s) don't exist in one of the DataFrames
+        pl.ColumnNotFoundError: If join column(s) don't exist in one of the DataFrames
+
+    Examples:
+        # Simple join with same grain (no aggregation)
+        >>> samples = pl.DataFrame({'sample_id': ['S1', 'S2'], 'tissue': ['liver', 'brain']})
+        >>> qc = pl.DataFrame({'sample_id': ['S1', 'S2'], 'reads': [1000, 2000]})
+        >>> result = grain_aware_join(samples, qc, on='sample_id')
+        >>> len(result) == 2
+        True
+
+        # Join with aggregation (cells to samples)
+        >>> samples = pl.DataFrame({'sample_id': ['S1', 'S2'], 'tissue': ['liver', 'brain']})
+        >>> cells = pl.DataFrame({
+        ...     'sample_id': ['S1', 'S1', 'S2'],
+        ...     'quality': [0.9, 0.8, 0.95]
+        ... })
+        >>> result = grain_aware_join(samples, cells, on='sample_id')
+        >>> len(result) == 2  # Aggregated to sample level
+        True
+
+        # Custom aggregations
+        >>> result = grain_aware_join(
+        ...     samples, cells, on='sample_id',
+        ...     aggregations={'quality': 'max'}
+        ... )
+    """
+    # Normalize join columns to list
+    if isinstance(on, str):
+        on_list = [on]
+    else:
+        on_list = on
+
+    # Check if join columns exist
+    for col in on_list:
+        if col not in df_base.columns:
+            raise KeyError(f"Join column '{col}' not found in base DataFrame")
+        if col not in df_other.columns:
+            raise KeyError(f"Join column '{col}' not found in other DataFrame")
+
+    # Check if df_other needs aggregation
+    if is_unique_grain(df_other, on_list):
+        # Same grain or coarser grain → just join (no aggregation needed)
+        result = df_base.join(df_other, on=on, how=how)
+    else:
+        # Finer grain → aggregate df_other first, then join
+        df_other_agg = _aggregate_to_grain(
+            df=df_other, grain_columns=on_list, aggregations=aggregations
+        )
+        result = df_base.join(df_other_agg, on=on, how=how)
+
+    return result
+
+
+def _aggregate_to_grain(
+    df: pl.DataFrame,
+    grain_columns: list[str],
+    aggregations: Union[dict[str, Union[str, pl.Expr]], None] = None,
+) -> pl.DataFrame:
+    """
+    Aggregate DataFrame to specified grain with type-based defaults.
+
+    Args:
+        df: DataFrame to aggregate
+        grain_columns: Columns that define the target grain
+        aggregations: Optional dict mapping column names to aggregation methods
+
+    Returns:
+        Aggregated DataFrame at the specified grain
+
+    Examples:
+        >>> df = pl.DataFrame({
+        ...     'sample_id': ['S1', 'S1', 'S2'],
+        ...     'quality': [0.9, 0.8, 0.95],
+        ...     'cell_type': ['T', 'B', 'T']
+        ... })
+        >>> result = _aggregate_to_grain(df, ['sample_id'])
+        >>> len(result) == 2  # Aggregated to sample level
+        True
+    """
+    # Initialize aggregations dict if not provided
+    if aggregations is None:
+        aggregations = {}
+
+    # Get columns to aggregate (exclude grain columns)
+    columns_to_agg = [col for col in df.columns if col not in grain_columns]
+
+    # Build aggregation expressions
+    agg_exprs = []
+
+    # Always add a count column to track number of rows aggregated
+    agg_exprs.append(pl.len().alias("n_rows"))
+
+    for col in columns_to_agg:
+        if col in aggregations:
+            # User-specified aggregation
+            user_agg = aggregations[col]
+
+            if isinstance(user_agg, str):
+                # String aggregation name (e.g., 'mean', 'sum', 'max')
+                agg_exprs.append(_build_agg_expr(col, user_agg))
+            elif isinstance(user_agg, pl.Expr):
+                # Polars expression
+                # Check if it already has an alias, if not add one
+                agg_exprs.append(user_agg)
+            else:
+                raise ValueError(
+                    f"Invalid aggregation type for column '{col}': {type(user_agg)}. "
+                    "Must be str or pl.Expr"
+                )
+        else:
+            # Infer aggregation from column type
+            agg_exprs.append(_infer_aggregation(df, col))
+
+    # Perform aggregation
+    result = df.group_by(grain_columns).agg(agg_exprs)
+
+    return result
+
+
+def _infer_aggregation(df: pl.DataFrame, column: str) -> pl.Expr:
+    """
+    Infer appropriate aggregation based on column dtype.
+
+    Default aggregation strategy:
+    - Numeric types (Int*, UInt*, Float*): mean
+    - String/Categorical: list (collect all values)
+    - Boolean: sum (count of True values)
+    - Other types: first (take first value)
+
+    Args:
+        df: DataFrame containing the column
+        column: Column name to infer aggregation for
+
+    Returns:
+        Polars aggregation expression with appropriate alias
+
+    Examples:
+        >>> df = pl.DataFrame({'value': [1.0, 2.0, 3.0]})
+        >>> expr = _infer_aggregation(df, 'value')
+        >>> # Returns: pl.col('value').mean().alias('value_mean')
+    """
+    dtype = df[column].dtype
+
+    # Numeric types → mean
+    if dtype in [
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+        pl.Float32,
+        pl.Float64,
+    ]:
+        return pl.col(column).mean().alias(f"{column}_mean")
+
+    # String/Categorical → list
+    elif dtype in [pl.Utf8, pl.Categorical, pl.String]:
+        return pl.col(column).implode().alias(f"{column}_list")
+
+    # Boolean → sum (count of True)
+    elif dtype == pl.Boolean:
+        return pl.col(column).sum().alias(f"{column}_sum")
+
+    # Default → first
+    else:
+        return pl.col(column).first().alias(f"{column}_first")
+
+
+def _build_agg_expr(column: str, agg_type: str) -> pl.Expr:
+    """
+    Build a Polars aggregation expression from a string aggregation type.
+
+    Args:
+        column: Column name to aggregate
+        agg_type: Aggregation type string ('mean', 'sum', 'max', 'min', 'first',
+                 'last', 'median', 'std', 'var', 'count', etc.)
+
+    Returns:
+        Polars aggregation expression with appropriate alias
+
+    Raises:
+        ValueError: If aggregation type is not recognized
+
+    Examples:
+        >>> expr = _build_agg_expr('quality', 'max')
+        >>> # Returns: pl.col('quality').max().alias('quality_max')
+    """
+    # Mapping of string names to Polars aggregation methods
+    agg_methods = {
+        "mean": lambda col: pl.col(col).mean(),
+        "sum": lambda col: pl.col(col).sum(),
+        "max": lambda col: pl.col(col).max(),
+        "min": lambda col: pl.col(col).min(),
+        "first": lambda col: pl.col(col).first(),
+        "last": lambda col: pl.col(col).last(),
+        "median": lambda col: pl.col(col).median(),
+        "std": lambda col: pl.col(col).std(),
+        "var": lambda col: pl.col(col).var(),
+        "count": lambda col: pl.col(col).count(),
+        "list": lambda col: pl.col(col).implode().alias(f"{col}_list"),
+        "n_unique": lambda col: pl.col(col).n_unique(),
+    }
+
+    if agg_type not in agg_methods:
+        raise ValueError(
+            f"Unknown aggregation type '{agg_type}'. "
+            f"Supported types: {', '.join(agg_methods.keys())}"
+        )
+
+    # Build expression with proper alias
+    expr = agg_methods[agg_type](column)
+
+    # Add alias if not already present
+    if not hasattr(expr, "meta"):
+        # If it's a simple aggregation without alias, add one
+        if agg_type != "list":  # list already has alias in the lambda
+            expr = expr.alias(f"{column}_{agg_type}")
+
+    return expr

--- a/depictio/tests/api/v1/test_grain_aware_joins.py
+++ b/depictio/tests/api/v1/test_grain_aware_joins.py
@@ -15,6 +15,7 @@ Key principles:
 
 import polars as pl
 import pytest
+from polars.exceptions import ColumnNotFoundError
 
 from depictio.api.v1.grain_aware_joins import (
     grain_aware_join,
@@ -183,14 +184,8 @@ class TestAggregationDirection:
         cell_type_col = [c for c in result.columns if "cell_type" in c][0]
 
         # S1 has 3 cells: ['T', 'T', 'B']
-        # Extract the list value properly from Polars
-        print(f"DEBUG: result columns = {result.columns}")
-        print(f"DEBUG: s1_row = {s1_row}")
-        print(f"DEBUG: cell_type_col = {cell_type_col}")
         row_dict = s1_row.row(0, named=True)
-        print(f"DEBUG: row_dict = {row_dict}")
         cell_types = row_dict[cell_type_col]
-        print(f"DEBUG: cell_types = {cell_types}, type = {type(cell_types)}")
         assert isinstance(cell_types, list)
         assert sorted(cell_types) == ["B", "T", "T"]
 
@@ -345,14 +340,14 @@ class TestEdgeCases:
 
     def test_missing_join_column_in_base(self, samples_df, qc_metrics_df):
         """Test error handling when join column missing in base DataFrame"""
-        with pytest.raises((KeyError, pl.ColumnNotFoundError)):
+        with pytest.raises((KeyError, ColumnNotFoundError)):
             grain_aware_join(samples_df, qc_metrics_df, on="nonexistent_column")
 
     def test_missing_join_column_in_other(self, samples_df):
         """Test error handling when join column missing in other DataFrame"""
         other_df = pl.DataFrame({"different_id": ["S1", "S2"], "value": [10, 20]})
 
-        with pytest.raises((KeyError, pl.ColumnNotFoundError)):
+        with pytest.raises((KeyError, ColumnNotFoundError)):
             grain_aware_join(samples_df, other_df, on="sample_id")
 
     def test_all_null_join_column(self):

--- a/depictio/tests/api/v1/test_grain_aware_joins.py
+++ b/depictio/tests/api/v1/test_grain_aware_joins.py
@@ -1,0 +1,427 @@
+"""
+Test suite for grain-aware join functionality using Polars.
+
+Following TDD approach:
+1. Write tests first
+2. Implement functions to pass tests
+3. Keep it simple (Polars-only, no DuckDB)
+
+Key principles:
+- Base DataFrame determines output grain
+- Automatic aggregation when needed
+- Sensible defaults with configuration overrides
+- No row explosion
+"""
+
+import polars as pl
+import pytest
+
+from depictio.api.v1.grain_aware_joins import (
+    grain_aware_join,
+    is_unique_grain,
+)
+
+# ============================================================================
+# Fixtures: Sample Data
+# ============================================================================
+
+
+@pytest.fixture
+def samples_df():
+    """Sample-level data (3 rows, grain: sample_id)"""
+    return pl.DataFrame(
+        {
+            "sample_id": ["S1", "S2", "S3"],
+            "tissue": ["liver", "brain", "liver"],
+            "age": [45, 62, 38],
+            "batch": ["B1", "B1", "B2"],
+        }
+    )
+
+
+@pytest.fixture
+def cells_df():
+    """Cell-level data (10 rows, grain: cell_id, multiple cells per sample)"""
+    return pl.DataFrame(
+        {
+            "cell_id": ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"],
+            "sample_id": ["S1", "S1", "S1", "S2", "S2", "S3", "S3", "S4", "S5", "S5"],
+            "quality": [0.92, 0.88, 0.95, 0.78, 0.85, 0.91, 0.87, 0.82, 0.96, 0.89],
+            "cell_type": ["T", "T", "B", "T", "B", "T", "T", "B", "T", "B"],
+            "is_dead": [False, False, False, True, False, False, False, True, False, False],
+        }
+    )
+
+
+@pytest.fixture
+def qc_metrics_df():
+    """QC metrics (3 rows, grain: sample_id)"""
+    return pl.DataFrame(
+        {
+            "sample_id": ["S1", "S2", "S3"],
+            "total_reads": [1_500_000, 2_100_000, 1_800_000],
+            "mapped_reads": [1_350_000, 1_890_000, 1_620_000],
+            "gc_content": [0.48, 0.52, 0.47],
+        }
+    )
+
+
+# ============================================================================
+# Tests: Grain Detection
+# ============================================================================
+
+
+class TestGrainDetection:
+    """Test is_unique_grain() functionality"""
+
+    def test_unique_single_column(self, samples_df):
+        """Test detection of unique grain with single column"""
+        assert is_unique_grain(samples_df, "sample_id") is True
+
+    def test_non_unique_single_column(self, cells_df):
+        """Test detection of non-unique column"""
+        # sample_id is not unique in cells_df (multiple cells per sample)
+        assert is_unique_grain(cells_df, "sample_id") is False
+
+    def test_unique_multi_column(self, cells_df):
+        """Test detection of unique grain with multiple columns"""
+        # cell_id alone should be unique
+        assert is_unique_grain(cells_df, "cell_id") is True
+
+    def test_unique_compound_key(self):
+        """Test compound key uniqueness detection"""
+        df = pl.DataFrame(
+            {
+                "sample_id": ["S1", "S1", "S2", "S2"],
+                "batch": ["B1", "B2", "B1", "B2"],
+                "value": [10, 20, 30, 40],
+            }
+        )
+        # Combination of sample_id + batch is unique
+        assert is_unique_grain(df, ["sample_id", "batch"]) is True
+        # But sample_id alone is not
+        assert is_unique_grain(df, "sample_id") is False
+
+    def test_empty_dataframe(self):
+        """Test grain detection on empty DataFrame"""
+        df = pl.DataFrame({"id": []})
+        # Empty DataFrame should be considered unique (vacuous truth)
+        assert is_unique_grain(df, "id") is True
+
+
+# ============================================================================
+# Tests: Simple Joins (Same Grain)
+# ============================================================================
+
+
+class TestSimpleJoins:
+    """Test joins between DataFrames with same grain"""
+
+    def test_same_grain_preserves_rows(self, samples_df, qc_metrics_df):
+        """Test that joining same-grain DataFrames preserves row count"""
+        result = grain_aware_join(samples_df, qc_metrics_df, on="sample_id")
+
+        # Should have same number of rows as base DataFrame
+        assert len(result) == len(samples_df)
+        # Should have columns from both DataFrames
+        assert "tissue" in result.columns
+        assert "total_reads" in result.columns
+
+    def test_same_grain_left_join(self, samples_df, qc_metrics_df):
+        """Test left join behavior with same grain"""
+        result = grain_aware_join(samples_df, qc_metrics_df, on="sample_id", how="left")
+
+        # All samples should be present
+        assert result["sample_id"].to_list() == ["S1", "S2", "S3"]
+
+    def test_same_grain_no_aggregation(self, samples_df, qc_metrics_df):
+        """Test that no aggregation occurs when grains match"""
+        result = grain_aware_join(samples_df, qc_metrics_df, on="sample_id")
+
+        # Values should be unchanged (not aggregated)
+        s1_row = result.filter(pl.col("sample_id") == "S1")
+        assert s1_row["total_reads"][0] == 1_500_000
+
+
+# ============================================================================
+# Tests: Aggregation Direction (Many → One)
+# ============================================================================
+
+
+class TestAggregationDirection:
+    """Test joins where df_other needs aggregation (many → one)"""
+
+    def test_aggregate_cells_to_samples(self, samples_df, cells_df):
+        """Test aggregating cell-level data to sample level"""
+        result = grain_aware_join(samples_df, cells_df, on="sample_id")
+
+        # Should have 3 rows (base DataFrame grain)
+        assert len(result) == 3
+
+        # Should have aggregated cell data
+        # Check that aggregated columns exist (with suffix/transformation)
+        assert any("quality" in col for col in result.columns)
+
+    def test_automatic_numeric_aggregation(self, samples_df, cells_df):
+        """Test that numeric columns are automatically averaged"""
+        result = grain_aware_join(samples_df, cells_df, on="sample_id")
+
+        # Quality should be aggregated (mean by default)
+        s1_row = result.filter(pl.col("sample_id") == "S1")
+        # S1 has 3 cells with quality [0.92, 0.88, 0.95]
+        expected_mean = (0.92 + 0.88 + 0.95) / 3
+        # Check for quality column (might be renamed to quality_mean)
+        quality_col = [c for c in result.columns if "quality" in c][0]
+        assert abs(s1_row[quality_col][0] - expected_mean) < 0.01
+
+    def test_automatic_string_aggregation(self, samples_df, cells_df):
+        """Test that string columns are aggregated as lists"""
+        result = grain_aware_join(samples_df, cells_df, on="sample_id")
+
+        # cell_type should be aggregated as list
+        s1_row = result.filter(pl.col("sample_id") == "S1")
+        cell_type_col = [c for c in result.columns if "cell_type" in c][0]
+
+        # S1 has 3 cells: ['T', 'T', 'B']
+        # Extract the list value properly from Polars
+        print(f"DEBUG: result columns = {result.columns}")
+        print(f"DEBUG: s1_row = {s1_row}")
+        print(f"DEBUG: cell_type_col = {cell_type_col}")
+        row_dict = s1_row.row(0, named=True)
+        print(f"DEBUG: row_dict = {row_dict}")
+        cell_types = row_dict[cell_type_col]
+        print(f"DEBUG: cell_types = {cell_types}, type = {type(cell_types)}")
+        assert isinstance(cell_types, list)
+        assert sorted(cell_types) == ["B", "T", "T"]
+
+    def test_automatic_boolean_aggregation(self, samples_df, cells_df):
+        """Test that boolean columns are aggregated as sum (count of True)"""
+        result = grain_aware_join(samples_df, cells_df, on="sample_id")
+
+        # is_dead should be counted
+        s2_row = result.filter(pl.col("sample_id") == "S2")
+        dead_col = [c for c in result.columns if "is_dead" in c][0]
+
+        # S2 has 2 cells: [True, False] → count should be 1
+        assert s2_row[dead_col][0] == 1
+
+    def test_row_count_column_added(self, samples_df, cells_df):
+        """Test that row count is automatically added during aggregation"""
+        result = grain_aware_join(samples_df, cells_df, on="sample_id")
+
+        # Should have a count column (e.g., n_cells or count)
+        count_cols = [c for c in result.columns if "count" in c.lower() or c.startswith("n_")]
+        assert len(count_cols) > 0
+
+        # S1 should have 3 cells
+        s1_row = result.filter(pl.col("sample_id") == "S1")
+        # Find the count column and verify
+        count_col = count_cols[0]
+        assert s1_row[count_col][0] == 3
+
+
+# ============================================================================
+# Tests: Broadcast Direction (One → Many)
+# ============================================================================
+
+
+class TestBroadcastDirection:
+    """Test joins where sample data is broadcast to cells (one → many)"""
+
+    def test_broadcast_samples_to_cells(self, cells_df, samples_df):
+        """Test broadcasting sample-level data to all cells"""
+        result = grain_aware_join(cells_df, samples_df, on="sample_id")
+
+        # Should have 10 rows (base DataFrame grain = cells)
+        assert len(result) == 10
+
+        # Should have both cell and sample columns
+        assert "cell_id" in result.columns
+        assert "tissue" in result.columns
+
+    def test_broadcast_no_aggregation(self, cells_df, samples_df):
+        """Test that sample data is not aggregated when broadcasting"""
+        result = grain_aware_join(cells_df, samples_df, on="sample_id")
+
+        # Sample values should be duplicated, not aggregated
+        c1_row = result.filter(pl.col("cell_id") == "C1")
+        # C1 belongs to S1, which has age=45
+        assert c1_row["age"][0] == 45
+
+        # All cells from S1 should have same sample data
+        s1_cells = result.filter(pl.col("sample_id") == "S1")
+        assert all(s1_cells["age"] == 45)
+        assert all(s1_cells["tissue"] == "liver")
+
+    def test_broadcast_no_row_explosion(self, cells_df, samples_df):
+        """Test that broadcasting doesn't cause row explosion"""
+        result = grain_aware_join(cells_df, samples_df, on="sample_id")
+
+        # Should have exactly the same number of rows as cells
+        assert len(result) == len(cells_df)
+
+        # Each cell should appear exactly once
+        assert result["cell_id"].is_unique().all()
+
+
+# ============================================================================
+# Tests: Custom Aggregations
+# ============================================================================
+
+
+class TestCustomAggregations:
+    """Test user-specified aggregation overrides"""
+
+    def test_custom_aggregation_override(self, samples_df, cells_df):
+        """Test that user can specify custom aggregations"""
+        custom_aggs = {
+            "quality": "max",  # Override default mean with max
+            "cell_type": "first",  # Override default list with first
+        }
+
+        result = grain_aware_join(samples_df, cells_df, on="sample_id", aggregations=custom_aggs)
+
+        # S1 has quality [0.92, 0.88, 0.95] → max should be 0.95
+        s1_row = result.filter(pl.col("sample_id") == "S1")
+        quality_col = [c for c in result.columns if "quality" in c][0]
+        assert s1_row[quality_col][0] == 0.95
+
+    def test_custom_aggregation_with_polars_expr(self, samples_df, cells_df):
+        """Test custom aggregation using Polars expressions"""
+        custom_aggs = {
+            "quality": pl.col("quality").median(),  # Use Polars expression
+        }
+
+        result = grain_aware_join(samples_df, cells_df, on="sample_id", aggregations=custom_aggs)
+
+        # Should use median instead of mean
+        s1_row = result.filter(pl.col("sample_id") == "S1")
+        # S1 has quality [0.92, 0.88, 0.95] → median should be 0.92
+        quality_col = [c for c in result.columns if "quality" in c][0]
+        assert s1_row[quality_col][0] == 0.92
+
+    def test_mixed_default_and_custom_aggregations(self, samples_df, cells_df):
+        """Test that custom aggregations can be mixed with defaults"""
+        custom_aggs = {
+            "quality": "max",  # Custom
+            # cell_type and is_dead should use defaults
+        }
+
+        result = grain_aware_join(samples_df, cells_df, on="sample_id", aggregations=custom_aggs)
+
+        # quality should use custom max
+        s1_row = result.filter(pl.col("sample_id") == "S1")
+        quality_col = [c for c in result.columns if "quality" in c][0]
+        assert s1_row[quality_col][0] == 0.95
+
+        # cell_type should still use default list
+        cell_type_col = [c for c in result.columns if "cell_type" in c][0]
+        assert isinstance(s1_row.select(cell_type_col).row(0)[0], list)
+
+
+# ============================================================================
+# Tests: Edge Cases
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+
+    def test_empty_base_dataframe(self, qc_metrics_df):
+        """Test joining with empty base DataFrame"""
+        empty_df = pl.DataFrame({"sample_id": [], "tissue": []})
+        result = grain_aware_join(empty_df, qc_metrics_df, on="sample_id")
+
+        # Result should be empty
+        assert len(result) == 0
+
+    def test_empty_other_dataframe(self, samples_df):
+        """Test joining with empty other DataFrame"""
+        empty_df = pl.DataFrame({"sample_id": [], "value": []})
+        result = grain_aware_join(samples_df, empty_df, on="sample_id")
+
+        # Should still have base DataFrame rows
+        assert len(result) == len(samples_df)
+
+    def test_missing_join_column_in_base(self, samples_df, qc_metrics_df):
+        """Test error handling when join column missing in base DataFrame"""
+        with pytest.raises((KeyError, pl.ColumnNotFoundError)):
+            grain_aware_join(samples_df, qc_metrics_df, on="nonexistent_column")
+
+    def test_missing_join_column_in_other(self, samples_df):
+        """Test error handling when join column missing in other DataFrame"""
+        other_df = pl.DataFrame({"different_id": ["S1", "S2"], "value": [10, 20]})
+
+        with pytest.raises((KeyError, pl.ColumnNotFoundError)):
+            grain_aware_join(samples_df, other_df, on="sample_id")
+
+    def test_all_null_join_column(self):
+        """Test handling of all-null join column"""
+        df1 = pl.DataFrame({"id": [None, None, None], "value": [1, 2, 3]})
+        df2 = pl.DataFrame({"id": [None, None], "other": [10, 20]})
+
+        result = grain_aware_join(df1, df2, on="id")
+        # Should handle nulls gracefully (Polars join behavior)
+        assert len(result) >= 0  # Non-negative rows
+
+
+# ============================================================================
+# Tests: Multi-Column Grain
+# ============================================================================
+
+
+class TestMultiColumnGrain:
+    """Test joins on compound keys (multiple columns)"""
+
+    def test_multi_column_grain_join(self):
+        """Test joining on multiple columns"""
+        df1 = pl.DataFrame(
+            {
+                "sample_id": ["S1", "S1", "S2", "S2"],
+                "batch": ["B1", "B2", "B1", "B2"],
+                "value": [10, 20, 30, 40],
+            }
+        )
+
+        df2 = pl.DataFrame(
+            {
+                "sample_id": ["S1", "S1", "S2"],
+                "batch": ["B1", "B2", "B1"],
+                "qc_score": [0.9, 0.8, 0.95],
+            }
+        )
+
+        result = grain_aware_join(df1, df2, on=["sample_id", "batch"])
+
+        # Should join on both columns
+        assert len(result) == 4
+        assert "qc_score" in result.columns
+
+    def test_multi_column_grain_with_aggregation(self):
+        """Test multi-column grain where aggregation is needed"""
+        # Base with sample+batch grain
+        df_base = pl.DataFrame(
+            {
+                "sample_id": ["S1", "S1", "S2"],
+                "batch": ["B1", "B2", "B1"],
+                "tissue": ["liver", "liver", "brain"],
+            }
+        )
+
+        # Other has finer grain (sample+batch+replicate)
+        df_other = pl.DataFrame(
+            {
+                "sample_id": ["S1", "S1", "S1", "S1"],
+                "batch": ["B1", "B1", "B2", "B2"],
+                "replicate": [1, 2, 1, 2],
+                "reads": [1000, 1100, 900, 950],
+            }
+        )
+
+        result = grain_aware_join(df_base, df_other, on=["sample_id", "batch"])
+
+        # Should aggregate replicates
+        assert len(result) == 3
+        # reads should be aggregated
+        reads_col = [c for c in result.columns if "reads" in c][0]
+        assert reads_col in result.columns


### PR DESCRIPTION
## Summary
Pure-Polars utility (`depictio/api/v1/grain_aware_joins.py`) that joins two frames while auto-detecting **grain**: the base frame sets output grain and the other side is aggregated (many→one) or broadcast (one→many), preventing accidental cartesian **row explosion**. Salvaged from a ~6-month-old `layout-revision` stash and brought up to current Polars. Closes #876 once wired in.

## Why
`join_deltatables_dev()` (`deltatables_utils.py`) does a naive `df1.join(df2, on=common, how=...)` with **no grain handling** — different-grain DCs (e.g. samples ↔ cells) can explode rows and break aggregation.

## What
- `grain_aware_join(df_base, df_other, on=...)`, `is_unique_grain()`, type-based aggregation inference.
- 26 tests (`test_grain_aware_joins.py`).

## Brought back to green (was bit-rotted vs current Polars)
- [x] String-list default no longer double-wraps via `.implode()` (group_by().agg() already collects to a per-group list).
- [x] Join-column dtypes aligned before join → empty inputs (Null-typed) & mismatched key types no longer raise `SchemaError`.
- [x] `how` typed as a Polars `JoinStrategy` Literal — **ty clean**.
- [x] `ColumnNotFoundError` imported from `polars.exceptions`; test debug prints removed.
- [x] ruff format + lint clean.
- [ ] **Integration** — wire into `join_deltatables_dev` (the real value-add; tracked in #876). Kept draft until then.

## Test
`pytest depictio/tests/api/v1/test_grain_aware_joins.py` → **26 passed**. ruff + ty clean.