### PR TITLE
feat(serve) Gateway API support for Depictio on Serve

### DIFF
--- a/helm-charts/depictio/templates/httproutes.yaml
+++ b/helm-charts/depictio/templates/httproutes.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.gateway.enabled }}
+{{- $backendHttpRoute := .Values.backend.httpRoute | default dict }}
+{{- $minioHttpRoute := .Values.minio.httpRoute | default dict }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-httproute
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: depictio
+    component: httproute
+    {{- if .Values.gateway.labels }}
+    {{- toYaml .Values.gateway.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml .Values.gateway.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ include "depictio.frontendUrl" . | quote }}
+    - "{{ .Release.Name }}.gw.{{ .Values.global.domain }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- if or .Values.gateway.snippetsFilter.enabled .Values.gateway.filters }}
+      filters:
+        {{- if .Values.gateway.snippetsFilter.enabled }}
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.nginx.org
+            kind: SnippetsFilter
+            name: {{ .Release.Name }}-auth
+        {{- end }}
+        {{- if .Values.gateway.filters }}
+        {{- toYaml .Values.gateway.filters | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      backendRefs:
+        - name: {{ .Release.Name }}-depictio-viewer
+          port: {{ .Values.viewer.service.httpPort }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-backend-httproute
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: depictio
+    component: backend-httproute
+    {{- if .Values.gateway.labels }}
+    {{- toYaml .Values.gateway.labels | nindent 4 }}
+    {{- end }}
+  {{- if $backendHttpRoute.annotations }}
+  annotations:
+    {{- toYaml $backendHttpRoute.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ include "depictio.apiUrl" . | quote }}
+    - "{{ .Release.Name }}-api.gw.{{ .Values.global.domain }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- if $backendHttpRoute.filters }}
+      filters:
+        {{- toYaml $backendHttpRoute.filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ .Release.Name }}-depictio-backend
+          port: {{ .Values.backend.service.httpPort }}
+{{- if .Values.minio.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-minio-httproute
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: depictio
+    component: minio-httproute
+    {{- if .Values.gateway.labels }}
+    {{- toYaml .Values.gateway.labels | nindent 4 }}
+    {{- end }}
+  {{- if $minioHttpRoute.annotations }}
+  annotations:
+    {{- toYaml $minioHttpRoute.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ include "depictio.minioUrl" . | quote }}
+    - "{{ .Release.Name }}-minio.gw.{{ .Values.global.domain }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- if $minioHttpRoute.filters }}
+      filters:
+        {{- toYaml $minioHttpRoute.filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ .Release.Name }}-minio
+          port: {{ .Values.minio.service.httpPort }}
+{{- end }}
+{{- end }}

--- a/helm-charts/depictio/templates/snippetsfilters.yaml
+++ b/helm-charts/depictio/templates/snippetsfilters.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.gateway.enabled .Values.gateway.snippetsFilter.enabled }}
+---
+apiVersion: gateway.nginx.org/v1alpha1
+kind: SnippetsFilter
+metadata:
+  name: {{ .Release.Name }}-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: depictio
+    component: snippets-filter
+    {{- if .Values.gateway.labels }}
+    {{- toYaml .Values.gateway.labels | nindent 4 }}
+    {{- end }}
+spec:
+  snippets:
+    {{- toYaml .Values.gateway.snippetsFilter.snippets | nindent 4 }}
+{{- end }}

--- a/helm-charts/depictio/values-serve.yaml
+++ b/helm-charts/depictio/values-serve.yaml
@@ -1,28 +1,15 @@
 # Serve-specific values for Depictio deployment.
-# Auth annotations on the shared ingress are rendered by the template based
-# on `permission` set by Serve at deploy time. Base nginx annotations on the
-# dedicated backend/minio ingresses are always rendered by the template.
-ingress:
+# Uses Gateway API (HTTPRoute) for routing. Three HTTPRoutes are always
+# created: frontend (viewer), backend, and minio. Auth filters on the
+# frontend route are injected per-app by Serve at deploy time via
+# gateway.filters in the app's k8s_values.
+gateway:
   enabled: true
-  ingressClassName: "nginx"
-  annotations:
-    nginx.ingress.kubernetes.io/custom-http-errors: "503,502"
-    nginx.ingress.kubernetes.io/default-backend: nginx-errors
-  tls:
-    - secretName: "serve-tls-secret"
-      hosts: []
+  # parentRefs is set at deploy time by Serve — points to the cluster's shared Gateway.
+  parentRefs: []
 
-# Backend and MinIO get dedicated ingresses so Serve auth annotations
-# on the shared frontend ingress do not affect them.
-backend:
-  ingress:
-    separateRoute: true
-    inheritDefaultAnnotations: false
-
-minio:
-  ingress:
-    separateRoute: true
-    inheritDefaultAnnotations: false
+ingress:
+  enabled: false
 
 global:
   domain: ""

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -210,6 +210,9 @@ minio:
     labels: {}
     hosts: []
     tls: []
+  httpRoute:
+    annotations: {}
+    filters: []
 
 # Backend settings
 backend:
@@ -316,6 +319,9 @@ backend:
     labels: {}
     hosts: []
     tls: []
+  httpRoute:
+    annotations: {}
+    filters: []
 
 # Celery Worker settings
 celery:
@@ -407,6 +413,29 @@ viewer:
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
+
+# Gateway API (HTTPRoute) configuration.
+# Enable this instead of ingress when the cluster uses a Gateway API controller.
+# gateway.parentRefs points to the Gateway resource(s) the HTTPRoute attaches to.
+# Separate HTTPRoutes are always created for frontend, backend, and minio.
+# Auth filters (gateway-implementation-specific) go in gateway.filters (frontend only)
+# or backend.httpRoute.filters / minio.httpRoute.filters.
+gateway:
+  enabled: false
+  # parentRefs defines the Gateway this HTTPRoute attaches to.
+  parentRefs: []
+  # Optional metadata for all HTTPRoute resources.
+  labels: {}
+  annotations: {}
+  # Arbitrary ExtensionRef / RequestRedirect / etc. filters for the frontend HTTPRoute.
+  # Backend and MinIO routes never inherit these.
+  filters: []
+  # NGINX Gateway Fabric SnippetsFilter for injecting raw nginx config into the
+  # frontend HTTPRoute. Serve populates snippets at deploy time (auth_request for
+  # private/project access). Ignored when gateway.enabled is false.
+  snippetsFilter:
+    enabled: false
+    snippets: []
 
 # Generic base ingress values
 ingress:


### PR DESCRIPTION
## Summary

Introduce changes to run Depictio on Serve using Gateway API instead of Ingress Nginx. This includes templates for HTTPRoutes, Snippetsfilter and changes to the `values-serve.yaml` file.

At the moment, 2 hostnames are being used in the HTTPRoutes. The `.gw` hostname will become obsolete once our cluster officially transitions to only using Gateway API.

## Type of change
- [ ] Bugfix
- [X] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
<!-- e.g. Closes #123 -->

## How was this tested?

This was tested by deploying a Depictio app containing those recent changes on Serve's dev cluster.

## Checklist
- [ ] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [ ] Tests added/updated and passing
- [ ] Docs updated if needed
