### PR TITLE
fix(ampliseq): supply METADATA_FILE to reference seed so Differential DCs aren't pruned

### DIFF
--- a/depictio/projects/nf-core/ampliseq/2.16.0/template.yaml
+++ b/depictio/projects/nf-core/ampliseq/2.16.0/template.yaml
@@ -51,6 +51,20 @@ template:
     - name: "SKIP_ANCOM"
       description: "Auto-set from params.json (skip_ancom). Prunes the ANCOM-BC differential-abundance DCs (qiime2/ancombc/ is absent)."
       required: false
+  # Variables supplied when materialising the BUNDLED reference/demo dataset
+  # (db_init_reference_datasets.resolve_template_for_init). The reference run is
+  # a metadata-present analysis (GROUP_COL=habitat) — the canonical *.tsv seeds
+  # were generated this way (see generate_seeds.sh). Without METADATA_FILE the
+  # `if_var_absent: METADATA_FILE` conditional prunes metadata/ancombc_results/
+  # ma_canonical/upset_canonical/alpha_rarefaction, leaving the Differential &
+  # Community showcase dashboards bound to DCs that no longer exist (→ 404).
+  reference:
+    vars:
+      METADATA_FILE: "{DATA_ROOT}/input/Metadata_full.tsv"
+      SAMPLESHEET_FILE: "{DATA_ROOT}/input/samplesheet.csv"
+      METADATA_ID_COL: "sample"
+      GROUP_COL: "habitat"
+      GROUP_COL_DISPLAY: "Habitat"
   dashboards:
     - "dashboards/base.yaml"
   conditional:


### PR DESCRIPTION
## Summary

On the ampliseq Differential dashboard, the volcano plot and the W/LFC range sliders failed with `Failed to fetch specs: 404` — `GET /deltatables/specs/{ancombc_results}` returned `Data collection not found or access denied`.

Root cause: the bundled ampliseq reference seed is a **metadata-present** analysis, but `db_init_reference_datasets.resolve_template_for_init` only supplied `DATA_ROOT` — it never provided `METADATA_FILE`. The `if_var_absent: METADATA_FILE` conditional in `template.yaml` then **pruned the metadata-dependent DCs** at seed time:

```
templates.py _apply_conditionals: removing DC tag 'ancombc_results'
Workflow 'ampliseq': removed 6 DC(s) (metadata, upset_canonical, ma_canonical, ancombc_results, sintax_rel_abundance, alpha_rarefaction)
```

…while the Differential/Community showcase dashboards (static `.db_seeds`) still bound tiles to those DCs → 404.

Fix: add a `template.reference.vars` block (a supported-but-unused hook on `resolve_template_for_init`) supplying `METADATA_FILE`, `SAMPLESHEET_FILE`, `METADATA_ID_COL=sample`, `GROUP_COL=habitat` — matching how `generate_seeds.sh` built the canonical `*.tsv` seeds. No DC config or dashboard change.

## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
<!-- volcano / range-slider 404 on ampliseq Differential dashboard -->

## How was this tested?

On the live demo: copied the fixed template into the backend pod, reseeded ampliseq, then verified `GET /deltatables/specs/646b0f3c1e4a2d7f8e5b8caa` (ancombc_results) returns **200** with the volcano columns (`neg_log10_qval`, `lfc`, `significant`, `w`) — previously 404. No "removing DC tag 'ancombc_results'" / "METADATA_FILE not provided" log lines after the fix.

Note: 2.14.0 has the same latent gap but is not the deployed reference version (`DATASET_PATHS` → 2.16.0); left untouched.

## Checklist
- [X] Code follows project style
- [ ] Tests added/updated and passing
- [ ] Docs updated if needed
