### PR TITLE
fix: dashboard list/table titles as standard links (middle-click / Ctrl+click → new tab)

### DIFF
--- a/depictio/viewer/src/dashboards/views/DashboardCompactCard.tsx
+++ b/depictio/viewer/src/dashboards/views/DashboardCompactCard.tsx
@@ -16,6 +16,7 @@ import type { DashboardListEntry } from 'depictio-react-core';
 import DashboardActionsMenu from '../DashboardActionsMenu';
 import type { CategoryInfo } from '../DashboardsList';
 import { coerceString, formatLastSaved, isImagePath } from '../lib/format';
+import { dashboardHref, dashboardLinkClickHandler } from '../lib/dashboardLinks';
 
 export interface DashboardCompactCardProps {
   dashboard: DashboardListEntry;
@@ -102,8 +103,10 @@ const DashboardCompactCard: React.FC<DashboardCompactCardProps> = ({
           )}
 
           <UnstyledButton
-            onClick={() => onView(dashboard)}
-            style={{ textAlign: 'left', flex: 1, minWidth: 0 }}
+            component="a"
+            href={dashboardHref(String(dashboard.dashboard_id))}
+            onClick={dashboardLinkClickHandler(() => onView(dashboard))}
+            style={{ textAlign: 'left', flex: 1, minWidth: 0, color: 'inherit' }}
           >
             <Text fw={600} size="sm" lineClamp={1}>
               {titleText}

--- a/depictio/viewer/src/dashboards/views/DashboardTableView.tsx
+++ b/depictio/viewer/src/dashboards/views/DashboardTableView.tsx
@@ -18,6 +18,7 @@ import type { DashboardListEntry } from 'depictio-react-core';
 import DashboardActionsMenu from '../DashboardActionsMenu';
 import type { CategoryInfo } from '../DashboardsList';
 import type { GroupedDashboards } from '../lib/splitDefaultSections';
+import { dashboardHref, dashboardLinkClickHandler } from '../lib/dashboardLinks';
 import { isOwnedByEmail } from '../lib/splitDefaultSections';
 import { coerceString, isImagePath } from '../lib/format';
 import type { Density } from '../hooks/useDashboardViewPrefs';
@@ -402,8 +403,10 @@ const DashboardTableView: React.FC<DashboardTableViewProps> = ({
                         </ThemeIcon>
                       )}
                       <UnstyledButton
-                        onClick={() => onView(r.dashboard)}
-                        style={{ textAlign: 'left' }}
+                        component="a"
+                        href={dashboardHref(String(r.dashboard.dashboard_id))}
+                        onClick={dashboardLinkClickHandler(() => onView(r.dashboard))}
+                        style={{ textAlign: 'left', color: 'inherit' }}
                       >
                         <Text fw={500} size="sm">
                           {r.titleText}


### PR DESCRIPTION
## Summary

Closes #880

On the `/dashboards` page, dashboard titles in **List** and **Table** views were plain `<UnstyledButton onClick={...}>` elements with no `href`, so:
- Middle-click → nothing
- Ctrl/Cmd+click → nothing
- Right-click → no "Open link in new tab" option

The **Thumbnail** view (`DashboardCard`) already handled this correctly with `component="a" href={...}` + `dashboardLinkClickHandler`. This PR applies the same pattern to the two remaining views.

## Changes

| File | Change |
|------|--------|
| `src/dashboards/views/DashboardCompactCard.tsx` | Title `UnstyledButton` → `component="a"` with `href` + `dashboardLinkClickHandler` |
| `src/dashboards/views/DashboardTableView.tsx` | Same fix for the name column button |

Both files import the existing helpers `dashboardHref` and `dashboardLinkClickHandler` from `lib/dashboardLinks.ts` — no new utilities introduced.

## Behaviour

| Interaction | Before | After |
|-------------|--------|-------|
| Plain left-click | SPA navigate (onView) | SPA navigate (onView) — unchanged |
| Middle-click | Nothing | Opens `/dashboard/{id}` in new tab |
| Ctrl/Cmd+click | Nothing | Opens `/dashboard/{id}` in new tab |
| Shift+click | Nothing | Opens `/dashboard/{id}` in new window |
| Right-click | No link options | "Open link in new tab / window" available |

## Test plan

- [ ] Open `/dashboards`, switch to **List** view, middle-click or Ctrl+click a dashboard title → new tab opens at the correct URL
- [ ] Same test in **Table** view
- [ ] Plain left-click still performs SPA navigation without a full page reload
- [ ] Thumbnail view behaviour is unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_019K8494JN1Lk66UqYGQkL4P)_