### PR TITLE
fix(api): keep date column specs BSON-encodable

### DIFF
--- a/depictio/api/v1/utils.py
+++ b/depictio/api/v1/utils.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datetime import datetime
+from datetime import date, datetime, time
 from pathlib import PosixPath
 
 import numpy as np
@@ -234,13 +234,31 @@ def serialize_for_mongo(data):
 
 
 def numpy_to_python(value):
-    """Converts numpy data types to native Python data types."""
+    """Converts numpy and temporal values to BSON-storable Python types.
+
+    Column specs are written straight into MongoDB, so every value that comes
+    out of a polars aggregation has to be BSON-encodable. numpy scalars need
+    unwrapping, and ``datetime.date`` / ``datetime.time`` have no BSON
+    representation at all: a Date column's min/max would otherwise fail the
+    whole Delta upsert with ``InvalidDocument: cannot encode object:
+    datetime.date(...)``, leaving the data collection with no deltatable
+    document and every component bound to it on a 404.
+    """
     if isinstance(value, (np.int64, np.int32, np.int16, np.int8)):
         return int(value)
     elif isinstance(value, (np.float64, np.float32, np.float16)):
         return float(value)
     elif isinstance(value, np.bool_):
         return bool(value)
+    # datetime subclasses date and is already BSON-native, so it must be
+    # matched before the date branch or it would be truncated to midnight.
+    elif isinstance(value, datetime):
+        return value
+    elif isinstance(value, date):
+        return datetime(value.year, value.month, value.day)
+    elif isinstance(value, time):
+        # BSON has no time type; ISO keeps it readable and sortable.
+        return value.isoformat()
     return value
 
 

--- a/depictio/tests/api/v1/test_precompute_columns_specs.py
+++ b/depictio/tests/api/v1/test_precompute_columns_specs.py
@@ -27,11 +27,12 @@ from __future__ import annotations
 
 import collections
 import math
-from datetime import datetime
+from datetime import date, datetime, time
 
 import numpy as np
 import polars as pl
 import pytest
+from bson import encode as bson_encode
 
 from depictio.api.v1.endpoints.deltatables_endpoints.utils import precompute_columns_specs
 from depictio.api.v1.utils import agg_functions as REAL_AGG_FUNCTIONS
@@ -408,3 +409,44 @@ def test_description_is_attached_from_dc_config() -> None:
         s["name"]: s["description"] for s in precompute_columns_specs(df, _AGG_FUNCTIONS, dc_data)
     }
     assert specs == {"c": "the c column", "other": None}
+
+
+# --------------------------------------------------------------------------
+# Temporal columns — the ampliseq ``metadata`` regression
+# --------------------------------------------------------------------------
+# Specs go straight into MongoDB, so every value has to be BSON-encodable.
+# polars hands back ``datetime.date`` for a Date column and ``datetime.time``
+# for a Time column, neither of which BSON can encode. The upsert answered 500
+# with ``InvalidDocument: cannot encode object: datetime.date(...)``, so no
+# deltatable document was written; the S3 prefix that had just been written was
+# then reaped as an orphan, and every component bound to the DC was left on a
+# 404. Hit in production by ampliseq's ``metadata`` DC, whose ``sampling_date``
+# is parsed by ``try_parse_dates``.
+def test_date_column_specs_are_bson_encodable() -> None:
+    df = pl.DataFrame({"sampling_date": [date(2023, 1, 5), date(2023, 3, 17)]})
+    [spec] = precompute_columns_specs(df, REAL_AGG_FUNCTIONS, _dc_data())
+
+    assert spec["type"] == "datetime"
+    # The exact call that used to raise.
+    bson_encode(spec["specs"])
+    assert spec["specs"]["min"] == datetime(2023, 1, 5)
+    assert spec["specs"]["max"] == datetime(2023, 3, 17)
+
+
+def test_datetime_column_specs_keep_their_time_component() -> None:
+    """``datetime`` is BSON-native and must not be truncated to midnight."""
+    stamps = [datetime(2023, 1, 5, 13, 45, 30), datetime(2023, 3, 17, 4, 20, 0)]
+    df = pl.DataFrame({"seen_at": stamps})
+    [spec] = precompute_columns_specs(df, REAL_AGG_FUNCTIONS, _dc_data())
+
+    bson_encode(spec["specs"])
+    assert spec["specs"]["min"] == stamps[0]
+    assert spec["specs"]["max"] == stamps[1]
+
+
+def test_time_column_specs_are_bson_encodable() -> None:
+    """A Time column normalizes to ``object``, whose mode is a ``datetime.time``."""
+    df = pl.DataFrame({"collected_at": [time(9, 30), time(17, 15)]})
+    [spec] = precompute_columns_specs(df, REAL_AGG_FUNCTIONS, _dc_data())
+
+    bson_encode(spec["specs"])

--- a/packages/depictio-react-core/src/components/interactive/DatePickerRenderer.tsx
+++ b/packages/depictio-react-core/src/components/interactive/DatePickerRenderer.tsx
@@ -127,8 +127,15 @@ const DatePickerRenderer: React.FC<{
       .catch((err) => {
         if (cancelled) return;
         console.warn('[DatePickerRenderer] fetchColumnDateRange failed:', err);
+        // Drop the rejected promise so a later mount can retry.
         dateRangeCache.delete(cacheKey);
-        setError(err?.message || String(err));
+        // A failed spec fetch says nothing about whether this control is
+        // usable: a data collection whose deltatable document is missing
+        // answers /specs with a 404. Fall back to an unconstrained picker
+        // rather than replacing the control with a raw "Failed to fetch
+        // specs: 404" — the user can still pick dates and the filter still
+        // applies downstream.
+        setBounds({ min: null, max: null });
       })
       .finally(() => {
         if (!cancelled) setLoading(false);


### PR DESCRIPTION
## Problem

The ampliseq `metadata` data collection answered `404` on `/deltatables/specs/{dc_id}`, so its DateRangePicker rendered `Failed to fetch specs: 404`. Every other data collection on the same dashboard was fine.

`precompute_columns_specs` runs server-side on every Delta upsert and funnels each spec value through `numpy_to_python`, which only unwrapped numpy scalars. polars returns `datetime.date` for a Date column and `datetime.time` for a Time column, and BSON can encode neither, so the upsert failed with:

```
bson.errors.InvalidDocument: cannot encode object: datetime.date(2023, 1, 5)
```

The consequences chained:

1. `POST /deltatables/upsert` → 500, so no `deltatables` document was written
2. the Delta table had already been written to S3, and with no document referencing it, `cleanup_orphaned_s3_files` reaped the prefix ~19s later
3. every component bound to that DC then answered 404

Observed on the EMBL demo: written at `08:51:37,172`, deleted at `08:51:56` as the only "orphaned" prefix.

`metadata` is the only ampliseq DC with both `try_parse_dates: true` and a real date column (`sampling_date`), which is why it was the lone failure among 20.

## Why it went unnoticed

Two reasons:

- The ingest swallows it (`cli/utils/process.py:139`): it logs a skipped *optional* data collection and still reports the run as completed, so no deploy is ever marked unhealthy.
- It only reproduces where the database is re-ingested from scratch. `docker-compose/.env` sets `DEPICTIO_MONGODB_WIPE=false`, so a local stack with an existing `deltatables` document never re-runs the failing path. The EMBL demos set `MONGODB_WIPE=true` plus `autoWipeOnUpgrade: true` and hit it on every boot.

## Changes

- **`depictio/api/v1/utils.py`** — `numpy_to_python` coerces `date` → `datetime` at midnight and `time` → ISO string. `datetime` is matched before `date` (it is a subclass) so real timestamps keep their time component.
- **`DatePickerRenderer.tsx`** — a failed spec fetch falls back to an unconstrained picker instead of replacing the control with a raw error string. The component already degraded this way for individually-missing bounds; this extends it to the fetch itself.
- **`test_precompute_columns_specs.py`** — three regression tests calling `bson.encode` on the produced specs for Date / Datetime / Time columns, which is the exact operation that raised.

## Verification

`uv run pytest depictio/tests/api/v1/test_precompute_columns_specs.py` → 35 passed (32 existing + 3 new).

The pre-fix path, reproduced against the old `numpy_to_python` body:

```
polars gives:  datetime.date(2023, 1, 5)   (type: date)
OLD -> InvalidDocument: cannot encode object: datetime.date(2023, 1, 5)
NEW -> encodes fine:    datetime.datetime(2023, 1, 5, 0, 0)
```

End-to-end on a fresh compose stack, after `down -v && up -d`:

```bash
# expect 1 (currently 0 on the demo)
mongosh "mongodb://localhost:27018/depictioDB" --quiet \
  --eval 'db.deltatables.countDocuments({data_collection_id: ObjectId("646b0f3c1e4a2d7f8e5b8ca5")})'
```

No image rebuild needed in dev: `./depictio` is bind-mounted.

## Notes

Pre-commit passes on all three changed files. Two repo-wide hook failures are pre-existing on `main` and untouched here: `ty check models` (2 diagnostics in `models/components/advanced_viz/catalog.py`) and `shellcheck` (viralrecon `generate_seeds.sh`, `scripts/security_audit_compose.sh`).
