### PR TITLE
docs(claude): drop stale Dash-era guidance from CLAUDE.md, correct commands and paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,81 +6,105 @@
 ```bash
 docker compose -f docker-compose.dev.yaml --env-file docker-compose/.env up
 ```
+Services: `mongo` (27018), `redis` (6379), `minio`, `depictio-backend` (8058),
+`depictio-viewer-dev` (Vite HMR, default viewer), `depictio-celery-worker`.
+Profile-gated: `depictio-viewer` (nginx + built bundle, `ci`), `flower` (`monitoring`).
 
 ### Python Environment
-Default: `depictio-venv-dash-v3/bin/python`
+Managed with **uv** (`uv.lock`). No venv is checked in — CI does
+`uv venv --python 3.12.9 venv && uv pip install -e ".[dev]"`. Prefix commands with `uv run`.
+`pixi.toml` offers an alternative Docker-free stack (`pixi run start-infra`, `pixi run api`).
 
 ### Testing
 ```bash
-pytest depictio/tests/ -xvs -n auto
+uv run pytest -xvs -n auto     # testpaths (pyproject.toml) = tests/{api,models,cli,unit}
 
-# E2E (Cypress)
-cd depictio/tests/e2e-tests && /Users/tweber/.nvm/versions/node/v20.16.0/bin/npx cypress run --config screenshotsFolder=cypress/screenshots,videosFolder=cypress/videos,trashAssetsBeforeRuns=false,video=true,screenshotOnRunFailure=true
+# E2E (Playwright — the suite CI runs)
+cd depictio/tests/e2e-playwright && npx playwright test
+# targets depictio-viewer-dev; override with PLAYWRIGHT_BASE_URL / PLAYWRIGHT_API_URL
 ```
+`depictio/tests/e2e-tests/` is the **legacy Cypress** suite — not run in CI.
 
 ### Code Quality
 ```bash
-ruff format . && ruff check .
-ty check depictio/models/ depictio/api/    # must pass with zero errors
-pre-commit run --all-files                 # mandatory after all code changes
+ruff format depictio && ruff check depictio
+uv run ty check depictio/models/   # only gated dir; must pass with zero errors
+pre-commit run --all-files         # mandatory after all code changes
 ```
 
 ## Entry Points & Key Dependencies
 
-- **API**: `depictio/api/main.py` (FastAPI + Beanie ODM)
-- **Dash**: `depictio/dash/app.py` (Plotly Dash + DMC 2.0)
+- **API**: `depictio/api/main.py` (FastAPI + Beanie ODM); also serves the built SPA
+- **Worker**: `depictio/api/celery_app.py` (Celery + Redis)
+- **Frontend**: `depictio/viewer/` — React 18 + Vite + Mantine 7 SPA (`src/main.tsx`)
 - **CLI**: `depictio/cli/depictio_cli.py` (Typer)
 - **Models**: `depictio/models/` (Pydantic, shared across all components)
-- Key deps: FastAPI, Dash/Plotly, Beanie, Polars, Delta Lake, Pydantic
+- **Catalog**: `depictio/catalog/` (tool-specific dashboard/DC definitions + `payload.py`)
+- Shared JS packages (pnpm workspace): `packages/depictio-components`,
+  `packages/depictio-react-core`, `packages/plotly-complexheatmap`, `packages/plotly-upset`
+- Key deps: FastAPI, Beanie, Celery, Polars, Delta Lake, Pydantic, Plotly, Playwright
 - Config: `pyproject.toml`, `pixi.toml`, `docker-compose.dev.yaml`
+
+> `depictio/react-frontend/` is an **abandoned scaffold** (its README still calls Dash
+> production). Not built or served by either compose file — don't edit it.
 
 ## Conventions & Rules
 
 ### Frontend
-- Use **DMC 2.0+** for all new components (detail in `depictio/dash/CLAUDE.md`)
-- Never hardcode colors — prefer DMC native theming, CSS variables as last resort
-- Dash v3: use `app.run()` not `run_server()`
+- **Mantine 7** for all new components; the Dash/DMC frontend is fully removed
+- Never hardcode colors — prefer Mantine native theming, CSS variables as last resort
 
 ### Environment & Config
 - Config source of truth: `depictio/api/v1/configs/settings_models.py`
-- Contexts: API, Dash, CLI (set via `DEPICTIO_CONTEXT`)
+- `DEPICTIO_CONTEXT`: `server` (default) or `cli`
 - Environment files:
   - Not in worktree: read `.env` and `docker-compose/.env`
   - In worktree: read `.env.instance`
-- Default MongoDB URL (if not modified by .env and .env.instance): `localhost:27018/depictioDB`
+- Default MongoDB URL (unless overridden by `.env` / `.env.instance`): `localhost:27018/depictioDB`
 
 ### Docker
 - Don't run docker commands except `docker logs`
 
 ### Code Quality
 - **Mandatory**: run `pre-commit run --all-files` after every code change
-- Type checking with `ty` must pass with zero errors
-- No `# type: ignore` comments
+- `ty` gate is narrowed to `depictio/models/`, with per-file excludes in
+  `[tool.ty.src]`. `depictio/api/` and `depictio/cli/` carry known type-debt and are
+  off the gate — don't widen the gate casually, don't add new debt
 
 ### Documentation
 - After significant PRs, update depictio-docs and Obsidian notes
 
 ## Architecture Pointers
 
-### Dash Multi-App Architecture (3 apps)
-Management (`/dashboards`) | Viewer (`/dashboard/{id}`) | Editor (`/dashboard/{id}/edit`)
-- Shared stores in `depictio/dash/layouts/shared_app_shell.py:create_shared_stores()`
-- **Detail**: see `depictio/dash/CLAUDE.md`
+### SPA Routes (served by FastAPI from `depictio/viewer` build)
+| Route | App |
+| --- | --- |
+| `/dashboards` | management |
+| `/dashboard/{id}` | viewer |
+| `/dashboard-edit/{id}` | editor (`+ /component/add/{id}`, `/component/edit/{id}`) |
+| `/about`, `/admin`, `/profile`, `/cli-agents` | supporting pages |
+
+Route dispatch is plain regex in `depictio/viewer/src/main.tsx` +
+`src/builder/routeMatch.ts` — no router lib.
 
 ### Screenshot System
-- Component-based composite targeting via `.react-grid-item`
+- Playwright drives the React SPA; composite targeting via `.react-grid-item`
 - **Detail**: see `depictio/api/v1/endpoints/utils_endpoints/CLAUDE.md`
 
 ### Dashboard YAML ↔ JSON Seeds
-- Fresh deployments load from `.db_seeds/*.json` files (via `db_init.py`), **not** from YAML
-- **After modifying dashboard YAML**: regenerate the corresponding `.db_seeds/*.json` or new components won't appear in fresh deployments
-- Path: `depictio/projects/{project}/dashboards/*.yaml` → `.db_seeds/*.json`
-- Multi-tab dashboards: main tab = `dashboard_multiqc.json`, child tabs = separate JSON files
+- Fresh deployments load from `.db_seeds/*.json` (via `db_init.py`), **not** from YAML
+- **After modifying dashboard YAML**: regenerate the matching `.db_seeds/*.json` or new
+  components won't appear in fresh deployments
+- Project dir `depictio/projects/{group}/{project}[/{version}]/` holds both
+  `dashboards/*.yaml` and `.db_seeds/*.json`
+- Multi-tab dashboards: one JSON per tab (e.g. nf-core `dashboard_multiqc.json`)
+- Reseed a running instance in place: `depictio/dev_scripts/reseed_project.py` (`/reseed`)
 
 ### Data Flow
-CLI ingests data → Delta/S3/MongoDB → API serves → Dash renders
+CLI ingests data → Delta/S3/MongoDB → API serves → React viewer renders
 
 ### Auth & Storage
-- JWT tokens, role-based access (users, groups, projects)
+- JWT tokens, role-based access (users, groups, projects); single-user mode via
+  `DEPICTIO_AUTH_SINGLE_USER_MODE`
 - S3-compatible storage (MinIO local, AWS prod), Delta Lake format
 - API endpoints at `/depictio/api/v1/`


### PR DESCRIPTION
## Summary

`CLAUDE.md` was last touched before the Dash → React migration, so it described a frontend, virtualenv, test runner and type gate that no longer exist. Every claim in the file was checked against the tree; stale entries were corrected rather than simply deleted, and the file was kept to roughly its original length.

**Corrections**

- **Frontend.** Dash is gone from the Python dependencies entirely — `pyproject.toml`'s own description now reads "FastAPI backend + Celery worker for the React viewer SPA", and there are no `import dash` statements left under `depictio/`. Both `depictio/dash/app.py` and `depictio/dash/CLAUDE.md` no longer exist, so those pointers are removed. Replaced with React 18 + Vite + Mantine 7 at `depictio/viewer/`, and the DMC 2.0 / `app.run()` conventions are dropped.
- **SPA routes.** The editor is `/dashboard-edit/{id}`, not `/dashboard/{id}/edit`. Dispatch is plain regex in `viewer/src/main.tsx` + `builder/routeMatch.ts` (no router lib); `shared_app_shell.py` no longer exists.
- **Python environment.** The documented `depictio-venv-dash-v3/bin/python` interpreter does not exist and no venv is checked in. The project is uv-managed (`uv.lock`).
- **Tests.** `pytest depictio/tests/` widens collection into the e2e directories; `testpaths` in `pyproject.toml` already scopes the run, so the path argument is removed.
- **E2E.** The documented Cypress command hardcoded a machine-specific nvm path and pointed at a suite CI does not run. The suite CI actually runs is Playwright, in `depictio/tests/e2e-playwright`; the Cypress directory is now labelled legacy.
- **`ty` gate.** The file claimed `depictio/models/ depictio/api/` must both pass. `api/` is explicitly off the gate (per the `.pre-commit-config.yaml` comment and `[tool.ty.src]` excludes). Also removed the "No `# type: ignore` comments" rule, which 298 in-tree occurrences contradict.
- **`DEPICTIO_CONTEXT`.** Values are `server` (default) and `cli`, not "API, Dash, CLI".
- **Seed layout.** Projects live at `depictio/projects/{group}/{project}[/{version}]/`, holding `dashboards/*.yaml` and `.db_seeds/*.json` side by side.

**Additions**, kept minimal: compose service/port list, the Celery and catalog entry points, the pnpm workspace packages, the `reseed_project.py` script, and a note that `depictio/react-frontend/` is an abandoned scaffold (its README still calls Dash production) that is neither built nor served.

## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [x] Documentation

## Related issue

None.

## How was this tested?

Documentation-only change — no tests added. Each factual claim was verified against the tree before being written:

- Path existence for every file and directory referenced.
- Compose services, profiles and host ports read from `docker-compose.dev.yaml`.
- Test invocation and `testpaths` cross-checked against `pyproject.toml` and the CI workflow.
- `ty check depictio/models/` run directly → `All checks passed!`.
- Routes confirmed against the FastAPI SPA handlers in `depictio/api/main.py` and the regex matchers in the viewer source.
- `trailing-whitespace` and `end-of-file-fixer` run against `CLAUDE.md` → both pass.

Two notes for reviewers:

1. The full `pre-commit run --all-files` fails on `shellcheck` and `Helm Lint`, but both are **pre-existing and unrelated** to this change: shellcheck fails identically on a clean tree (findings are in `depictio/projects/.../*.sh` and `scripts/security_audit_compose.sh`, none touched here), and `helm` is not installed in the environment used. Hooks affected by a markdown-only change pass.
2. `depictio/api/v1/endpoints/utils_endpoints/CLAUDE.md`, which the root file points to, is itself partially stale — it references `depictio/dash/celery_app.py` (actual path: `depictio/api/celery_app.py`) and describes the Dash screenshot path as retained for rollback, which is no longer possible. Left untouched as out of scope; happy to follow up in a separate PR.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [ ] Tests added/updated and passing
- [x] Docs updated if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMSZZDKgf2wqL2ZgpUBR9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMSZZDKgf2wqL2ZgpUBR9n)_