### PR TITLE
Add 1 visualization to mosdepth

### DIFF
--- a/depictio/catalog/mosdepth/amplicon_coverage.yaml
+++ b/depictio/catalog/mosdepth/amplicon_coverage.yaml
@@ -14,3 +14,4 @@ fixture: amplicon_coverage.tsv
 renders_as:
   - { id: coverage_track_amplicon, component: advanced_viz, kind: coverage_track, roles: {chromosome: chrom, position: start, value: coverage} }
   - { component: card, column: coverage, aggregation: average } # mean amplicon depth
+  - { id: table, component: table }


### PR DESCRIPTION
## Summary
Adds 1 visualization to the existing **mosdepth** tool (output `amplicon_coverage`), authored with [Depictio Tools Studio](https://depictio.github.io/depictio/).

Only `depictio/catalog/mosdepth/amplicon_coverage.yaml` changes — new item appended under `renders_as`.

## Validation
CI `dev catalog validate` is the authoritative check for this entry.

<details><summary>depictio/catalog/mosdepth/amplicon_coverage.yaml</summary>

```yaml
id: mosdepth_amplicon_coverage
mode: amplicon
description: Per-amplicon coverage depth, aggregated across all samples (bindable as-is).
find: { path_glob: "**/mosdepth/amplicon/all_samples.mosdepth.coverage.tsv" }
# no recipe → declare the columns:
columns:
  chrom: String
  start: Int64
  end: Int64
  region: String
  coverage: Float64
  sample: String
fixture: amplicon_coverage.tsv
renders_as:
  - { id: coverage_track_amplicon, component: advanced_viz, kind: coverage_track, roles: {chromosome: chrom, position: start, value: coverage} }
  - { component: card, column: coverage, aggregation: average } # mean amplicon depth
  - { id: table, component: table }
```
</details>