### PR TITLE
chore(hooks): guard the default dashboard thumbnails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,17 @@ repos:
         files: ^helm-charts/depictio/
         pass_filenames: false
 
+# Guard the shipped default dashboard thumbnails against drive-by regeneration
+-   repo: local
+    hooks:
+      - id: check-screenshot-churn
+        name: Guard default dashboard thumbnails
+        description: 'Block accidental commits of regenerated default screenshots (opt in with DEPICTIO_ALLOW_SCREENSHOT_UPDATE=1)'
+        entry: scripts/check-screenshot-churn.sh
+        language: system
+        files: ^depictio/api/static/screenshots/.*\.png$
+        pass_filenames: false
+
 # Clean jupyter notebooks
 -   repo: https://github.com/kynan/nbstripout
     rev: 0.9.1

--- a/scripts/check-screenshot-churn.sh
+++ b/scripts/check-screenshot-churn.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Block accidental commits of the shipped default dashboard thumbnails.
+#
+# depictio/api/static/screenshots/ holds the default thumbnails that a fresh
+# deployment seeds into the screenshots PVC (see the copy-screenshot-files init
+# container in helm-charts/depictio/templates/deployments.yaml). Running a local
+# stack regenerates them in place, so they surface as modified files during
+# unrelated work and get swept into feature commits.
+#
+# That is not hypothetical: 55db1a16 ("feat(realtime): full-width timeline
+# footer, table column control, and dashboard layout polish") shipped 64
+# thumbnails captured against un-ingested data collections — red "required data
+# collection(s) were not ingested" banners and "Failed to render ... DC has no
+# materialised Delta table" instead of plots — as the defaults for every new
+# deployment, and it stayed that way for over a week.
+#
+# Regenerating is legitimate, it just has to be deliberate. Opt in with:
+#
+#   DEPICTIO_ALLOW_SCREENSHOT_UPDATE=1 git commit ...
+#
+# and only after confirming the dashboards actually render with data.
+set -euo pipefail
+
+if [ "${DEPICTIO_ALLOW_SCREENSHOT_UPDATE:-0}" != "0" ]; then
+    exit 0
+fi
+
+SCREENSHOT_DIR="depictio/api/static/screenshots"
+
+staged=$(git diff --cached --name-only --diff-filter=ACM -- "$SCREENSHOT_DIR")
+
+if [ -z "$staged" ]; then
+    exit 0
+fi
+
+count=$(printf '%s\n' "$staged" | wc -l | tr -d '[:space:]')
+
+echo "Blocked: ${count} default dashboard thumbnail(s) staged."
+echo
+printf '%s\n' "$staged" | sed 's/^/  /'
+echo
+echo "These ship as the default thumbnails for every fresh deployment, and a local"
+echo "stack rewrites them in place, so they are usually unintended churn."
+echo
+echo "If the update IS intended, verify the dashboards render with data, then:"
+echo "  DEPICTIO_ALLOW_SCREENSHOT_UPDATE=1 git commit ..."
+echo
+echo "Otherwise drop the churn:"
+echo "  git restore --source origin/main --staged --worktree -- ${SCREENSHOT_DIR}"
+exit 1


### PR DESCRIPTION
## Why

`depictio/api/static/screenshots/` holds the 72 default thumbnails a fresh deployment seeds into the screenshots PVC (via the `copy-screenshot-files` init container). Running a local stack regenerates them **in place**, so they show up as modified files during unrelated work.

That is how `55db1a16` — a feature commit about the timeline footer, table column control and layout polish — came to ship 64 thumbnails captured against un-ingested data collections, complete with *"2 required data collection(s) were not ingested"* banners and *"Failed to render — DC has no materialised Delta table"* where the plots should be. Those became the defaults for every new deployment and went unnoticed for over a week. #926 restores them.

## What

A pre-commit hook that refuses any commit staging those PNGs, printing the offending files and both ways forward:

```
Blocked: 1 default dashboard thumbnail(s) staged.

  depictio/api/static/screenshots/646b0f3c1e4a2d7f8e5b8ca2_light.png

These ship as the default thumbnails for every fresh deployment, and a local
stack rewrites them in place, so they are usually unintended churn.

If the update IS intended, verify the dashboards render with data, then:
  DEPICTIO_ALLOW_SCREENSHOT_UPDATE=1 git commit ...

Otherwise drop the churn:
  git restore --source origin/main --staged --worktree -- depictio/api/static/screenshots
```

Regenerating stays entirely possible — it just has to be deliberate.

## Design note

The hook runs at the **pre-commit** stage rather than `commit-msg`, which would have allowed a nicer message-based opt-in (e.g. requiring a `chore(screenshots):` prefix). The repo's `.pre-commit-config.yaml` declares no `default_install_hook_types`, so only the `pre-commit` hook type gets installed by a plain `pre-commit install` — a `commit-msg` hook would silently never fire for anyone with an existing setup, which is the worst outcome for a guard. The env-var opt-in works immediately with no re-install.

## Verification

Both paths exercised through real `git commit` invocations, not just the script in isolation:

| Case | Result |
| --- | --- |
| screenshot staged, no opt-in | `Guard default dashboard thumbnails......Failed`, `Blocked: 1 ...`, commit exit 1, nothing landed |
| screenshot staged, `DEPICTIO_ALLOW_SCREENSHOT_UPDATE=1` | `Guard default dashboard thumbnails......Passed`, commit landed |
| no screenshots staged | hook skipped by the `files:` filter |

`shellcheck` passes on the new script, so this adds no lint debt.
