### PR TITLE
feat(realtime): polish microscopy timeline, gallery highlights, and dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,8 @@ dump.rdb
 *.gz
 *.csv
 *.tsv
+# Allow the adapt_feedb_ms realtime-demo seed (imported by the deploy doc's quickstart)
+!depictio/projects/test/adapt_feedb_ms/phenobase.csv
 # Allow nf-core ampliseq data files
 !depictio/projects/nf-core/ampliseq/2.14.0/*.tsv
 !depictio/projects/nf-core/ampliseq/2.16.0/*.tsv

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -2213,15 +2213,37 @@ def render_image_paths_endpoint(
     # Pick a default sort column when the caller didn't ask for one. Prefer the
     # first column whose name contains "acquisition" (covers the Adaptive
     # Feedback Microscopy `acquisition_timestamp` column and similar) so that
-    # newest images land first without per-project config. Fall back to the
-    # image_column itself for stable, user-visible ordering.
+    # newest images land first without per-project config.
     available = set(df.columns)
     chosen_sort = sort_by
+    descending = sort_dir == "desc"
     if not chosen_sort:
         for cand in df.columns:
             if "acquisition" in cand.lower() and ("time" in cand.lower() or "date" in cand.lower()):
                 chosen_sort = cand
                 break
+        # No acquisition-like column: fall back to newest-first on a stable,
+        # NUMERIC id column (``index_index`` / ``*_id`` / ``*_index`` / ``index``).
+        # A numeric ingest counter is monotonic, so descending surfaces the most
+        # recently added images first — matching the detail table's default and,
+        # crucially, keeping realtime new-image highlights inside the capped
+        # gallery window (a batch always appends the highest ids; oldest-first
+        # order strands them past ``max_images`` where they can never glow).
+        # The numeric gate matters: a string id (``sample_id``, ``depictio_run_id``)
+        # would sort lexicographically, which is not ingestion order — so we leave
+        # such projects in their prior natural order rather than mis-sort them.
+        if not chosen_sort:
+            numeric_cols = {c for c, dt in zip(df.columns, df.dtypes) if dt.is_numeric()}
+            if "index_index" in numeric_cols:
+                chosen_sort = "index_index"
+            else:
+                for cand in df.columns:
+                    lc = cand.lower()
+                    if cand in numeric_cols and (lc.endswith(("_id", "_index")) or lc == "index"):
+                        chosen_sort = cand
+                        break
+            if chosen_sort:
+                descending = True
     if chosen_sort and chosen_sort not in available:
         # Caller asked to sort by an unknown column — silently skip (don't 500
         # for a UI-driven sort dropdown that may race a schema change).
@@ -2229,9 +2251,16 @@ def render_image_paths_endpoint(
 
     df_filtered = df.filter(df[image_column].is_not_null())
     if chosen_sort:
-        df_filtered = df_filtered.sort(
-            chosen_sort, descending=(sort_dir == "desc"), nulls_last=True
-        )
+        sort_cols = [chosen_sort]
+        sort_desc = [descending]
+        # Tie-break by the numeric row id so a coarse/tied sort column — e.g. a
+        # per-acquisition timestamp every row in a batch shares — still yields a
+        # deterministic newest-first order instead of arbitrary within-tie order
+        # (which would strand the batch's highest-id images outside the window).
+        if "index_index" in available and chosen_sort != "index_index":
+            sort_cols.append("index_index")
+            sort_desc.append(descending)
+        df_filtered = df_filtered.sort(sort_cols, descending=sort_desc, nulls_last=True)
     df_top = df_filtered.head(limit)
 
     # Serialize to JSON-safe dicts. Polars' default `to_dicts()` returns
@@ -2250,7 +2279,7 @@ def render_image_paths_endpoint(
         "rows": rows,
         "image_column": image_column,
         "sort_by": chosen_sort,
-        "sort_dir": sort_dir,
+        "sort_dir": "desc" if descending else "asc",
         "sortable_columns": list(df.columns),
         # Backwards-compatible: callers that haven't been updated still see
         # the bare path list. Drop after every front-end caller migrates.

--- a/depictio/api/v1/endpoints/deltatables_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/deltatables_endpoints/routes.py
@@ -253,7 +253,48 @@ async def upsert_deltatable(
                 },
             )
 
+    # Broadcast a real-time event so connected dashboards refresh. The change
+    # stream watcher only watches data_collections, not the deltatables
+    # collection, so an upsert would otherwise complete silently. Mirrors the
+    # test-trigger endpoint's invalidate-then-broadcast pattern.
+    await _broadcast_dc_update(str(data_collection_oid))
+
     return {"message": "DeltaTableAggregated upserted successfully", "result": "success"}
+
+
+async def _broadcast_dc_update(dc_id: str) -> None:
+    """Invalidate the DC cache and broadcast a data-collection-updated event to all subscribers."""
+    from datetime import timezone
+
+    from depictio.api.v1.deltatables_utils import invalidate_data_collection_cache
+    from depictio.api.v1.endpoints.events_endpoints.routes import _build_event_payload
+    from depictio.api.v1.services.events import connection_manager
+    from depictio.models.models.realtime import EventMessage, EventSourceType, EventType
+
+    dropped = invalidate_data_collection_cache(dc_id)
+    logger.info(f"Upsert {dc_id}: invalidated {dropped} cached DataFrame(s)")
+
+    # Build the same rich payload the test-trigger path produces (row delta vs.
+    # the previous delta version, new-id sample, aggregation version/hash/time,
+    # live row count) so the RealtimeIndicator journal has something to show.
+    # Runs after the upsert recorded a fresh aggregation entry, so the version/
+    # hash/time reflect the write that just landed. Best-effort, never raises.
+    payload = _build_event_payload(dc_id, operation="upsert")
+
+    event = EventMessage(
+        event_type=EventType.DATA_COLLECTION_UPDATED,
+        source_type=EventSourceType.MONGODB_CHANGES,
+        timestamp=datetime.now(timezone.utc),
+        data_collection_id=dc_id,
+        payload=payload,
+    )
+
+    subscribed = connection_manager.get_all_subscribed_dashboards()
+    for dashboard_id in subscribed:
+        event_copy = event.model_copy(update={"dashboard_id": dashboard_id})
+        await connection_manager.broadcast_to_dashboard(dashboard_id, event_copy)
+
+    logger.info(f"Upsert event broadcast for DC {dc_id} to {len(subscribed)} dashboard(s)")
 
 
 def _owned_or_admin_query(current_user: User, base: dict) -> dict:

--- a/depictio/api/v1/endpoints/events_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/events_endpoints/routes.py
@@ -54,7 +54,20 @@ def _user_can_access_dashboard(user: User | None, dashboard_id: str) -> bool:
     from depictio.api.v1.endpoints.dashboards_endpoints.routes import check_project_permission
 
     try:
-        dashboard = dashboards_collection.find_one({"dashboard_id": dashboard_id})
+        # ``dashboard_id`` arrives as a raw string from the WS query param, but
+        # the stored ``dashboard_id`` field is an ObjectId (mirrors ``_id``).
+        # Query by the ObjectId form (with a string/`_id` fallback for any
+        # deployments that persisted it differently) — a plain string match
+        # silently misses and denies every subscribe.
+        try:
+            oid = ObjectId(dashboard_id)
+            dashboard_query: dict = {
+                "$or": [{"dashboard_id": oid}, {"dashboard_id": dashboard_id}, {"_id": oid}]
+            }
+        except Exception:
+            dashboard_query = {"dashboard_id": dashboard_id}
+
+        dashboard = dashboards_collection.find_one(dashboard_query)
         if not dashboard:
             logger.debug(f"WS subscribe denied: dashboard {dashboard_id} not found")
             return False
@@ -238,6 +251,12 @@ async def get_events_status(
     }
 
 
+# Upper bound on the per-batch id list shipped in the payload — keeps the
+# WebSocket frame (and the localStorage-persisted journal) from ballooning on a
+# very large upsert while still covering realistic streaming batches.
+_MAX_NEW_IDS = 1000
+
+
 def _build_event_payload(dc_id: str, operation: str = "update") -> dict[str, Any]:
     """Assemble a meaningful WS payload for a DC update.
 
@@ -341,6 +360,10 @@ def _build_event_payload(dc_id: str, operation: str = "update") -> dict[str, Any
                                 payload["id_column"] = id_col
                                 payload["new_ids_sample"] = new_ids[:10]
                                 payload["new_ids_total"] = len(new_ids)
+                                # Full (bounded) id set so the frontend can
+                                # highlight every row a batch added and re-apply
+                                # that highlight later from the event log.
+                                payload["new_ids"] = new_ids[:_MAX_NEW_IDS]
                         except Exception:
                             pass
             except Exception as diff_err:

--- a/depictio/projects/test/adapt_feedb_ms/dashboard.yaml
+++ b/depictio/projects/test/adapt_feedb_ms/dashboard.yaml
@@ -294,7 +294,7 @@ components:
     s3_base_folder: "s3://depictio-bucket/750a1b2c3d4e5f6a7b8c9d10/images/phenobase/"
     thumbnail_size: 120
     columns: 4
-    max_images: 50
+    max_images: 500
     layout:
       x: 0
       y: 18

--- a/depictio/projects/test/adapt_feedb_ms/phenobase.csv
+++ b/depictio/projects/test/adapt_feedb_ms/phenobase.csv
@@ -1,0 +1,3 @@
+index_index,coord_counter,meta_acquisition_timestamp,features_area,features_eccentricity,features_solidity,features_intensity_mean-0,features_intensity_mean-1,features_intensity_mean-2,bounding_box_x0,bounding_box_y0,classifications_taxa,patches_patches_2d_rgb_path
+1,0,2026-05-04T12:00:00Z,1234.5,0.42,0.95,128.3,140.1,98.4,100,200,1,cell_001.png
+2,0,2026-05-04T12:00:00Z,987.2,0.71,0.82,95.5,110.2,180.6,150,250,2,cell_002.png

--- a/depictio/projects/test/adapt_feedb_ms/project.yaml
+++ b/depictio/projects/test/adapt_feedb_ms/project.yaml
@@ -34,7 +34,7 @@ workflows:
             columns_description:
               index_index: "Unique cell identifier"
               coord_counter: "Image counter index"
-              acquisition_timestamp: "Acquisition time (ISO 8601)"
+              meta_acquisition_timestamp: "Acquisition time (ISO 8601)"
               features_area: "ROI area in pixels"
               features_eccentricity: "Cell shape eccentricity (0=circle, 1=elongated)"
               features_solidity: "Cell shape solidity (1=convex, lower=irregular)"

--- a/depictio/projects/test/adapt_feedb_ms/run_simulation.sh
+++ b/depictio/projects/test/adapt_feedb_ms/run_simulation.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Run an SVLT virtual-microscopy simulation against a Depictio instance.
-# Each acquisition tick: PhenoBase.write() pushes a delta table to MinIO, then
-# POSTs to depictio so connected dashboards refresh.
+# Each acquisition tick, the svltx-depictio extension (hooked onto
+# session_phenobase.write) exports the PhenoBase table to MinIO as a Delta
+# table, then POSTs to depictio so connected dashboards refresh.
+#
+# Requires the `svltx-depictio` package installed in $SVLT_ENV and the
+# experiment script to `import svltx.depictio` (proj0039-...-simulate does).
 #
 # Works in two modes:
 #   • Worktree/dev — auto-derives ports + MinIO creds from ../../../../.env.instance
@@ -12,9 +16,9 @@
 # Every value below can be overridden by exporting the matching env var first;
 # defaults target a stock local Depictio (FastAPI :8058, MinIO :9000).
 #
-# NOTE: phenobase.py reads SVLT_API_URL / SVLT_API_ENDPOINT / SVLT_API_TOKEN /
-# SVLT_API_PAYLOAD (the older SVLT_DEPICTIO_API / SVLT_DEPICTIO_TOKEN names are
-# no longer read).
+# NOTE: svltx.depictio reads SVLT_API_URL / SVLT_API_ENDPOINT / SVLT_API_TOKEN /
+# SVLT_API_PAYLOAD and the SVLT_S3_* vars (the older SVLT_DEPICTIO_API /
+# SVLT_DEPICTIO_TOKEN names are no longer read).
 #
 # We notify via /deltatables/upsert (NOT /events/test-trigger). test-trigger
 # only broadcasts + drops the cache; it does NOT recompute column specs or bump
@@ -58,6 +62,19 @@ export SVLT_S3_KEY="${SVLT_S3_KEY:-${DEPICTIO_MINIO_ROOT_USER:-minio}}"
 export SVLT_S3_SECRET="${SVLT_S3_SECRET:-${DEPICTIO_MINIO_ROOT_PASSWORD:-minio123}}"
 export SVLT_S3_BUCKET="${SVLT_S3_BUCKET:-depictio-bucket}"
 export SVLT_DC_ID="$DC_ID"
+# This simulator uses PhenoBase.write() directly, so svlt's own sync_to_bucket
+# never runs — have the extension mirror images itself. In deployments where
+# svlt pushes images to the same bucket, leave this unset (default: off).
+export SVLT_UPLOAD_IMAGES="${SVLT_UPLOAD_IMAGES:-1}"
+
+# Completeness gate: the analysis pipeline writes PhenoBase twice per
+# acquisition — once after segmentation (cells, no image patches) and once after
+# ROI-square generation (same cells, now with 2D-RGB image paths). Only the
+# second write yields displayable rows, so gate the Depictio sync on this column
+# being populated: each acquisition then fires a single realtime event, and
+# dashboards never refresh onto rows whose images don't exist yet. Unset it to
+# restore per-write notifications.
+export SVLT_IMAGE_COLUMN="${SVLT_IMAGE_COLUMN:-patches_patches_2d_rgb_path}"
 
 # --- API notify -> depictio (re-specs the delta + fires the WS broadcast) ----
 export SVLT_API_URL="${SVLT_API_URL:-http://localhost:${FASTAPI_PORT}/depictio/api/v1}"
@@ -73,7 +90,11 @@ if [[ -z "${SVLT_API_TOKEN:-}" ]]; then
 fi
 : "${SVLT_API_TOKEN:?set SVLT_API_TOKEN (or provide admin_config.yaml) for the API notify}"
 export SVLT_API_TOKEN
+# Headless: svlt's startup.main() opens a browser on launch. SVLT_NO_BROWSER
+# only helps if svlt carries the guard patch; BROWSER=echo is the universal
+# no-op (Python's webbrowser runs `echo <url>` instead of opening a browser).
 export SVLT_NO_BROWSER=1
+export BROWSER="${BROWSER:-echo}"
 
 echo "SVLT -> S3   : $SVLT_S3_ENDPOINT  (dc $DC_ID)"
 echo "SVLT -> API  : ${SVLT_API_URL}${SVLT_API_ENDPOINT}"
@@ -82,7 +103,8 @@ echo "EXP_ROOT     : $EXP_ROOT   (extra args: ${SVLT_EXTRA_ARGS:-none})"
 # SVLT refuses to overwrite prior output
 rm -rf "$EXP_ROOT/experiment" "$EXP_ROOT/session"
 
-# shellcheck disable=SC2086 -- SVLT_EXTRA_ARGS is intentionally word-split
+# SVLT_EXTRA_ARGS is intentionally word-split into separate CLI args.
+# shellcheck disable=SC2086
 exec "${MAMBA_EXE:-micromamba}" run -n "$SVLT_ENV" python \
     "$SVLT_SCRIPT" \
     --root "$EXP_ROOT" \

--- a/depictio/projects/test/adapt_feedb_ms/stream_test.sh
+++ b/depictio/projects/test/adapt_feedb_ms/stream_test.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Stream test driver for the adapt_feedb_ms realtime dashboard.
-# Each "tick" appends one row to phenobase.csv, re-runs depictio-cli to
-# rewrite the delta table, and POSTs to /events/test-trigger so the
-# WebSocket subscribers receive a `data_collection_updated` event with
-# row_delta + new_ids in the payload.
+# Each "tick" appends one row to phenobase.csv and re-runs depictio-cli. The
+# CLI re-ingest hits /deltatables/upsert, which broadcasts a
+# `data_collection_updated` event on its own — so subscribed viewers refresh
+# with NO dev endpoints required (works with DEPICTIO_ENABLE_DEV_ENDPOINTS off).
 #
-# NOTE: /events/test-trigger is a dev-only endpoint gated behind
-# DEPICTIO_ENABLE_DEV_ENDPOINTS — start the API with that set to true,
-# otherwise the POST below returns 404.
+# Optional: set TRIGGER_WS=1 to also POST /events/test-trigger after each tick
+# for a richer WS payload digest (row_delta + new_ids + conns). That endpoint is
+# dev-only (DEPICTIO_ENABLE_DEV_ENDPOINTS=true) — leave TRIGGER_WS off otherwise.
 #
 # Modes:
 #   reset                       Wipe CSV down to 2 seed rows, run CLI.
@@ -22,19 +22,25 @@
 #                               payload digest.
 #
 # Watch the dashboard at:
-#   http://localhost:8055/dashboard/69f899234da0b143a8538e0e
+#   $API_URL/dashboard/750a1b2c3d4e5f6a7b8c9d20
+#
+# Defaults target a stock local Depictio (stable docker-compose: API :8058,
+# CLI config ~/.depictio/CLI.yaml). Override any of API_URL / CLI_CONFIG /
+# DEPICTIO_CLI by exporting the matching env var first.
 
 set -euo pipefail
 
 MODE="${1:-reset}"
 
-WORKTREE="/Users/tweber/Gits/workspaces/depictio-workspace/depictio-worktrees/viralrecon-template-dashboard"
-CSV="$WORKTREE/depictio/projects/test/adapt_feedb_ms/phenobase.csv"
-CLI_CONFIG="$WORKTREE/depictio/.depictio/test_user_config.yaml"
-PROJECT_CONFIG="$WORKTREE/depictio/projects/test/adapt_feedb_ms/project.yaml"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CSV="$SCRIPT_DIR/phenobase.csv"
+PROJECT_CONFIG="$SCRIPT_DIR/project.yaml"
+CLI_CONFIG="${CLI_CONFIG:-$HOME/.depictio/CLI.yaml}"
+DEPICTIO_CLI="${DEPICTIO_CLI:-depictio-cli}"
+TRIGGER_WS="${TRIGGER_WS:-0}"   # 1 = also ping the dev-only /events/test-trigger for a payload digest
 DC_ID="750a1b2c3d4e5f6a7b8c9d10"
-DASHBOARD_ID="69f899234da0b143a8538e0e"
-API_URL="http://localhost:8055"
+DASHBOARD_ID="750a1b2c3d4e5f6a7b8c9d20"
+API_URL="${API_URL:-http://localhost:8058}"
 
 HEADER="index_index,coord_counter,acquisition_timestamp,features_area,features_eccentricity,features_solidity,features_intensity_mean-0,features_intensity_mean-1,features_intensity_mean-2,bounding_box_x0,bounding_box_y0,classifications_taxa,patches_patches_2d_rgb_path"
 
@@ -88,7 +94,7 @@ next_row() {
 }
 
 run_cli() {
-  ( cd "$WORKTREE" && /opt/homebrew/bin/uv run --no-sync python -m depictio.cli run \
+  "$DEPICTIO_CLI" run \
       --CLI-config-path "$CLI_CONFIG" \
       --project-config-path "$PROJECT_CONFIG" \
       --update-config \
@@ -96,7 +102,7 @@ run_cli() {
       --overwrite \
       --skip-dashboard-import \
       --skip-s3-check \
-      --skip-join 2>&1 | tail -1 )
+      --skip-join 2>&1 | tail -1
 }
 
 # Trigger + format the response into one digestible line:
@@ -157,7 +163,7 @@ bump_n() {
     echo "[$i/$n] CSV had ${before} data rows"
     append_one
     run_cli
-    trigger_ws
+    [ "$TRIGGER_WS" = "1" ] && trigger_ws || echo "  [ws] broadcast via CLI upsert"
     echo ""
   done
 }
@@ -207,7 +213,7 @@ case "$MODE" in
       printf '[tick %d] CSV has %d data row(s) — appending\n' "$tick" "$before"
       append_one
       run_cli
-      trigger_ws
+      [ "$TRIGGER_WS" = "1" ] && trigger_ws || echo "  [ws] broadcast via CLI upsert"
       if [ "$MAX" -gt 0 ] && [ "$tick" -ge "$MAX" ]; then
         echo "=== DONE: added $tick row(s) ==="
         break
@@ -222,9 +228,11 @@ case "$MODE" in
     echo "Data rows: $rows"
     echo "Dashboard: $API_URL/dashboard/$DASHBOARD_ID"
     echo "Last DC: $DC_ID"
-    echo ""
-    echo "Latest payload (test-trigger, no append):"
-    trigger_ws
+    if [ "$TRIGGER_WS" = "1" ]; then
+      echo ""
+      echo "Latest payload (test-trigger, no append):"
+      trigger_ws
+    fi
     ;;
 
   *)

--- a/depictio/projects/test/adapt_feedb_ms/stream_test.sh
+++ b/depictio/projects/test/adapt_feedb_ms/stream_test.sh
@@ -42,7 +42,11 @@ DC_ID="750a1b2c3d4e5f6a7b8c9d10"
 DASHBOARD_ID="750a1b2c3d4e5f6a7b8c9d20"
 API_URL="${API_URL:-http://localhost:8058}"
 
-HEADER="index_index,coord_counter,acquisition_timestamp,features_area,features_eccentricity,features_solidity,features_intensity_mean-0,features_intensity_mean-1,features_intensity_mean-2,bounding_box_x0,bounding_box_y0,classifications_taxa,patches_patches_2d_rgb_path"
+# Column names mirror the SVLT flattened PhenoBase schema (group-prefixed), so
+# a CSV-driven run and a live run_simulation.sh run feed the dashboard
+# identically. Note meta_acquisition_timestamp (not bare acquisition_timestamp)
+# — the acquisition-timeline component binds to that exact name.
+HEADER="index_index,coord_counter,meta_acquisition_timestamp,features_area,features_eccentricity,features_solidity,features_intensity_mean-0,features_intensity_mean-1,features_intensity_mean-2,bounding_box_x0,bounding_box_y0,classifications_taxa,patches_patches_2d_rgb_path"
 
 # Predefined "nice" seed rows. Used by `reset` and consumed first by
 # `stream`/`bump`. Past row 8 we generate synthetic rows so the test can run

--- a/depictio/projects/test/image_demo/dashboards/gallery.yaml
+++ b/depictio/projects/test/image_demo/dashboards/gallery.yaml
@@ -1,48 +1,12 @@
 # Image Component Demo Dashboard
-version: 1
 title: "Image Component Demo"
 subtitle: "Demonstrating the image gallery component with cross-DC filtering"
 project_tag: "Image Component Demo Project"
-dashboard_id: "6997872a694d2122240775c6"
+dashboard_id: "699787c53b3f99adda510694"
 
 components:
-  # Image gallery component
-  - tag: sample-gallery
-    component_type: image
-    workflow_tag: python/image_demo_workflow
-    data_collection_tag: sample_images
-    image_column: image_path
-    s3_base_folder: "s3://depictio-bucket/image_demo/images/"
-    thumbnail_size: 150
-    columns: 3
-    max_images: 9
+  # ── Row 0 (y=0, h=2): 3 cards + range slider ────────────────────────────────
 
-  # Bar chart of samples by category
-  - tag: category-distribution
-    component_type: figure
-    workflow_tag: python/image_demo_workflow
-    data_collection_tag: sample_images
-    visu_type: bar
-    dict_kwargs:
-      x: category
-      title: "Samples by Category"
-      color: category
-
-  # Scatter plot of quality scores - with selection filtering enabled
-  - tag: quality-scatter
-    component_type: figure
-    workflow_tag: python/image_demo_workflow
-    data_collection_tag: sample_images
-    visu_type: scatter
-    dict_kwargs:
-      x: category
-      y: quality_score
-      title: "Quality Score by Category (click/lasso to filter)"
-      color: category
-    selection_enabled: true
-    selection_column: sample_id
-
-  # Card: Total samples
   - tag: total-samples
     component_type: card
     workflow_tag: python/image_demo_workflow
@@ -52,8 +16,12 @@ components:
     column_type: object
     icon_name: mdi:image-multiple
     icon_color: "#2196F3"
+    layout:
+      x: 0
+      y: 0
+      w: 2
+      h: 2
 
-  # Card: Average quality score
   - tag: avg-quality
     component_type: card
     workflow_tag: python/image_demo_workflow
@@ -63,8 +31,12 @@ components:
     column_type: float64
     icon_name: mdi:star
     icon_color: "#FF9800"
+    layout:
+      x: 2
+      y: 0
+      w: 2
+      h: 2
 
-  # Card: Number of categories
   - tag: category-count
     component_type: card
     workflow_tag: python/image_demo_workflow
@@ -74,30 +46,12 @@ components:
     column_type: object
     icon_name: mdi:shape
     icon_color: "#4CAF50"
+    layout:
+      x: 4
+      y: 0
+      w: 2
+      h: 2
 
-  # Interactive filter: Sample selection
-  - tag: sample-filter
-    component_type: interactive
-    workflow_tag: python/image_demo_workflow
-    data_collection_tag: sample_images
-    interactive_component_type: MultiSelect
-    column_name: sample_id
-    column_type: object
-    custom_color: "#2196F3"
-    icon_name: mdi:image-filter
-
-  # Interactive filter: Category selection
-  - tag: category-filter
-    component_type: interactive
-    workflow_tag: python/image_demo_workflow
-    data_collection_tag: sample_images
-    interactive_component_type: MultiSelect
-    column_name: category
-    column_type: object
-    custom_color: "#9C27B0"
-    icon_name: mdi:filter-variant
-
-  # Interactive filter: Quality score range
   - tag: quality-filter
     component_type: interactive
     workflow_tag: python/image_demo_workflow
@@ -107,8 +61,114 @@ components:
     column_type: float64
     custom_color: "#FF9800"
     icon_name: mdi:tune
+    layout:
+      x: 6
+      y: 0
+      w: 2
+      h: 2
 
-  # Data table showing all sample information - with row selection filtering enabled
+  # ── Row 2 (y=2, h=2): 2 multi-select filters ────────────────────────────────
+
+  - tag: sample-filter
+    component_type: interactive
+    workflow_tag: python/image_demo_workflow
+    data_collection_tag: sample_images
+    interactive_component_type: MultiSelect
+    column_name: sample_id
+    column_type: object
+    custom_color: "#2196F3"
+    icon_name: mdi:image-filter
+    layout:
+      x: 0
+      y: 2
+      w: 4
+      h: 2
+
+  - tag: category-filter
+    component_type: interactive
+    workflow_tag: python/image_demo_workflow
+    data_collection_tag: sample_images
+    interactive_component_type: MultiSelect
+    column_name: category
+    column_type: object
+    custom_color: "#9C27B0"
+    icon_name: mdi:filter-variant
+    layout:
+      x: 4
+      y: 2
+      w: 4
+      h: 2
+
+  # ── Row 4 (y=4, h=4): quality scatter + category bar ────────────────────────
+
+  - tag: quality-scatter
+    component_type: figure
+    workflow_tag: python/image_demo_workflow
+    data_collection_tag: sample_images
+    visu_type: scatter
+    dict_kwargs:
+      x: sample_id
+      y: quality_score
+      title: "Quality Score per Sample"
+      color: category
+    layout:
+      x: 0
+      y: 4
+      w: 4
+      h: 4
+
+  - tag: category-distribution
+    component_type: figure
+    workflow_tag: python/image_demo_workflow
+    data_collection_tag: sample_images
+    visu_type: bar
+    dict_kwargs:
+      x: category
+      title: "Samples by Category"
+      color: category
+    layout:
+      x: 4
+      y: 4
+      w: 4
+      h: 4
+
+  # ── Row 8 (y=8, h=4): selection scatter + image gallery ─────────────────────
+
+  - tag: quality-scatter-by-category
+    component_type: figure
+    workflow_tag: python/image_demo_workflow
+    data_collection_tag: sample_images
+    visu_type: scatter
+    dict_kwargs:
+      x: category
+      y: quality_score
+      title: "Quality by Category (select to filter)"
+      color: category
+    selection_enabled: true
+    selection_column: sample_id
+    layout:
+      x: 0
+      y: 8
+      w: 4
+      h: 4
+
+  - tag: sample-gallery
+    component_type: image
+    workflow_tag: python/image_demo_workflow
+    data_collection_tag: sample_images
+    image_column: image_path
+    s3_base_folder: "s3://depictio-bucket/image_demo/images/"
+    thumbnail_size: 150
+    columns: 3
+    max_images: 9
+    layout:
+      x: 4
+      y: 8
+      w: 4
+      h: 4
+
+  # ── Row 12 (y=12, h=4): full-width table ────────────────────────────────────
+
   - tag: samples-table
     component_type: table
     workflow_tag: python/image_demo_workflow
@@ -116,3 +176,8 @@ components:
     page_size: 10
     row_selection_enabled: true
     row_selection_column: sample_id
+    layout:
+      x: 0
+      y: 12
+      w: 8
+      h: 4

--- a/depictio/projects/test/image_demo/data/images_data.csv
+++ b/depictio/projects/test/image_demo/data/images_data.csv
@@ -8,3 +8,4 @@ S006,sample_006.png,C,0.94
 S007,sample_007.png,C,0.81
 S008,sample_008.png,B,0.96
 S009,sample_009.png,A,0.73
+S010,sample_010.png,C,0.88

--- a/depictio/projects/test/image_demo/project.yaml
+++ b/depictio/projects/test/image_demo/project.yaml
@@ -2,8 +2,13 @@
 # Uses a single Image DC with delta table support (like Table DC but with mandatory image_column)
 id: "650a1b2c3d4e5f6a7b8c9d0e"
 name: "Image Component Demo Project"
-project_type: "basic"
 is_public: true
+
+# Real-time event configuration
+realtime:
+  enabled: true
+  debounce_ms: 1000  # Batch rapid updates within 1 second
+
 workflows:
   - id: "650a1b2c3d4e5f6a7b8c9d0f"
     name: "image_demo_workflow"

--- a/depictio/viewer/src/App.tsx
+++ b/depictio/viewer/src/App.tsx
@@ -32,6 +32,7 @@ import {
   useDataCollectionUpdates,
   RealtimeIndicator,
   useRealtimeJournal,
+  batchIdsFromPayload,
   fetchProjectFromDashboard,
   fetchIngestionHealth,
 } from 'depictio-react-core';
@@ -41,6 +42,8 @@ import type {
   DashboardSummary,
   InteractiveFilter,
   RealtimeMode,
+  ActiveHighlight,
+  RealtimeJournalEntry,
   IngestionSummary,
 } from 'depictio-react-core';
 import { parseTemplateOrigin } from './projects/template';
@@ -240,6 +243,34 @@ const App: React.FC = () => {
   // the "Reset" button on the dropdown.
   const [journal, appendJournal, clearJournal] = useRealtimeJournal(50);
 
+  // The batch currently highlighted across the dashboard. Live arrivals set it
+  // transiently (auto-fade); the event log can pin a past batch (sticky). The
+  // nonce (monotonic) re-arms the renderers' fade window on every (re-)trigger.
+  const [activeHighlight, setActiveHighlight] = useState<ActiveHighlight | null>(null);
+  const highlightNonce = useRef(0);
+  const applyHighlight = useCallback(
+    (batch: { idColumn?: string; ids: string[] }, dcId?: string, sticky = false, batchKey?: string) => {
+      highlightNonce.current += 1;
+      const nonce = highlightNonce.current;
+      setActiveHighlight((prev) => {
+        // A live (non-sticky) arrival must not replace a batch the user pinned
+        // from the event log — otherwise the next stream event wipes it.
+        if (!sticky && prev?.sticky) return prev;
+        return { ...batch, dcId, sticky, batchKey, nonce };
+      });
+    },
+    [],
+  );
+  const handleHighlightBatch = useCallback(
+    (entry: RealtimeJournalEntry) => {
+      const batch = batchIdsFromPayload(entry.payload);
+      if (!batch) return;
+      applyHighlight(batch, entry.dataCollectionId, true, entry.receivedAt);
+    },
+    [applyHighlight],
+  );
+  const handleClearHighlight = useCallback(() => setActiveHighlight(null), []);
+
   const triggerRefresh = useCallback(() => {
     setRefreshTick((t) => t + 1);
   }, []);
@@ -273,6 +304,10 @@ const App: React.FC = () => {
         payload,
       });
       if (auto) {
+        // Glow exactly the rows this batch added (auto-fade). Falls back to the
+        // renderers' client-side diff when the payload carries no id list.
+        const batch = batchIdsFromPayload(payload);
+        if (batch) applyHighlight(batch, event.data_collection_id, false);
         triggerRefresh();
         return;
       }
@@ -284,7 +319,7 @@ const App: React.FC = () => {
         onClick: () => triggerRefresh(),
       });
     },
-    [triggerRefresh, appendJournal],
+    [triggerRefresh, appendJournal, applyHighlight],
   );
 
   // Only subscribe + render the indicator when the dashboard's project has
@@ -406,6 +441,9 @@ const App: React.FC = () => {
                     }}
                     journal={journal}
                     onClearJournal={clearJournal}
+                    onHighlightBatch={handleHighlightBatch}
+                    onClearHighlight={handleClearHighlight}
+                    activeHighlightKey={activeHighlight?.batchKey}
                   />
                 </span>
               )}
@@ -550,6 +588,7 @@ const App: React.FC = () => {
                         members={g.members}
                         filters={filters}
                         onFilterChange={handleFilterChange}
+                        refreshTick={refreshTick}
                       />
                     ) : (
                       <ComponentRenderer
@@ -557,6 +596,7 @@ const App: React.FC = () => {
                         metadata={g.members[0]}
                         filters={filters}
                         onFilterChange={handleFilterChange}
+                        refreshTick={refreshTick}
                       />
                     ),
                   )}
@@ -592,6 +632,7 @@ const App: React.FC = () => {
                   components={topComponents}
                   filters={filters}
                   onFilterChange={handleFilterChange}
+                  refreshTick={refreshTick}
                 />
               )}
               <Box style={{ flex: 1, minHeight: 0 }}>
@@ -644,6 +685,7 @@ const App: React.FC = () => {
                     cardSecondaryValues={cardSecondaryValues}
                     cardValuesLoading={cardsLoading}
                     refreshTick={refreshTick}
+                    activeHighlight={activeHighlight}
                     isDraggable={false}
                     isResizable={false}
                     editMode={false}

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -63,6 +63,7 @@ import {
   useDataCollectionUpdates,
   RealtimeIndicator,
   useRealtimeJournal,
+  batchIdsFromPayload,
 } from 'depictio-react-core';
 import type {
   DashboardData,
@@ -71,6 +72,8 @@ import type {
   InteractiveFilter,
   StoredMetadata,
   RealtimeMode,
+  ActiveHighlight,
+  RealtimeJournalEntry,
 } from 'depictio-react-core';
 
 import LeftFilterPanel from './components/LeftFilterPanel';
@@ -574,6 +577,33 @@ const EditorApp: React.FC = () => {
     setFilters((prev) => [...prev]);
   }, []);
   const [journal, appendJournal, clearJournal] = useRealtimeJournal(50);
+
+  // Per-batch highlight (mirrors App.tsx). Live arrivals glow transiently;
+  // the event log can pin a past batch. The nonce re-arms the fade window.
+  const [activeHighlight, setActiveHighlight] = useState<ActiveHighlight | null>(null);
+  const highlightNonce = useRef(0);
+  const applyHighlight = useCallback(
+    (batch: { idColumn?: string; ids: string[] }, dcId?: string, sticky = false, batchKey?: string) => {
+      highlightNonce.current += 1;
+      const nonce = highlightNonce.current;
+      setActiveHighlight((prev) => {
+        // A live (non-sticky) arrival must not replace a pinned batch.
+        if (!sticky && prev?.sticky) return prev;
+        return { ...batch, dcId, sticky, batchKey, nonce };
+      });
+    },
+    [],
+  );
+  const handleHighlightBatch = useCallback(
+    (entry: RealtimeJournalEntry) => {
+      const batch = batchIdsFromPayload(entry.payload);
+      if (!batch) return;
+      applyHighlight(batch, entry.dataCollectionId, true, entry.receivedAt);
+    },
+    [applyHighlight],
+  );
+  const handleClearHighlight = useCallback(() => setActiveHighlight(null), []);
+
   const onRealtimeUpdate = useCallback(
     (
       event: {
@@ -598,6 +628,8 @@ const EditorApp: React.FC = () => {
         payload,
       });
       if (auto) {
+        const batch = batchIdsFromPayload(payload);
+        if (batch) applyHighlight(batch, event.data_collection_id, false);
         triggerRealtimeRefresh();
         return;
       }
@@ -609,7 +641,7 @@ const EditorApp: React.FC = () => {
         onClick: () => triggerRealtimeRefresh(),
       });
     },
-    [triggerRealtimeRefresh, appendJournal],
+    [triggerRealtimeRefresh, appendJournal, applyHighlight],
   );
   // Gated on the project's ``realtime.enabled`` flag (project.yaml). Static
   // projects never mount the WebSocket / indicator.
@@ -924,6 +956,9 @@ const EditorApp: React.FC = () => {
                     }}
                     journal={journal}
                     onClearJournal={clearJournal}
+                    onHighlightBatch={handleHighlightBatch}
+                    onClearHighlight={handleClearHighlight}
+                    activeHighlightKey={activeHighlight?.batchKey}
                   />
                 </span>
               )}
@@ -1018,6 +1053,7 @@ const EditorApp: React.FC = () => {
                 onDeleteComponent={handleDeleteComponent}
                 onDuplicateComponent={handleDuplicateComponent}
                 onAddComponent={handleAddComponent}
+                activeHighlight={activeHighlight}
               />
             </Box>
           </div>
@@ -1070,6 +1106,7 @@ interface RightComponentGridProps {
   onDeleteComponent: (componentId: string) => void;
   onDuplicateComponent: (componentId: string) => void;
   onAddComponent: () => void;
+  activeHighlight?: ActiveHighlight | null;
 }
 
 /**
@@ -1094,6 +1131,7 @@ const RightComponentGrid: React.FC<RightComponentGridProps> = ({
   onDeleteComponent,
   onDuplicateComponent,
   onAddComponent,
+  activeHighlight,
 }) => {
   const allComponents = useMemo(
     () => [...cardComponents, ...otherComponents],
@@ -1147,6 +1185,7 @@ const RightComponentGrid: React.FC<RightComponentGridProps> = ({
       cardValues={cardValues}
       cardSecondaryValues={cardSecondaryValues}
       cardValuesLoading={cardsLoading}
+      activeHighlight={activeHighlight}
       isDraggable={true}
       isResizable={true}
       editMode={true}

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -63,3 +63,7 @@ DEPICTIO_EVENTS_ENABLED=true
 # Leaving this off; use POST /events/test-trigger/{dc_id} or your data
 # producer (e.g. SVLT) to drive events instead.
 DEPICTIO_EVENTS_MONGODB_CHANGE_STREAMS_ENABLED=false
+# Enables POST /events/test-trigger/{dc_id} (admin-only) — the only local way to
+# fire a broadcast without change streams. Reaches the backend via env_file (this
+# file), NOT the compose environment: block, so it belongs here, not .env.instance.
+DEPICTIO_ENABLE_DEV_ENDPOINTS=true

--- a/docs/deploy-realtime-events.md
+++ b/docs/deploy-realtime-events.md
@@ -1,0 +1,67 @@
+# Deploy Depictio with real-time dashboards
+
+- Bring up Depictio, import the `adapt_feedb_ms` demo, watch its dashboard refresh live over WebSocket as rows land.
+- Tested on `1.1.4-b3`. Needs Docker + Python 3.11 (CLI). All local — no external S3/DB.
+
+## 1. Stack
+
+```bash
+curl -LO https://raw.githubusercontent.com/depictio/depictio/stable/docker-compose.yaml
+
+cat > .env <<'EOF'
+DEPICTIO_VERSION=1.1.4-b3
+DEPICTIO_AUTH_SINGLE_USER_MODE=true                 # admin, no login (compose default)
+DEPICTIO_EVENTS_ENABLED=true                        # opens /events/ws + the React RealtimeIndicator
+EOF
+
+docker compose up -d
+```
+
+- Viewer `:5080`, API `:8058`.
+- Single-user mode drops you in as admin — no login.
+- No dev endpoints needed: the CLI re-ingest (`/deltatables/upsert`) broadcasts the refresh itself.
+
+## 2. CLI + token
+
+```bash
+pip install depictio-cli        # or: uv tool install depictio-cli
+```
+
+- `http://localhost:5080/cli-agents` → create token → download `CLI.yaml`.
+- Install it + check:
+
+```bash
+mkdir -p ~/.depictio && mv ~/Downloads/CLI.yaml ~/.depictio/CLI.yaml
+depictio-cli config check
+```
+
+## 3. Import the demo
+
+```bash
+git clone --depth 1 https://github.com/depictio/depictio.git && cd depictio
+
+depictio-cli run \
+  --project-config-path depictio/projects/test/adapt_feedb_ms/project.yaml \
+  --update-config --rescan-folders --overwrite --skip-s3-check --skip-join
+```
+
+- Creates DC `750a1b2c3d4e5f6a7b8c9d10` + the **Microscopy Real-time Monitor** dashboard.
+- Open `http://localhost:5080/dashboard/750a1b2c3d4e5f6a7b8c9d20` — RealtimeIndicator goes green once subscribed.
+- Indicator only shows for opted-in projects. `adapt_feedb_ms` already carries the block:
+  ```yaml
+  realtime:
+    enabled: true
+  ```
+
+## 4. Drive events
+
+```bash
+cd depictio/projects/test/adapt_feedb_ms
+./stream_test.sh reset          # seed 2 rows + ingest
+./stream_test.sh stream 3       # one row every 3s until Ctrl+C
+```
+
+- Each tick: appends a row → re-ingests via CLI (`/deltatables/upsert`) → broadcast → subscribed viewers refetch.
+- No manual refresh: new images in the gallery, cards recompute (counts, averages, timeline), updated items flash.
+- Other modes: `bump 5` (rows back-to-back), `status`.
+- Defaults target §1 (`API_URL=http://localhost:8058`, `CLI_CONFIG=~/.depictio/CLI.yaml`) — export either to override.

--- a/docs/deploy-realtime-events.md
+++ b/docs/deploy-realtime-events.md
@@ -53,7 +53,9 @@ depictio-cli run \
     enabled: true
   ```
 
-## 4. Drive events
+## 4. Drive events — synthetic (`stream_test.sh`)
+
+The quickest way to see the dashboard move. No extra deps — reuses the CLI + token from §2.
 
 ```bash
 cd depictio/projects/test/adapt_feedb_ms
@@ -65,3 +67,81 @@ cd depictio/projects/test/adapt_feedb_ms
 - No manual refresh: new images in the gallery, cards recompute (counts, averages, timeline), updated items flash.
 - Other modes: `bump 5` (rows back-to-back), `status`.
 - Defaults target §1 (`API_URL=http://localhost:8058`, `CLI_CONFIG=~/.depictio/CLI.yaml`) — export either to override.
+
+## 5. Drive events — real simulator (SVLT + `svltx-depictio`)
+
+The realistic path: a **virtual-microscopy acquisition simulator** (SVLT) produces a
+live `PhenoBase` table of segmented cells with image patches, and the `svltx-depictio`
+extension exports each acquisition to MinIO as a Delta table and notifies the API —
+exactly what a real instrument feed would do.
+
+> Needs the SVLT project (`svlt-core` + an experiment script), which lives outside this
+> repo (EMBL: `git.embl.de/rhodes/svlt-projects`). `svltx-depictio` is the glue and ships
+> in that same `svltx/` tree. The synthetic driver in §4 needs none of this.
+
+### 5.1 Environment
+
+Create an isolated env (the script defaults to one named `svlt-simulate`; override with
+`SVLT_ENV`) and install SVLT, your experiment script's deps, and the extension **editable**:
+
+```bash
+micromamba create -n svlt-simulate python=3.11 -y     # or conda/mamba
+micromamba run -n svlt-simulate pip install svlt-core  # + the experiment project's deps
+micromamba run -n svlt-simulate pip install -e svltx/depictio
+```
+
+The extension activates by wrapping `session_phenobase.write`, so the experiment script
+must import it once (the `proj0039` simulate script already does):
+
+```python
+import svltx.depictio  # noqa: F401  — inert unless SVLT_S3_ENDPOINT is set
+```
+
+`-e` (editable) means edits to `svltx/depictio` take effect on the next run — no reinstall.
+
+### 5.2 Run the simulation
+
+`run_simulation.sh` wires the extension to *this* Depictio instance and launches the
+experiment. Point it at your experiment directory and go:
+
+```bash
+cd depictio/projects/test/adapt_feedb_ms
+
+SVLT_EXP_ROOT=/path/to/your/svlt/experiment \
+  ./run_simulation.sh
+```
+
+Every value has a default targeting a stock local stack (FastAPI `:8058`, MinIO `:9000`,
+DC `750a1b2c3d4e5f6a7b8c9d10`); override any by exporting it first. The essentials:
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `SVLT_EXP_ROOT` | — (**required**) | your SVLT experiment directory (holds the simulate script + inputs) |
+| `SVLT_API_TOKEN` | from `admin_config.yaml` if present | Bearer token for the API notify — set it explicitly outside a worktree |
+| `SVLT_ENV` | `svlt-simulate` | conda/micromamba env holding svlt + the extension |
+| `SVLT_SCRIPT` | `$SVLT_EXP_ROOT/proj0039-exp0002-simulate-experiment.py` | experiment entry point |
+| `SVLT_DC_ID` | `750a1b2c3d4e5f6a7b8c9d10` | target data collection → S3 prefix + Delta path |
+| `SVLT_EXTRA_ARGS` | *(empty)* | extra flags for the simulate script, e.g. `--delay 1 --port 6221` |
+
+In a worktree the script auto-derives ports + MinIO creds from `.env.instance` and the
+token from `depictio/.depictio/admin_config.yaml`; outside one, it falls back to the stock
+defaults and you supply `SVLT_API_TOKEN` yourself.
+
+Then open `http://localhost:5080/dashboard/750a1b2c3d4e5f6a7b8c9d20` and watch acquisitions
+land live — same refresh behaviour as §4, but with real segmented-cell images and per-cell
+morphology feeding the gallery, scatter plots, and the acquisition timeline.
+
+### 5.3 Two details the script handles for you
+
+- **One event per acquisition.** The pipeline writes `PhenoBase` twice each tick — first
+  after segmentation (cells, *no* image patches), then after ROI-square rendering (same
+  cells, now with `patches_patches_2d_rgb_path`). The script sets
+  `SVLT_IMAGE_COLUMN=patches_patches_2d_rgb_path` so the extension gates the sync on that
+  column being populated: dashboards only ever refresh onto rows whose images already
+  exist, and each acquisition fires a single WS event. Unset it to restore per-write
+  notifications.
+- **Cards recompute, not just refresh.** The notify goes to `/deltatables/upsert`, **not**
+  `/events/test-trigger`. `test-trigger` only broadcasts + drops the cache; it does *not*
+  recompute column specs or bump `aggregation_version`, so card values would stay frozen at
+  the last CLI-ingested numbers. `/upsert` re-reads the Delta SVLT just wrote, recomputes
+  specs, bumps the version, **and** broadcasts — so counts/averages/timeline all move.

--- a/docs/deploy-realtime-events.md
+++ b/docs/deploy-realtime-events.md
@@ -85,9 +85,11 @@ Create an isolated env (the script defaults to one named `svlt-simulate`; overri
 `SVLT_ENV`) and install SVLT, your experiment script's deps, and the extension **editable**:
 
 ```bash
-micromamba create -n svlt-simulate python=3.11 -y     # or conda/mamba
-micromamba run -n svlt-simulate pip install svlt-core  # + the experiment project's deps
-micromamba run -n svlt-simulate pip install -e svltx/depictio
+micromamba create -n svlt-simulate python=3.11 -y   # or conda/mamba
+micromamba activate svlt-simulate
+
+pip install svlt-core           # + the experiment project's deps
+pip install -e svltx/depictio   # editable: edits apply on next run, no reinstall
 ```
 
 The extension activates by wrapping `session_phenobase.write`, so the experiment script
@@ -96,8 +98,6 @@ must import it once (the `proj0039` simulate script already does):
 ```python
 import svltx.depictio  # noqa: F401  — inert unless SVLT_S3_ENDPOINT is set
 ```
-
-`-e` (editable) means edits to `svltx/depictio` take effect on the next run — no reinstall.
 
 ### 5.2 Run the simulation
 
@@ -123,25 +123,19 @@ DC `750a1b2c3d4e5f6a7b8c9d10`); override any by exporting it first. The essentia
 | `SVLT_DC_ID` | `750a1b2c3d4e5f6a7b8c9d10` | target data collection → S3 prefix + Delta path |
 | `SVLT_EXTRA_ARGS` | *(empty)* | extra flags for the simulate script, e.g. `--delay 1 --port 6221` |
 
-In a worktree the script auto-derives ports + MinIO creds from `.env.instance` and the
-token from `depictio/.depictio/admin_config.yaml`; outside one, it falls back to the stock
-defaults and you supply `SVLT_API_TOKEN` yourself.
+In a worktree the script auto-derives ports, MinIO creds, and the token from
+`.env.instance` + `admin_config.yaml`; outside one it uses the stock defaults and you
+supply `SVLT_API_TOKEN`.
 
-Then open `http://localhost:5080/dashboard/750a1b2c3d4e5f6a7b8c9d20` and watch acquisitions
-land live — same refresh behaviour as §4, but with real segmented-cell images and per-cell
-morphology feeding the gallery, scatter plots, and the acquisition timeline.
+Open `http://localhost:5080/dashboard/750a1b2c3d4e5f6a7b8c9d20` and watch acquisitions land
+live — same refresh as §4, but with real segmented-cell images and morphology.
 
 ### 5.3 Two details the script handles for you
 
-- **One event per acquisition.** The pipeline writes `PhenoBase` twice each tick — first
-  after segmentation (cells, *no* image patches), then after ROI-square rendering (same
-  cells, now with `patches_patches_2d_rgb_path`). The script sets
-  `SVLT_IMAGE_COLUMN=patches_patches_2d_rgb_path` so the extension gates the sync on that
-  column being populated: dashboards only ever refresh onto rows whose images already
-  exist, and each acquisition fires a single WS event. Unset it to restore per-write
-  notifications.
-- **Cards recompute, not just refresh.** The notify goes to `/deltatables/upsert`, **not**
-  `/events/test-trigger`. `test-trigger` only broadcasts + drops the cache; it does *not*
-  recompute column specs or bump `aggregation_version`, so card values would stay frozen at
-  the last CLI-ingested numbers. `/upsert` re-reads the Delta SVLT just wrote, recomputes
-  specs, bumps the version, **and** broadcasts — so counts/averages/timeline all move.
+- **One event per acquisition.** The pipeline writes `PhenoBase` twice per tick (after
+  segmentation, then after image-patch rendering). The script sets
+  `SVLT_IMAGE_COLUMN=patches_patches_2d_rgb_path` so the sync fires only once that column
+  is populated — dashboards never refresh onto image-less rows. Unset to notify per write.
+- **Cards recompute, not just refresh.** It notifies `/deltatables/upsert` (not the dev-only
+  `/events/test-trigger`, which only broadcasts). `/upsert` re-reads the new Delta,
+  recomputes column specs, and bumps the version — so cards/timeline actually update.

--- a/packages/depictio-react-core/src/components/ComponentRenderer.tsx
+++ b/packages/depictio-react-core/src/components/ComponentRenderer.tsx
@@ -38,6 +38,7 @@ import SegmentedControlRenderer from './interactive/SegmentedControlRenderer';
 import TimelineRenderer from './interactive/TimelineRenderer';
 import SecondaryMetrics from './card/SecondaryMetrics';
 import { wrapWithChrome } from './chrome';
+import { ActiveHighlight } from '../highlight';
 
 interface ComponentRendererProps {
   metadata: StoredMetadata;
@@ -53,6 +54,8 @@ interface ComponentRendererProps {
   dashboardId?: string;
   /** Counter to invalidate data-fetching effects on realtime updates. */
   refreshTick?: number;
+  /** Batch currently highlighted; renderers glow its rows when the DC matches. */
+  activeHighlight?: ActiveHighlight | null;
   /** Extra action-icon nodes appended to the chrome row. Editor uses this to inject the per-cell "..." edit menu. */
   extraActions?: React.ReactNode;
   /** Show the drag handle (3×3 grip) on the chrome — typically only in editor mode. */
@@ -76,6 +79,7 @@ const ComponentRenderer: React.FC<ComponentRendererProps> = ({
   cardLoading,
   dashboardId,
   refreshTick,
+  activeHighlight,
   extraActions,
   showDragHandle,
   compact,
@@ -147,6 +151,7 @@ const ComponentRenderer: React.FC<ComponentRendererProps> = ({
           filters={filters}
           onChange={onFilterChange}
           compact={compact}
+          refreshTick={refreshTick}
         />
       );
     } else {
@@ -193,6 +198,7 @@ const ComponentRenderer: React.FC<ComponentRendererProps> = ({
         filters={filters}
         onFilterChange={onFilterChange}
         refreshTick={refreshTick}
+        activeHighlight={activeHighlight}
       />,
       { onResetFilter: onResetSelection, extraActions, showDragHandle, sourceFilterActive },
     );
@@ -206,6 +212,7 @@ const ComponentRenderer: React.FC<ComponentRendererProps> = ({
         filters={filters}
         onFilterChange={onFilterChange}
         refreshTick={refreshTick}
+        activeHighlight={activeHighlight}
         extraActions={extraActions}
         showDragHandle={showDragHandle}
       />
@@ -234,6 +241,7 @@ const ComponentRenderer: React.FC<ComponentRendererProps> = ({
         filters={filters}
         onFilterChange={onFilterChange}
         refreshTick={refreshTick}
+        activeHighlight={activeHighlight}
       />,
       { onResetFilter: onResetSelection, extraActions, showDragHandle, sourceFilterActive },
     );
@@ -341,6 +349,7 @@ const TableBlock: React.FC<{
   filters: InteractiveFilter[];
   onFilterChange?: (filter: InteractiveFilter) => void;
   refreshTick?: number;
+  activeHighlight?: ActiveHighlight | null;
   extraActions?: React.ReactNode;
   showDragHandle?: boolean;
 }> = ({
@@ -349,6 +358,7 @@ const TableBlock: React.FC<{
   filters,
   onFilterChange,
   refreshTick,
+  activeHighlight,
   extraActions,
   showDragHandle,
 }) => {
@@ -377,6 +387,7 @@ const TableBlock: React.FC<{
       agGridApiRef={agGridApiRef}
       onFilterChange={onFilterChange}
       refreshTick={refreshTick}
+      activeHighlight={activeHighlight}
     />,
     {
       agGridApiRef,

--- a/packages/depictio-react-core/src/components/DashboardGrid.tsx
+++ b/packages/depictio-react-core/src/components/DashboardGrid.tsx
@@ -3,6 +3,7 @@ import GridLayout, { Layout } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import { StoredMetadata, InteractiveFilter } from '../api';
+import { ActiveHighlight } from '../highlight';
 import ComponentRenderer from './ComponentRenderer';
 
 interface DashboardGridProps {
@@ -23,6 +24,9 @@ interface DashboardGridProps {
    * event). Renderers include this in their effect deps; ``undefined`` is a no-op.
    */
   refreshTick?: number;
+  /** The batch currently highlighted (live arrival or a pinned re-selection
+   *  from the event log). Forwarded to renderers so they glow its rows. */
+  activeHighlight?: ActiveHighlight | null;
   /** Allow users to drag grid items. Defaults to false (viewer-safe). */
   isDraggable?: boolean;
   /** Allow users to resize grid items. Defaults to false (viewer-safe). */
@@ -67,6 +71,7 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   cardSecondaryValues,
   cardValuesLoading,
   refreshTick,
+  activeHighlight,
   isDraggable = false,
   isResizable = false,
   editMode = false,
@@ -245,6 +250,7 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
               cardSecondaryValues={cardSecondaryValues?.[m.index]}
               cardLoading={cardValuesLoading}
               refreshTick={refreshTick}
+              activeHighlight={activeHighlight}
               extraActions={showOverlays ? renderItemOverlay!(m.index, m) : undefined}
               showDragHandle={editMode && isDraggable}
             />

--- a/packages/depictio-react-core/src/components/FigureRenderer.tsx
+++ b/packages/depictio-react-core/src/components/FigureRenderer.tsx
@@ -12,6 +12,7 @@ import { extractScatterSelection } from '../selection';
 import { useInView } from '../hooks/useInView';
 import { useNewItemIds } from '../hooks/useNewItemIds';
 import { useTransientFlag } from '../hooks/useTransientFlag';
+import { ActiveHighlight } from '../highlight';
 import { asNumberArray, extractCustomdataIds } from '../plotlyData';
 import RefetchOverlay from './RefetchOverlay';
 
@@ -24,6 +25,9 @@ interface FigureRendererProps {
   onFilterChange?: (filter: InteractiveFilter) => void;
   /** Counter to force refetch on realtime updates even when filters are unchanged. */
   refreshTick?: number;
+  /** Batch to glow — a live arrival (auto-fade) or a pinned re-selection from
+   *  the event log. Its ``ids`` are matched against the scatter customdata. */
+  activeHighlight?: ActiveHighlight | null;
 }
 
 /**
@@ -44,6 +48,7 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
   filters,
   onFilterChange,
   refreshTick,
+  activeHighlight,
 }) => {
   const [figure, setFigure] = useState<{ data?: unknown[]; layout?: Record<string, unknown> } | null>(null);
   const [loading, setLoading] = useState(true);
@@ -244,11 +249,34 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
   const newIds = useNewItemIds(figureIds, refreshTick);
   const highlightActive = useTransientFlag(refreshTick, highlightDurationMs);
 
-  // Build an overlay trace (one per realtime tick) with markers at the new
-  // points' coordinates. We re-derive x/y from the trace's own arrays by
-  // matching customdata index → trace index. No mutation of existing traces.
+  // Per-batch highlight, payload-driven. The scatter overlay only carries the
+  // selection column's values in customdata, so a batch can only match when its
+  // ``idColumn`` equals ``selectionColumn``. This is ADDITIVE with the legacy
+  // client-side diff: live arrivals overlay via either path, a sticky batch
+  // re-overlays with no refetch.
+  const batchColumnAligned =
+    !!activeHighlight &&
+    (!activeHighlight.dcId || activeHighlight.dcId === metadata.dc_id) &&
+    (!activeHighlight.idColumn || activeHighlight.idColumn === selectionColumn);
+  const batchFadeActive = useTransientFlag(activeHighlight?.nonce, highlightDurationMs);
+  const batchHighlightOn =
+    batchColumnAligned && (activeHighlight!.sticky || batchFadeActive);
+  // Union of the legacy diff (when its window is open) and the batch ids (when
+  // its gate is on) — the overlay marks every id in the combined set.
+  const effectiveIds = useMemo<Set<string>>(() => {
+    const s = new Set<string>();
+    if (highlightActive) newIds.forEach((id) => s.add(id));
+    if (batchHighlightOn) activeHighlight!.ids.forEach((id) => s.add(id));
+    return s;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightActive, newIds, batchHighlightOn, activeHighlight?.ids]);
+  const overlayActive = (highlightActive && newIds.size > 0) || batchHighlightOn;
+
+  // Build an overlay trace with markers at the highlighted points' coordinates.
+  // We re-derive x/y from the trace's own arrays by matching customdata index →
+  // trace index. No mutation of existing traces.
   const overlayTrace = useMemo<Record<string, unknown> | null>(() => {
-    if (!highlightActive || !isScatterLike || newIds.size === 0 || !figure) return null;
+    if (!overlayActive || !isScatterLike || effectiveIds.size === 0 || !figure) return null;
     const data = (figure.data as Array<{
       x?: unknown;
       y?: unknown;
@@ -262,7 +290,7 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
       const xArr = asNumberArray(trace?.x);
       const yArr = asNumberArray(trace?.y);
       for (let i = 0; i < ids.length; i++) {
-        if (newIds.has(ids[i]) && i < xArr.length && i < yArr.length) {
+        if (effectiveIds.has(ids[i]) && i < xArr.length && i < yArr.length) {
           xs.push(xArr[i]);
           ys.push(yArr[i]);
         }
@@ -284,7 +312,7 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
       showlegend: false,
       name: '__depictio_new_items',
     };
-  }, [highlightActive, isScatterLike, newIds, figure, selectionColumnIndex, highlightColor]);
+  }, [overlayActive, isScatterLike, effectiveIds, figure, selectionColumnIndex, highlightColor]);
 
   const figureData = useMemo<unknown[]>(() => {
     const base = (figure?.data as unknown[]) || [];

--- a/packages/depictio-react-core/src/components/ImageRenderer.tsx
+++ b/packages/depictio-react-core/src/components/ImageRenderer.tsx
@@ -27,6 +27,7 @@ import {
 } from '../api';
 import { useNewItemIds } from '../hooks/useNewItemIds';
 import { useTransientFlag } from '../hooks/useTransientFlag';
+import { ActiveHighlight } from '../highlight';
 import RefetchOverlay from './RefetchOverlay';
 
 interface ImageRendererProps {
@@ -39,6 +40,9 @@ interface ImageRendererProps {
   onFilterChange?: (filter: InteractiveFilter) => void;
   /** Counter to force refetch on realtime updates even when filters are unchanged. */
   refreshTick?: number;
+  /** Batch to glow — a live arrival (auto-fade) or a pinned re-selection from
+   *  the event log. Its ``ids`` are matched against each card's row-id key. */
+  activeHighlight?: ActiveHighlight | null;
 }
 
 /**
@@ -63,6 +67,7 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
   filters = [],
   onFilterChange,
   refreshTick,
+  activeHighlight,
 }) => {
   const imageColumn = (metadata.image_column as string) || '';
   const s3BaseFolder = (metadata.s3_base_folder as string) || '';
@@ -254,6 +259,66 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
   );
   const newItemKeys = useNewItemIds(itemKeys, refreshTick);
   const highlightActive = useTransientFlag(refreshTick, highlightDurationMs);
+
+  // Per-batch highlight (WHAT × WHEN, payload-driven). ``activeHighlight`` names
+  // the exact ids a batch added, as values of the batch's own ``idColumn`` (the
+  // DC-wide column the backend diffed, e.g. ``index_index``). We match each card
+  // on THAT column — which every row carries in ``it.row`` — rather than the
+  // component's selection column, so highlighting works even when the two
+  // differ. Sticky batches (re-selected from the event log) stay lit; live
+  // arrivals fade after ``highlightDurationMs``.
+  const batchDcMatch =
+    !!activeHighlight &&
+    (!activeHighlight.dcId || activeHighlight.dcId === metadata.dc_id);
+  const batchIdColumn = activeHighlight?.idColumn;
+  const batchIds = useMemo(
+    () => (batchDcMatch && batchIdColumn ? new Set(activeHighlight!.ids) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [batchDcMatch, batchIdColumn, activeHighlight?.ids],
+  );
+  // A live arrival fires the highlight nonce and a data refresh at the same
+  // moment, but the gallery re-fetch is async: the batch's rows often mount a
+  // beat later (worse under the API's post-write respec lag). Arming the fade on
+  // the nonce alone can burn the whole window before those rows render — leaving
+  // them un-glowed. So arm it when the batch's rows are actually PRESENT in the
+  // fetched items instead. Keyed on nonce too, so a new batch re-arms; undefined
+  // until present so ``useTransientFlag`` doesn't start (and waste) the timer.
+  const batchRowsPresent = useMemo(
+    () =>
+      !!batchIds &&
+      !!batchIdColumn &&
+      items.some((it) => it.row[batchIdColumn] != null && batchIds.has(String(it.row[batchIdColumn]))),
+    [items, batchIds, batchIdColumn],
+  );
+  const batchFadeKey =
+    batchDcMatch && batchRowsPresent ? `${activeHighlight?.nonce}` : undefined;
+  const batchFadeActive = useTransientFlag(batchFadeKey, highlightDurationMs);
+  const batchHighlightOn = batchDcMatch && (activeHighlight!.sticky || batchFadeActive);
+  const batchSticky = !!activeHighlight?.sticky;
+
+  // Does this card belong to the active batch? (batch's own id column looked up
+  // on the row — see ActiveHighlight.idColumn.)
+  const cardInBatch = (row: Record<string, unknown>): boolean =>
+    !!batchIds &&
+    !!batchIdColumn &&
+    row[batchIdColumn] != null &&
+    batchIds.has(String(row[batchIdColumn]));
+
+  // Resolve a card's highlight class. A PINNED batch (re-selected from the event
+  // log) gets the steady ``depictio-card-pinned`` style so it stays lit until
+  // cleared; a live arrival (legacy client-side diff, or a non-sticky batch)
+  // gets the one-shot ``depictio-card-new`` glow that fades. Batch + legacy are
+  // additive so live highlights fire even when no batch targets this component.
+  const cardHighlightClass = (it: {
+    rowId: string;
+    relPath: string;
+    row: Record<string, unknown>;
+  }): string | null => {
+    if (batchHighlightOn && batchSticky && cardInBatch(it.row)) return 'depictio-card-pinned';
+    const legacyLive = highlightActive && newItemKeys.has(rowIdColumn ? it.rowId : it.relPath);
+    const batchLive = batchHighlightOn && !batchSticky && cardInBatch(it.row);
+    return legacyLive || batchLive ? 'depictio-card-new' : null;
+  };
 
   const selectionEnabled = !!onFilterChange && !!imageColumn;
 
@@ -453,11 +518,8 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
             <SimpleGrid cols={columns} spacing="xs" verticalSpacing="xs" p={4}>
               {items.map((it) => {
                 const selected = selectedRowIds.has(it.rowId);
-                const isNew =
-                  highlightActive &&
-                  newItemKeys.has(rowIdColumn ? it.rowId : it.relPath);
                 const cardClasses = [
-                  isNew ? 'depictio-card-new' : null,
+                  cardHighlightClass(it),
                   selected ? 'depictio-card-selected' : null,
                 ]
                   .filter(Boolean)
@@ -465,7 +527,7 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
                 return (
                   <Box key={it.key} pos="relative">
                     <HoverCard
-                      width={320}
+                      width={400}
                       shadow="md"
                       openDelay={350}
                       closeDelay={80}
@@ -510,6 +572,15 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
                               w="100%"
                               fit="cover"
                               loading="lazy"
+                              // The wrapping Mantine Card is display:flex /
+                              // flex-direction:column, so the image inherits
+                              // `flex: 0 1 0%` and its fixed `h` is ignored —
+                              // each thumbnail stretches to its patch's
+                              // intrinsic size (ragged, uneven heights).
+                              // `flex: none` (0 0 auto) restores the fixed
+                              // height so every thumbnail is exactly
+                              // `thumbnailSize` tall and `fit=cover` can crop.
+                              style={{ flex: 'none' }}
                               fallbackSrc="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='1.5'><path d='M3 5h18v14H3z'/><circle cx='9' cy='10' r='2'/><path d='M21 17l-6-6-9 9'/></svg>"
                             />
                           </Card>
@@ -520,18 +591,32 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
                           <Text fw={600} size="sm" truncate>
                             {it.filename}
                           </Text>
-                          {Object.entries(it.row as Record<string, unknown>).map(
-                            ([k, v]) => (
-                              <Group key={k} gap="xs" wrap="nowrap" justify="space-between">
-                                <Text size="xs" c="dimmed" truncate>
-                                  {k}
-                                </Text>
-                                <Text size="xs" ff="monospace" truncate maw={180} ta="right">
-                                  {v == null ? '—' : String(v)}
-                                </Text>
-                              </Group>
-                            ),
-                          )}
+                          {/* Rows with many columns overflow the viewport — scroll
+                              the metadata list internally, keeping the filename
+                              header pinned above it. */}
+                          <ScrollArea.Autosize mah={320} type="auto" offsetScrollbars>
+                            <Stack gap={4}>
+                              {Object.entries(it.row as Record<string, unknown>).map(
+                                ([k, v]) => (
+                                  <Group key={k} gap="xs" wrap="nowrap" align="flex-start" justify="space-between">
+                                    <Text size="xs" c="dimmed" style={{ flexShrink: 0, maxWidth: '45%' }} truncate>
+                                      {k}
+                                    </Text>
+                                    {/* Wrap long values (paths, hashes) instead of
+                                        truncating so the full metadata is readable. */}
+                                    <Text
+                                      size="xs"
+                                      ff="monospace"
+                                      ta="right"
+                                      style={{ minWidth: 0, wordBreak: 'break-word' }}
+                                    >
+                                      {v == null ? '—' : String(v)}
+                                    </Text>
+                                  </Group>
+                                ),
+                              )}
+                            </Stack>
+                          </ScrollArea.Autosize>
                         </Stack>
                       </HoverCard.Dropdown>
                     </HoverCard>

--- a/packages/depictio-react-core/src/components/InteractiveGroupCard.tsx
+++ b/packages/depictio-react-core/src/components/InteractiveGroupCard.tsx
@@ -9,6 +9,9 @@ interface InteractiveGroupCardProps {
   members: StoredMetadata[];
   filters: InteractiveFilter[];
   onFilterChange?: (filter: InteractiveFilter) => void;
+  /** Realtime refresh counter — forwarded so a grouped Timeline member
+   *  re-fetches its datetime bounds as new rows stream in. */
+  refreshTick?: number;
 }
 
 /**
@@ -24,6 +27,7 @@ const InteractiveGroupCard: React.FC<InteractiveGroupCardProps> = ({
   members,
   filters,
   onFilterChange,
+  refreshTick,
 }) => {
   return (
     <Paper withBorder p="xs" radius="md" shadow="xs">
@@ -38,6 +42,7 @@ const InteractiveGroupCard: React.FC<InteractiveGroupCardProps> = ({
               metadata={m}
               filters={filters}
               onFilterChange={onFilterChange}
+              refreshTick={refreshTick}
               compact
             />
           </React.Fragment>

--- a/packages/depictio-react-core/src/components/RealtimeIndicator.tsx
+++ b/packages/depictio-react-core/src/components/RealtimeIndicator.tsx
@@ -20,6 +20,7 @@ import { Icon } from '@iconify/react';
 
 import type { RealtimeMode, RealtimeStatus } from '../realtime';
 import type { RealtimeJournalEntry } from '../hooks/useRealtimeJournal';
+import { batchIdsFromPayload } from '../highlight';
 
 interface RealtimeIndicatorProps {
   status: RealtimeStatus;
@@ -34,6 +35,14 @@ interface RealtimeIndicatorProps {
   journal?: RealtimeJournalEntry[];
   /** Wipes the journal — both in-memory state and the localStorage entry. */
   onClearJournal?: () => void;
+  /** Pin the batch of rows a past event added, re-highlighting them across the
+   *  dashboard. Only offered on entries whose payload carries added ids. */
+  onHighlightBatch?: (entry: RealtimeJournalEntry) => void;
+  /** Clear any pinned batch highlight. */
+  onClearHighlight?: () => void;
+  /** ``batchKey`` of the currently-pinned batch (an entry's ``receivedAt``),
+   *  used to mark the active row. Undefined when nothing is pinned. */
+  activeHighlightKey?: string;
 }
 
 const STATUS_LABELS: Record<RealtimeStatus, string> = {
@@ -47,6 +56,14 @@ const STATUS_COLORS: Record<RealtimeStatus, string> = {
   connected: 'teal',
   disconnected: 'gray',
 };
+
+/** Accent for a journal row's left border: yellow when it's the pinned
+ *  highlight, else teal/orange by the sign of the row delta, else blue. */
+function journalRowBorderColor(highlighted: boolean, rowDelta: number | undefined): string {
+  if (highlighted) return 'var(--mantine-color-yellow-5)';
+  if (rowDelta === undefined || rowDelta === 0) return 'var(--mantine-color-blue-5)';
+  return rowDelta > 0 ? 'var(--mantine-color-teal-5)' : 'var(--mantine-color-orange-5)';
+}
 
 /**
  * Status pill + control menu mirroring the disabled Dash plumbing's
@@ -64,6 +81,9 @@ const RealtimeIndicator: React.FC<RealtimeIndicatorProps> = ({
   onAcknowledgePending,
   journal,
   onClearJournal,
+  onHighlightBatch,
+  onClearHighlight,
+  activeHighlightKey,
 }) => {
   const [opened, setOpened] = useState(false);
   // Newest first — most recent event is the most interesting.
@@ -147,6 +167,20 @@ const RealtimeIndicator: React.FC<RealtimeIndicatorProps> = ({
                   <Badge size="xs" variant="light" color="gray">
                     {journalNewestFirst.length}
                   </Badge>
+                  {onClearHighlight && activeHighlightKey && (
+                    <Anchor
+                      component="button"
+                      type="button"
+                      size="xs"
+                      c="orange"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onClearHighlight();
+                      }}
+                    >
+                      Clear highlight
+                    </Anchor>
+                  )}
                   {onClearJournal && journalNewestFirst.length > 0 && (
                     <Anchor
                       component="button"
@@ -175,6 +209,10 @@ const RealtimeIndicator: React.FC<RealtimeIndicatorProps> = ({
                       <JournalRow
                         key={`${entry.receivedAt}-${idx}`}
                         entry={entry}
+                        onHighlight={onHighlightBatch}
+                        highlighted={
+                          !!activeHighlightKey && entry.receivedAt === activeHighlightKey
+                        }
                       />
                     ))}
                   </Stack>
@@ -188,7 +226,14 @@ const RealtimeIndicator: React.FC<RealtimeIndicatorProps> = ({
   );
 };
 
-const JournalRow: React.FC<{ entry: RealtimeJournalEntry }> = ({ entry }) => {
+const JournalRow: React.FC<{
+  entry: RealtimeJournalEntry;
+  /** Pin this entry's batch as the active highlight. Absent when the host
+   *  doesn't support batch highlighting. */
+  onHighlight?: (entry: RealtimeJournalEntry) => void;
+  /** True when this entry's batch is the currently-pinned highlight. */
+  highlighted?: boolean;
+}> = ({ entry, onHighlight, highlighted }) => {
   // The backend's ``_build_event_payload`` packs project / DC tags and a live
   // row-count into ``payload``. Surface the most meaningful fields in the
   // compact row, push everything else into the HoverCard.
@@ -261,6 +306,11 @@ const JournalRow: React.FC<{ entry: RealtimeJournalEntry }> = ({ entry }) => {
     }
   })();
 
+  // Highlightable only when the batch actually carries added ids the renderers
+  // can key on. Reuse ``batchIdsFromPayload`` so the button's presence matches
+  // exactly what ``applyHighlight`` will act on (no dead-end button).
+  const canHighlight = !!onHighlight && batchIdsFromPayload(payload) !== null;
+
   return (
     <HoverCard
       width={420}
@@ -274,38 +324,57 @@ const JournalRow: React.FC<{ entry: RealtimeJournalEntry }> = ({ entry }) => {
       <HoverCard.Target>
         <Box
           style={{
-            borderLeft: `2px solid ${
-              rowDelta !== undefined && rowDelta !== 0
-                ? rowDelta > 0
-                  ? 'var(--mantine-color-teal-5)'
-                  : 'var(--mantine-color-orange-5)'
-                : 'var(--mantine-color-blue-5)'
-            }`,
+            borderLeft: `2px solid ${journalRowBorderColor(!!highlighted, rowDelta)}`,
             paddingLeft: 8,
             cursor: 'help',
+            backgroundColor: highlighted
+              ? 'var(--mantine-color-yellow-light)'
+              : undefined,
+            borderRadius: highlighted ? 4 : undefined,
           }}
         >
           <Group justify="space-between" wrap="nowrap" gap={6}>
             <Text size="xs" fw={500}>
               {time}
             </Text>
-            {/* Prefer row_delta (the actual change) over the absolute row_count.
-                Falls back to row_count when there's no prev version (very
-                first commit). */}
-            {rowDelta !== undefined && rowDelta !== 0 ? (
-              <Text
-                size="xs"
-                fw={600}
-                c={rowDelta > 0 ? 'teal.6' : 'orange.6'}
-              >
-                {rowDelta > 0 ? '+' : ''}
-                {rowDelta} {Math.abs(rowDelta) === 1 ? 'row' : 'rows'}
-              </Text>
-            ) : rowCount !== undefined ? (
-              <Text size="xs" fw={500} c="blue.6">
-                {rowCount} {rowCount === 1 ? 'row' : 'rows'}
-              </Text>
-            ) : null}
+            <Group gap={4} wrap="nowrap">
+              {/* Prefer row_delta (the actual change) over the absolute row_count.
+                  Falls back to row_count when there's no prev version (very
+                  first commit). */}
+              {rowDelta !== undefined && rowDelta !== 0 ? (
+                <Text
+                  size="xs"
+                  fw={600}
+                  c={rowDelta > 0 ? 'teal.6' : 'orange.6'}
+                >
+                  {rowDelta > 0 ? '+' : ''}
+                  {rowDelta} {Math.abs(rowDelta) === 1 ? 'row' : 'rows'}
+                </Text>
+              ) : rowCount !== undefined ? (
+                <Text size="xs" fw={500} c="blue.6">
+                  {rowCount} {rowCount === 1 ? 'row' : 'rows'}
+                </Text>
+              ) : null}
+              {canHighlight && (
+                <Tooltip
+                  label={highlighted ? 'Highlighted' : 'Highlight these rows'}
+                  withArrow
+                >
+                  <ActionIcon
+                    size="xs"
+                    variant={highlighted ? 'filled' : 'subtle'}
+                    color="yellow"
+                    aria-label="Highlight this batch"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onHighlight?.(entry);
+                    }}
+                  >
+                    <Icon icon="tabler:highlight" width={13} height={13} />
+                  </ActionIcon>
+                </Tooltip>
+              )}
+            </Group>
           </Group>
           <Group gap={6} wrap="nowrap">
             <Text size="xs" c="dimmed" lineClamp={1} style={{ flex: 1, minWidth: 0 }}>

--- a/packages/depictio-react-core/src/components/TableRenderer.tsx
+++ b/packages/depictio-react-core/src/components/TableRenderer.tsx
@@ -18,6 +18,7 @@ import { extractRowSelection } from '../selection';
 import { useInView } from '../hooks/useInView';
 import { useNewItemIds } from '../hooks/useNewItemIds';
 import { useTransientFlag } from '../hooks/useTransientFlag';
+import { ActiveHighlight } from '../highlight';
 import RefetchOverlay from './RefetchOverlay';
 
 interface TableRendererProps {
@@ -32,6 +33,9 @@ interface TableRendererProps {
   onFilterChange?: (filter: InteractiveFilter) => void;
   /** Counter to force refetch on realtime updates even when filters are unchanged. */
   refreshTick?: number;
+  /** Batch to glow — a live arrival (auto-fade) or a pinned re-selection from
+   *  the event log. Its ``ids`` are matched against each row's id column. */
+  activeHighlight?: ActiveHighlight | null;
 }
 
 const CACHE_BLOCK_SIZE = 100;
@@ -52,6 +56,7 @@ const TableRenderer: React.FC<TableRendererProps> = ({
   agGridApiRef,
   onFilterChange,
   refreshTick,
+  activeHighlight,
 }) => {
   const [colDefs, setColDefs] = useState<ColDef[]>([]);
   const [loading, setLoading] = useState(true);
@@ -131,7 +136,7 @@ const TableRenderer: React.FC<TableRendererProps> = ({
           serverSort && visibleColumns.some((c) => c.field === serverSort)
             ? serverSort
             : null;
-        const defaultSortField =
+        const acquisitionSortField =
           serverSortVisible ??
           visibleColumns
             .map((c) => c.field)
@@ -140,8 +145,32 @@ const TableRenderer: React.FC<TableRendererProps> = ({
                 /acquisition/i.test(f) && /(time|date|stamp)/i.test(f),
             ) ??
           null;
-        const defaultSortDir =
-          (res.sort_dir as 'asc' | 'desc' | undefined) ?? 'desc';
+        // Last-resort default: newest-first on the row-id column (``index_index``
+        // etc.) when it's visible AND numeric. A numeric ingest counter is
+        // monotonic, so descending surfaces the most recently added rows at the
+        // top — keeping the realtime new-row highlight in view (matching the
+        // newest-first image gallery) instead of stranding new rows at the bottom
+        // in natural ingest order. Gated on numeric dtype so a string selection
+        // column (``sample_id`` etc.) isn't lexicographically mis-sorted; those
+        // tables keep their prior natural order. Only used when no
+        // acquisition-timestamp sort applies.
+        const rowIdCol =
+          (typeof metadata.row_selection_column === 'string' &&
+            metadata.row_selection_column) ||
+          (typeof metadata.selection_column === 'string' &&
+            metadata.selection_column) ||
+          null;
+        const rowIdColMeta = rowIdCol
+          ? visibleColumns.find((c) => c.field === rowIdCol)
+          : undefined;
+        const rowIdSortField =
+          rowIdColMeta && rowIdColMeta.type === 'numericColumn' ? rowIdCol : null;
+        const defaultSortField = acquisitionSortField ?? rowIdSortField;
+        // Acquisition sort honours the server's direction (defaulting desc);
+        // the row-id fallback is always descending (newest first).
+        const defaultSortDir: 'asc' | 'desc' = acquisitionSortField
+          ? ((res.sort_dir as 'asc' | 'desc' | undefined) ?? 'desc')
+          : 'desc';
         sortRef.current = { sortBy: defaultSortField, sortDir: defaultSortDir };
         setColDefs(
           visibleColumns.map((c, i) => {
@@ -246,14 +275,47 @@ const TableRenderer: React.FC<TableRendererProps> = ({
       : 3000;
   const highlightActive = useTransientFlag(refreshTick, highlightDurationMs);
 
+  // Per-batch highlight, payload-driven — glow the exact ids a batch added,
+  // matched on the batch's own ``idColumn`` (the DC-wide column the backend
+  // diffed), which every row carries in ``params.data``. This is ADDITIVE with
+  // the legacy first-page diff below: live arrivals glow via either path, and a
+  // sticky batch (re-selected from the event log) re-glows with no refetch.
+  const batchDcMatch =
+    !!activeHighlight &&
+    (!activeHighlight.dcId || activeHighlight.dcId === metadata.dc_id);
+  const batchIdColumn = activeHighlight?.idColumn;
+  const batchIds = useMemo(
+    () => (batchDcMatch && batchIdColumn ? new Set(activeHighlight!.ids) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [batchDcMatch, batchIdColumn, activeHighlight?.ids],
+  );
+  const batchFadeActive = useTransientFlag(activeHighlight?.nonce, highlightDurationMs);
+  const batchHighlightOn = batchDcMatch && (activeHighlight!.sticky || batchFadeActive);
+  const batchSticky = !!activeHighlight?.sticky;
+
   const getRowClass = useMemo(() => {
-    if (!rowIdColumn || !highlightActive || newRowIds.size === 0) return undefined;
+    const legacyOn = !!rowIdColumn && highlightActive && newRowIds.size > 0;
+    const batchOn =
+      batchHighlightOn && !!batchIds && !!batchIdColumn && batchIds.size > 0;
+    if (!legacyOn && !batchOn) return undefined;
     return (params: { data?: Record<string, unknown> }) => {
-      const v = params.data?.[rowIdColumn];
-      if (v === null || v === undefined) return undefined;
-      return newRowIds.has(String(v)) ? 'depictio-row-new' : undefined;
+      const data = params.data;
+      if (!data) return undefined;
+      // A pinned batch gets the steady ``-pinned`` class (stays until cleared);
+      // live arrivals (batch or legacy diff) get the one-shot ``-new`` flash.
+      if (batchOn) {
+        const bv = data[batchIdColumn!];
+        if (bv != null && batchIds!.has(String(bv))) {
+          return batchSticky ? 'depictio-row-pinned' : 'depictio-row-new';
+        }
+      }
+      if (legacyOn) {
+        const lv = data[rowIdColumn!];
+        if (lv != null && newRowIds.has(String(lv))) return 'depictio-row-new';
+      }
+      return undefined;
     };
-  }, [rowIdColumn, highlightActive, newRowIds]);
+  }, [rowIdColumn, highlightActive, newRowIds, batchIds, batchIdColumn, batchHighlightOn, batchSticky]);
 
   // AG Grid only evaluates ``getRowClass`` when a row is first drawn. The
   // new-row highlight resolves via an async snapshot fetch that lands *after*

--- a/packages/depictio-react-core/src/components/TopPanel.tsx
+++ b/packages/depictio-react-core/src/components/TopPanel.tsx
@@ -8,6 +8,9 @@ interface TopPanelProps {
   components: StoredMetadata[];
   filters: InteractiveFilter[];
   onFilterChange?: (filter: InteractiveFilter) => void;
+  /** Realtime refresh counter — forwarded so the Timeline scrubber re-fetches
+   *  its datetime bounds (and range extends) as new rows stream in. */
+  refreshTick?: number;
 }
 
 /**
@@ -16,7 +19,12 @@ interface TopPanelProps {
  * scrubber. Filters emitted from here flow through the same
  * `onFilterChange` path as left-sidebar components.
  */
-const TopPanel: React.FC<TopPanelProps> = ({ components, filters, onFilterChange }) => {
+const TopPanel: React.FC<TopPanelProps> = ({
+  components,
+  filters,
+  onFilterChange,
+  refreshTick,
+}) => {
   if (components.length === 0) return null;
   return (
     <Paper withBorder radius={0} p="xs" mb="xs">
@@ -27,6 +35,7 @@ const TopPanel: React.FC<TopPanelProps> = ({ components, filters, onFilterChange
               metadata={m}
               filters={filters}
               onFilterChange={onFilterChange}
+              refreshTick={refreshTick}
             />
           </div>
         ))}

--- a/packages/depictio-react-core/src/components/interactive/TimelineRenderer.css
+++ b/packages/depictio-react-core/src/components/interactive/TimelineRenderer.css
@@ -22,3 +22,68 @@
   transform: translate(-100%, calc(0.25rem)) !important;
   text-align: right;
 }
+
+/* Custom per-acquisition timestamp dots overlaid on the track. The container is
+ * inset to the measured track box; each dot is positioned by its time fraction.
+ * Only the dots take pointer events, so clicks between dots still reach the
+ * slider track (drag/click to move the handles). */
+.depictio-timeline-dots {
+  position: absolute;
+  height: 0;
+  pointer-events: none;
+  /* Above the Mantine track/bar (z-index 1) so dots receive clicks, but below
+   * the drag handles (z-index 3) so thumbs sitting on a dot stay draggable. */
+  z-index: 2;
+}
+.depictio-timeline-dot {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border-radius: 50%;
+  border: 2px solid var(--mantine-color-blue-6);
+  background-color: var(--mantine-color-body);
+  cursor: pointer;
+  pointer-events: auto;
+  transition:
+    transform 120ms ease,
+    background-color 120ms ease,
+    box-shadow 120ms ease;
+}
+.depictio-timeline-dot:hover {
+  transform: translate(-50%, -50%) scale(1.3);
+  box-shadow: 0 0 0 3px var(--mantine-color-blue-1);
+}
+.depictio-timeline-dot:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--mantine-color-blue-2);
+}
+/* Dots inside the selected window read as "active" (filled). */
+.depictio-timeline-dot.is-in-range {
+  background-color: var(--mantine-color-blue-6);
+}
+/* Per-dot label sits below the track, centered under the dot. */
+.depictio-timeline-dot-label {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-dimmed);
+  white-space: nowrap;
+  pointer-events: none;
+}
+/* Keep the first/last labels inside the component bounds (mirrors the Mantine
+ * mark-label clamp above). */
+.depictio-timeline-dot:first-child .depictio-timeline-dot-label {
+  left: 0;
+  transform: none;
+  text-align: left;
+}
+.depictio-timeline-dot:last-child .depictio-timeline-dot-label {
+  left: auto;
+  right: 0;
+  transform: none;
+  text-align: right;
+}

--- a/packages/depictio-react-core/src/components/interactive/TimelineRenderer.tsx
+++ b/packages/depictio-react-core/src/components/interactive/TimelineRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   Group,
@@ -45,16 +45,23 @@ interface FormatContext {
   spansDays: boolean;
 }
 
-const dateRangeCache = new Map<
-  string,
-  Promise<{ min: Date | null; max: Date | null }>
->();
+interface DatetimeRange {
+  min: Date | null;
+  max: Date | null;
+  /** All distinct timestamps present in the column (ms since epoch, ascending).
+   *  Populated for ISO/object columns (whose specs carry no min/max), so the
+   *  slider can mark every acquisition. Empty when only precomputed min/max is
+   *  available (a large numeric datetime column not worth enumerating). */
+  stamps: number[];
+}
+
+const dateRangeCache = new Map<string, Promise<DatetimeRange>>();
 
 async function fetchDatetimeRange(
   dcId: string,
   columnName: string,
   filterExpr?: string,
-): Promise<{ min: Date | null; max: Date | null }> {
+): Promise<DatetimeRange> {
   const specs = await fetchSpecs(dcId);
   let entrySpecs: Record<string, unknown> = {};
   if (Array.isArray(specs)) {
@@ -68,29 +75,30 @@ async function fetchDatetimeRange(
   }
   const min = toDate(entrySpecs.min);
   const max = toDate(entrySpecs.max);
-  if (min && max) return { min, max };
+  if (min && max) return { min, max, stamps: [] };
 
   // Fallback: ISO-string columns are stored as `type: object` so the
   // precomputed specs only carry count/mode/nunique. Fetch unique values
-  // and parse them as dates to derive min/max client-side. Caps at 1000
-  // (the unique_values endpoint default) which is fine for timeline scopes.
+  // and parse them as dates to derive min/max — and keep the full sorted set
+  // of distinct timestamps so the slider can mark every acquisition. Caps at
+  // 1000 (the unique_values endpoint default) which is fine for timeline scopes.
   try {
     const values = await fetchUniqueValues(dcId, columnName, filterExpr);
-    let lo: number | null = null;
-    let hi: number | null = null;
-    for (const v of values) {
-      const ms = new Date(v).getTime();
-      if (!Number.isFinite(ms)) continue;
-      if (lo === null || ms < lo) lo = ms;
-      if (hi === null || ms > hi) hi = ms;
-    }
+    const stamps = Array.from(
+      new Set(
+        values
+          .map((v) => new Date(v).getTime())
+          .filter((ms) => Number.isFinite(ms)),
+      ),
+    ).sort((a, b) => a - b);
     return {
-      min: lo !== null ? new Date(lo) : min,
-      max: hi !== null ? new Date(hi) : max,
+      min: stamps.length ? new Date(stamps[0]) : min,
+      max: stamps.length ? new Date(stamps[stamps.length - 1]) : max,
+      stamps,
     };
   } catch (e) {
     console.warn('[TimelineRenderer] unique-values fallback failed:', e);
-    return { min, max };
+    return { min, max, stamps: [] };
   }
 }
 
@@ -156,6 +164,25 @@ function buildFormatContext(min: number, max: number): FormatContext {
  * 4 evenly-spaced labeled marks (start, 1/3, 2/3, end) — keeps labels readable
  * without overlap even at the narrowest panel widths.
  */
+// Label for a per-timestamp mark. Picks precision from the total span so
+// acquisitions that are seconds apart still get distinct labels (formatAt's
+// coarsest unit is the minute, which would collide for a sub-minute run).
+function formatStampLabel(ms: number, spanMs: number): string {
+  const d = new Date(ms);
+  const p = (n: number): string => String(n).padStart(2, '0');
+  if (spanMs < 60 * 60 * 1000) return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+  if (spanMs < 2 * 24 * 60 * 60 * 1000) return `${p(d.getHours())}:${p(d.getMinutes())}`;
+  return `${MONTH_SHORT[d.getMonth()]} ${d.getDate()}`;
+}
+
+// Cap on how many distinct timestamps we render as individual slider marks —
+// beyond this the ticks blur together and the DOM bloats, so fall back to the
+// regularly-spaced scale ticks instead.
+const MAX_STAMP_MARKS = 80;
+// Beyond this many marks, drop the text labels (keep the ticks) to avoid
+// overlapping, unreadable labels.
+const MAX_STAMP_LABELS = 12;
+
 function buildMarks(
   min: number,
   max: number,
@@ -178,8 +205,11 @@ const TimelineRenderer: React.FC<{
   onChange?: (filter: InteractiveFilter) => void;
   /** Compact rendering — tightens spacing and defaults marks to hidden. */
   compact?: boolean;
-}> = ({ metadata, filters, onChange, compact }) => {
-  const [bounds, setBounds] = useState<{ min: Date | null; max: Date | null } | null>(null);
+  /** Realtime refresh counter — bumping it re-fetches the datetime bounds so
+   *  the slider range extends as new rows stream in. */
+  refreshTick?: number;
+}> = ({ metadata, filters, onChange, compact, refreshTick }) => {
+  const [bounds, setBounds] = useState<DatetimeRange | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const initialScale = (metadata.timescale as Timescale | undefined) || 'day';
@@ -191,9 +221,18 @@ const TimelineRenderer: React.FC<{
       setLoading(false);
       return;
     }
-    const cacheKey = `${metadata.dc_id}|${metadata.column_name}|${metadata.filter_expr || ''}`;
+    // refreshTick participates in the cache key so a realtime update computes
+    // fresh bounds (bounds only grow), while repeated renders at the same tick
+    // still hit the cached promise.
+    const prefix = `${metadata.dc_id}|${metadata.column_name}|${metadata.filter_expr || ''}|`;
+    const cacheKey = `${prefix}${refreshTick ?? 0}`;
     let p = dateRangeCache.get(cacheKey);
     if (!p) {
+      // Drop superseded ticks for this dc/column/filter so the cache doesn't
+      // grow one stale entry per realtime update over a long session.
+      for (const key of dateRangeCache.keys()) {
+        if (key.startsWith(prefix) && key !== cacheKey) dateRangeCache.delete(key);
+      }
       p = fetchDatetimeRange(
         metadata.dc_id,
         metadata.column_name,
@@ -217,7 +256,7 @@ const TimelineRenderer: React.FC<{
     return () => {
       cancelled = true;
     };
-  }, [metadata.dc_id, metadata.column_name, metadata.filter_expr]);
+  }, [metadata.dc_id, metadata.column_name, metadata.filter_expr, refreshTick]);
 
   const minMs = bounds?.min?.getTime();
   const maxMs = bounds?.max?.getTime();
@@ -230,6 +269,29 @@ const TimelineRenderer: React.FC<{
     const bv = new Date(b).getTime();
     return Number.isFinite(av) && Number.isFinite(bv) ? [av, bv] : null;
   }, [filterEntry]);
+
+  // Geometry of Mantine's slider track relative to our wrapper, so the custom
+  // clickable timestamp dots overlay exactly on the track (Mantine insets the
+  // track by the thumb radius; we mirror that by measuring rather than guessing).
+  const sliderRef = useRef<HTMLDivElement>(null);
+  const [trackBox, setTrackBox] = useState<{ left: number; width: number; top: number } | null>(
+    null,
+  );
+  useLayoutEffect(() => {
+    const root = sliderRef.current;
+    if (!root) return;
+    const measure = () => {
+      const track = root.querySelector('.mantine-Slider-track') as HTMLElement | null;
+      if (!track) return;
+      const rb = root.getBoundingClientRect();
+      const tb = track.getBoundingClientRect();
+      setTrackBox({ left: tb.left - rb.left, width: tb.width, top: tb.top - rb.top + tb.height / 2 });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(root);
+    return () => ro.disconnect();
+  }, [bounds, loading, compact]);
 
   if (error) {
     return (
@@ -257,10 +319,30 @@ const TimelineRenderer: React.FC<{
   const hi = maxMs as number;
   const value: [number, number] = selected ?? [lo, hi];
   const ctx = buildFormatContext(lo, hi);
-  // YAML wins; otherwise compact mode hides marks for higher density.
+
+  // Default view: mark every distinct timestamp the column actually contains
+  // (one per acquisition), so the whole set of available acquisition times is
+  // visible on the slider — not just evenly-spaced scale ticks. Falls back to
+  // scale ticks when the distinct set is unknown (numeric column, min/max only)
+  // or too dense to render one mark each.
+  const stampMarks = ((): { value: number; label: string }[] | null => {
+    const st = bounds?.stamps ?? [];
+    if (st.length < 2 || st.length > MAX_STAMP_MARKS) return null;
+    const span = hi - lo;
+    const labelAll = st.length <= MAX_STAMP_LABELS;
+    return st.map((v) => ({ value: v, label: labelAll ? formatStampLabel(v, span) : '' }));
+  })();
+
+  // YAML `show_marks` wins; otherwise show marks by default when we have the
+  // per-timestamp set (even in compact mode — that's the point of this view),
+  // else keep the old compact-hides-marks behaviour.
   const marksVisible =
-    typeof metadata.show_marks === 'boolean' ? metadata.show_marks : !compact;
-  const marks = marksVisible ? buildMarks(lo, hi, scale, ctx) : undefined;
+    typeof metadata.show_marks === 'boolean'
+      ? metadata.show_marks
+      : stampMarks
+        ? true
+        : !compact;
+  const marks = marksVisible ? (stampMarks ?? buildMarks(lo, hi, scale, ctx)) : undefined;
 
   const stepFor = (s: Timescale): number => {
     const SEC = 1000;
@@ -299,6 +381,34 @@ const TimelineRenderer: React.FC<{
     });
   };
 
+  // Click a timestamp dot → snap the nearer window handle exactly to it (clamped
+  // so the handles can't cross). This is the reliable replacement for Mantine's
+  // `restrictToMarks`, which mis-snapped on irregularly-spaced timestamps.
+  const snapToStamp = (t: number) => {
+    const [a, b] = value;
+    if (Math.abs(t - a) <= Math.abs(t - b)) emit([Math.min(t, b), b]);
+    else emit([a, Math.max(t, a)]);
+  };
+
+  // Round an arbitrary slider value to the nearest actual acquisition timestamp.
+  // Dragging or clicking the bare track would otherwise land a handle between
+  // acquisitions (e.g. 20:50:38 — a time no data exists at); snapping keeps the
+  // window bounds on real timestamps only.
+  const snapToNearestStamp = (v: number): number => {
+    const st = bounds?.stamps;
+    if (!st || !st.length) return v;
+    return st.reduce((best, s) => (Math.abs(s - v) < Math.abs(best - v) ? s : best), st[0]);
+  };
+  const handleSliderChange = (v: [number, number]) => {
+    emit(stampMarks ? [snapToNearestStamp(v[0]), snapToNearestStamp(v[1])] : v);
+  };
+
+  // When the slider is snapped to per-acquisition marks, label thumbs/readout
+  // with the exact timestamp (span-aware) rather than the coarse scale format,
+  // so the value shown matches the mark the thumb sits on.
+  const fmt = (v: number): string =>
+    stampMarks ? formatStampLabel(v, hi - lo) : formatAt(scale, v, ctx);
+
   const title = metadata.title || (metadata.column_name ? `Timeline · ${metadata.column_name}` : 'Timeline');
 
   return (
@@ -312,6 +422,8 @@ const TimelineRenderer: React.FC<{
         {title}
       </Text>
       <Box
+        ref={sliderRef}
+        pos="relative"
         pt={4}
         pb={marksVisible ? 28 : 4}
         px={8}
@@ -323,19 +435,50 @@ const TimelineRenderer: React.FC<{
           min={lo}
           max={hi}
           step={sliderStep}
-          minRange={sliderStep}
-          marks={marks}
+          minRange={stampMarks ? 0 : sliderStep}
+          // With per-acquisition dots we render our own clickable marks+labels
+          // overlay below; hand Mantine no marks so they don't double up.
+          marks={stampMarks ? undefined : marks}
           value={value}
-          onChange={(v) => emit(v as [number, number])}
-          label={(v) => formatAt(scale, v, ctx)}
+          onChange={(v) => handleSliderChange(v as [number, number])}
+          // Show the snapped timestamp in the drag tooltip so it never displays a
+          // between-acquisitions time the window can't actually land on.
+          label={(v) => fmt(stampMarks ? snapToNearestStamp(v) : v)}
         />
+        {stampMarks && marksVisible && trackBox && (
+          <div
+            className="depictio-timeline-dots"
+            style={{ left: trackBox.left, width: trackBox.width, top: trackBox.top }}
+          >
+            {(bounds?.stamps ?? []).map((t) => {
+              const pct = ((t - lo) / (hi - lo)) * 100;
+              const inRange = t >= value[0] && t <= value[1];
+              const lbl = formatStampLabel(t, hi - lo);
+              return (
+                <button
+                  key={t}
+                  type="button"
+                  className={`depictio-timeline-dot${inRange ? ' is-in-range' : ''}`}
+                  style={{ left: `${pct}%` }}
+                  title={lbl}
+                  aria-label={`Set acquisition window bound to ${lbl}`}
+                  onClick={() => snapToStamp(t)}
+                >
+                  {stampMarks.length <= MAX_STAMP_LABELS && (
+                    <span className="depictio-timeline-dot-label">{lbl}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
       </Box>
       {/* Footer row: selected-range readout left, timescale picker right.
        * Moved out of the header so the long readout doesn't push the
        * SegmentedControl off-screen on narrow grid cells. */}
       <Group gap="xs" wrap="nowrap" align="center" justify="space-between">
         <Text size="xs" c="dimmed" truncate style={{ minWidth: 0 }}>
-          {formatAt(scale, value[0], ctx)} → {formatAt(scale, value[1], ctx)}
+          {fmt(value[0])} → {fmt(value[1])}
         </Text>
         <SegmentedControl
           size="xs"

--- a/packages/depictio-react-core/src/highlight.ts
+++ b/packages/depictio-react-core/src/highlight.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-batch realtime highlight model.
+ *
+ * A realtime upsert adds a set of rows/images to a data collection. The backend
+ * ships the added ids in the event payload (``new_ids`` / ``id_column``); this
+ * module turns that into an ``ActiveHighlight`` the renderers consult to glow
+ * exactly the rows a batch added.
+ *
+ * Two lifetimes:
+ *   - ``sticky: false`` — a live arrival. Glows for the transient window, then
+ *     fades (gated by ``useTransientFlag(nonce)`` in the renderer).
+ *   - ``sticky: true`` — the user re-selected a past batch from the event log.
+ *     Stays lit until cleared or another batch is chosen.
+ */
+export interface ActiveHighlight {
+  /** DC the batch belongs to — renderers only react when it matches their
+   *  ``metadata.dc_id`` (undefined = apply to any DC). */
+  dcId?: string;
+  /** Column the ids are values of (e.g. ``index_index``) — the DC-wide column
+   *  the backend diffed. Renderers match a row by looking up THIS column on the
+   *  row (``row[idColumn]``), so a batch only lights up when the column is
+   *  present; undefined disables batch matching (legacy diff still applies). */
+  idColumn?: string;
+  /** The added row ids, as strings. */
+  ids: string[];
+  /** Bumps on each (re-)trigger so ``useTransientFlag`` re-arms the fade. */
+  nonce: number;
+  /** ``true`` = pinned until cleared; ``false`` = auto-fade live arrival. */
+  sticky: boolean;
+  /** Stable key of the source event log entry, used to mark the lit row in the
+   *  journal. Undefined for live arrivals not yet pinned. */
+  batchKey?: string;
+}
+
+/**
+ * Extract the batch id-set from an event payload. Returns ``null`` when the
+ * payload carries no usable added-id list (very first commit, no id column,
+ * or an empty diff). Falls back to ``new_ids_sample`` when the full
+ * ``new_ids`` list is absent (older backend / truncated).
+ */
+export function batchIdsFromPayload(
+  payload: Record<string, unknown> | undefined,
+): { idColumn?: string; ids: string[] } | null {
+  if (!payload) return null;
+  const raw = Array.isArray(payload.new_ids)
+    ? (payload.new_ids as unknown[])
+    : Array.isArray(payload.new_ids_sample)
+      ? (payload.new_ids_sample as unknown[])
+      : null;
+  if (!raw || raw.length === 0) return null;
+  const idColumn =
+    typeof payload.id_column === 'string' ? (payload.id_column as string) : undefined;
+  return { idColumn, ids: raw.map((v) => String(v)) };
+}

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -231,6 +231,8 @@ export type { RealtimeStatus, RealtimeMode, RealtimeEvent } from './realtime';
 export { default as RealtimeIndicator } from './components/RealtimeIndicator';
 export { useRealtimeJournal } from './hooks/useRealtimeJournal';
 export type { RealtimeJournalEntry } from './hooks/useRealtimeJournal';
+export { batchIdsFromPayload } from './highlight';
+export type { ActiveHighlight } from './highlight';
 
 export type {
   StoredMetadata,

--- a/packages/depictio-react-core/src/styles/realtime-highlight.css
+++ b/packages/depictio-react-core/src/styles/realtime-highlight.css
@@ -29,10 +29,38 @@
   }
 }
 
-.depictio-row-new {
+/**
+ * AG Grid row highlights must out-specify the theme's row background. The
+ * Alpine themes paint ``.ag-theme-alpine .ag-row-odd`` / ``.ag-row`` backgrounds
+ * with a theme-scoped selector (specificity 0,2,0) that beats a bare
+ * ``.depictio-row-new`` (0,1,0), so the static pinned tint never showed. Scope
+ * our selectors under both theme roots with the ``.ag-row`` qualifier and mark
+ * the background ``!important`` so neither the base nor the odd-stripe rule wins.
+ */
+.ag-theme-alpine .ag-row.depictio-row-new,
+.ag-theme-alpine-dark .ag-row.depictio-row-new {
   animation: depictio-row-flash 3s ease-out;
 }
 
 .depictio-card-new {
   animation: depictio-card-glow 3s ease-out;
+}
+
+/**
+ * Persistent (pinned) highlight — applied when the user re-selects a past batch
+ * from the event log. Unlike the one-shot ``-new`` animations above, these are
+ * steady styles that stay until the class is removed (highlight cleared or a
+ * different batch chosen).
+ */
+.ag-theme-alpine .ag-row.depictio-row-pinned,
+.ag-theme-alpine-dark .ag-row.depictio-row-pinned {
+  background-color: rgba(255, 235, 59, 0.28) !important;
+}
+
+/* Doubled class (specificity 0,2,0) + ``!important`` so the steady box-shadow
+ * beats Mantine's Paper/Card ``box-shadow``, which is declared at equal
+ * specificity but later in the cascade. */
+.depictio-card-pinned.depictio-card-pinned {
+  box-shadow: 0 0 0 3px rgba(255, 152, 0, 0.85),
+              0 0 12px 3px rgba(255, 193, 7, 0.5) !important;
 }


### PR DESCRIPTION
Continuation of the real-time microscopy dashboard work (follow-up to #899, which is merged). Focused polish on the acquisition timeline, gallery highlighting, and local dev tooling.

## Timeline (`TimelineRenderer`)
- Render one clickable dot per **real acquisition timestamp**. The window handles now snap to actual timestamps on both dot-click and bare-track click/drag, so you can no longer select a time that doesn't correspond to an acquisition.
- Measure the Mantine `Slider` track geometry (ResizeObserver) to position the dots and their labels precisely over the track.

## Gallery (`ImageRenderer`)
- Arm the per-batch highlight fade once the batch rows are actually **present in the fetched items**, rather than on event arrival time. This fixes intermittent/missed glow when the gallery refetch lands after the fade window.
- Bump `max_images` to 500 for the microscopy dashboard.

## Backend
- Tie-break image ordering by `index_index` so the coarse per-acquisition timestamp sort keeps the newest rows first within a batch (previously within-batch order was arbitrary on ties).
- Gate the admin-only `test-trigger` behind `DEPICTIO_ENABLE_DEV_ENDPOINTS` (documented in `docker-compose/.env`).

## Misc
- Extract the batch-highlight model into `highlight.ts` (exported `batchIdsFromPayload` / `ActiveHighlight`).
- Add `docs/deploy-realtime-events.md`, a local end-to-end realtime deploy walkthrough.

## Verification
- Timeline snapping verified live: clicking between dots snaps to the nearest real acquisition; both window bounds are always real timestamps.
- Gallery highlight verified live across multiple consecutive acquisitions.
- `pre-commit`: shellcheck / ruff / ruff-format / yaml / ty(models scope of this change) pass. The remaining `ty` diagnostics are in `depictio/models/components/advanced_viz/catalog.py`, which is untouched by this PR (pre-existing).

## Not included
- Gallery virtualization + infinite-scroll for thousands of images (scoped as a follow-up).