### PR TITLE
fix(realtime): repair microscopy dashboard timeline + new-item highlights

### DIFF
--- a/depictio/projects/test/adapt_feedb_ms/dashboard.yaml
+++ b/depictio/projects/test/adapt_feedb_ms/dashboard.yaml
@@ -16,7 +16,7 @@ components:
     workflow_tag: python/microscopy_workflow
     data_collection_tag: microscopy_phenobase
     interactive_component_type: Timeline
-    column_name: acquisition_timestamp
+    column_name: meta_acquisition_timestamp
     column_type: datetime
     placement: top
     timescale: minute

--- a/depictio/projects/test/adapt_feedb_ms/run_simulation.sh
+++ b/depictio/projects/test/adapt_feedb_ms/run_simulation.sh
@@ -1,27 +1,89 @@
 #!/usr/bin/env bash
-# Run Chris's SVLT virtual microscopy simulation with S3/depictio integration.
-# PhenoBase.write() will push delta tables to MinIO and notify the depictio API.
+# Run an SVLT virtual-microscopy simulation against a Depictio instance.
+# Each acquisition tick: PhenoBase.write() pushes a delta table to MinIO, then
+# POSTs to depictio so connected dashboards refresh.
 #
-# Usage: ./run_simulation.sh
-#        SVLT_DELAY=10 ./run_simulation.sh
+# Works in two modes:
+#   • Worktree/dev — auto-derives ports + MinIO creds from ../../../../.env.instance
+#                    and the admin token from depictio/.depictio/admin_config.yaml.
+#   • Generic SVLT — no worktree/.env.instance needed; set the SVLT_* vars below
+#                    (at minimum SVLT_EXP_ROOT and SVLT_API_TOKEN) and go.
+#
+# Every value below can be overridden by exporting the matching env var first;
+# defaults target a stock local Depictio (FastAPI :8058, MinIO :9000).
+#
+# NOTE: phenobase.py reads SVLT_API_URL / SVLT_API_ENDPOINT / SVLT_API_TOKEN /
+# SVLT_API_PAYLOAD (the older SVLT_DEPICTIO_API / SVLT_DEPICTIO_TOKEN names are
+# no longer read).
+#
+# We notify via /deltatables/upsert (NOT /events/test-trigger). test-trigger
+# only broadcasts + drops the cache; it does NOT recompute column specs or bump
+# aggregation_version — so card values (which read the precomputed, version-
+# salted specs) stay frozen at the last CLI-ingested numbers. /upsert re-reads
+# the S3 delta SVLT just wrote, recomputes specs, bumps the version, AND
+# broadcasts the refresh event.
 
-export SVLT_S3_ENDPOINT="${SVLT_S3_ENDPOINT:-http://localhost:9000}"
-export SVLT_S3_KEY="${SVLT_S3_KEY:-minio}"
-export SVLT_S3_SECRET="${SVLT_S3_SECRET:-minio123}"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPICTIO_ROOT="${DEPICTIO_ROOT:-$(cd "$SCRIPT_DIR/../../../.." && pwd)}"
+
+# --- Instance config (optional) ---------------------------------------------
+# In a worktree, .env.instance provides MINIO_PORT / FASTAPI_PORT /
+# DEPICTIO_MINIO_ROOT_USER / DEPICTIO_MINIO_ROOT_PASSWORD. Absent elsewhere —
+# fall back to stock defaults or the SVLT_* overrides below.
+ENV_INSTANCE="${ENV_INSTANCE:-$DEPICTIO_ROOT/.env.instance}"
+if [[ -f "$ENV_INSTANCE" ]]; then
+    # shellcheck disable=SC1090
+    source "$ENV_INSTANCE"
+fi
+
+MINIO_PORT="${MINIO_PORT:-9000}"
+FASTAPI_PORT="${FASTAPI_PORT:-8058}"
+
+DC_ID="${SVLT_DC_ID:-750a1b2c3d4e5f6a7b8c9d10}"
+EXP_ROOT="${SVLT_EXP_ROOT:?set SVLT_EXP_ROOT to your SVLT experiment directory}"
+SVLT_ENV="${SVLT_ENV:-svlt-simulate}"
+SVLT_SCRIPT="${SVLT_SCRIPT:-$EXP_ROOT/proj0039-exp0002-simulate-experiment.py}"
+
+# Extra CLI args for the simulate script — varies per script. Some accept
+# --delay / --port; the proj0039 exp0002 script accepts only --root (delay/port
+# are hardcoded inside it), so this defaults to empty. Override as needed, e.g.
+# SVLT_EXTRA_ARGS="--delay 1 --port 6221".
+SVLT_EXTRA_ARGS="${SVLT_EXTRA_ARGS:-}"
+
+# --- S3 sync -> this instance's MinIO ---------------------------------------
+export SVLT_S3_ENDPOINT="${SVLT_S3_ENDPOINT:-http://localhost:${MINIO_PORT}}"
+export SVLT_S3_KEY="${SVLT_S3_KEY:-${DEPICTIO_MINIO_ROOT_USER:-minio}}"
+export SVLT_S3_SECRET="${SVLT_S3_SECRET:-${DEPICTIO_MINIO_ROOT_PASSWORD:-minio123}}"
 export SVLT_S3_BUCKET="${SVLT_S3_BUCKET:-depictio-bucket}"
-export SVLT_DC_ID="${SVLT_DC_ID:-750a1b2c3d4e5f6a7b8c9d10}"
-export SVLT_DEPICTIO_API="${SVLT_DEPICTIO_API}"
-export SVLT_DEPICTIO_TOKEN="${SVLT_DEPICTIO_TOKEN}"
+export SVLT_DC_ID="$DC_ID"
 
-EXP_ROOT="${SVLT_EXP_ROOT:-/Users/tweber/Data/chris-microscopy-virtual-experiment/exp0002}"
-DELAY="${SVLT_DELAY:-5}"
-PORT="${SVLT_PORT:-6221}"
+# --- API notify -> depictio (re-specs the delta + fires the WS broadcast) ----
+export SVLT_API_URL="${SVLT_API_URL:-http://localhost:${FASTAPI_PORT}/depictio/api/v1}"
+export SVLT_API_ENDPOINT="${SVLT_API_ENDPOINT:-/deltatables/upsert}"
+export SVLT_API_PAYLOAD="${SVLT_API_PAYLOAD:-{\"data_collection_id\":\"${DC_ID}\",\"delta_table_location\":\"s3://${SVLT_S3_BUCKET}/${DC_ID}\",\"update\":true}}"
 
-# Clean stale output from previous runs (SVLT refuses to overwrite)
+# Token: explicit SVLT_API_TOKEN wins; else read admin_config.yaml if present.
+if [[ -z "${SVLT_API_TOKEN:-}" ]]; then
+    ADMIN_CONFIG="${ADMIN_CONFIG:-$DEPICTIO_ROOT/depictio/.depictio/admin_config.yaml}"
+    if [[ -f "$ADMIN_CONFIG" ]]; then
+        SVLT_API_TOKEN="$(grep 'access_token:' "$ADMIN_CONFIG" | head -1 | awk '{print $2}')"
+    fi
+fi
+: "${SVLT_API_TOKEN:?set SVLT_API_TOKEN (or provide admin_config.yaml) for the API notify}"
+export SVLT_API_TOKEN
+export SVLT_NO_BROWSER=1
+
+echo "SVLT -> S3   : $SVLT_S3_ENDPOINT  (dc $DC_ID)"
+echo "SVLT -> API  : ${SVLT_API_URL}${SVLT_API_ENDPOINT}"
+echo "EXP_ROOT     : $EXP_ROOT   (extra args: ${SVLT_EXTRA_ARGS:-none})"
+
+# SVLT refuses to overwrite prior output
 rm -rf "$EXP_ROOT/experiment" "$EXP_ROOT/session"
 
-exec micromamba run -n svlt-simulate python \
-    "$EXP_ROOT/proj0039-exp0002-simulate-experiment.py" \
+# shellcheck disable=SC2086 -- SVLT_EXTRA_ARGS is intentionally word-split
+exec "${MAMBA_EXE:-micromamba}" run -n "$SVLT_ENV" python \
+    "$SVLT_SCRIPT" \
     --root "$EXP_ROOT" \
-    --delay "$DELAY" \
-    --port "$PORT"
+    $SVLT_EXTRA_ARGS

--- a/packages/depictio-react-core/src/components/ImageRenderer.tsx
+++ b/packages/depictio-react-core/src/components/ImageRenderer.tsx
@@ -165,7 +165,6 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
     sortDir,
   ]);
 
-  const paths = response ? response.paths : null;
   const rows = response ? response.rows : null;
   const sortableColumns = response?.sortable_columns ?? [];
   const effectiveSortBy = response?.sort_by ?? null;
@@ -235,14 +234,25 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
   const totalRowsCount = rows ? rows.length : 0;
 
   // ── New-item highlight pipeline ───────────────────────────────────────────
-  // ``useNewItemIds`` is the WHAT (which paths just arrived);
+  // ``useNewItemIds`` is the WHAT (which items just arrived);
   // ``useTransientFlag`` is the WHEN (only ~3 s after a refreshTick
   // increment). Filter edits don't change refreshTick → no glow.
+  //
+  // Diff on the row-id column (``index_index`` etc.) rather than the image
+  // path: drivers frequently recycle a small pool of filenames across many
+  // rows (e.g. the adapt_feedb_ms stream test reuses cell_001..008.png), so a
+  // path-keyed diff would report zero new items even though fresh rows landed.
+  // Row-ids are unique per row, so newly-ingested rows are always detected.
+  // Falls back to the path when no row-id column resolves.
   const highlightDurationMs =
     typeof metadata.highlight_duration_ms === 'number'
       ? (metadata.highlight_duration_ms as number)
       : 3000;
-  const newPaths = useNewItemIds(paths || [], refreshTick);
+  const itemKeys = useMemo(
+    () => items.map((it) => (rowIdColumn ? it.rowId : it.relPath)),
+    [items, rowIdColumn],
+  );
+  const newItemKeys = useNewItemIds(itemKeys, refreshTick);
   const highlightActive = useTransientFlag(refreshTick, highlightDurationMs);
 
   const selectionEnabled = !!onFilterChange && !!imageColumn;
@@ -443,7 +453,9 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
             <SimpleGrid cols={columns} spacing="xs" verticalSpacing="xs" p={4}>
               {items.map((it) => {
                 const selected = selectedRowIds.has(it.rowId);
-                const isNew = highlightActive && newPaths.has(it.relPath);
+                const isNew =
+                  highlightActive &&
+                  newItemKeys.has(rowIdColumn ? it.rowId : it.relPath);
                 const cardClasses = [
                   isNew ? 'depictio-card-new' : null,
                   selected ? 'depictio-card-selected' : null,

--- a/packages/depictio-react-core/src/components/TableRenderer.tsx
+++ b/packages/depictio-react-core/src/components/TableRenderer.tsx
@@ -255,6 +255,15 @@ const TableRenderer: React.FC<TableRendererProps> = ({
     };
   }, [rowIdColumn, highlightActive, newRowIds]);
 
+  // AG Grid only evaluates ``getRowClass`` when a row is first drawn. The
+  // new-row highlight resolves via an async snapshot fetch that lands *after*
+  // the grid has already painted the refreshed page, so changing the prop
+  // alone never re-classes the visible rows. Force a redraw whenever the
+  // highlight set flips on (or off) so the flash actually reaches the DOM.
+  useEffect(() => {
+    gridApiRef.current?.redrawRows();
+  }, [getRowClass]);
+
   const datasource = useMemo<IDatasource>(
     () => ({
       getRows: (params: IGetRowsParams) => {


### PR DESCRIPTION
## Summary

Two follow-up fixes on top of the merged realtime-events work, for the **Microscopy Real-time Monitor** dashboard (`adapt_feedb_ms`).

### 1. Timeline showed "Timeline unavailable for column acquisition_timestamp"
The dashboard bound the Timeline to `acquisition_timestamp`, but the real SVLT/phenobase driver flattens the field to **`meta_acquisition_timestamp`**. `TimelineRenderer`'s unique-values fallback 404'd → no min/max → the "unavailable" branch. Repointed the binding (verified live: the correct column returns parseable ISO values); the deployed dashboard's stored metadata was also updated in Mongo.

### 2. Table rows never highlighted
AG Grid only evaluates `getRowClass` at row-draw time. The new-row set resolves via an async snapshot fetch that lands *after* the page is painted, so the class change never reached the DOM. Added `redrawRows()` on highlight-set change.

### 3. Gallery images never highlighted
Highlight diffed on the image **path**, but drivers recycle a small filename pool across rows → zero "new" items. Now diffs on the unique row-id column (falls back to path when none resolves).

### Also
- `run_simulation.sh`: instance-aware (worktree `.env.instance` port/cred derivation, generic SVLT fallback); notifies via `/deltatables/upsert` so card specs recompute per acquisition tick.

## Notes
- The highlight remains **transient** (3s fade) by design — these fixes make it appear reliably, not persist until the next acquisition.
- Local `tsc` not run (worktree deps not installed; Vite dev container compiles). TS edits are type-correct by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)