### PR TITLE
prototype: standalone LiteLLM/LangChain AI dashboard (dev/)

### DIFF
--- a/dev/litellm-prototype/.env.example
+++ b/dev/litellm-prototype/.env.example
@@ -1,9 +1,13 @@
 # LiteLLM model string — provider is inferred from the prefix
 # See: https://docs.litellm.ai/docs/providers
-LLM_MODEL=anthropic/claude-sonnet-4-20250514
 
-# Provider API keys — set the one matching your model
-ANTHROPIC_API_KEY=sk-ant-...
+# OpenRouter (recommended — single key for all models)
+LLM_MODEL=openrouter/anthropic/claude-sonnet-4-6
+OPENROUTER_API_KEY=sk-or-...
+
+# Anthropic direct
+# LLM_MODEL=anthropic/claude-sonnet-4-6
+# ANTHROPIC_API_KEY=sk-ant-...
 
 # OpenAI
 # LLM_MODEL=gpt-4o

--- a/dev/litellm-prototype/.env.example
+++ b/dev/litellm-prototype/.env.example
@@ -1,0 +1,22 @@
+# LiteLLM model string — provider is inferred from the prefix
+# See: https://docs.litellm.ai/docs/providers
+LLM_MODEL=anthropic/claude-sonnet-4-20250514
+
+# Provider API keys — set the one matching your model
+ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI
+# LLM_MODEL=gpt-4o
+# OPENAI_API_KEY=sk-...
+
+# Google Gemini
+# LLM_MODEL=gemini/gemini-2.0-flash
+# GEMINI_API_KEY=...
+
+# Ollama (local, no key needed)
+# LLM_MODEL=ollama/llama3
+
+# Azure OpenAI
+# LLM_MODEL=azure/gpt-4
+# AZURE_API_KEY=...
+# AZURE_API_BASE=https://your-resource.openai.azure.com

--- a/dev/litellm-prototype/README.md
+++ b/dev/litellm-prototype/README.md
@@ -1,0 +1,14 @@
+# LiteLLM AI Dashboard Prototype
+
+Provider-agnostic AI-assisted dashboard with Dash + DMC 2.0.
+
+## Quick Start
+
+```bash
+cd dev/litellm-prototype
+cp .env.example .env        # add your API key
+uv sync                     # install deps
+uv run python app.py        # http://localhost:8050
+```
+
+Set `LLM_MODEL` in `.env` to any provider: `anthropic/claude-sonnet-4-20250514`, `gpt-4o`, `ollama/llama3`, etc.

--- a/dev/litellm-prototype/app.py
+++ b/dev/litellm-prototype/app.py
@@ -13,7 +13,7 @@ import traceback
 import dash_mantine_components as dmc
 import pandas as pd
 import plotly.express as px
-from dash import Dash, Input, Output, State, callback, ctx, dcc, html, no_update
+from dash import ClientsideFunction, Dash, Input, Output, State, callback, ctx, dcc, html, no_update
 from dash_iconify import DashIconify
 
 import llm_client
@@ -190,6 +190,8 @@ app.layout = dmc.MantineProvider(
                             ),
                             # Dynamic AI-generated figures area
                             html.Div(id="ai-generated-figures"),
+                            # Hidden div for step filter clientside callback
+                            html.Div(id="step-filter-output", style={"display": "none"}),
                         ],
                         gap="lg",
                         pt="md",
@@ -203,6 +205,17 @@ app.layout = dmc.MantineProvider(
         padding="md",
     ),
     forceColorScheme="light",
+)
+
+
+# ---------------------------------------------------------------------------
+# Clientside callback: filter execution trace steps
+# ---------------------------------------------------------------------------
+app.clientside_callback(
+    ClientsideFunction(namespace="step_filter", function_name="filter_steps"),
+    Output("step-filter-output", "children"),
+    Input("analysis-step-filter", "value"),
+    prevent_initial_call=True,
 )
 
 
@@ -403,8 +416,8 @@ def run_ai_analysis(n_clicks, user_prompt, dataset_key):
         # LangChain pandas agent — writes + executes real pandas code
         result = llm_client.analyze_data(user_prompt, df)
 
-        # Render answer + collapsible execution trace
-        return render_execution_trace(result)
+        # Render answer + collapsible execution trace with column highlighting
+        return render_execution_trace(result, columns=list(df.columns))
 
     except Exception as e:
         logging.error("AI analysis failed: %s", traceback.format_exc())

--- a/dev/litellm-prototype/app.py
+++ b/dev/litellm-prototype/app.py
@@ -1,0 +1,465 @@
+"""AI Dashboard Prototype — LiteLLM + Dash + DMC 2.0.
+
+Run: python app.py
+Requires: .env file with LLM_MODEL and provider API key (see .env.example)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import traceback
+
+import dash_mantine_components as dmc
+import pandas as pd
+import plotly.express as px
+from dash import Dash, Input, Output, State, callback, ctx, dcc, html, no_update
+from dash_iconify import DashIconify
+
+import llm_client
+from components.ai_panel import create_ai_component_creator, create_ai_data_analyst
+from components.cards import create_stat_card
+from components.figures import create_figure
+from components.interactive import create_multiselect, create_range_slider, create_select
+from components.tables import create_table
+from sample_data import DATASETS, get_column_metadata
+
+logging.basicConfig(level=logging.INFO)
+
+# ---------------------------------------------------------------------------
+# App init
+# ---------------------------------------------------------------------------
+app = Dash(
+    __name__,
+    external_stylesheets=dmc.styles.ALL,
+    suppress_callback_exceptions=True,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset configs — defines default cards, figures, and filters per dataset
+# ---------------------------------------------------------------------------
+DATASET_CONFIGS = {
+    "iris": {
+        "cards": [
+            {"title": "Total Samples", "col": None, "agg": "count", "icon": "mdi:flower", "color": "#7c3aed"},
+            {"title": "Avg Sepal Length", "col": "sepal_length", "agg": "mean", "icon": "mdi:ruler", "color": "#2563eb"},
+            {"title": "Avg Petal Width", "col": "petal_width", "agg": "mean", "icon": "mdi:leaf", "color": "#059669"},
+            {"title": "Varieties", "col": "variety", "agg": "nunique", "icon": "mdi:tag-multiple", "color": "#d97706"},
+        ],
+        "figures": [
+            {"visu_type": "scatter", "kwargs": {"x": "sepal_length", "y": "sepal_width", "color": "variety"}, "title": "Sepal: Length vs Width"},
+            {"visu_type": "histogram", "kwargs": {"x": "petal_length", "color": "variety"}, "title": "Petal Length Distribution"},
+        ],
+        "filters": {
+            "select": {"col": "variety", "label": "Variety"},
+            "range": {"col": "sepal_length", "label": "Sepal Length"},
+            "multiselect": {"col": "variety", "label": "Include Varieties"},
+        },
+    },
+    "genomics_qc": {
+        "cards": [
+            {"title": "Total Samples", "col": None, "agg": "count", "icon": "mdi:dna", "color": "#7c3aed"},
+            {"title": "Avg Mapping Rate", "col": "mapping_rate", "agg": "mean", "icon": "mdi:target", "color": "#2563eb"},
+            {"title": "Avg Duplication", "col": "duplication_rate", "agg": "mean", "icon": "mdi:content-copy", "color": "#dc2626"},
+            {"title": "Pass Rate", "col": "status", "agg": "pass_rate", "icon": "mdi:check-circle", "color": "#059669"},
+        ],
+        "figures": [
+            {"visu_type": "scatter", "kwargs": {"x": "mapping_rate", "y": "duplication_rate", "color": "status"}, "title": "Mapping vs Duplication"},
+            {"visu_type": "histogram", "kwargs": {"x": "gc_content", "color": "library_type"}, "title": "GC Content Distribution"},
+        ],
+        "filters": {
+            "select": {"col": "library_type", "label": "Library Type"},
+            "range": {"col": "mapping_rate", "label": "Mapping Rate (%)"},
+            "multiselect": {"col": "status", "label": "Include Statuses"},
+        },
+    },
+}
+
+
+def compute_card_value(df: pd.DataFrame, col: str | None, agg: str) -> str:
+    """Compute a metric value for a stat card."""
+    if agg == "count":
+        return f"{len(df):,}"
+    if agg == "nunique":
+        return str(df[col].nunique())
+    if agg == "pass_rate":
+        rate = (df[col] == "PASS").mean() * 100
+        return f"{rate:.1f}%"
+    val = getattr(df[col], agg)()
+    return f"{val:,.2f}"
+
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+app.layout = dmc.MantineProvider(
+    dmc.AppShell(
+        [
+            # Header
+            dmc.AppShellHeader(
+                dmc.Group(
+                    [
+                        dmc.Group(
+                            [
+                                DashIconify(icon="mdi:robot-happy", width=28, color="violet"),
+                                dmc.Text("AI Dashboard Prototype", size="xl", fw=700),
+                            ],
+                            gap="xs",
+                        ),
+                        dmc.Group(
+                            [
+                                dmc.Text("Dataset:", size="sm", fw=500),
+                                dmc.Select(
+                                    id="dataset-selector",
+                                    data=[{"label": v["label"], "value": k} for k, v in DATASETS.items()],
+                                    value="iris",
+                                    w=200,
+                                    size="sm",
+                                ),
+                                dmc.Badge(
+                                    f"LLM: {llm_client.get_model()}",
+                                    variant="outline",
+                                    color="violet",
+                                    size="lg",
+                                ),
+                            ],
+                            gap="sm",
+                        ),
+                    ],
+                    justify="space-between",
+                    h="100%",
+                    px="md",
+                ),
+                h=60,
+            ),
+            # Main content
+            dmc.AppShellMain(
+                dmc.Container(
+                    dmc.Stack(
+                        [
+                            # Metric Cards row
+                            dmc.SimpleGrid(id="cards-row", cols=4, spacing="md"),
+                            # Figures row
+                            dmc.SimpleGrid(id="figures-row", cols=2, spacing="md"),
+                            # Filters row
+                            dmc.Paper(
+                                dmc.Group(
+                                    [
+                                        dmc.Group(
+                                            [
+                                                DashIconify(icon="mdi:filter-variant", width=20),
+                                                dmc.Text("Filters", size="md", fw=600),
+                                            ],
+                                            gap="xs",
+                                        ),
+                                        html.Div(id="filters-row", style={"display": "flex", "gap": "1rem", "flex": 1, "alignItems": "flex-end"}),
+                                    ],
+                                    gap="md",
+                                    align="flex-end",
+                                ),
+                                withBorder=True,
+                                radius="md",
+                                p="md",
+                            ),
+                            # Table
+                            html.Div(id="table-container"),
+                            # AI section header
+                            dmc.Divider(
+                                label=dmc.Group(
+                                    [
+                                        DashIconify(icon="mdi:robot", width=20),
+                                        dmc.Text("AI Assistant", fw=600),
+                                    ],
+                                    gap="xs",
+                                ),
+                                labelPosition="center",
+                                size="sm",
+                            ),
+                            # AI panels
+                            dmc.SimpleGrid(
+                                [
+                                    create_ai_component_creator(),
+                                    create_ai_data_analyst(),
+                                ],
+                                cols=2,
+                                spacing="md",
+                            ),
+                            # Dynamic AI-generated figures area
+                            html.Div(id="ai-generated-figures"),
+                        ],
+                        gap="lg",
+                        pt="md",
+                    ),
+                    size="xl",
+                    py="md",
+                ),
+            ),
+        ],
+        header={"height": 60},
+        padding="md",
+    ),
+    forceColorScheme="light",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: load dataset
+# ---------------------------------------------------------------------------
+def load_dataset(dataset_key: str) -> pd.DataFrame:
+    return DATASETS[dataset_key]["loader"]()
+
+
+# ---------------------------------------------------------------------------
+# Callback: dataset change → rebuild cards, figures, filters, table
+# ---------------------------------------------------------------------------
+@callback(
+    Output("cards-row", "children"),
+    Output("figures-row", "children"),
+    Output("filters-row", "children"),
+    Output("table-container", "children"),
+    Input("dataset-selector", "value"),
+)
+def update_dashboard(dataset_key):
+    df = load_dataset(dataset_key)
+    config = DATASET_CONFIGS[dataset_key]
+
+    # Cards
+    cards = []
+    for c in config["cards"]:
+        val = compute_card_value(df, c["col"], c["agg"])
+        cards.append(create_stat_card(c["title"], val, c["icon"], c["color"]))
+
+    # Figures
+    figures = []
+    for f in config["figures"]:
+        figures.append(create_figure(df, f["visu_type"], f["kwargs"], title=f["title"]))
+
+    # Filters
+    fc = config["filters"]
+    select_col = fc["select"]["col"]
+    range_col = fc["range"]["col"]
+    multi_col = fc["multiselect"]["col"]
+
+    filters = [
+        create_select("filter-select", fc["select"]["label"], df[select_col].unique().tolist()),
+        html.Div(
+            create_range_slider("filter-range", fc["range"]["label"], float(df[range_col].min()), float(df[range_col].max())),
+            style={"flex": 1},
+        ),
+        create_multiselect("filter-multiselect", fc["multiselect"]["label"], df[multi_col].unique().tolist()),
+    ]
+
+    # Table
+    table = create_table(df, "data-table")
+
+    return cards, figures, filters, table
+
+
+# ---------------------------------------------------------------------------
+# Callback: filters → update figures + table
+# ---------------------------------------------------------------------------
+@callback(
+    Output("figures-row", "children", allow_duplicate=True),
+    Output("table-container", "children", allow_duplicate=True),
+    Input("filter-select", "value"),
+    Input("filter-range", "value"),
+    Input("filter-multiselect", "value"),
+    State("dataset-selector", "value"),
+    prevent_initial_call=True,
+)
+def apply_filters(select_val, range_val, multi_val, dataset_key):
+    df = load_dataset(dataset_key)
+    config = DATASET_CONFIGS[dataset_key]
+    fc = config["filters"]
+
+    # Apply select filter
+    if select_val:
+        df = df[df[fc["select"]["col"]] == select_val]
+
+    # Apply range filter
+    if range_val and len(range_val) == 2:
+        col = fc["range"]["col"]
+        df = df[(df[col] >= range_val[0]) & (df[col] <= range_val[1])]
+
+    # Apply multiselect filter
+    if multi_val:
+        df = df[df[fc["multiselect"]["col"]].isin(multi_val)]
+
+    # Rebuild figures
+    figures = []
+    for f in config["figures"]:
+        figures.append(create_figure(df, f["visu_type"], f["kwargs"], title=f["title"]))
+
+    # Rebuild table
+    table = create_table(df, "data-table")
+
+    return figures, table
+
+
+# ---------------------------------------------------------------------------
+# Callback: AI Component Creator — Generate
+# ---------------------------------------------------------------------------
+@callback(
+    Output("ai-plot-preview", "children"),
+    Output("ai-plot-suggestion-store", "data"),
+    Output("ai-plot-add-btn", "disabled"),
+    Input("ai-plot-generate-btn", "n_clicks"),
+    State("ai-plot-input", "value"),
+    State("dataset-selector", "value"),
+    prevent_initial_call=True,
+)
+def generate_ai_plot(n_clicks, user_prompt, dataset_key):
+    if not user_prompt:
+        return dmc.Alert("Please describe a visualization.", color="yellow"), None, True
+
+    try:
+        df = load_dataset(dataset_key)
+        metadata = get_column_metadata(df)
+        suggestion = llm_client.suggest_plot(user_prompt, metadata)
+
+        # Render preview
+        fig = create_figure(df, suggestion.visu_type, suggestion.dict_kwargs, title=suggestion.title, graph_id="ai-preview-graph")
+
+        preview = dmc.Stack(
+            [
+                fig,
+                dmc.Alert(
+                    children=dmc.Stack(
+                        [
+                            dmc.Text(f"Type: {suggestion.visu_type}", size="sm"),
+                            dmc.Text(f"Config: {json.dumps(suggestion.dict_kwargs)}", size="sm", ff="monospace"),
+                            dmc.Text(suggestion.explanation, size="sm", c="dimmed"),
+                        ],
+                        gap=4,
+                    ),
+                    title="Generated Configuration",
+                    color="violet",
+                    variant="light",
+                ),
+            ],
+            gap="sm",
+        )
+
+        return preview, suggestion.model_dump(), False
+
+    except Exception as e:
+        logging.error("AI plot generation failed: %s", traceback.format_exc())
+        return dmc.Alert(f"Error: {e}", color="red", title="Generation Failed"), None, True
+
+
+# ---------------------------------------------------------------------------
+# Callback: AI Component Creator — Add to Dashboard
+# ---------------------------------------------------------------------------
+@callback(
+    Output("ai-generated-figures", "children"),
+    Input("ai-plot-add-btn", "n_clicks"),
+    State("ai-plot-suggestion-store", "data"),
+    State("dataset-selector", "value"),
+    State("ai-generated-figures", "children"),
+    prevent_initial_call=True,
+)
+def add_ai_plot_to_dashboard(n_clicks, suggestion_data, dataset_key, existing_children):
+    if not suggestion_data:
+        return no_update
+
+    df = load_dataset(dataset_key)
+    fig = create_figure(
+        df,
+        suggestion_data["visu_type"],
+        suggestion_data["dict_kwargs"],
+        title=f"[AI] {suggestion_data['title']}",
+        graph_id=f"ai-added-{n_clicks}",
+    )
+
+    children = existing_children or []
+    if not isinstance(children, list):
+        children = [children]
+    children.append(fig)
+
+    return children
+
+
+# ---------------------------------------------------------------------------
+# Callback: AI Data Analyst — Analyze
+# ---------------------------------------------------------------------------
+@callback(
+    Output("ai-analysis-results", "children"),
+    Input("ai-analysis-btn", "n_clicks"),
+    State("ai-analysis-input", "value"),
+    State("dataset-selector", "value"),
+    prevent_initial_call=True,
+)
+def run_ai_analysis(n_clicks, user_prompt, dataset_key):
+    if not user_prompt:
+        return dmc.Alert("Please ask a question about the data.", color="yellow")
+
+    try:
+        df = load_dataset(dataset_key)
+        metadata = get_column_metadata(df)
+        sample_rows = df.head(5).to_string(index=False)
+
+        result = llm_client.analyze_data(user_prompt, metadata, sample_rows)
+
+        # Build results display
+        findings_list = dmc.List(
+            [dmc.ListItem(f) for f in result.key_findings],
+            size="sm",
+            spacing="xs",
+        )
+
+        results = dmc.Stack(
+            [
+                dmc.Alert(
+                    children=dmc.Text(result.summary, size="sm"),
+                    title="Summary",
+                    color="teal",
+                    variant="light",
+                ),
+                dmc.Paper(
+                    dmc.Stack(
+                        [
+                            dmc.Text("Key Findings", size="md", fw=600),
+                            findings_list,
+                        ],
+                        gap="xs",
+                    ),
+                    withBorder=True,
+                    p="md",
+                    radius="md",
+                ),
+            ],
+            gap="sm",
+        )
+
+        # Add suggested plots if any
+        if result.suggested_plots:
+            plot_previews = []
+            for i, sp in enumerate(result.suggested_plots[:3]):  # max 3
+                try:
+                    plot_previews.append(
+                        create_figure(df, sp.visu_type, sp.dict_kwargs, title=sp.title, graph_id=f"analysis-plot-{i}")
+                    )
+                except Exception:
+                    pass
+
+            if plot_previews:
+                results.children.append(
+                    dmc.Stack(
+                        [dmc.Text("Suggested Visualizations", size="md", fw=600)]
+                        + plot_previews,
+                        gap="sm",
+                    )
+                )
+
+        return results
+
+    except Exception as e:
+        logging.error("AI analysis failed: %s", traceback.format_exc())
+        return dmc.Alert(f"Error: {e}", color="red", title="Analysis Failed")
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    app.run(debug=True, port=8050)

--- a/dev/litellm-prototype/app.py
+++ b/dev/litellm-prototype/app.py
@@ -17,12 +17,12 @@ from dash import Dash, Input, Output, State, callback, ctx, dcc, html, no_update
 from dash_iconify import DashIconify
 
 import llm_client
-from components.ai_panel import create_ai_component_creator, create_ai_data_analyst
+from components.ai_panel import create_ai_component_creator, create_ai_data_analyst, render_execution_trace
 from components.cards import create_stat_card
 from components.figures import create_figure
 from components.interactive import create_multiselect, create_range_slider, create_select
 from components.tables import create_table
-from sample_data import DATASETS, compute_data_profile, get_column_metadata
+from sample_data import DATASETS, get_column_metadata
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -399,63 +399,12 @@ def run_ai_analysis(n_clicks, user_prompt, dataset_key):
 
     try:
         df = load_dataset(dataset_key)
-        metadata = get_column_metadata(df)
-        data_profile = compute_data_profile(df)
 
-        result = llm_client.analyze_data(user_prompt, metadata, data_profile)
+        # LangChain pandas agent — writes + executes real pandas code
+        result = llm_client.analyze_data(user_prompt, df)
 
-        # Build results display
-        findings_list = dmc.List(
-            [dmc.ListItem(f) for f in result.key_findings],
-            size="sm",
-            spacing="xs",
-        )
-
-        results = dmc.Stack(
-            [
-                dmc.Alert(
-                    children=dmc.Text(result.summary, size="sm"),
-                    title="Summary",
-                    color="teal",
-                    variant="light",
-                ),
-                dmc.Paper(
-                    dmc.Stack(
-                        [
-                            dmc.Text("Key Findings", size="md", fw=600),
-                            findings_list,
-                        ],
-                        gap="xs",
-                    ),
-                    withBorder=True,
-                    p="md",
-                    radius="md",
-                ),
-            ],
-            gap="sm",
-        )
-
-        # Add suggested plots if any
-        if result.suggested_plots:
-            plot_previews = []
-            for i, sp in enumerate(result.suggested_plots[:3]):  # max 3
-                try:
-                    plot_previews.append(
-                        create_figure(df, sp.visu_type, sp.dict_kwargs, title=sp.title, graph_id=f"analysis-plot-{i}")
-                    )
-                except Exception:
-                    pass
-
-            if plot_previews:
-                results.children.append(
-                    dmc.Stack(
-                        [dmc.Text("Suggested Visualizations", size="md", fw=600)]
-                        + plot_previews,
-                        gap="sm",
-                    )
-                )
-
-        return results
+        # Render answer + collapsible execution trace
+        return render_execution_trace(result)
 
     except Exception as e:
         logging.error("AI analysis failed: %s", traceback.format_exc())

--- a/dev/litellm-prototype/app.py
+++ b/dev/litellm-prototype/app.py
@@ -22,7 +22,7 @@ from components.cards import create_stat_card
 from components.figures import create_figure
 from components.interactive import create_multiselect, create_range_slider, create_select
 from components.tables import create_table
-from sample_data import DATASETS, get_column_metadata
+from sample_data import DATASETS, compute_data_profile, get_column_metadata
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -400,9 +400,9 @@ def run_ai_analysis(n_clicks, user_prompt, dataset_key):
     try:
         df = load_dataset(dataset_key)
         metadata = get_column_metadata(df)
-        sample_rows = df.head(5).to_string(index=False)
+        data_profile = compute_data_profile(df)
 
-        result = llm_client.analyze_data(user_prompt, metadata, sample_rows)
+        result = llm_client.analyze_data(user_prompt, metadata, data_profile)
 
         # Build results display
         findings_list = dmc.List(

--- a/dev/litellm-prototype/app.py
+++ b/dev/litellm-prototype/app.py
@@ -24,7 +24,11 @@ from components.interactive import create_multiselect, create_range_slider, crea
 from components.tables import create_table
 from sample_data import DATASETS, get_column_metadata
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(name)-12s %(levelname)-5s %(message)s",
+    datefmt="%H:%M:%S",
+)
 
 # ---------------------------------------------------------------------------
 # App init

--- a/dev/litellm-prototype/assets/step_filter.js
+++ b/dev/litellm-prototype/assets/step_filter.js
@@ -1,0 +1,26 @@
+/**
+ * Clientside callback: filter execution trace steps by status.
+ * Listens to the chip-group value and hides/shows accordion items.
+ */
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+    step_filter: {
+        filter_steps: function(filterValue) {
+            // Small delay to let DOM render
+            setTimeout(function() {
+                var items = document.querySelectorAll('[data-step-status]');
+                items.forEach(function(item) {
+                    var status = item.getAttribute('data-step-status');
+                    if (filterValue === 'all') {
+                        item.style.display = '';
+                    } else if (filterValue === 'errors') {
+                        item.style.display = (status === 'error' || status === 'warning') ? '' : 'none';
+                    } else if (filterValue === 'code') {
+                        item.style.display = (status === 'success') ? '' : 'none';
+                    }
+                });
+            }, 50);
+            // Return empty div (no-op output)
+            return '';
+        }
+    }
+});

--- a/dev/litellm-prototype/components/__init__.py
+++ b/dev/litellm-prototype/components/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard component builders."""

--- a/dev/litellm-prototype/components/ai_panel.py
+++ b/dev/litellm-prototype/components/ai_panel.py
@@ -1,0 +1,116 @@
+"""AI assistant panels — Component Creator + Data Analyst."""
+
+from __future__ import annotations
+
+import dash_mantine_components as dmc
+from dash import dcc, html
+from dash_iconify import DashIconify
+
+
+def create_ai_component_creator() -> dmc.Paper:
+    """Panel for AI-assisted plot/component creation."""
+    return dmc.Paper(
+        dmc.Stack(
+            [
+                dmc.Group(
+                    [
+                        DashIconify(icon="mdi:creation", width=24, color="violet"),
+                        dmc.Text("AI Component Creator", size="lg", fw=600),
+                    ],
+                    gap="xs",
+                ),
+                dmc.Text(
+                    "Describe a visualization in natural language and the AI will generate a Plotly chart.",
+                    size="sm",
+                    c="dimmed",
+                ),
+                dmc.Textarea(
+                    id="ai-plot-input",
+                    placeholder='e.g. "scatter plot of sepal length vs width, colored by variety"',
+                    minRows=2,
+                    maxRows=4,
+                    w="100%",
+                ),
+                dmc.Group(
+                    [
+                        dmc.Button(
+                            "Generate",
+                            id="ai-plot-generate-btn",
+                            leftSection=DashIconify(icon="mdi:auto-fix"),
+                            variant="gradient",
+                            gradient={"from": "violet", "to": "grape"},
+                        ),
+                        dmc.Button(
+                            "Add to Dashboard",
+                            id="ai-plot-add-btn",
+                            leftSection=DashIconify(icon="mdi:plus-circle"),
+                            variant="outline",
+                            color="violet",
+                            disabled=True,
+                        ),
+                    ],
+                    gap="sm",
+                ),
+                # Loading + preview area
+                dcc.Loading(
+                    id="ai-plot-loading",
+                    type="circle",
+                    children=html.Div(id="ai-plot-preview", style={"minHeight": "50px"}),
+                ),
+                # Store the suggestion JSON for "Add to Dashboard"
+                dcc.Store(id="ai-plot-suggestion-store"),
+            ],
+            gap="md",
+        ),
+        withBorder=True,
+        radius="md",
+        p="lg",
+        shadow="sm",
+    )
+
+
+def create_ai_data_analyst() -> dmc.Paper:
+    """Panel for AI-assisted data analysis."""
+    return dmc.Paper(
+        dmc.Stack(
+            [
+                dmc.Group(
+                    [
+                        DashIconify(icon="mdi:brain", width=24, color="teal"),
+                        dmc.Text("AI Data Analyst", size="lg", fw=600),
+                    ],
+                    gap="xs",
+                ),
+                dmc.Text(
+                    "Ask questions about your data and get structured analysis with key findings.",
+                    size="sm",
+                    c="dimmed",
+                ),
+                dmc.Textarea(
+                    id="ai-analysis-input",
+                    placeholder='e.g. "What are the key differences between iris varieties?"',
+                    minRows=2,
+                    maxRows=4,
+                    w="100%",
+                ),
+                dmc.Button(
+                    "Analyze",
+                    id="ai-analysis-btn",
+                    leftSection=DashIconify(icon="mdi:magnify"),
+                    variant="gradient",
+                    gradient={"from": "teal", "to": "cyan"},
+                ),
+                # Loading + results area
+                dcc.Loading(
+                    id="ai-analysis-loading",
+                    type="circle",
+                    children=html.Div(id="ai-analysis-results", style={"minHeight": "50px"}),
+                ),
+            ],
+            gap="md",
+        ),
+        withBorder=True,
+        radius="md",
+        p="lg",
+        shadow="sm",
+    )

--- a/dev/litellm-prototype/components/ai_panel.py
+++ b/dev/litellm-prototype/components/ai_panel.py
@@ -2,11 +2,54 @@
 
 from __future__ import annotations
 
+import re
+
 import dash_mantine_components as dmc
 from dash import dcc, html
 from dash_iconify import DashIconify
 
 from schemas import AnalysisAgentResult
+
+
+def _highlight_answer(text: str, columns: list[str] | None = None) -> list:
+    """Parse answer text and return Dash components with highlighted numbers and column names.
+
+    - Numbers/percentages → bold teal
+    - Column names → monospace violet badge
+    - Rest → plain text
+    """
+    # Build regex: match column names (longest first) OR numbers with optional %/,/.
+    patterns = []
+    col_set = set()
+    if columns:
+        # Sort by length descending so longer names match first
+        sorted_cols = sorted(columns, key=len, reverse=True)
+        col_patterns = [re.escape(c) for c in sorted_cols]
+        col_set = set(columns)
+        patterns.append(f"({'|'.join(col_patterns)})")
+    # Numbers: integers, decimals, percentages, with optional comma separators
+    patterns.append(r"(\d[\d,]*\.?\d*%?)")
+
+    if not patterns:
+        return [text]
+
+    combined = "|".join(patterns)
+    parts = re.split(f"({combined})", text)
+
+    result = []
+    for part in parts:
+        if not part:
+            continue
+        if part in col_set:
+            result.append(
+                dmc.Badge(part, variant="light", color="violet", size="sm", radius="sm",
+                          style={"fontFamily": "monospace", "verticalAlign": "middle"})
+            )
+        elif re.fullmatch(r"\d[\d,]*\.?\d*%?", part):
+            result.append(dmc.Text(part, span=True, fw=700, c="teal", ff="monospace"))
+        else:
+            result.append(part)
+    return result
 
 
 def create_ai_component_creator() -> dmc.Paper:
@@ -71,54 +114,189 @@ def create_ai_component_creator() -> dmc.Paper:
     )
 
 
-def render_execution_trace(result: AnalysisAgentResult) -> dmc.Stack:
-    """Render the agent's answer + collapsible execution trace (thought → code → output)."""
-    # Final answer
+def _classify_step(step) -> str:
+    """Classify a step as 'success', 'error', or 'info' based on its output."""
+    output_lower = step.output.lower()
+    if any(kw in output_lower for kw in ("error", "traceback", "exception", "invalid")):
+        return "error"
+    if any(kw in output_lower for kw in ("warning", "deprecat")):
+        return "warning"
+    return "success"
+
+
+_STEP_BADGE = {
+    "success": {"color": "teal", "icon": "mdi:check-circle"},
+    "error": {"color": "red", "icon": "mdi:alert-circle"},
+    "warning": {"color": "yellow", "icon": "mdi:alert"},
+}
+
+
+def render_execution_trace(
+    result: AnalysisAgentResult,
+    columns: list[str] | None = None,
+) -> dmc.Stack:
+    """Render the agent's answer + collapsible execution trace with highlighting.
+
+    Args:
+        result: The agent result with answer and execution steps.
+        columns: Optional list of DataFrame column names for highlighting in the answer.
+    """
+    # --- Final answer with highlighted numbers and column names ---
+    highlighted_answer = _highlight_answer(result.answer, columns)
+
     answer_section = dmc.Alert(
-        children=dmc.Text(result.answer, size="sm"),
+        children=dmc.Text(highlighted_answer, size="sm"),
         title="Answer",
         color="teal",
         variant="light",
+        icon=DashIconify(icon="mdi:lightbulb-on", width=20),
     )
 
-    # Build accordion items for each execution step
+    # --- Execution trace with step classification and filtering ---
     if result.steps:
+        # Classify steps
+        step_classes = [_classify_step(step) for step in result.steps]
+        n_success = step_classes.count("success")
+        n_error = step_classes.count("error")
+        n_warning = step_classes.count("warning")
+
+        # Summary badges
+        summary_badges = [
+            dmc.Badge(f"{len(result.steps)} steps", variant="light", color="gray", size="sm"),
+        ]
+        if n_success:
+            summary_badges.append(
+                dmc.Badge(f"{n_success} passed", variant="light", color="teal", size="sm",
+                          leftSection=DashIconify(icon="mdi:check-circle", width=14))
+            )
+        if n_error:
+            summary_badges.append(
+                dmc.Badge(f"{n_error} errors", variant="light", color="red", size="sm",
+                          leftSection=DashIconify(icon="mdi:alert-circle", width=14))
+            )
+        if n_warning:
+            summary_badges.append(
+                dmc.Badge(f"{n_warning} warnings", variant="light", color="yellow", size="sm",
+                          leftSection=DashIconify(icon="mdi:alert", width=14))
+            )
+
+        # Filter chips (stored as data attributes, filtered via CSS)
+        filter_chips = dmc.ChipGroup(
+            [
+                dmc.Chip("All", value="all", variant="outline", size="xs"),
+                dmc.Chip("Code Only", value="code", variant="outline", size="xs", color="violet"),
+                dmc.Chip("Errors", value="errors", variant="outline", size="xs", color="red"),
+            ],
+            id="analysis-step-filter",
+            value="all",
+        )
+
+        # Build accordion items with status badges
         accordion_items = []
-        for i, step in enumerate(result.steps, 1):
+        for i, (step, cls) in enumerate(zip(result.steps, step_classes), 1):
+            badge_cfg = _STEP_BADGE[cls]
+
+            # Thought section — highlight column names if available
+            thought_content = _highlight_answer(step.thought, columns) if columns else [step.thought]
+
+            # Output section — highlight numbers
+            output_highlighted = _highlight_answer(step.output, columns) if columns else [step.output]
+
             item_content = dmc.Stack(
                 [
                     # Thought
-                    dmc.Text("Thought", size="xs", fw=600, c="dimmed"),
-                    dmc.Text(step.thought, size="sm"),
+                    dmc.Group(
+                        [
+                            DashIconify(icon="mdi:thought-bubble", width=16, color="dimmed"),
+                            dmc.Text("Thought", size="xs", fw=600, c="dimmed"),
+                        ],
+                        gap=4,
+                    ),
+                    dmc.Blockquote(
+                        dmc.Text(thought_content, size="sm", c="dimmed"),
+                        color="gray",
+                        p="xs",
+                        style={"fontSize": "0.85rem"},
+                    ),
                     # Code
-                    dmc.Text("Code", size="xs", fw=600, c="dimmed"),
-                    dmc.Code(step.code, block=True),
+                    dmc.Group(
+                        [
+                            DashIconify(icon="mdi:code-braces", width=16, color="violet"),
+                            dmc.Text("Code", size="xs", fw=600, c="dimmed"),
+                        ],
+                        gap=4,
+                    ),
+                    dmc.Code(step.code, block=True, color="violet"),
                     # Output
-                    dmc.Text("Output", size="xs", fw=600, c="dimmed"),
-                    dmc.Code(step.output, block=True),
+                    dmc.Group(
+                        [
+                            DashIconify(icon="mdi:console", width=16, color=badge_cfg["color"]),
+                            dmc.Text("Output", size="xs", fw=600, c="dimmed"),
+                        ],
+                        gap=4,
+                    ),
+                    dmc.Code(
+                        step.output if cls == "error" else None,
+                        block=True,
+                        color="red" if cls == "error" else None,
+                    )
+                    if cls == "error"
+                    else dmc.Paper(
+                        dmc.Text(output_highlighted, size="sm", ff="monospace"),
+                        p="xs",
+                        radius="sm",
+                        bg="gray.0",
+                    ),
                 ],
                 gap=4,
             )
+
+            # Step label with status badge
+            step_label = dmc.Group(
+                [
+                    dmc.Badge(
+                        f"Step {i}",
+                        variant="filled",
+                        color=badge_cfg["color"],
+                        size="sm",
+                        leftSection=DashIconify(icon=badge_cfg["icon"], width=14),
+                    ),
+                    dmc.Text(
+                        step.code[:60] + ("..." if len(step.code) > 60 else ""),
+                        size="sm",
+                        ff="monospace",
+                        truncate="end",
+                    ),
+                ],
+                gap="xs",
+            )
+
             accordion_items.append(
                 dmc.AccordionItem(
                     [
-                        dmc.AccordionControl(f"Step {i}: {step.code[:60]}{'...' if len(step.code) > 60 else ''}"),
+                        dmc.AccordionControl(step_label),
                         dmc.AccordionPanel(item_content),
                     ],
                     value=f"step-{i}",
+                    **{"data-step-status": cls},
                 )
             )
 
         trace_section = dmc.Paper(
             dmc.Stack(
                 [
-                    dmc.Text(
-                        f"Execution Trace ({len(result.steps)} steps)",
-                        size="md",
-                        fw=600,
+                    dmc.Group(
+                        [
+                            DashIconify(icon="mdi:code-json", width=20),
+                            dmc.Text("Execution Trace", size="md", fw=600),
+                            *summary_badges,
+                        ],
+                        gap="xs",
                     ),
+                    filter_chips,
                     dmc.Accordion(
                         accordion_items,
+                        id="analysis-steps-accordion",
                         variant="separated",
                     ),
                 ],

--- a/dev/litellm-prototype/components/ai_panel.py
+++ b/dev/litellm-prototype/components/ai_panel.py
@@ -6,6 +6,8 @@ import dash_mantine_components as dmc
 from dash import dcc, html
 from dash_iconify import DashIconify
 
+from schemas import AnalysisAgentResult
+
 
 def create_ai_component_creator() -> dmc.Paper:
     """Panel for AI-assisted plot/component creation."""
@@ -69,6 +71,69 @@ def create_ai_component_creator() -> dmc.Paper:
     )
 
 
+def render_execution_trace(result: AnalysisAgentResult) -> dmc.Stack:
+    """Render the agent's answer + collapsible execution trace (thought → code → output)."""
+    # Final answer
+    answer_section = dmc.Alert(
+        children=dmc.Text(result.answer, size="sm"),
+        title="Answer",
+        color="teal",
+        variant="light",
+    )
+
+    # Build accordion items for each execution step
+    if result.steps:
+        accordion_items = []
+        for i, step in enumerate(result.steps, 1):
+            item_content = dmc.Stack(
+                [
+                    # Thought
+                    dmc.Text("Thought", size="xs", fw=600, c="dimmed"),
+                    dmc.Text(step.thought, size="sm"),
+                    # Code
+                    dmc.Text("Code", size="xs", fw=600, c="dimmed"),
+                    dmc.Code(step.code, block=True),
+                    # Output
+                    dmc.Text("Output", size="xs", fw=600, c="dimmed"),
+                    dmc.Code(step.output, block=True),
+                ],
+                gap=4,
+            )
+            accordion_items.append(
+                dmc.AccordionItem(
+                    [
+                        dmc.AccordionControl(f"Step {i}: {step.code[:60]}{'...' if len(step.code) > 60 else ''}"),
+                        dmc.AccordionPanel(item_content),
+                    ],
+                    value=f"step-{i}",
+                )
+            )
+
+        trace_section = dmc.Paper(
+            dmc.Stack(
+                [
+                    dmc.Text(
+                        f"Execution Trace ({len(result.steps)} steps)",
+                        size="md",
+                        fw=600,
+                    ),
+                    dmc.Accordion(
+                        accordion_items,
+                        variant="separated",
+                    ),
+                ],
+                gap="xs",
+            ),
+            withBorder=True,
+            p="md",
+            radius="md",
+        )
+    else:
+        trace_section = dmc.Text("No execution steps recorded.", size="sm", c="dimmed")
+
+    return dmc.Stack([answer_section, trace_section], gap="sm")
+
+
 def create_ai_data_analyst() -> dmc.Paper:
     """Panel for AI-assisted data analysis."""
     return dmc.Paper(
@@ -82,7 +147,8 @@ def create_ai_data_analyst() -> dmc.Paper:
                     gap="xs",
                 ),
                 dmc.Text(
-                    "Ask questions about your data and get structured analysis with key findings.",
+                    "Ask questions about your data — the AI writes and runs real pandas code, "
+                    "then shows you every step.",
                     size="sm",
                     c="dimmed",
                 ),

--- a/dev/litellm-prototype/components/cards.py
+++ b/dev/litellm-prototype/components/cards.py
@@ -1,0 +1,59 @@
+"""Metric stat card components."""
+
+from __future__ import annotations
+
+import dash_mantine_components as dmc
+from dash_iconify import DashIconify
+
+
+def create_stat_card(
+    title: str,
+    value: str | int | float,
+    icon: str = "mdi:chart-line",
+    color: str | None = None,
+) -> dmc.Card:
+    """Create a metric card matching depictio's card style.
+
+    Args:
+        title: Card title text.
+        value: The metric value to display.
+        icon: Material Design Icon name.
+        color: Optional accent color.
+    """
+    icon_style = {"color": color} if color else {}
+
+    card_content = dmc.Stack(
+        [
+            dmc.Group(
+                [
+                    DashIconify(icon=icon, width=24, style=icon_style),
+                    dmc.Text(title, size="sm", fw=500, c="dimmed"),
+                ],
+                gap="xs",
+                align="center",
+            ),
+            dmc.Text(
+                str(value),
+                size="xl",
+                fw=700,
+            ),
+        ],
+        gap="xs",
+    )
+
+    return dmc.Card(
+        dmc.CardSection(
+            card_content,
+            p="md",
+            style={
+                "height": "100%",
+                "display": "flex",
+                "flexDirection": "column",
+                "justifyContent": "center",
+            },
+        ),
+        withBorder=True,
+        shadow="sm",
+        radius="md",
+        style={"height": "100%", "minHeight": "120px"},
+    )

--- a/dev/litellm-prototype/components/figures.py
+++ b/dev/litellm-prototype/components/figures.py
@@ -1,0 +1,61 @@
+"""Plotly Express figure builder from dict_kwargs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import dash_mantine_components as dmc
+import pandas as pd
+import plotly.express as px
+from dash import dcc
+
+ALLOWED_TYPES = {"scatter", "bar", "line", "histogram", "box", "violin", "heatmap"}
+
+
+def create_figure(
+    df: pd.DataFrame,
+    visu_type: str,
+    dict_kwargs: dict[str, Any],
+    title: str | None = None,
+    graph_id: str | None = None,
+) -> dmc.Paper:
+    """Build a Plotly Express figure from a visu_type and dict_kwargs.
+
+    Args:
+        df: Source DataFrame.
+        visu_type: Plotly Express function name (scatter, bar, etc.).
+        dict_kwargs: Keyword arguments for the px function.
+        title: Optional figure title override.
+        graph_id: Optional Dash component ID for the dcc.Graph.
+    """
+    if visu_type not in ALLOWED_TYPES:
+        visu_type = "scatter"
+
+    plot_fn = getattr(px, visu_type)
+
+    # Filter dict_kwargs to only include columns that exist
+    safe_kwargs = {}
+    for k, v in dict_kwargs.items():
+        if isinstance(v, str) and k in ("x", "y", "color", "size", "facet_col", "facet_row", "symbol", "text"):
+            if v in df.columns:
+                safe_kwargs[k] = v
+        else:
+            safe_kwargs[k] = v
+
+    fig = plot_fn(df, **safe_kwargs)
+    if title:
+        fig.update_layout(title=title)
+    fig.update_layout(margin=dict(l=40, r=20, t=50, b=40))
+
+    return dmc.Paper(
+        dcc.Graph(
+            figure=fig,
+            id=graph_id or f"fig-{visu_type}",
+            style={"height": "100%"},
+            config={"displayModeBar": False},
+        ),
+        withBorder=True,
+        radius="md",
+        p="xs",
+        style={"height": "380px"},
+    )

--- a/dev/litellm-prototype/components/figures.py
+++ b/dev/litellm-prototype/components/figures.py
@@ -42,6 +42,22 @@ def create_figure(
         else:
             safe_kwargs[k] = v
 
+    # Guard: px functions need at least x (or y for histogram) to avoid
+    # wide-form fallback on mixed-type DataFrames.
+    needs_x = visu_type not in ("histogram",)
+    if needs_x and "x" not in safe_kwargs:
+        numeric_cols = df.select_dtypes(include="number").columns.tolist()
+        if len(numeric_cols) >= 2:
+            safe_kwargs.setdefault("x", numeric_cols[0])
+            safe_kwargs.setdefault("y", numeric_cols[1])
+        elif numeric_cols:
+            safe_kwargs["x"] = numeric_cols[0]
+
+    if visu_type == "histogram" and "x" not in safe_kwargs and "y" not in safe_kwargs:
+        numeric_cols = df.select_dtypes(include="number").columns.tolist()
+        if numeric_cols:
+            safe_kwargs["x"] = numeric_cols[0]
+
     fig = plot_fn(df, **safe_kwargs)
     if title:
         fig.update_layout(title=title)

--- a/dev/litellm-prototype/components/figures.py
+++ b/dev/litellm-prototype/components/figures.py
@@ -46,17 +46,15 @@ def create_figure(
     # wide-form fallback on mixed-type DataFrames.
     needs_x = visu_type not in ("histogram",)
     if needs_x and "x" not in safe_kwargs:
-        numeric_cols = df.select_dtypes(include="number").columns.tolist()
-        if len(numeric_cols) >= 2:
-            safe_kwargs.setdefault("x", numeric_cols[0])
-            safe_kwargs.setdefault("y", numeric_cols[1])
-        elif numeric_cols:
-            safe_kwargs["x"] = numeric_cols[0]
-
+        raise ValueError(
+            f"Cannot create '{visu_type}' plot: missing required 'x' column mapping in dict_kwargs. "
+            f"Available columns: {list(df.columns)}"
+        )
     if visu_type == "histogram" and "x" not in safe_kwargs and "y" not in safe_kwargs:
-        numeric_cols = df.select_dtypes(include="number").columns.tolist()
-        if numeric_cols:
-            safe_kwargs["x"] = numeric_cols[0]
+        raise ValueError(
+            f"Cannot create histogram: missing 'x' or 'y' column mapping in dict_kwargs. "
+            f"Available columns: {list(df.columns)}"
+        )
 
     fig = plot_fn(df, **safe_kwargs)
     if title:

--- a/dev/litellm-prototype/components/interactive.py
+++ b/dev/litellm-prototype/components/interactive.py
@@ -1,0 +1,82 @@
+"""Interactive filter components."""
+
+from __future__ import annotations
+
+import dash_mantine_components as dmc
+
+
+def create_select(
+    component_id: str,
+    label: str,
+    options: list[str],
+    value: str | None = None,
+) -> dmc.Select:
+    """Create a single-select dropdown."""
+    data = [{"label": str(v), "value": str(v)} for v in sorted(options)]
+    return dmc.Select(
+        id=component_id,
+        label=label,
+        data=data,
+        value=value or (data[0]["value"] if data else None),
+        clearable=True,
+        searchable=True,
+        w="100%",
+        size="sm",
+    )
+
+
+def create_range_slider(
+    component_id: str,
+    label: str,
+    min_val: float,
+    max_val: float,
+    step: float | None = None,
+) -> dmc.Stack:
+    """Create a labeled range slider."""
+    if step is None:
+        span = max_val - min_val
+        step = round(span / 100, 2) if span > 0 else 1
+
+    marks = [
+        {"value": min_val, "label": f"{min_val:.1f}"},
+        {"value": (min_val + max_val) / 2, "label": f"{(min_val + max_val) / 2:.1f}"},
+        {"value": max_val, "label": f"{max_val:.1f}"},
+    ]
+
+    return dmc.Stack(
+        [
+            dmc.Text(label, size="sm", fw=500),
+            dmc.RangeSlider(
+                id=component_id,
+                min=min_val,
+                max=max_val,
+                value=[min_val, max_val],
+                marks=marks,
+                step=step,
+                size="md",
+                w="100%",
+                styles={"root": {"paddingBottom": "1rem"}},
+            ),
+        ],
+        gap="xs",
+    )
+
+
+def create_multiselect(
+    component_id: str,
+    label: str,
+    options: list[str],
+    value: list[str] | None = None,
+) -> dmc.MultiSelect:
+    """Create a multi-select dropdown."""
+    data = [{"label": str(v), "value": str(v)} for v in sorted(options)]
+    return dmc.MultiSelect(
+        id=component_id,
+        label=label,
+        data=data,
+        value=value or [d["value"] for d in data],
+        searchable=True,
+        clearable=True,
+        w="100%",
+        size="sm",
+    )

--- a/dev/litellm-prototype/components/tables.py
+++ b/dev/litellm-prototype/components/tables.py
@@ -1,0 +1,65 @@
+"""AG Grid data table component."""
+
+from __future__ import annotations
+
+import dash_ag_grid as dag
+import dash_mantine_components as dmc
+import pandas as pd
+
+
+def _column_defs(df: pd.DataFrame) -> list[dict]:
+    """Auto-generate AG Grid column definitions from DataFrame dtypes."""
+    defs = []
+    for col in df.columns:
+        col_def: dict = {
+            "field": col,
+            "headerName": col.replace("_", " ").title(),
+            "sortable": True,
+            "filter": True,
+            "resizable": True,
+            "floatingFilter": True,
+        }
+        if pd.api.types.is_numeric_dtype(df[col]):
+            col_def["filter"] = "agNumberColumnFilter"
+        else:
+            col_def["filter"] = "agTextColumnFilter"
+        defs.append(col_def)
+    return defs
+
+
+def create_table(df: pd.DataFrame, table_id: str = "data-table") -> dmc.Paper:
+    """Create an AG Grid table from a DataFrame.
+
+    Args:
+        df: Source DataFrame.
+        table_id: Dash component ID.
+    """
+    return dmc.Paper(
+        dag.AgGrid(
+            id=table_id,
+            rowData=df.to_dict("records"),
+            columnDefs=_column_defs(df),
+            defaultColDef={
+                "flex": 1,
+                "minWidth": 120,
+                "sortable": True,
+                "resizable": True,
+                "floatingFilter": True,
+                "filter": True,
+            },
+            dashGridOptions={
+                "pagination": True,
+                "paginationPageSize": 50,
+                "paginationPageSizeSelector": [25, 50, 100],
+                "rowSelection": "multiple",
+                "enableCellTextSelection": True,
+                "animateRows": True,
+            },
+            style={"height": "400px", "width": "100%"},
+            className="ag-theme-alpine",
+        ),
+        withBorder=True,
+        radius="md",
+        p="xs",
+        style={"overflow": "hidden"},
+    )

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -139,15 +139,18 @@ CRITICAL RULES:
         {"role": "user", "content": user_prompt},
     ]
 
-    # Try up to 2 times — retry if LLM returns empty dict_kwargs
+    # Do NOT pass response_format=PlotSuggestion to litellm — the JSON Schema
+    # for dict[str, Any] becomes {"type": "object"} which allows {}, causing
+    # the LLM to return empty dict_kwargs. Plain text mode follows the prompt.
     last_error = None
     for attempt in range(2):
-        result = completion(messages, response_format=PlotSuggestion)
+        result = completion(messages)
         try:
-            if isinstance(result, str):
-                parsed = PlotSuggestion.model_validate_json(result)
-            else:
-                parsed = PlotSuggestion.model_validate(result)
+            # Strip markdown fences if present
+            text = result.strip()
+            if text.startswith("```"):
+                text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+            parsed = PlotSuggestion.model_validate_json(text)
             break  # validation passed
         except Exception as e:
             last_error = e

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -219,6 +219,14 @@ def analyze_data(user_prompt: str, df: pd.DataFrame) -> AnalysisAgentResult:
         allow_dangerous_code=True,  # required — we control the data
         handle_parsing_errors=True,  # recover when LLM skips Action:/Action Input: format
         max_iterations=10,
+        prefix=(
+            "You are a data analysis expert working with a pandas DataFrame called `df`.\n"
+            "When providing your Final Answer:\n"
+            "- Include specific numbers and statistics (exact values, not vague descriptions)\n"
+            "- Reference column names exactly as they appear in the DataFrame\n"
+            "- Structure findings clearly: lead with the key insight, then supporting details\n"
+            "- If there are multiple findings, number them\n"
+        ),
     )
 
     result = agent.invoke({"input": user_prompt})

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -1,0 +1,143 @@
+"""Provider-agnostic LLM client using LiteLLM with in-memory caching."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+
+import litellm
+from dotenv import load_dotenv
+
+from schemas import AnalysisResult, PlotSuggestion
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+# Suppress litellm's verbose logging
+litellm.suppress_debug_info = True
+
+# In-memory cache (use Redis in production)
+_cache: dict[str, str] = {}
+
+
+def get_model() -> str:
+    return os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-20250514")
+
+
+def _cache_key(messages: list[dict], model: str) -> str:
+    payload = json.dumps({"messages": messages, "model": model}, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def completion(messages: list[dict], response_format: type | None = None) -> str:
+    """Call LiteLLM with caching and optional structured output.
+
+    Args:
+        messages: Chat messages in OpenAI format.
+        response_format: Optional Pydantic model class for structured output.
+
+    Returns:
+        Raw string content from the LLM response.
+    """
+    model = get_model()
+    key = _cache_key(messages, model)
+
+    if key in _cache:
+        logger.info("Cache hit for %s", key[:12])
+        return _cache[key]
+
+    kwargs: dict = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": 2048,
+    }
+    if response_format is not None:
+        kwargs["response_format"] = response_format
+
+    logger.info("Calling %s (response_format=%s)", model, response_format)
+    response = litellm.completion(**kwargs)
+    content = response.choices[0].message.content
+
+    _cache[key] = content
+    return content
+
+
+def suggest_plot(user_prompt: str, column_metadata: str) -> PlotSuggestion:
+    """Ask the LLM to suggest a Plotly Express plot configuration."""
+    system_prompt = f"""You are a data visualization expert. Given a dataset description and a user request,
+suggest a single Plotly Express plot configuration.
+
+DATASET:
+{column_metadata}
+
+Respond with valid JSON matching this exact schema:
+{{
+    "visu_type": "scatter|bar|line|histogram|box|violin|heatmap",
+    "dict_kwargs": {{"x": "column_name", "y": "column_name", ...}},
+    "title": "Chart title",
+    "explanation": "Why this plot is useful"
+}}
+
+IMPORTANT:
+- dict_kwargs must only contain valid Plotly Express parameter names (x, y, color, size, facet_col, facet_row, etc.)
+- Column names in dict_kwargs MUST match the dataset columns exactly
+- Do NOT include the DataFrame as a parameter — only column mappings
+- Respond with ONLY the JSON object, no markdown fences or extra text"""
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    result = completion(messages, response_format=PlotSuggestion)
+
+    # Parse — litellm may return raw JSON string or already-parsed content
+    if isinstance(result, str):
+        return PlotSuggestion.model_validate_json(result)
+    return PlotSuggestion.model_validate(result)
+
+
+def analyze_data(user_prompt: str, column_metadata: str, sample_rows: str) -> AnalysisResult:
+    """Ask the LLM to analyze the dataset."""
+    system_prompt = f"""You are a data analyst. Given a dataset description and sample rows,
+answer the user's question with structured analysis.
+
+DATASET:
+{column_metadata}
+
+SAMPLE ROWS (first 5):
+{sample_rows}
+
+Respond with valid JSON matching this exact schema:
+{{
+    "summary": "Markdown-formatted summary paragraph",
+    "key_findings": ["finding 1", "finding 2", ...],
+    "suggested_plots": [
+        {{
+            "visu_type": "scatter|bar|line|histogram|box|violin|heatmap",
+            "dict_kwargs": {{"x": "col", "y": "col", ...}},
+            "title": "Chart title",
+            "explanation": "Why this plot"
+        }}
+    ] or null
+}}
+
+IMPORTANT:
+- key_findings should be 3-6 concise bullet points
+- suggested_plots is optional — include only if relevant visualizations would help
+- Column names must match the dataset exactly
+- Respond with ONLY the JSON object, no markdown fences or extra text"""
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    result = completion(messages, response_format=AnalysisResult)
+
+    if isinstance(result, str):
+        return AnalysisResult.model_validate_json(result)
+    return AnalysisResult.model_validate(result)

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -137,27 +137,36 @@ IMPORTANT:
     return parsed
 
 
-def analyze_data(user_prompt: str, column_metadata: str, sample_rows: str) -> AnalysisResult:
-    """Ask the LLM to analyze the dataset."""
+def analyze_data(user_prompt: str, column_metadata: str, data_profile: str) -> AnalysisResult:
+    """Ask the LLM to analyze the dataset using pre-computed statistics.
+
+    The data_profile contains real pandas operations: describe(), corr(),
+    value_counts(), groupby().agg(), sample rows — so the LLM reasons
+    about actual computed numbers.
+    """
     logger.info("═══ analyze_data() ═══")
     logger.debug("─── Column Metadata ───")
     logger.debug("%s", column_metadata)
-    logger.debug("─── Sample Rows ───")
-    logger.debug("%s", sample_rows)
+    logger.debug("─── Data Profile (%d chars) ───", len(data_profile))
+    logger.debug("%s", data_profile)
 
-    system_prompt = f"""You are a data analyst. Given a dataset description and sample rows,
-answer the user's question with structured analysis.
+    system_prompt = f"""You are a data analyst. You have been given a dataset description and
+PRE-COMPUTED STATISTICS from real pandas operations (describe, correlations, value counts,
+group-by aggregations, and sample rows). Use these actual numbers to answer the user's question.
 
-DATASET:
+DATASET SCHEMA:
 {column_metadata}
 
-SAMPLE ROWS (first 5):
-{sample_rows}
+PRE-COMPUTED DATA PROFILE:
+{data_profile}
+
+Base your analysis on the actual statistics above. Reference specific numbers, correlations,
+and group differences. Do not guess — use the computed values.
 
 Respond with valid JSON matching this exact schema:
 {{
-    "summary": "Markdown-formatted summary paragraph",
-    "key_findings": ["finding 1", "finding 2", ...],
+    "summary": "Markdown-formatted summary paragraph referencing actual statistics",
+    "key_findings": ["finding 1 with actual numbers", "finding 2 with actual numbers", ...],
     "suggested_plots": [
         {{
             "visu_type": "scatter|bar|line|histogram|box|violin|heatmap",
@@ -169,7 +178,7 @@ Respond with valid JSON matching this exact schema:
 }}
 
 IMPORTANT:
-- key_findings should be 3-6 concise bullet points
+- key_findings should be 3-6 concise bullet points with actual numbers from the profile
 - suggested_plots is optional — include only if relevant visualizations would help
 - Column names must match the dataset exactly
 - Respond with ONLY the JSON object, no markdown fences or extra text"""

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -191,6 +191,7 @@ def analyze_data(user_prompt: str, df: pd.DataFrame) -> AnalysisAgentResult:
         verbose=True,  # prints full ReAct chain to terminal
         return_intermediate_steps=True,
         allow_dangerous_code=True,  # required — we control the data
+        handle_parsing_errors=True,  # recover when LLM skips Action:/Action Input: format
         max_iterations=10,
     )
 
@@ -201,9 +202,19 @@ def analyze_data(user_prompt: str, df: pd.DataFrame) -> AnalysisAgentResult:
     steps = []
     for action, observation in result.get("intermediate_steps", []):
         # action is an AgentAction with .tool_input and .log
-        code = action.tool_input if isinstance(action.tool_input, str) else action.tool_input.get("query", str(action.tool_input))
+        # When handle_parsing_errors kicks in, tool_input may be the raw
+        # unparseable text — still useful to show the user what happened.
+        tool_input = getattr(action, "tool_input", "")
+        if isinstance(tool_input, str):
+            code = tool_input
+        elif isinstance(tool_input, dict):
+            code = tool_input.get("query", str(tool_input))
+        else:
+            code = str(tool_input)
+
+        thought = getattr(action, "log", "").strip()
         steps.append(ExecutionStep(
-            thought=action.log.strip(),
+            thought=thought,
             code=code,
             output=str(observation).strip(),
         ))

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -23,7 +23,7 @@ _cache: dict[str, str] = {}
 
 
 def get_model() -> str:
-    return os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-20250514")
+    return os.getenv("LLM_MODEL", "openrouter/anthropic/claude-sonnet-4-6")
 
 
 def _cache_key(messages: list[dict], model: str) -> str:

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -118,6 +118,7 @@ Respond with valid JSON matching this exact schema:
 }}
 
 IMPORTANT:
+- dict_kwargs MUST NOT be empty — always include at least "x" (and "y" for scatter/line/bar)
 - dict_kwargs must only contain valid Plotly Express parameter names (x, y, color, size, facet_col, facet_row, etc.)
 - Column names in dict_kwargs MUST match the dataset columns exactly
 - Do NOT include the DataFrame as a parameter — only column mappings

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -112,16 +112,26 @@ DATASET:
 Respond with valid JSON matching this exact schema:
 {{
     "visu_type": "scatter|bar|line|histogram|box|violin|heatmap",
-    "dict_kwargs": {{"x": "column_name", "y": "column_name", ...}},
+    "dict_kwargs": {{"x": "column_name", "y": "column_name", "color": "column_name", ...}},
     "title": "Chart title",
     "explanation": "Why this plot is useful"
 }}
 
-IMPORTANT:
-- dict_kwargs MUST NOT be empty — always include at least "x" (and "y" for scatter/line/bar)
-- dict_kwargs must only contain valid Plotly Express parameter names (x, y, color, size, facet_col, facet_row, etc.)
-- Column names in dict_kwargs MUST match the dataset columns exactly
-- Do NOT include the DataFrame as a parameter — only column mappings
+EXAMPLE — for "scatter plot of sepal length vs width colored by variety":
+{{
+    "visu_type": "scatter",
+    "dict_kwargs": {{"x": "sepal_length", "y": "sepal_width", "color": "variety"}},
+    "title": "Sepal Length vs Width by Variety",
+    "explanation": "Shows how sepal dimensions differ across iris varieties."
+}}
+
+CRITICAL RULES:
+- dict_kwargs MUST NOT be empty — it MUST contain column mappings like "x", "y", "color", "size", etc.
+- For scatter/line/bar: dict_kwargs MUST include at least "x" and "y"
+- For histogram: dict_kwargs MUST include at least "x"
+- All column names in dict_kwargs MUST exactly match the dataset column names listed above
+- Only use valid Plotly Express parameter names: x, y, color, size, facet_col, facet_row, symbol, text, hover_name
+- Do NOT include the DataFrame — only column name mappings
 - Respond with ONLY the JSON object, no markdown fences or extra text"""
 
     messages = [
@@ -129,12 +139,24 @@ IMPORTANT:
         {"role": "user", "content": user_prompt},
     ]
 
-    result = completion(messages, response_format=PlotSuggestion)
-
-    if isinstance(result, str):
-        parsed = PlotSuggestion.model_validate_json(result)
+    # Try up to 2 times — retry if LLM returns empty dict_kwargs
+    last_error = None
+    for attempt in range(2):
+        result = completion(messages, response_format=PlotSuggestion)
+        try:
+            if isinstance(result, str):
+                parsed = PlotSuggestion.model_validate_json(result)
+            else:
+                parsed = PlotSuggestion.model_validate(result)
+            break  # validation passed
+        except Exception as e:
+            last_error = e
+            logger.warning("Attempt %d failed validation: %s — retrying", attempt + 1, e)
+            # Bust cache so retry gets a fresh LLM call
+            key = _cache_key(messages, get_model())
+            _cache.pop(key, None)
     else:
-        parsed = PlotSuggestion.model_validate(result)
+        raise ValueError(f"LLM returned invalid plot config after 2 attempts: {last_error}")
 
     logger.info(
         "═══ Parsed: PlotSuggestion ═══  type=%s | kwargs=%s | title=%s",

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -1,4 +1,8 @@
-"""Provider-agnostic LLM client using LiteLLM with in-memory caching."""
+"""Provider-agnostic LLM client using LiteLLM with in-memory caching.
+
+Uses LangChain's pandas agent for data analysis — the LLM writes and
+executes real pandas code, with full execution trace for explainability.
+"""
 
 from __future__ import annotations
 
@@ -9,9 +13,12 @@ import os
 import time
 
 import litellm
+import pandas as pd
 from dotenv import load_dotenv
+from langchain_community.chat_models import ChatLiteLLM
+from langchain_experimental.agents.agent_toolkits import create_pandas_dataframe_agent
 
-from schemas import AnalysisResult, PlotSuggestion
+from schemas import AnalysisAgentResult, ExecutionStep, PlotSuggestion
 
 load_dotenv()
 logger = logging.getLogger(__name__)
@@ -137,73 +144,85 @@ IMPORTANT:
     return parsed
 
 
-def analyze_data(user_prompt: str, column_metadata: str, data_profile: str) -> AnalysisResult:
-    """Ask the LLM to analyze the dataset using pre-computed statistics.
+# ---------------------------------------------------------------------------
+# Analysis cache — same question + same data + same model → same result
+# ---------------------------------------------------------------------------
+_analysis_cache: dict[str, AnalysisAgentResult] = {}
 
-    The data_profile contains real pandas operations: describe(), corr(),
-    value_counts(), groupby().agg(), sample rows — so the LLM reasons
-    about actual computed numbers.
+
+def _analysis_cache_key(prompt: str, df: pd.DataFrame) -> str:
+    """Deterministic cache key from question + data content + model."""
+    df_hash = hashlib.sha256(
+        pd.util.hash_pandas_object(df).values.tobytes()
+    ).hexdigest()[:16]
+    return hashlib.sha256(
+        f"{prompt}:{df_hash}:{get_model()}".encode()
+    ).hexdigest()
+
+
+def analyze_data(user_prompt: str, df: pd.DataFrame) -> AnalysisAgentResult:
+    """Run LangChain pandas agent — the LLM writes + executes real pandas code.
+
+    Returns the final answer plus a full execution trace (thought → code → output)
+    for every step, enabling both explainability (UI accordion) and reproducibility
+    (cached by question + data hash + model).
     """
-    logger.info("═══ analyze_data() ═══")
-    logger.debug("─── Column Metadata ───")
-    logger.debug("%s", column_metadata)
-    logger.debug("─── Data Profile (%d chars) ───", len(data_profile))
-    logger.debug("%s", data_profile)
+    # Check cache first
+    cache_key = _analysis_cache_key(user_prompt, df)
+    if cache_key in _analysis_cache:
+        cached = _analysis_cache[cache_key]
+        logger.info("═══ Analysis Cache HIT ═══  key=%s  steps=%d", cache_key[:12], len(cached.steps))
+        return cached
 
-    system_prompt = f"""You are a data analyst. You have been given a dataset description and
-PRE-COMPUTED STATISTICS from real pandas operations (describe, correlations, value counts,
-group-by aggregations, and sample rows). Use these actual numbers to answer the user's question.
+    logger.info("═══ analyze_data() — LangChain pandas agent ═══")
+    logger.info("Question: %s", user_prompt)
+    logger.info("DataFrame: %d rows x %d cols  columns=%s", len(df), len(df.columns), list(df.columns))
 
-DATASET SCHEMA:
-{column_metadata}
+    t0 = time.perf_counter()
 
-PRE-COMPUTED DATA PROFILE:
-{data_profile}
+    # Create LangChain LLM backed by LiteLLM (provider-agnostic)
+    llm = ChatLiteLLM(model=get_model(), temperature=0)
 
-Base your analysis on the actual statistics above. Reference specific numbers, correlations,
-and group differences. Do not guess — use the computed values.
-
-Respond with valid JSON matching this exact schema:
-{{
-    "summary": "Markdown-formatted summary paragraph referencing actual statistics",
-    "key_findings": ["finding 1 with actual numbers", "finding 2 with actual numbers", ...],
-    "suggested_plots": [
-        {{
-            "visu_type": "scatter|bar|line|histogram|box|violin|heatmap",
-            "dict_kwargs": {{"x": "col", "y": "col", ...}},
-            "title": "Chart title",
-            "explanation": "Why this plot"
-        }}
-    ] or null
-}}
-
-IMPORTANT:
-- key_findings should be 3-6 concise bullet points with actual numbers from the profile
-- suggested_plots is optional — include only if relevant visualizations would help
-- Column names must match the dataset exactly
-- Respond with ONLY the JSON object, no markdown fences or extra text"""
-
-    messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": user_prompt},
-    ]
-
-    result = completion(messages, response_format=AnalysisResult)
-
-    if isinstance(result, str):
-        parsed = AnalysisResult.model_validate_json(result)
-    else:
-        parsed = AnalysisResult.model_validate(result)
-
-    n_plots = len(parsed.suggested_plots) if parsed.suggested_plots else 0
-    logger.info(
-        "═══ Parsed: AnalysisResult ═══  summary=%d chars | findings=%d | suggested_plots=%d",
-        len(parsed.summary),
-        len(parsed.key_findings),
-        n_plots,
+    # Create pandas agent — it gets a Python REPL with `df` in scope
+    agent = create_pandas_dataframe_agent(
+        llm,
+        df,
+        agent_type="zero-shot-react-description",
+        verbose=True,  # prints full ReAct chain to terminal
+        return_intermediate_steps=True,
+        allow_dangerous_code=True,  # required — we control the data
+        max_iterations=10,
     )
-    logger.info("─── Key Findings ───")
-    for i, finding in enumerate(parsed.key_findings, 1):
-        logger.info("  %d. %s", i, finding)
 
-    return parsed
+    result = agent.invoke({"input": user_prompt})
+    elapsed = time.perf_counter() - t0
+
+    # Extract execution trace from intermediate steps
+    steps = []
+    for action, observation in result.get("intermediate_steps", []):
+        # action is an AgentAction with .tool_input and .log
+        code = action.tool_input if isinstance(action.tool_input, str) else action.tool_input.get("query", str(action.tool_input))
+        steps.append(ExecutionStep(
+            thought=action.log.strip(),
+            code=code,
+            output=str(observation).strip(),
+        ))
+
+    agent_result = AnalysisAgentResult(
+        answer=result["output"],
+        steps=steps,
+    )
+
+    # Log summary
+    logger.info("═══ Agent complete (%.1fs) — %d steps ═══", elapsed, len(steps))
+    for i, step in enumerate(steps, 1):
+        logger.info("─── Step %d ───", i)
+        logger.info("  Code: %s", step.code)
+        logger.info("  Output: %s", step.output[:200] + ("..." if len(step.output) > 200 else ""))
+    logger.info("─── Final Answer ───")
+    logger.info("  %s", agent_result.answer[:500])
+
+    # Cache for reproducibility
+    _analysis_cache[cache_key] = agent_result
+
+    return agent_result

--- a/dev/litellm-prototype/llm_client.py
+++ b/dev/litellm-prototype/llm_client.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 
 import litellm
 from dotenv import load_dotenv
@@ -15,7 +16,7 @@ from schemas import AnalysisResult, PlotSuggestion
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-# Suppress litellm's verbose logging
+# Suppress litellm's verbose internal logging
 litellm.suppress_debug_info = True
 
 # In-memory cache (use Redis in production)
@@ -31,22 +32,29 @@ def _cache_key(messages: list[dict], model: str) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
+def _log_messages(messages: list[dict]) -> None:
+    """Log each message role and content at DEBUG level."""
+    for msg in messages:
+        role = msg["role"].upper()
+        logger.debug("─── %s Prompt ───", role)
+        logger.debug("%s", msg["content"])
+
+
 def completion(messages: list[dict], response_format: type | None = None) -> str:
-    """Call LiteLLM with caching and optional structured output.
-
-    Args:
-        messages: Chat messages in OpenAI format.
-        response_format: Optional Pydantic model class for structured output.
-
-    Returns:
-        Raw string content from the LLM response.
-    """
+    """Call LiteLLM with caching and optional structured output."""
     model = get_model()
     key = _cache_key(messages, model)
+    fmt_name = response_format.__name__ if response_format else "None"
 
     if key in _cache:
-        logger.info("Cache hit for %s", key[:12])
+        logger.info("═══ Cache HIT ═══  key=%s format=%s", key[:12], fmt_name)
+        logger.debug("─── Cached Response ───")
+        logger.debug("%s", _cache[key])
         return _cache[key]
+
+    logger.info("═══ LLM Request ═══")
+    logger.info("Model: %s | temperature: 0 | format: %s", model, fmt_name)
+    _log_messages(messages)
 
     kwargs: dict = {
         "model": model,
@@ -57,9 +65,26 @@ def completion(messages: list[dict], response_format: type | None = None) -> str
     if response_format is not None:
         kwargs["response_format"] = response_format
 
-    logger.info("Calling %s (response_format=%s)", model, response_format)
+    t0 = time.perf_counter()
     response = litellm.completion(**kwargs)
+    elapsed = time.perf_counter() - t0
     content = response.choices[0].message.content
+
+    # Token usage
+    usage = getattr(response, "usage", None)
+    if usage:
+        logger.info(
+            "═══ LLM Response (%.1fs) ═══  Tokens: %d prompt + %d completion = %d total",
+            elapsed,
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            usage.total_tokens,
+        )
+    else:
+        logger.info("═══ LLM Response (%.1fs) ═══  (no token usage reported)", elapsed)
+
+    logger.debug("─── Raw Response ───")
+    logger.debug("%s", content)
 
     _cache[key] = content
     return content
@@ -67,6 +92,10 @@ def completion(messages: list[dict], response_format: type | None = None) -> str
 
 def suggest_plot(user_prompt: str, column_metadata: str) -> PlotSuggestion:
     """Ask the LLM to suggest a Plotly Express plot configuration."""
+    logger.info("═══ suggest_plot() ═══")
+    logger.debug("─── Column Metadata ───")
+    logger.debug("%s", column_metadata)
+
     system_prompt = f"""You are a data visualization expert. Given a dataset description and a user request,
 suggest a single Plotly Express plot configuration.
 
@@ -94,14 +123,28 @@ IMPORTANT:
 
     result = completion(messages, response_format=PlotSuggestion)
 
-    # Parse — litellm may return raw JSON string or already-parsed content
     if isinstance(result, str):
-        return PlotSuggestion.model_validate_json(result)
-    return PlotSuggestion.model_validate(result)
+        parsed = PlotSuggestion.model_validate_json(result)
+    else:
+        parsed = PlotSuggestion.model_validate(result)
+
+    logger.info(
+        "═══ Parsed: PlotSuggestion ═══  type=%s | kwargs=%s | title=%s",
+        parsed.visu_type,
+        parsed.dict_kwargs,
+        parsed.title,
+    )
+    return parsed
 
 
 def analyze_data(user_prompt: str, column_metadata: str, sample_rows: str) -> AnalysisResult:
     """Ask the LLM to analyze the dataset."""
+    logger.info("═══ analyze_data() ═══")
+    logger.debug("─── Column Metadata ───")
+    logger.debug("%s", column_metadata)
+    logger.debug("─── Sample Rows ───")
+    logger.debug("%s", sample_rows)
+
     system_prompt = f"""You are a data analyst. Given a dataset description and sample rows,
 answer the user's question with structured analysis.
 
@@ -139,5 +182,19 @@ IMPORTANT:
     result = completion(messages, response_format=AnalysisResult)
 
     if isinstance(result, str):
-        return AnalysisResult.model_validate_json(result)
-    return AnalysisResult.model_validate(result)
+        parsed = AnalysisResult.model_validate_json(result)
+    else:
+        parsed = AnalysisResult.model_validate(result)
+
+    n_plots = len(parsed.suggested_plots) if parsed.suggested_plots else 0
+    logger.info(
+        "═══ Parsed: AnalysisResult ═══  summary=%d chars | findings=%d | suggested_plots=%d",
+        len(parsed.summary),
+        len(parsed.key_findings),
+        n_plots,
+    )
+    logger.info("─── Key Findings ───")
+    for i, finding in enumerate(parsed.key_findings, 1):
+        logger.info("  %d. %s", i, finding)
+
+    return parsed

--- a/dev/litellm-prototype/pyproject.toml
+++ b/dev/litellm-prototype/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "litellm>=1.50",
     "pydantic>=2.0",
     "python-dotenv",
+    "langchain>=0.3",
+    "langchain-community>=0.3",
+    "langchain-experimental>=0.3",
 ]
 
 [build-system]

--- a/dev/litellm-prototype/pyproject.toml
+++ b/dev/litellm-prototype/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "litellm-prototype"
+version = "0.1.0"
+description = "AI Dashboard Prototype — LiteLLM + Dash + DMC"
+requires-python = ">=3.11"
+dependencies = [
+    "dash>=3.0",
+    "dash-mantine-components>=0.14",
+    "dash-iconify",
+    "dash-ag-grid",
+    "plotly",
+    "pandas",
+    "litellm>=1.50",
+    "pydantic>=2.0",
+    "python-dotenv",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/dev/litellm-prototype/requirements.txt
+++ b/dev/litellm-prototype/requirements.txt
@@ -1,0 +1,9 @@
+dash>=3.0
+dash-mantine-components>=0.14
+dash-iconify
+dash-ag-grid
+plotly
+pandas
+litellm>=1.50
+pydantic>=2.0
+python-dotenv

--- a/dev/litellm-prototype/requirements.txt
+++ b/dev/litellm-prototype/requirements.txt
@@ -1,9 +1,0 @@
-dash>=3.0
-dash-mantine-components>=0.14
-dash-iconify
-dash-ag-grid
-plotly
-pandas
-litellm>=1.50
-pydantic>=2.0
-python-dotenv

--- a/dev/litellm-prototype/sample_data.py
+++ b/dev/litellm-prototype/sample_data.py
@@ -1,0 +1,83 @@
+"""Sample datasets for the AI dashboard prototype."""
+
+import numpy as np
+import pandas as pd
+
+
+def get_iris_data() -> pd.DataFrame:
+    """Classic iris dataset — 150 rows, 5 columns."""
+    np.random.seed(42)
+    n = 50
+    data = []
+    for variety, sl, sw, pl, pw in [
+        ("setosa", 5.0, 3.4, 1.5, 0.2),
+        ("versicolor", 5.9, 2.8, 4.3, 1.3),
+        ("virginica", 6.6, 3.0, 5.6, 2.0),
+    ]:
+        data.append(
+            pd.DataFrame(
+                {
+                    "sepal_length": np.random.normal(sl, 0.35, n).round(1),
+                    "sepal_width": np.random.normal(sw, 0.38, n).round(1),
+                    "petal_length": np.random.normal(pl, 0.17 if variety == "setosa" else 0.47, n).round(1),
+                    "petal_width": np.random.normal(pw, 0.10 if variety == "setosa" else 0.20, n).round(1),
+                    "variety": variety,
+                }
+            )
+        )
+    return pd.concat(data, ignore_index=True)
+
+
+def get_genomics_qc_data() -> pd.DataFrame:
+    """Synthetic genomics QC dataset — 200 rows, 7 columns."""
+    np.random.seed(123)
+    n = 200
+    library_types = np.random.choice(["WGS", "WES", "RNA-seq", "ChIP-seq"], n, p=[0.3, 0.25, 0.3, 0.15])
+    total_reads = np.random.lognormal(mean=17.5, sigma=0.5, size=n).astype(int)
+    mapping_rate = np.clip(np.random.beta(30, 3, n) * 100, 50, 99.9).round(1)
+    gc_content = np.clip(np.random.normal(45, 5, n), 25, 65).round(1)
+    duplication_rate = np.clip(np.random.exponential(8, n), 1, 50).round(1)
+
+    # Status based on QC thresholds
+    status = np.where(
+        (mapping_rate > 80) & (duplication_rate < 20),
+        "PASS",
+        np.where(
+            (mapping_rate > 70) & (duplication_rate < 30),
+            "WARNING",
+            "FAIL",
+        ),
+    )
+
+    return pd.DataFrame(
+        {
+            "sample_id": [f"SAMPLE_{i:04d}" for i in range(n)],
+            "total_reads": total_reads,
+            "mapping_rate": mapping_rate,
+            "gc_content": gc_content,
+            "duplication_rate": duplication_rate,
+            "library_type": library_types,
+            "status": status,
+        }
+    )
+
+
+DATASETS = {
+    "iris": {"loader": get_iris_data, "label": "Iris (Botanical)"},
+    "genomics_qc": {"loader": get_genomics_qc_data, "label": "Genomics QC"},
+}
+
+
+def get_column_metadata(df: pd.DataFrame) -> str:
+    """Build a text summary of columns for LLM context."""
+    lines = []
+    for col in df.columns:
+        dtype = str(df[col].dtype)
+        if pd.api.types.is_numeric_dtype(df[col]):
+            stats = f"min={df[col].min()}, max={df[col].max()}, mean={df[col].mean():.2f}"
+        else:
+            uniq = df[col].nunique()
+            examples = df[col].unique()[:5].tolist()
+            stats = f"unique={uniq}, examples={examples}"
+        lines.append(f"  - {col} ({dtype}): {stats}")
+    return f"Columns ({len(df)} rows):\n" + "\n".join(lines)

--- a/dev/litellm-prototype/sample_data.py
+++ b/dev/litellm-prototype/sample_data.py
@@ -81,3 +81,63 @@ def get_column_metadata(df: pd.DataFrame) -> str:
             stats = f"unique={uniq}, examples={examples}"
         lines.append(f"  - {col} ({dtype}): {stats}")
     return f"Columns ({len(df)} rows):\n" + "\n".join(lines)
+
+
+def compute_data_profile(df: pd.DataFrame) -> str:
+    """Run real pandas operations and return a comprehensive text profile.
+
+    This gives the LLM actual computed statistics to reason about,
+    not just metadata. All operations are logged to the terminal.
+    """
+    import logging
+
+    logger = logging.getLogger("data_profile")
+    sections = []
+
+    # --- 1. Shape & dtypes ---
+    logger.info("─── Computing: shape & dtypes ───")
+    sections.append(f"SHAPE: {df.shape[0]} rows x {df.shape[1]} columns")
+
+    # --- 2. df.describe() for numeric columns ---
+    numeric_cols = df.select_dtypes(include="number").columns.tolist()
+    if numeric_cols:
+        logger.info("─── Computing: df.describe() on %s ───", numeric_cols)
+        desc = df[numeric_cols].describe().round(3)
+        sections.append(f"DESCRIPTIVE STATISTICS (numeric):\n{desc.to_string()}")
+
+        # --- 3. Correlation matrix ---
+        if len(numeric_cols) >= 2:
+            logger.info("─── Computing: df[%s].corr() ───", numeric_cols)
+            corr = df[numeric_cols].corr().round(3)
+            sections.append(f"CORRELATION MATRIX:\n{corr.to_string()}")
+
+        # --- 4. Null counts ---
+        logger.info("─── Computing: df.isnull().sum() ───")
+        nulls = df[numeric_cols].isnull().sum()
+        if nulls.any():
+            sections.append(f"NULL COUNTS:\n{nulls.to_string()}")
+        else:
+            sections.append("NULL COUNTS: none")
+
+    # --- 5. Categorical columns: value counts ---
+    cat_cols = df.select_dtypes(include=["object", "category"]).columns.tolist()
+    for col in cat_cols:
+        logger.info("─── Computing: df['%s'].value_counts() ───", col)
+        vc = df[col].value_counts()
+        sections.append(f"VALUE COUNTS for '{col}':\n{vc.to_string()}")
+
+    # --- 6. Group-by stats (categorical × numeric) ---
+    if cat_cols and numeric_cols:
+        for cat_col in cat_cols[:2]:  # max 2 categorical columns
+            logger.info("─── Computing: df.groupby('%s')[%s].agg(['mean','std','count']) ───", cat_col, numeric_cols)
+            grouped = df.groupby(cat_col)[numeric_cols].agg(["mean", "std", "count"]).round(3)
+            sections.append(f"GROUP-BY '{cat_col}' STATISTICS:\n{grouped.to_string()}")
+
+    # --- 7. Sample rows ---
+    logger.info("─── Computing: df.head(5) + df.tail(5) ───")
+    sections.append(f"FIRST 5 ROWS:\n{df.head(5).to_string(index=False)}")
+    sections.append(f"LAST 5 ROWS:\n{df.tail(5).to_string(index=False)}")
+
+    profile = "\n\n".join(sections)
+    logger.info("─── Data profile complete: %d chars ───", len(profile))
+    return profile

--- a/dev/litellm-prototype/schemas.py
+++ b/dev/litellm-prototype/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class PlotSuggestion(BaseModel):
@@ -18,6 +18,20 @@ class PlotSuggestion(BaseModel):
     )
     title: str = Field(description="Human-readable chart title")
     explanation: str = Field(description="Brief explanation of why this visualization was suggested")
+
+    @model_validator(mode="after")
+    def check_dict_kwargs_not_empty(self) -> "PlotSuggestion":
+        if not self.dict_kwargs:
+            raise ValueError(
+                "dict_kwargs must not be empty — it must contain at least 'x' "
+                "(and 'y' for scatter/line/bar) with valid column names."
+            )
+        needs_x = self.visu_type not in ("histogram",)
+        if needs_x and "x" not in self.dict_kwargs:
+            raise ValueError(
+                f"dict_kwargs for '{self.visu_type}' must contain at least 'x' with a valid column name."
+            )
+        return self
 
 
 class CardSuggestion(BaseModel):

--- a/dev/litellm-prototype/schemas.py
+++ b/dev/litellm-prototype/schemas.py
@@ -1,0 +1,41 @@
+"""Pydantic output schemas for structured LLM responses."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class PlotSuggestion(BaseModel):
+    """Structured output for plot generation — maps directly to Plotly Express kwargs."""
+
+    visu_type: Literal["scatter", "bar", "line", "histogram", "box", "violin", "heatmap"] = Field(
+        description="Plotly Express function name"
+    )
+    dict_kwargs: dict[str, Any] = Field(
+        description="Keyword arguments passed to the Plotly Express function (e.g. x, y, color, size, facet_col)"
+    )
+    title: str = Field(description="Human-readable chart title")
+    explanation: str = Field(description="Brief explanation of why this visualization was suggested")
+
+
+class CardSuggestion(BaseModel):
+    """Structured output for metric card generation."""
+
+    column: str = Field(description="DataFrame column to aggregate")
+    aggregation: Literal["count", "sum", "mean", "median", "min", "max", "std"] = Field(
+        description="Aggregation function to apply"
+    )
+    title: str = Field(description="Card display title")
+    icon: str = Field(description="Material Design Icon name (e.g. mdi:chart-line)")
+
+
+class AnalysisResult(BaseModel):
+    """Structured output for data analysis."""
+
+    summary: str = Field(description="Markdown-formatted summary of the analysis")
+    key_findings: list[str] = Field(description="List of key findings as bullet points")
+    suggested_plots: list[PlotSuggestion] | None = Field(
+        default=None, description="Optional list of suggested visualizations"
+    )

--- a/dev/litellm-prototype/schemas.py
+++ b/dev/litellm-prototype/schemas.py
@@ -32,10 +32,25 @@ class CardSuggestion(BaseModel):
 
 
 class AnalysisResult(BaseModel):
-    """Structured output for data analysis."""
+    """Structured output for data analysis (legacy — kept for reference)."""
 
     summary: str = Field(description="Markdown-formatted summary of the analysis")
     key_findings: list[str] = Field(description="List of key findings as bullet points")
     suggested_plots: list[PlotSuggestion] | None = Field(
         default=None, description="Optional list of suggested visualizations"
     )
+
+
+class ExecutionStep(BaseModel):
+    """A single step in the LangChain pandas agent's execution trace."""
+
+    thought: str = Field(description="The agent's reasoning for this step")
+    code: str = Field(description="The pandas code that was executed")
+    output: str = Field(description="The result of executing the code")
+
+
+class AnalysisAgentResult(BaseModel):
+    """Result from the LangChain pandas agent — answer + full execution trace."""
+
+    answer: str = Field(description="Final natural-language answer from the agent")
+    steps: list[ExecutionStep] = Field(description="Ordered list of code execution steps")


### PR DESCRIPTION
Draft — opened to preserve/review this exploratory prototype before retiring the worktree. Fully self-contained under `dev/litellm-prototype/`; touches no production code.

## What's here (~1,648 insertions, 11 commits)
- `app.py` — standalone Dash AI dashboard
- `llm_client.py` + `components/ai_panel.py` — LangChain pandas agent, LLM-driven plot suggestions, verbose token/timing logging
- Sample data, schemas, cards/figures/tables/interactive components

## Status
Exploratory only — never integrated. No AI/LLM code exists on `main`; the later `claude/ai-compatible-depictio-gR9q7` branch is a separate, newer exploration (not a port of this). Kept for the LangChain-agent approach reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)