### PR TITLE
perf(docker,api): scope the dev-mode file watchers, idle CPU ~44% to ~4%

### DIFF
--- a/depictio/api/run.py
+++ b/depictio/api/run.py
@@ -23,6 +23,13 @@ def main() -> None:
         port=port,
         reload=True,
         reload_dirs=RELOAD_DIRS,
+        # `watchfiles` n'est pas une dépendance, donc uvicorn retombe sur
+        # StatReload : à chaque passe il fait rglob("*.py") + stat() + resolve()
+        # sur tout RELOAD_DIRS, et `reload_excludes` est ignoré (uvicorn le
+        # signale explicitement). Le défaut de 0.25s donne ~4 passes/s à travers
+        # le bind mount macOS, pour rien la plupart du temps. 1s garde un reload
+        # confortable en divisant par ~4 le CPU idle du reloader.
+        reload_delay=1.0,
     )
 
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -62,6 +62,13 @@ services:
       - 127.0.0.1:${FASTAPI_PORT:-8058}:8058
     volumes:
       - ./depictio:/app/depictio
+      # Masque le venv CLI de l'hôte (~10 300 fichiers, construit pour macOS).
+      # Il n'arrive ici que via le bind mount ci-dessus — .dockerignore l'exclut
+      # déjà de l'image, et ses shebangs absolus le rendent inutilisable dans le
+      # conteneur. Sans ce masque, le reloader uvicorn de dev mode (StatReload,
+      # faute de watchfiles) le rglob+stat 4x/s : ~95% de son travail, et ~20-30%
+      # de CPU backend en idle.
+      - /app/depictio/cli/.venv
       - ./dashboards:/app/dashboards
       - ./pyproject.toml:/app/pyproject.toml
       - ./packages/plotly-complexheatmap:/app/packages/plotly-complexheatmap
@@ -198,6 +205,13 @@ services:
       context: .
     volumes:
       - ./depictio:/app/depictio
+      # Mêmes raisons que le backend, plus depictio/tests : en dev mode le worker
+      # tourne sous watchmedo --debug-force-polling, qui prend un snapshot stat()
+      # de tout /app/depictio chaque seconde (--patterns filtre les événements,
+      # pas le walk). Ces deux arbres pèsent ~92% des ~19 700 entrées et ne sont
+      # jamais importés par le worker. Tous deux sont déjà exclus de l'image.
+      - /app/depictio/cli/.venv
+      - /app/depictio/tests
       - ./dashboards:/app/dashboards
       - ./packages/plotly-complexheatmap:/app/packages/plotly-complexheatmap
       - ./packages/plotly-upset:/app/packages/plotly-upset

--- a/docker-images/run_celery_worker.sh
+++ b/docker-images/run_celery_worker.sh
@@ -16,8 +16,21 @@ set -euo pipefail
 # copies) via DEPICTIO_CELERY_WORKERS.
 CELERY_WORKERS=${DEPICTIO_CELERY_WORKERS:-4}
 
+# Recycle each prefork child after N tasks so the DataFrame / multiqc.report
+# memory it accumulated is actually returned to the OS. Celery's own default is
+# unlimited, so without this children grow for the lifetime of the container.
+#
+# `CeleryConfig.worker_max_tasks_per_child = 50` already declares this intent in
+# settings_models.py, but it is dead config here: the `celery_app.conf.update()`
+# block in depictio/api/celery_app.py is commented out, so nothing in that class
+# reaches the worker. We pass it on the CLI rather than reviving that block —
+# doing so would also apply `default_queue`, which routes work to a queue no
+# worker consumes and silently stops every task (see the comments in
+# celery_app.py before touching it).
+CELERY_MAX_TASKS_PER_CHILD=${DEPICTIO_CELERY_MAX_TASKS_PER_CHILD:-50}
+
 echo "✅ CELERY WORKER: Starting Celery worker (required for design mode)"
-echo "🔧 CELERY WORKER: Workers = $CELERY_WORKERS"
+echo "🔧 CELERY WORKER: Workers = $CELERY_WORKERS, max tasks/child = $CELERY_MAX_TASKS_PER_CHILD"
 if [ "${DEPICTIO_CELERY_ENABLED:-false}" = "true" ]; then
     echo "🔧 CELERY WORKER: Dashboard view mode will use background callbacks"
 else
@@ -33,6 +46,14 @@ fi
 # because native fs events don't cross the macOS/Colima → Linux VM bind-mount
 # boundary (same reason the Vite viewer uses VITE_USE_POLLING). Prod runs
 # celery directly (no watcher, no polling cost).
+#
+# `--interval=5` (watchdog's default is 1s): polling means a full stat() snapshot
+# of every watched entry on each tick, so the tick rate is the cost driver. 5s is
+# ample for a worker — you rarely iterate on task code in a tight loop — and it
+# cuts the watcher's idle CPU fivefold. Note `--patterns` filters *events*, not
+# the walk, so it does nothing for that cost; only the interval and the watched
+# directory set do. The two heaviest trees (depictio/cli/.venv, depictio/tests)
+# are masked out of the container in docker-compose.dev.yaml.
 DEV_MODE_LOWER=$(echo "${DEPICTIO_DEV_MODE:-false}" | tr '[:upper:]' '[:lower:]')
 if [ "$DEV_MODE_LOWER" = "true" ]; then
     echo "🔁 CELERY WORKER: dev mode — live reload via watchmedo (watching /app/depictio/**/*.py)"
@@ -42,11 +63,14 @@ if [ "$DEV_MODE_LOWER" = "true" ]; then
         --ignore-patterns='*/__pycache__/*;*.pyc' \
         --recursive \
         --debug-force-polling \
+        --interval=5 \
         -- celery -A depictio.api.celery_worker:celery_app worker \
             --loglevel=info \
+            --max-tasks-per-child="$CELERY_MAX_TASKS_PER_CHILD" \
             --concurrency="$CELERY_WORKERS"
 else
     exec celery -A depictio.api.celery_worker:celery_app worker \
         --loglevel=info \
+        --max-tasks-per-child="$CELERY_MAX_TASKS_PER_CHILD" \
         --concurrency="$CELERY_WORKERS"
 fi


### PR DESCRIPTION
The dev stack idled at ~44% CPU with nothing running: backend ~26%, celery worker ~18% while logging not a single line in three minutes. None of it was application work.

## What was actually running

Both services bind-mount the whole repo at `/app/depictio`. That drags in two trees the container has no use for, and the dev-mode watchers then poll them across the macOS bind mount:

| path | entries | what it is |
|---|---|---|
| `depictio/cli/.venv` | 10,314 (3,894 `.py`) | host venv built for macOS, created by the `cli-venv` workflow |
| `depictio/tests` | 7,685 | the test suite |

**Backend.** `watchfiles` is not a dependency, so uvicorn falls back to `StatReload`, confirmed by `Started reloader process [10] using StatReload`. Its loop does `rglob("*.py")` + `.stat()` + `.resolve()` over 4,118 files with a 0.25s pause between passes. `RELOAD_DIRS` includes `/app/depictio/cli`, so 95% of that is the venv. `reload_excludes` cannot help: uvicorn ignores it without watchfiles and logs a warning saying so.

**Celery worker.** It runs under `watchmedo auto-restart --debug-force-polling`, whose `PollingObserver` takes a full `DirectorySnapshot` (one `stat()` per entry) of 19,659 entries every second. `--patterns='*.py'` filters *events* after the snapshot, so it does nothing for the walk.

## The change

Mask both trees per-container instead of narrowing the watch scopes. Neither exists in the images already (`.dockerignore` excludes `depictio/tests/` and `**/.venv/`), and the host venv is unusable in-container regardless since its shebangs are absolute macOS paths. The mask only restores what the image already looks like.

Narrowing `reload_dirs` / `--directory` was the obvious alternative and is why it was rejected: `depictio/cli/cli_logging.py` and `depictio/cli/__init__.py` sit on the eager import path via `logging_init.py:13-14`, and an allowlist would have silently stopped reloading them. It would also need maintaining every time a new top-level package enters the worker's import graph.

With the volume handled, the remaining cost was cadence, so the polls are spaced out: `reload_delay=1.0` on uvicorn, `--interval=5` on watchmedo.

## Celery children never recycled

Unrelated to CPU but found on the way. `CeleryConfig.worker_max_tasks_per_child = 50` is declared in `settings_models.py`, but the `celery_app.conf.update()` block is commented out and `conf.update` appears nowhere else, so no field of that class reaches the worker. Celery's own default of unlimited wins, and prefork children keep the DataFrame and `multiqc.report` memory they accumulate for the container's whole life.

Passed as `--max-tasks-per-child` on the CLI rather than reviving that block, which would also apply `default_queue = "dashboard_tasks"` and route every task to a queue no worker consumes, with no error anywhere. Override with `DEPICTIO_CELERY_MAX_TASKS_PER_CHILD`.

This is a guard against growth under load, not a reduction of current usage.

## Verification

Idle CPU, six `docker stats` samples per stage:

| | before | after mask | after cadence |
|---|---|---|---|
| backend | 26.0% | 8.2% | **3.1%** |
| celery-worker | 18.1% | 2.8% | **0.8%** |
| combined | ~44% | ~11% | **~3.9%** |

Both land where the file-count arithmetic predicted. The celery samples after the interval change are 0.17-0.37% with one 3.41% outlier, which is the expected signature of a 5s tick sampled by a 1s window rather than noise.

Hot reload was re-checked on the case an allowlist would have broken: touching `depictio/cli/cli_logging.py` produced `StatReload detected changes ... Reloading` on the backend and a full watchmedo restart plus `16 task(s) registered` on the worker.

Production and Kubernetes are untouched: `docker-compose.yaml` bind-mounts no source, and helm pins `DEPICTIO_DEV_MODE=false`, so both run gunicorn and bare celery with no watcher at all. CI does run dev mode, so it picks up the same saving.

## Notes

- On a CI runner `depictio/cli/.venv` does not exist, so Docker will create an empty mountpoint for it in the checkout. It is gitignored and harmless. `depictio/tests` exists everywhere, so no such mountpoint is created there.
- The anonymous volumes go dangling on `--force-recreate`; `docker volume prune` clears them.
- Two pre-commit hooks fail on this branch and are untouched by it: `ty` on `depictio/models/components/advanced_viz/catalog.py:396,506`, and shellcheck on `upload.sh`, the two `generate_seeds.sh` and `security_audit_compose.sh`.
