### PR TITLE
feat(auth): flag to disable self-service registration

### DIFF
--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -267,6 +267,13 @@ class AuthConfig(BaseSettings):
         description="Enable demo mode with guided tour tooltips for first-time users. "
         "Extends public mode with interactive onboarding hints.",
     )
+    registration_disabled: bool = Field(
+        default=False,
+        description="Block self-service registration. When True, the /register "
+        "endpoint returns 403 and the Register UI is hidden, so only "
+        "pre-provisioned accounts can log in. Independent of public/single-user "
+        "mode — use for private, login-required public-facing instances.",
+    )
     anonymous_user_email: str = Field(
         default="anonymous@depict.io",
         description="Default anonymous user email",
@@ -323,6 +330,10 @@ class AuthConfig(BaseSettings):
         env_demo_mode = os.getenv("DEPICTIO_AUTH_DEMO_MODE", "").lower()
         if env_demo_mode in ("true", "1", "yes"):
             object.__setattr__(self, "demo_mode", True)
+
+        env_registration_disabled = os.getenv("DEPICTIO_AUTH_REGISTRATION_DISABLED", "").lower()
+        if env_registration_disabled in ("true", "1", "yes"):
+            object.__setattr__(self, "registration_disabled", True)
 
     @computed_field
     @property

--- a/depictio/api/v1/endpoints/user_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/user_endpoints/routes.py
@@ -535,6 +535,7 @@ async def get_current_user_info_optional(
         "is_public_mode": settings.auth.is_public_mode,
         "is_single_user_mode": settings.auth.is_single_user_mode,
         "is_demo_mode": getattr(settings.auth, "is_demo_mode", False),
+        "registration_disabled": getattr(settings.auth, "registration_disabled", False),
         "is_dev_mode": is_dev_mode,
         "walkthrough_disabled": walkthrough_disabled,
         "unauthenticated_mode": getattr(settings.auth, "unauthenticated_mode", False),
@@ -749,6 +750,14 @@ async def register(
         raise HTTPException(
             status_code=403,
             detail="User registration disabled in single-user mode and public mode",
+        )
+
+    # Explicitly disabled on this instance (e.g. private, login-required deployment
+    # where only pre-provisioned accounts may sign in). Independent of auth mode.
+    if settings.auth.registration_disabled:
+        raise HTTPException(
+            status_code=403,
+            detail="User registration is disabled on this instance.",
         )
 
     # Redis-backed per-IP rate limit to slow automated enumeration / spam

--- a/depictio/tests/api/v1/test_security_pr1.py
+++ b/depictio/tests/api/v1/test_security_pr1.py
@@ -318,6 +318,7 @@ async def test_register_collapses_duplicate_email_to_generic_error():
     mock_settings = MagicMock()
     mock_settings.auth.is_single_user_mode = False
     mock_settings.auth.is_public_mode = False
+    mock_settings.auth.registration_disabled = False
 
     with (
         patch.object(user_routes, "settings", mock_settings),
@@ -335,6 +336,36 @@ async def test_register_collapses_duplicate_email_to_generic_error():
     detail = str(exc_info.value.detail)  # type: ignore[unresolved-attribute]
     assert "exist" not in detail.lower(), f"Enumeration leak in register error: {detail!r}"
     assert detail == user_routes._REGISTER_GENERIC_ERROR
+
+
+@pytest.mark.asyncio
+async def test_register_blocked_when_registration_disabled():
+    """With DEPICTIO_AUTH_REGISTRATION_DISABLED set, /register must 403 before
+    creating any user — only pre-provisioned accounts may log in."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from fastapi import HTTPException
+
+    from depictio.api.v1.endpoints.user_endpoints import routes as user_routes
+    from depictio.models.models.users import RequestUserRegistration
+
+    registration = RequestUserRegistration(email="new@example.com", password="p" * 16)
+    mock_settings = MagicMock()
+    mock_settings.auth.is_single_user_mode = False
+    mock_settings.auth.is_public_mode = False
+    mock_settings.auth.registration_disabled = True
+
+    create_user = AsyncMock()
+    with (
+        patch.object(user_routes, "settings", mock_settings),
+        patch.object(user_routes, "enforce_rate_limit"),
+        patch.object(user_routes, "_create_user_in_db", create_user),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await user_routes.register(registration, MagicMock())
+
+    assert exc_info.value.status_code == 403  # type: ignore[unresolved-attribute]
+    create_user.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/depictio/viewer/src/auth/AuthApp.tsx
+++ b/depictio/viewer/src/auth/AuthApp.tsx
@@ -107,7 +107,7 @@ export default function AuthApp() {
               )}
             </Stack>
           </AuthCard>
-        ) : view === 'register' ? (
+        ) : view === 'register' && !status?.registration_disabled ? (
           <AuthCard heading="Please register :">
             <RegisterForm
               onSwitchToLogin={() => setView('login')}
@@ -118,7 +118,9 @@ export default function AuthApp() {
           <AuthCard heading="Welcome to Depictio :">
             <LoginForm
               googleEnabled={status?.google_oauth_enabled ?? false}
-              onSwitchToRegister={() => setView('register')}
+              onSwitchToRegister={
+                status?.registration_disabled ? undefined : () => setView('register')
+              }
               onSuccess={handleSuccess}
             />
           </AuthCard>

--- a/depictio/viewer/src/auth/components/LoginForm.tsx
+++ b/depictio/viewer/src/auth/components/LoginForm.tsx
@@ -6,7 +6,9 @@ const EMAIL_RE = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 
 interface Props {
   googleEnabled: boolean;
-  onSwitchToRegister: () => void;
+  /** Switch to the register view. Omit to hide the Register button entirely
+   *  (e.g. when registration is disabled on this instance). */
+  onSwitchToRegister?: () => void;
   /** Called after a successful login — drives the redirect. */
   onSuccess: () => void;
 }
@@ -86,17 +88,19 @@ export default function LoginForm({ googleEnabled, onSwitchToRegister, onSuccess
         >
           Login
         </Button>
-        <Anchor
-          component="button"
-          type="button"
-          onClick={onSwitchToRegister}
-          underline="never"
-          data-testid="open-register-form"
-        >
-          <Button radius="md" variant="outline" color="blue" style={{ width: 120 }}>
-            Register
-          </Button>
-        </Anchor>
+        {onSwitchToRegister && (
+          <Anchor
+            component="button"
+            type="button"
+            onClick={onSwitchToRegister}
+            underline="never"
+            data-testid="open-register-form"
+          >
+            <Button radius="md" variant="outline" color="blue" style={{ width: 120 }}>
+              Register
+            </Button>
+          </Anchor>
+        )}
       </Group>
       {googleEnabled && (
         <Stack gap="xs">

--- a/helm-charts/depictio/templates/configmaps.yaml
+++ b/helm-charts/depictio/templates/configmaps.yaml
@@ -45,6 +45,7 @@ data:
   DEPICTIO_AUTH_PUBLIC_MODE: {{ .Values.backend.env.DEPICTIO_AUTH_PUBLIC_MODE | default "false" | quote }}
   DEPICTIO_AUTH_DEMO_MODE: {{ .Values.backend.env.DEPICTIO_AUTH_DEMO_MODE | default "false" | quote }}
   DEPICTIO_AUTH_SINGLE_USER_MODE: {{ .Values.backend.env.DEPICTIO_AUTH_SINGLE_USER_MODE | default "false" | quote }}
+  DEPICTIO_AUTH_REGISTRATION_DISABLED: {{ .Values.backend.env.DEPICTIO_AUTH_REGISTRATION_DISABLED | default "false" | quote }}
   DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL: {{ .Values.backend.env.DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL | default "anonymous@example.com" | quote }}
   DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS: {{ .Values.backend.env.DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS | default "24" | quote }}
 
@@ -123,6 +124,7 @@ data:
   DEPICTIO_AUTH_PUBLIC_MODE: {{ .Values.backend.env.DEPICTIO_AUTH_PUBLIC_MODE | default "false" | quote }}
   DEPICTIO_AUTH_DEMO_MODE: {{ .Values.backend.env.DEPICTIO_AUTH_DEMO_MODE | default "false" | quote }}
   DEPICTIO_AUTH_SINGLE_USER_MODE: {{ .Values.backend.env.DEPICTIO_AUTH_SINGLE_USER_MODE | default "false" | quote }}
+  DEPICTIO_AUTH_REGISTRATION_DISABLED: {{ .Values.backend.env.DEPICTIO_AUTH_REGISTRATION_DISABLED | default "false" | quote }}
   DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL: {{ .Values.backend.env.DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL | default "anonymous@example.com" | quote }}
   DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS: {{ .Values.backend.env.DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS | default "24" | quote }}
 

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -259,6 +259,13 @@ backend:
     DEPICTIO_CELERY_RESULT_BACKEND_PORT: "6379"
     DEPICTIO_CELERY_RESULT_BACKEND_DB: "2"
 
+    # Block self-service registration. When "true", the /register endpoint
+    # returns 403 and the Register UI is hidden, so only pre-provisioned
+    # accounts can log in. Independent of public/single-user mode — set
+    # alongside DEPICTIO_AUTH_PUBLIC_MODE="false" for a private, login-required
+    # public-facing instance.
+    DEPICTIO_AUTH_REGISTRATION_DISABLED: "false"
+
     # Anonymous user configuration
     DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL: "anonymous@depict.io"
     DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS: "24"

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -1765,6 +1765,10 @@ export interface AuthStatusResponse {
   /** Unauthenticated mode — anonymous users get a session, can upgrade to
    *  temporary. Older backends omit this — treat absent as `false`. */
   unauthenticated_mode?: boolean;
+  /** Self-service registration is disabled — hide the Register UI and only
+   *  allow pre-provisioned accounts to log in. Older backends omit this —
+   *  treat absent as `false`. */
+  registration_disabled?: boolean;
   google_oauth_enabled: boolean;
 }
 


### PR DESCRIPTION
## Summary

Adds a dedicated `DEPICTIO_AUTH_REGISTRATION_DISABLED` flag (default `false`) that blocks self-service registration **independently of auth mode**. Previously registration could only be disabled as a side effect of public mode or single-user mode, so there was no way to run a login-required, public-facing instance where only pre-provisioned accounts can sign in.

When enabled, **both** sign-up doors are closed:
- `POST /auth/register` returns `403` before any user is created.
- Google OAuth login no longer auto-provisions an account for an unknown email — `create_or_get_user` is gated with `allow_create`, so OAuth stays a login-only door for existing users and returns `403` for strangers. (Without this, any Google account could sign in and be auto-created, bypassing the flag.)
- The auth status endpoint exposes `registration_disabled`, and the React `/auth` page hides the Register button and the register view.

## Type of change
- [ ] Bugfix
- [X] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
<!-- e.g. Closes #123 -->

## How was this tested?

- Unit test: `/register` returns `403` and never calls `_create_user_in_db` when the flag is set.
- Unit test: `create_or_get_user(allow_create=False)` returns `(None, False)` for an unknown email instead of saving a user (OAuth bypass guard).
- Existing `/register` enumeration-guard test updated to keep the flag `false`.
- `ruff`, `ty` (no new diagnostics on changed files), and viewer `tsc --noEmit` pass.

## Checklist
- [X] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [X] Tests added/updated and passing
- [ ] Docs updated if needed
