### PR TITLE
fix(auth): gate Google OAuth login behind registration_disabled

### DIFF
--- a/depictio/api/v1/endpoints/auth_endpoints/google_oauth_routes.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/google_oauth_routes.py
@@ -124,9 +124,19 @@ async def google_oauth_callback(
         logger.info("Fetching user information from Google")
         google_user = await fetch_google_user_info(token_data["access_token"])
 
-        # Step 3: Create or get existing user
+        # Step 3: Create or get existing user. When registration is disabled,
+        # OAuth must not provision new accounts — it stays a login-only door
+        # for pre-provisioned users (mirrors the /register 403 guard).
         logger.info(f"Processing user: {google_user.email}")
-        user, user_created = await create_or_get_user(google_user)
+        user, user_created = await create_or_get_user(
+            google_user, allow_create=not settings.auth.registration_disabled
+        )
+        if user is None:
+            raise HTTPException(
+                status_code=403,
+                detail="Registration is disabled on this instance. "
+                "Ask an administrator for access.",
+            )
 
         # Step 4: Create authentication token for the user
         logger.info(f"Creating authentication token for user: {user.id}")

--- a/depictio/api/v1/endpoints/auth_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/utils.py
@@ -124,11 +124,22 @@ async def fetch_google_user_info(access_token: str) -> GoogleUserInfo:
         return GoogleUserInfo(**user_data)
 
 
-async def create_or_get_user(google_user: GoogleUserInfo) -> tuple[UserBeanie, bool]:
+async def create_or_get_user(
+    google_user: GoogleUserInfo, *, allow_create: bool = True
+) -> tuple[UserBeanie | None, bool]:
     """Create new user or get existing user from Google OAuth info.
 
+    Args:
+        google_user: Verified Google account info.
+        allow_create: When False, never provision a new account — return
+            ``(None, False)`` for an unknown email. Used to honour
+            ``registration_disabled`` so OAuth is a login-only door for
+            pre-provisioned accounts, not a registration bypass.
+
     Returns:
-        Tuple of (user, created) where created is True if user was newly created
+        Tuple of (user, created) where created is True if user was newly
+        created. ``user`` is None when the email is unknown and
+        ``allow_create`` is False.
     """
     # Check if user already exists
     existing_user = await UserBeanie.find_one({"email": google_user.email})
@@ -136,6 +147,13 @@ async def create_or_get_user(google_user: GoogleUserInfo) -> tuple[UserBeanie, b
     if existing_user:
         logger.info(f"Existing user found for OAuth login: {google_user.email}")
         return existing_user, False
+
+    if not allow_create:
+        logger.warning(
+            f"OAuth login rejected for unregistered email (registration disabled): "
+            f"{google_user.email}"
+        )
+        return None, False
 
     # Create new user
     logger.info(f"Creating new user from OAuth: {google_user.email}")

--- a/depictio/tests/api/v1/endpoints/auth_endpoints/test_google_oauth.py
+++ b/depictio/tests/api/v1/endpoints/auth_endpoints/test_google_oauth.py
@@ -218,6 +218,10 @@ class TestGoogleOAuthCallback:
                 "google_oauth_redirect_uri"
             ]
             mock_settings.auth.google_oauth_enabled = True
+            # Normal mode: registration enabled, so a new OAuth user is
+            # auto-provisioned. (MagicMock returns a truthy default otherwise,
+            # which would trip the registration_disabled gate.)
+            mock_settings.auth.registration_disabled = False
 
             response = client.get(
                 "/auth/google/callback",
@@ -528,6 +532,10 @@ class TestGoogleOAuthIntegration:
                 "google_oauth_client_id"
             ]
             mock_settings.auth.google_oauth_enabled = True
+            # Normal mode: registration enabled so the new OAuth user is
+            # auto-provisioned (MagicMock default is truthy, which would
+            # otherwise trip the registration_disabled gate).
+            mock_settings.auth.registration_disabled = False
             mock_settings.auth.google_oauth_redirect_uri = google_oauth_config[
                 "google_oauth_redirect_uri"
             ]

--- a/depictio/tests/api/v1/test_security_pr1.py
+++ b/depictio/tests/api/v1/test_security_pr1.py
@@ -368,6 +368,28 @@ async def test_register_blocked_when_registration_disabled():
     create_user.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_oauth_create_or_get_user_blocks_unknown_when_create_disallowed():
+    """With registration disabled, OAuth must not provision a new account for
+    an unknown email — create_or_get_user(allow_create=False) returns
+    (None, False) instead of saving a user (the OAuth registration bypass)."""
+    from unittest.mock import AsyncMock, patch
+
+    from depictio.api.v1.endpoints.auth_endpoints import utils as oauth_utils
+    from depictio.models.models.google_oauth import GoogleUserInfo
+
+    google_user = GoogleUserInfo(
+        id="g-123", email="stranger@example.com", verified_email=True, name="Stranger"
+    )
+
+    with patch.object(oauth_utils.UserBeanie, "find_one", AsyncMock(return_value=None)) as find_one:
+        user, created = await oauth_utils.create_or_get_user(google_user, allow_create=False)
+
+    find_one.assert_awaited_once()
+    assert user is None
+    assert created is False
+
+
 # ---------------------------------------------------------------------------
 # PR-C — backup restore: backup_id format + path containment
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #883. The `DEPICTIO_AUTH_REGISTRATION_DISABLED` flag shipped in 1.1.1 only gated the password `/register` path — Google OAuth was a second, ungated door: `create_or_get_user` auto-provisioned an account for **any** Google email, bypassing the flag entirely.

This gates OAuth user creation behind the same flag:
- `create_or_get_user` takes `allow_create` (default `True`); when `False` it returns `(None, False)` for an unknown email instead of saving a user.
- The OAuth callback passes `allow_create=not settings.auth.registration_disabled` and returns **403** when no account exists.

Net effect: with registration disabled, OAuth stays a login-only door for pre-provisioned users — existing users sign in normally, strangers get 403.

## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
Follow-up to #883.

## How was this tested?

- Unit test: `create_or_get_user(allow_create=False)` returns `(None, False)` for an unknown email instead of saving a user.
- Existing `/register` guard tests still pass.
- `ruff`, `ty` (no new diagnostics on changed files) pass.

## Checklist
- [X] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [X] Tests added/updated and passing
- [ ] Docs updated if needed
