### PR TITLE
fix(viewer): DC manager upload, collapse & coordinate map + editor route

### DIFF
--- a/depictio/viewer/src/App.tsx
+++ b/depictio/viewer/src/App.tsx
@@ -623,7 +623,7 @@ const App: React.FC = () => {
                       {isOwner && (
                         <Button
                           component="a"
-                          href={`/dashboard-beta-edit/${dashboardId}`}
+                          href={`/dashboard-edit/${dashboardId}`}
                           leftSection={<Icon icon="mdi:pencil" width={16} />}
                           size="md"
                           variant="filled"

--- a/depictio/viewer/src/builder/catalog/CatalogTab.tsx
+++ b/depictio/viewer/src/builder/catalog/CatalogTab.tsx
@@ -201,7 +201,7 @@ const CatalogTab: React.FC<CatalogTabProps> = ({ projectId }) => {
     try {
       const metadata = buildMetadata(state);
       await upsertComponent(dashboardId, metadata, { appendLayout: true });
-      window.location.assign(`/dashboard-beta-edit/${dashboardId}`);
+      window.location.assign(`/dashboard-edit/${dashboardId}`);
     } catch {
       // Fall back to Edit & Add so the user can fix the issue in the Design step.
       // (initFromCatalog is already called above, so the Design step will show.)

--- a/depictio/viewer/src/hooks/useFolderDropzone.ts
+++ b/depictio/viewer/src/hooks/useFolderDropzone.ts
@@ -49,6 +49,12 @@ interface UseFolderDropzoneResult {
   clear: () => void;
   /** Programmatically open the OS picker bound to `inputRef`. */
   openPicker: () => void;
+  /** Bind to the hidden `<input onChange={...}>`. Uses React's delegated
+   *  change event instead of an imperative addEventListener so the handler
+   *  always tracks the live DOM node — an addEventListener bound in an effect
+   *  goes stale when React recreates the input node (e.g. StrictMode remount)
+   *  and the effect doesn't re-run, silently dropping the file selection. */
+  onInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Accept a `FileList` directly (e.g. from a parent `<input>`). Useful for tests. */
   addFromFileList: (files: FileList | File[] | null) => void;
 }
@@ -309,19 +315,19 @@ export function useFolderDropzone(
     };
   }, []);
 
-  // Hook the click-to-pick input — owner attaches via `inputRef` and chooses
-  // file-picker vs folder-picker semantics by setting `webkitdirectory`.
-  useEffect(() => {
-    const input = inputRef.current;
-    if (!input) return;
-    const onChange = (event: Event) => {
-      const target = event.target as HTMLInputElement;
+  // Click-to-pick change handler — owner attaches via `onChange={onInputChange}`
+  // and chooses file-picker vs folder-picker semantics by setting
+  // `webkitdirectory` on the input. React's delegated onChange always fires on
+  // the live node, unlike an addEventListener bound to inputRef.current in an
+  // effect (which orphans onto a detached node when React recreates the input).
+  const onInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const target = event.currentTarget;
       if (target.files?.length) ingest(Array.from(target.files));
       target.value = '';
-    };
-    input.addEventListener('change', onChange);
-    return () => input.removeEventListener('change', onChange);
-  }, [ingest]);
+    },
+    [ingest],
+  );
 
   const removeFile = useCallback((file: File) => {
     setFiles((prev) => prev.filter((f) => f !== file));
@@ -359,6 +365,7 @@ export function useFolderDropzone(
     removeFile,
     clear,
     openPicker,
+    onInputChange,
     addFromFileList,
   };
 }

--- a/depictio/viewer/src/projects/detail/CoordinatesMapPreview.tsx
+++ b/depictio/viewer/src/projects/detail/CoordinatesMapPreview.tsx
@@ -4,7 +4,7 @@
  * and renders a Plotly scattermapbox where hovering a marker shows the row's
  * non-coord columns — same hover UX as the dashboard's Map component.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Badge,
@@ -37,6 +37,43 @@ function escapeHtml(s: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+const MAP_HEIGHT = 360;
+// Leave a margin so edge points aren't flush against the frame.
+const ZOOM_PADDING = 0.5;
+// Keep a lone point (or tightly-clustered points) from zooming to street level.
+const MAX_ZOOM = 12;
+const SINGLE_POINT_ZOOM = 9;
+
+/**
+ * Web-Mercator "fit these bounds into a WxH viewport" zoom — Plotly's
+ * scattermapbox has no fitBounds, so we derive the zoom that frames every
+ * point. Mirrors the classic Google Maps getBoundsZoom, using mapbox-gl's
+ * 512px world tile. Returns the tighter of the lat/lon fits so both axes stay
+ * inside the viewport.
+ */
+function fitBoundsZoom(
+  minLat: number,
+  maxLat: number,
+  minLon: number,
+  maxLon: number,
+  widthPx: number,
+  heightPx: number,
+): number {
+  const WORLD = 512;
+  const latRad = (lat: number) => {
+    const sin = Math.sin((lat * Math.PI) / 180);
+    const rad = Math.log((1 + sin) / (1 - sin)) / 2;
+    return Math.max(Math.min(rad, Math.PI), -Math.PI) / 2;
+  };
+  const latFraction = (latRad(maxLat) - latRad(minLat)) / Math.PI;
+  let lonDiff = maxLon - minLon;
+  if (lonDiff < 0) lonDiff += 360;
+  const lonFraction = lonDiff / 360;
+  const latZoom = Math.log2(heightPx / WORLD / (latFraction || Number.EPSILON));
+  const lonZoom = Math.log2(widthPx / WORLD / (lonFraction || Number.EPSILON));
+  return Math.min(latZoom, lonZoom);
 }
 
 const CoordinatesMapPreview: React.FC<{ dc: DcLike }> = ({ dc }) => {
@@ -110,13 +147,43 @@ const CoordinatesMapPreview: React.FC<{ dc: DcLike }> = ({ dc }) => {
       };
     }, [preview, latCol, lonCol]);
 
-  // Auto-center on the mean lat/lon so the map opens roughly framed.
-  const center = useMemo(() => {
-    if (!lats.length) return { lat: 0, lon: 0 };
-    const sumLat = lats.reduce((a, b) => a + b, 0);
-    const sumLon = lons.reduce((a, b) => a + b, 0);
-    return { lat: sumLat / lats.length, lon: sumLon / lons.length };
-  }, [lats, lons]);
+  // Measure the rendered map width so the fit-bounds zoom accounts for the
+  // actual aspect ratio (height is fixed at MAP_HEIGHT). Starts at 0 → first
+  // paint uses a sensible fallback, then the ResizeObserver refines it.
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const [mapWidth, setMapWidth] = useState(0);
+  useEffect(() => {
+    const el = mapContainerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      if (w) setMapWidth(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Frame the view to the points' bounding box: center on the bbox midpoint and
+  // pick the zoom that fits every point (padded + clamped), instead of a fixed
+  // world-scale zoom.
+  const { center, zoom } = useMemo(() => {
+    if (!lats.length) return { center: { lat: 0, lon: 0 }, zoom: 1 };
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLon = Math.min(...lons);
+    const maxLon = Math.max(...lons);
+    const center = { lat: (minLat + maxLat) / 2, lon: (minLon + maxLon) / 2 };
+    // All points coincident (or a single point): no span to fit.
+    if (minLat === maxLat && minLon === maxLon) {
+      return { center, zoom: SINGLE_POINT_ZOOM };
+    }
+    const width = mapWidth || 600;
+    const raw = fitBoundsZoom(minLat, maxLat, minLon, maxLon, width, MAP_HEIGHT);
+    let z = raw - ZOOM_PADDING;
+    if (!Number.isFinite(z)) z = SINGLE_POINT_ZOOM;
+    z = Math.max(0, Math.min(z, MAX_ZOOM));
+    return { center, zoom: z };
+  }, [lats, lons, mapWidth]);
 
   if (!latCol || !lonCol) {
     return (
@@ -179,7 +246,7 @@ const CoordinatesMapPreview: React.FC<{ dc: DcLike }> = ({ dc }) => {
           </Badge>
         )}
       </Group>
-      <div style={{ width: '100%', height: 360 }}>
+      <div ref={mapContainerRef} style={{ width: '100%', height: MAP_HEIGHT }}>
         <Plot
           data={[
             {
@@ -203,7 +270,7 @@ const CoordinatesMapPreview: React.FC<{ dc: DcLike }> = ({ dc }) => {
             mapbox: {
               style: mapStyle,
               center,
-              zoom: 1,
+              zoom,
             },
             showlegend: false,
           }}

--- a/depictio/viewer/src/projects/detail/ManageDataCollectionModal.tsx
+++ b/depictio/viewer/src/projects/detail/ManageDataCollectionModal.tsx
@@ -136,6 +136,7 @@ const ManageDataCollectionModal: React.FC<ManageDataCollectionModalProps> = ({
     removeFile,
     clear,
     openPicker,
+    onInputChange,
   } = useFolderDropzone(dropzoneOptions);
 
   // Reset on open / close.
@@ -332,7 +333,13 @@ const ManageDataCollectionModal: React.FC<ManageDataCollectionModalProps> = ({
                     </Text>
                   </Stack>
                 </UnstyledDropZone>
-                <input ref={inputRef} type="file" multiple style={{ display: 'none' }} />
+                <input
+                  ref={inputRef}
+                  type="file"
+                  multiple
+                  style={{ display: 'none' }}
+                  onChange={onInputChange}
+                />
               </div>
 
               {files.length > 0 && (

--- a/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
+++ b/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
@@ -308,6 +308,11 @@ const ProjectDetailApp: React.FC = () => {
 
   const [mobileOpened, { toggle: toggleMobile }] = useDisclosure(false);
   const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
+  // Held at this level (not inside DataCollectionsManagerSection) so the
+  // expand/collapse state survives the remount that a refresh() triggers —
+  // every DC mutation bumps refreshKey → setLoading(true) swaps the section
+  // for a <Loader/>, and section-local state would reset to collapsed.
+  const [dcManagerOpened, { toggle: toggleDcManager }] = useDisclosure(false);
 
   const { user } = useCurrentUser();
   const projectId = readProjectIdFromPath();
@@ -533,6 +538,8 @@ const ProjectDetailApp: React.FC = () => {
                     dataCollections={dataCollections}
                     selectedDcId={selectedDcId}
                     canMutate={canMutate}
+                    opened={dcManagerOpened}
+                    onToggle={toggleDcManager}
                     onSelect={setSelectedDcId}
                     onRename={setRenameTarget}
                     onDelete={setDeleteTarget}
@@ -950,6 +957,7 @@ const TableFileDropZone: React.FC<{
         type="file"
         accept=".csv,.tsv,.tab,.parquet,.pq,.feather,.arrow"
         style={{ display: 'none' }}
+        onChange={dropzone.onInputChange}
       />
     </div>
     {dropzone.error && (
@@ -1567,6 +1575,7 @@ const CreateDataCollectionModal: React.FC<{
                 // filterFilename:'multiqc.parquet' does the real filtering.
                 // @ts-expect-error — webkitdirectory is non-standard but widely supported.
                 webkitdirectory=""
+                onChange={multiqcDropzone.onInputChange}
               />
             </div>
             {multiqcDropzone.error && (
@@ -2147,6 +2156,12 @@ const DataCollectionsManagerSection: React.FC<{
   dataCollections: DataCollectionShape[];
   selectedDcId: string | null;
   canMutate: boolean;
+  /** Expand/collapse state, lifted to the parent so it survives the remount a
+   *  refresh() triggers after any DC mutation. Collapsed by default keeps the
+   *  Overview tab compact; expands into a height-capped scroll area so a long
+   *  DC list never dominates the page. */
+  opened: boolean;
+  onToggle: () => void;
   onSelect: (id: string | null) => void;
   onRename: (dc: DataCollectionShape) => void;
   onDelete: (dc: DataCollectionShape) => void;
@@ -2160,18 +2175,17 @@ const DataCollectionsManagerSection: React.FC<{
   dataCollections,
   selectedDcId,
   canMutate,
+  opened,
+  onToggle,
   onSelect,
   onRename,
   onDelete,
   onManage,
   onCreate,
 }) => {
-  // Collapsed by default to keep the Overview tab compact; expands into a
-  // height-capped scroll area so a long DC list never dominates the page.
-  const [opened, { toggle }] = useDisclosure(false);
   return (
     <Card withBorder radius="md" p="sm">
-      <UnstyledButton onClick={toggle} w="100%">
+      <UnstyledButton onClick={onToggle} w="100%">
         <Group gap="xs" wrap="nowrap">
           <Icon
             icon="mdi:database-outline"


### PR DESCRIPTION
Small viewer fixes surfaced while using the Project Data Manager and an empty dashboard.

## Fixes

### 1. Click-to-pick file upload silently did nothing
`useFolderDropzone` bound the file input's `change` event via `addEventListener` to `inputRef.current` inside an effect keyed on `[ingest]`. When React recreated the input node (StrictMode remount / reconciliation) the effect never re-ran, so the listener orphaned onto a detached node and the picked file was dropped — the tell-tale is `input.value` not being cleared after selection. Switched to React's delegated `onChange` prop, which always fires on the live node. Fixes the **table**, **MultiQC**, and **Manage-modal** dropzones.

### 2. Data Collections Manager collapsed on every operation
The expand/collapse state lived inside `DataCollectionsManagerSection`, which unmounts while `refresh()` shows the loading spinner after any create/rename/delete/manage op — so the disclosure reset to collapsed each time. Lifted the state to `ProjectDetailApp` so it survives the remount.

### 3. Coordinates preview map opened at world scale
`CoordinatesMapPreview` used a fixed `zoom: 1` centered on the mean of the points, leaving them tiny and off-frame. Now computes the view from the points' bounding box: center on the bbox midpoint and derive a Web-Mercator fit-bounds zoom (measuring container width via `ResizeObserver` for the real aspect ratio), with padding, a max-zoom clamp, and a single-point fallback.

### 4. "Start editing" pointed at the removed beta route
The empty-dashboard "Start editing" button and the catalog "add component" redirect still used `/dashboard-beta-edit/{id}` (a Dash→React cutover leftover that 404s). Both now point at the canonical `/dashboard-edit/{id}`.

## Verification
Driven live against the dev viewer:
- Upload now registers the picked file (chip shown, coordinate columns auto-detected, name auto-filled).
- Manager stays expanded across a rename operation.
- Created a 6-city Europe coordinates DC → map frames all points with margins (not world scale); test DC deleted afterward.
- Confirmed `/dashboard-edit/` is the canonical route used everywhere else.

`tsc --noEmit` clean; `pre-commit` passed.