### PR TITLE
fix(advanced-viz): DC schema 500 on deltalake 1.6 (arro3) + bindings Required column

### DIFF
--- a/depictio/api/v1/endpoints/datacollections_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/datacollections_endpoints/utils.py
@@ -168,6 +168,7 @@ async def _get_data_collection_polars_schema(
     if not delta_location:
         raise HTTPException(status_code=404, detail="Delta-table location is missing.")
 
+    import pyarrow as pa
     from deltalake import DeltaTable
 
     from depictio.api.v1.s3 import polars_s3_config
@@ -182,9 +183,22 @@ async def _get_data_collection_polars_schema(
         schema = dt.schema()
         to_arrow = getattr(schema, "to_arrow", None) or getattr(schema, "to_pyarrow")
         arrow_schema = to_arrow()
+        # deltalake 1.x's ``to_arrow()`` returns arro3 Arrow types, whose DataType
+        # objects lack the ``.id`` attribute that ``pyarrow.types.is_*`` introspection
+        # relies on (below). Coerce to a real ``pyarrow.Schema`` via the Arrow
+        # PyCapsule protocol so the dtype mapping works on both deltalake 0.24
+        # (already pyarrow) and 1.6 (arro3).
+        if not isinstance(arrow_schema, pa.Schema):
+            arrow_schema = pa.schema(arrow_schema)
     except Exception as exc:
-        logger.warning(f"polars_schema: cannot read delta schema at {delta_location}: {exc}")
-        raise HTTPException(status_code=500, detail="Unable to read Delta schema.") from exc
+        logger.warning(
+            f"polars_schema: cannot read delta schema at {delta_location}: "
+            f"{type(exc).__name__}: {exc}"
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unable to read Delta schema ({type(exc).__name__}).",
+        ) from exc
 
     # Stringify pyarrow dtypes into the polars naming convention expected by
     # validate_binding(): polars uses CamelCase ("Float64", "Int64", "Utf8"/"String").

--- a/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
+++ b/depictio/viewer/src/builder/advanced_viz/AdvancedVizBuilder.tsx
@@ -177,8 +177,8 @@ function roleBindingLabel(
   );
 }
 
-/** One row of the "Bindings overview" table: role name + a colour-coded
- *  required/optional badge, a simplified type, and the role description. */
+/** One row of the "Bindings overview" table: role name, a simplified type, a
+ *  colour-coded required/optional column, and the role description. */
 function exampleInputRow(
   role: string,
   typeLabel: string,
@@ -187,24 +187,19 @@ function exampleInputRow(
 ): React.ReactNode {
   return (
     <Table.Tr key={`${required ? 'req' : 'opt'}-${role}`}>
-      {/* Role + Type never wrap, so they always fit their content; Description
-          is the only wrapping column and absorbs the remaining width. */}
+      {/* Role, Type + Required never wrap, so they always fit their content;
+          Description is the only wrapping column and absorbs the remaining width. */}
       <Table.Td style={{ whiteSpace: 'nowrap', width: '1%' }}>
-        <Group gap={6} wrap="nowrap">
-          <Text size="xs" fw={500}>
-            {role}
-          </Text>
-          <Badge
-            size="xs"
-            variant="light"
-            color={required ? REQUIRED_COLOR : OPTIONAL_COLOR}
-            style={{ flexShrink: 0 }}
-          >
-            {required ? 'required' : 'optional'}
-          </Badge>
-        </Group>
+        <Text size="xs" fw={500}>
+          {role}
+        </Text>
       </Table.Td>
       <Table.Td style={{ whiteSpace: 'nowrap', width: '1%' }}>{typeLabel}</Table.Td>
+      <Table.Td style={{ whiteSpace: 'nowrap', width: '96px' }}>
+        <Badge size="xs" variant="light" color={required ? REQUIRED_COLOR : OPTIONAL_COLOR}>
+          {required ? 'required' : 'optional'}
+        </Badge>
+      </Table.Td>
       <Table.Td>
         <Text size="xs" c="dimmed">
           {description || '—'}
@@ -667,6 +662,7 @@ const AdvancedVizBuilder: React.FC = () => {
                     <Table.Tr>
                       <Table.Th style={{ whiteSpace: 'nowrap', width: '1%' }}>Role</Table.Th>
                       <Table.Th style={{ whiteSpace: 'nowrap', width: '1%' }}>Type</Table.Th>
+                      <Table.Th style={{ whiteSpace: 'nowrap', width: '96px' }}>Required</Table.Th>
                       <Table.Th>Description</Table.Th>
                     </Table.Tr>
                   </Table.Thead>


### PR DESCRIPTION
The advanced-viz builder's DC schema endpoint (`GET /datacollections/polars_schema/{id}`) 500'd on the deployed runtime for every data collection: deltalake 1.6's `Schema.to_arrow()` returns arro3 Arrow types whose `DataType` lacks the `.id` attribute `pyarrow.types.is_*` relies on, so `_pyarrow_to_polars_dtype_name` raised `AttributeError` on the first field. The dev venv (deltalake 0.24, real pyarrow) hid it locally.

Fix: coerce the arro3 schema to a real `pyarrow.Schema` via the Arrow PyCapsule protocol (`pa.schema(...)`) before mapping dtypes, and include the exception class in the 500 detail/log so future read failures are self-diagnosing.

Also moves the required/optional badge in the bindings-overview table into its own dedicated **Required** column.

Verified in a py3.12 venv with the pinned `deltalake==1.6.0` + `pyarrow==20.0.0` that the coercion returns correct polars dtype names.
