### PR TITLE
fix(viewer): route every API call through authFetch so sessions refresh

### DIFF
--- a/depictio/tests/e2e-playwright/tests/auth/session-refresh.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/auth/session-refresh.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect, Route } from "@playwright/test";
+
+/**
+ * Session-refresh contract for the viewer's shared `authFetch` layer.
+ *
+ * Every authenticated request goes through `authFetch`, which refreshes the
+ * access token when it is at or near expiry. That is load-bearing (a login
+ * mints a 1 h access token against a 7 day refresh token) but it must not be
+ * applied to the requests that merely *ask* whether a session exists, or
+ * logging out stops working: sign-out is client-side only, the refresh token
+ * stays valid server-side, and a minting probe on `/auth` mints a new access
+ * token off it and bounces the user straight back into the app.
+ *
+ * These specs drive the real UI against a fully mocked backend, so they hold
+ * in every auth mode and do not depend on the deployment the suite runs
+ * against. The backend contract they model is the real one:
+ *
+ *   - `/auth/refresh` overwrites the stored access token
+ *     (user_endpoints/routes.py `refresh_token_browser`).
+ *   - a bearer authenticates only while it is the currently stored token
+ *     (user_endpoints/core_functions.py `_async_fetch_user_from_token`).
+ *   - `/auth/me/optional` answers 200 with `user: null` for an unusable token.
+ */
+
+const USER = { id: "u1", email: "session_refresh@example.com", is_admin: false };
+
+function statusBody(user: unknown) {
+  return {
+    auth_mode: "standard",
+    user,
+    is_public_mode: false,
+    is_single_user_mode: false,
+    is_demo_mode: false,
+    registration_disabled: false,
+    is_dev_mode: true,
+    walkthrough_disabled: true,
+    unauthenticated_mode: false,
+    google_oauth_enabled: false,
+  };
+}
+
+function bearerOf(route: Route): string | null {
+  const header = route.request().headers()["authorization"];
+  return header ? header.replace(/^Bearer\s+/i, "") : null;
+}
+
+/** Seed the viewer's `local-store` session. `expire` omitted reproduces what
+ *  the auth fixture writes: no expiry, which `authFetch` treats as "refresh
+ *  now". */
+async function seedSession(
+  page: import("@playwright/test").Page,
+  access: string,
+  refresh: string,
+  expire?: string,
+): Promise<void> {
+  await page.addInitScript(
+    ([a, r, e]) => {
+      const payload: Record<string, unknown> = {
+        access_token: a,
+        refresh_token: r,
+        logged_in: true,
+        user_id: "u1",
+        email: "session_refresh@example.com",
+      };
+      if (e) payload.expire_datetime = e;
+      window.localStorage.setItem("local-store", JSON.stringify(payload));
+    },
+    [access, refresh, expire ?? ""] as const,
+  );
+}
+
+test.describe("Session refresh", () => {
+  test("logging out is not undone by a token refresh", async ({ page }) => {
+    // Server-side token store: only this exact string authenticates.
+    let storedAccess = "seeded-token";
+    let refreshes = 0;
+
+    await page.route("**/api/v1/auth/refresh", async (route) => {
+      refreshes += 1;
+      storedAccess = `refreshed-${refreshes}`;
+      await route.fulfill({
+        json: {
+          access_token: storedAccess,
+          expire_datetime: "2030-01-01 00:00:00",
+          token_type: "bearer",
+        },
+      });
+    });
+    await page.route("**/api/v1/auth/me/optional**", async (route) => {
+      const tok = bearerOf(route);
+      await route.fulfill({ json: statusBody(tok === storedAccess ? USER : null) });
+    });
+    await page.route("**/api/v1/auth/me", async (route) => {
+      if (bearerOf(route) !== storedAccess) {
+        await route.fulfill({ status: 401, json: { detail: "Invalid token" } });
+        return;
+      }
+      await route.fulfill({ json: { ...USER, groups: [], tokens: [] } });
+    });
+    await page.route("**/api/v1/utils/status**", (r) =>
+      r.fulfill({ json: { version: "test", status: "ok" } }),
+    );
+    await page.route("**/api/v1/dashboards/list**", (r) => r.fulfill({ json: [] }));
+    await page.route("**/api/v1/projects/get/all**", (r) => r.fulfill({ json: [] }));
+
+    await seedSession(page, "seeded-token", "live-refresh");
+
+    await page.goto("/profile");
+    await page.locator("[data-testid='logout-button']").click();
+
+    // The auth card renders and the app STAYS on /auth. The regression this
+    // guards let /auth mint a fresh token off the still-live refresh token,
+    // see a logged-in user, and redirect back to /dashboards.
+    await expect(page.locator("[data-testid='modal-content']")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page).toHaveURL(/\/auth/);
+
+    // And it must still be signed out a moment later — a late refresh
+    // resolving after logout would put a working session back and redirect.
+    //
+    // The session token itself is not asserted here: `addInitScript` re-runs
+    // on every navigation, so the harness re-seeds `local-store` as /auth
+    // loads. What matters is that the app does not *act* on it — a token the
+    // server no longer recognises leaves the user on the login screen.
+    await page.waitForTimeout(1_500);
+    await expect(page).toHaveURL(/\/auth/);
+    await expect(page.locator("[data-testid='modal-content']")).toBeVisible();
+  });
+
+  test("an expired access token is refreshed for a real API call", async ({ page }) => {
+    // The case the refresh machinery exists for: the access token died an hour
+    // ago, the refresh token is still good.
+    let storedAccess = "expired-token";
+    let refreshes = 0;
+    const listBearers: (string | null)[] = [];
+
+    await page.route("**/api/v1/auth/refresh", async (route) => {
+      refreshes += 1;
+      storedAccess = "fresh-token";
+      await route.fulfill({
+        json: {
+          access_token: storedAccess,
+          expire_datetime: "2030-01-01 00:00:00",
+          token_type: "bearer",
+        },
+      });
+    });
+    await page.route("**/api/v1/auth/me/optional**", async (route) => {
+      const tok = bearerOf(route);
+      await route.fulfill({ json: statusBody(tok === storedAccess ? USER : null) });
+    });
+    // Strict endpoint: 401s anything that is not the current token.
+    await page.route("**/api/v1/dashboards/list**", async (route) => {
+      const tok = bearerOf(route);
+      listBearers.push(tok);
+      if (tok !== storedAccess) {
+        await route.fulfill({ status: 401, json: { detail: "Invalid token" } });
+        return;
+      }
+      await route.fulfill({ json: [] });
+    });
+    await page.route("**/api/v1/utils/status**", (r) =>
+      r.fulfill({ json: { version: "test", status: "ok" } }),
+    );
+    await page.route("**/api/v1/projects/get/all**", (r) => r.fulfill({ json: [] }));
+
+    const anHourAgo = new Date(Date.now() - 3_600_000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+    await seedSession(page, "expired-token", "live-refresh", anHourAgo);
+
+    await page.goto("/dashboards");
+    await expect(page).toHaveURL(/\/dashboards/);
+    await expect
+      .poll(() => listBearers.length, { timeout: 15_000 })
+      .toBeGreaterThan(0);
+
+    expect(refreshes, "an expired token must be refreshed").toBeGreaterThan(0);
+    // Every data request carried the refreshed credential, not the dead one.
+    expect(listBearers.every((t) => t === "fresh-token")).toBe(true);
+    expect(
+      await page.evaluate(
+        () => JSON.parse(localStorage.getItem("local-store") ?? "{}").access_token,
+      ),
+    ).toBe("fresh-token");
+  });
+});

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -64,6 +64,7 @@ import {
   RealtimeIndicator,
   useRealtimeJournal,
   batchIdsFromPayload,
+  authFetch,
 } from 'depictio-react-core';
 import type {
   DashboardData,
@@ -107,25 +108,6 @@ function dashOrigin(): string {
   return '';
 }
 
-/** Local helper — uses the same auth pattern as `depictio-react-core/api.ts`. */
-function authHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  try {
-    const stored = localStorage.getItem('local-store');
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      if (parsed?.access_token) {
-        headers.Authorization = `Bearer ${parsed.access_token}`;
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return headers;
-}
-
 /** Local POST wrapper for layout/component persistence. Surfaces the response
  *  body on failure so callers can debug 422 validation errors at the console.
  *  Pass `forceScreenshot=true` for an explicit Save click — the backend bypasses
@@ -139,9 +121,8 @@ async function saveDashboard(
   const url = opts.forceScreenshot
     ? `${API_BASE}/dashboards/save/${dashboardId}?force_screenshot=true`
     : `${API_BASE}/dashboards/save/${dashboardId}`;
-  const res = await fetch(url, {
+  const res = await authFetch(url, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(dashboardData),
   });
   if (!res.ok) {

--- a/depictio/viewer/src/hooks/useCurrentUser.ts
+++ b/depictio/viewer/src/hooks/useCurrentUser.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { authFetch } from 'depictio-react-core';
+import { fetchAuthStatus } from 'depictio-react-core';
 
 /**
  * Calls /depictio/api/v1/auth/me/optional to identify the current user.
@@ -8,9 +8,13 @@ import { authFetch } from 'depictio-react-core';
  * body `null`, or any non-2xx). The strict `/auth/me` would 401 for anon —
  * the React viewer needs the optional variant so the badge degrades to
  * "Sign In" instead of erroring.
+ *
+ * Goes through `fetchAuthStatus` rather than `authFetch` on purpose: this is
+ * an identity *probe*, and `authFetch` would refresh the token before asking,
+ * i.e. answer "who am I?" by first making sure the answer is "somebody". The
+ * chrome that owns this hook is mounted on `/auth` too, so a minting probe
+ * signs a just-logged-out user straight back in. See `fetchAuthStatus`.
  */
-
-const ME_URL = '/depictio/api/v1/auth/me/optional';
 
 export interface CurrentUser {
   /** MongoDB ObjectId of the user. Required for project permissions checks
@@ -70,57 +74,22 @@ export function useCurrentUser(): UseCurrentUserResult {
     let cancelled = false;
     (async () => {
       try {
-        const res = await authFetch(ME_URL);
-        if (!res.ok) {
-          if (!cancelled) {
-            setUser(null);
-            setLoading(false);
-          }
-          return;
-        }
-        // Backend now returns { auth_mode, user, is_public_mode, is_demo_mode,
-        // is_single_user_mode }. Older shape (just user) is tolerated for
-        // forward/backward compat during rollout.
-        const data = (await res.json()) as
-          | {
-              auth_mode?: AuthMode;
-              user?: { id?: string; email?: string; is_admin?: boolean } | null;
-              id?: string;
-              email?: string;
-              is_admin?: boolean;
-              is_public_mode?: boolean;
-              is_demo_mode?: boolean;
-              is_dev_mode?: boolean;
-              walkthrough_disabled?: boolean;
-              is_single_user_mode?: boolean;
-              temporary_user_expiry_hours?: number;
-              temporary_user_expiry_minutes?: number;
-            }
-          | null;
+        const data = await fetchAuthStatus();
         if (cancelled) return;
-        const mode: AuthMode = (data?.auth_mode as AuthMode) ?? 'standard';
-        const u =
-          data?.user ??
-          (data?.email
-            ? { id: data.id, email: data.email, is_admin: data.is_admin }
-            : null);
-        setAuthMode(mode);
-        setIsPublicMode(Boolean(data?.is_public_mode));
-        setIsDemoMode(Boolean(data?.is_demo_mode));
-        setIsDevMode(Boolean(data?.is_dev_mode));
-        setWalkthroughDisabled(Boolean(data?.walkthrough_disabled));
-        setIsSingleUserMode(Boolean(data?.is_single_user_mode));
-        if (typeof data?.temporary_user_expiry_hours === 'number') {
+        setAuthMode((data.auth_mode as AuthMode) ?? 'standard');
+        setIsPublicMode(Boolean(data.is_public_mode));
+        setIsDemoMode(Boolean(data.is_demo_mode));
+        setIsDevMode(Boolean(data.is_dev_mode));
+        setWalkthroughDisabled(Boolean(data.walkthrough_disabled));
+        setIsSingleUserMode(Boolean(data.is_single_user_mode));
+        if (typeof data.temporary_user_expiry_hours === 'number') {
           setTemporaryUserExpiryHours(data.temporary_user_expiry_hours);
         }
-        if (typeof data?.temporary_user_expiry_minutes === 'number') {
+        if (typeof data.temporary_user_expiry_minutes === 'number') {
           setTemporaryUserExpiryMinutes(data.temporary_user_expiry_minutes);
         }
-        setUser(
-          u && u.email
-            ? { id: u.id, email: u.email, is_admin: Boolean(u.is_admin) }
-            : null,
-        );
+        const u = data.user;
+        setUser(u?.email ? { id: u.id, email: u.email, is_admin: Boolean(u.is_admin) } : null);
       } catch {
         if (!cancelled) setUser(null);
       } finally {

--- a/depictio/viewer/src/hooks/useCurrentUser.ts
+++ b/depictio/viewer/src/hooks/useCurrentUser.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { authFetch } from 'depictio-react-core';
+
 /**
  * Calls /depictio/api/v1/auth/me/optional to identify the current user.
  * Anonymous-tolerant: returns null on missing/invalid token (HTTP 200 with
@@ -52,22 +54,6 @@ export interface UseCurrentUserResult {
   loading: boolean;
 }
 
-function authHeaders(): Record<string, string> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  try {
-    const stored = localStorage.getItem('local-store');
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      if (parsed?.access_token) {
-        headers.Authorization = `Bearer ${parsed.access_token}`;
-      }
-    }
-  } catch {
-    // ignore malformed localStorage
-  }
-  return headers;
-}
-
 export function useCurrentUser(): UseCurrentUserResult {
   const [user, setUser] = useState<CurrentUser | null>(null);
   const [authMode, setAuthMode] = useState<AuthMode>('standard');
@@ -84,7 +70,7 @@ export function useCurrentUser(): UseCurrentUserResult {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(ME_URL, { headers: authHeaders() });
+        const res = await authFetch(ME_URL);
         if (!res.ok) {
           if (!cancelled) {
             setUser(null);

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -2,6 +2,9 @@
  * Thin fetch wrapper for Depictio's FastAPI backend. Preserves the same auth
  * contract as the Dash app: JWT bearer token from localStorage, with a public
  * fallback that relies on get_user_or_anonymous middleware for anonymous mode.
+ *
+ * All requests go through `authFetch`, which owns token refresh and 401
+ * recovery. Do not attach the bearer by hand — see its docstring for why.
  */
 
 import { enqueueFetch } from './fetchQueue';
@@ -26,18 +29,6 @@ function readStoredSession(): Record<string, unknown> | null {
   } catch {
     return null;
   }
-}
-
-function authHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  const session = readStoredSession();
-  const token = session?.access_token;
-  if (typeof token === 'string' && token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-  return headers;
 }
 
 /** Send the user back to the login page when their session can no longer be
@@ -78,6 +69,24 @@ async function refreshAccessToken(refreshToken: string): Promise<{
  *  cache. Reset to null when the refresh resolves. */
 let pendingRefresh: Promise<string | null> | null = null;
 
+/** Parse a timestamp the API produced, as UTC.
+ *
+ * The backend stamps expiries with a naive `datetime.now()` in a UTC container
+ * and serialises them without an offset. `Date.parse` reads an offset-less ISO
+ * string as *local* time, which skews the comparison by the viewer's UTC
+ * offset: east of UTC every token looks already dead, so the client refreshes
+ * ahead of every request; west of UTC a dead token still looks live, so the
+ * proactive refresh never fires and the 401 retry has to catch it. The admin
+ * and dashboard panels already pin these timestamps to UTC the same way. */
+function parseBackendTimestamp(iso: string): number {
+  const hasOffset = /(?:Z|[+-]\d{2}:?\d{2})$/.test(iso);
+  return Date.parse(hasOffset ? iso : `${iso}Z`);
+}
+
+/** Current access token, refreshed first if it is at or near expiry.
+ *
+ * Exported for the callers that cannot go through `authFetch`: a WebSocket
+ * carries its credential in the URL, so it has to resolve the token itself. */
 async function ensureFreshAccessToken(): Promise<string | null> {
   const session = readStoredSession();
   const access = typeof session?.access_token === 'string' ? session.access_token : null;
@@ -86,7 +95,7 @@ async function ensureFreshAccessToken(): Promise<string | null> {
 
   if (!access || !refresh) return access;
 
-  const expireMs = expireIso ? Date.parse(expireIso) : NaN;
+  const expireMs = expireIso ? parseBackendTimestamp(expireIso) : NaN;
   if (Number.isFinite(expireMs) && expireMs - Date.now() > REFRESH_WINDOW_MS) {
     return access;
   }
@@ -117,6 +126,17 @@ async function ensureFreshAccessToken(): Promise<string | null> {
  * access token when it's near expiry, and on a 401 retries once with a freshly
  * minted access token. After persistent 401s the session is cleared so the
  * SPA falls back to the unauthenticated path on the next route resolution.
+ *
+ * Every authenticated request in the app goes through here, and must: a login
+ * mints a 1 h access token against a 7 day refresh token, so anything that
+ * attaches the stored bearer itself starts failing an hour into the session.
+ * Endpoints behind strict `get_current_user` surface that as a bare 401
+ * "Invalid token"; the larger number behind `get_user_or_anonymous` are worse,
+ * silently answering as the anonymous user, so a signed-in user's own projects
+ * just stop appearing in the list.
+ *
+ * Content-Type is set to application/json only for string bodies, leaving the
+ * browser to stamp the multipart boundary on FormData uploads.
  */
 async function authFetch(url: string, init: RequestInit = {}): Promise<Response> {
   await ensureFreshAccessToken();
@@ -264,9 +284,7 @@ export interface DashboardData {
 
 /** Fetch dashboard including stored_metadata. Mirrors what the Dash viewer reads. */
 export async function fetchDashboard(dashboardId: string): Promise<DashboardData> {
-  const res = await fetch(`${API_BASE}/dashboards/get/${dashboardId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/dashboards/get/${dashboardId}`);
   if (!res.ok) throw new Error(`Failed to fetch dashboard: ${res.status}`);
   return res.json();
 }
@@ -292,9 +310,7 @@ export interface DashboardSummary {
 }
 
 export async function fetchAllDashboards(): Promise<DashboardSummary[]> {
-  const res = await fetch(`${API_BASE}/dashboards/list?include_child_tabs=true`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/dashboards/list?include_child_tabs=true`);
   if (!res.ok) return [];
   const data = await res.json();
   return Array.isArray(data) ? data : data.dashboards || [];
@@ -302,9 +318,7 @@ export async function fetchAllDashboards(): Promise<DashboardSummary[]> {
 
 /** Fetch precomputed column specs for a data collection (includes aggregations). */
 export async function fetchSpecs(dcId: string): Promise<Record<string, unknown>> {
-  const res = await fetch(`${API_BASE}/deltatables/specs/${dcId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/deltatables/specs/${dcId}`);
   if (!res.ok) throw new Error(`Failed to fetch specs: ${res.status}`);
   return res.json();
 }
@@ -326,10 +340,7 @@ export async function fetchUniqueValues(
 ): Promise<string[]> {
   const params = new URLSearchParams({ column: columnName });
   if (filterExpr) params.set('filter_expr', filterExpr);
-  const res = await fetch(
-    `${API_BASE}/deltatables/unique_values/${dcId}?${params.toString()}`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/deltatables/unique_values/${dcId}?${params.toString()}`);
   if (!res.ok) throw new Error(`Failed to fetch unique values: ${res.status}`);
   const body = (await res.json()) as { values?: string[] };
   return body.values || [];
@@ -404,11 +415,10 @@ export async function fetchComponentData(
   componentId: string,
   filters: InteractiveFilter[],
 ): Promise<{ value?: unknown; secondary_metrics?: unknown; comparison?: unknown }> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/get_component_data/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters }),
     },
   );
@@ -441,11 +451,10 @@ export async function bulkComputeCards(
   filters: InteractiveFilter[],
   componentIds?: string[],
 ): Promise<BulkComputeResponse> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/bulk_compute_cards/${dashboardId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters, component_ids: componentIds }),
     },
   );
@@ -479,11 +488,10 @@ export async function renderFigure(
   fullLoad = false,
   signal?: AbortSignal,
 ): Promise<FigureResponse> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/render_figure/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters, theme, full_load: fullLoad }),
       signal,
     },
@@ -542,7 +550,7 @@ export interface AdvancedVizKindDescriptor {
 
 /** Metadata used by the builder's viz-kind picker. Cached on first load. */
 export async function fetchAdvancedVizKinds(): Promise<AdvancedVizKindDescriptor[]> {
-  const res = await fetch(`${API_BASE}/advanced_viz/kinds`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/advanced_viz/kinds`);
   if (!res.ok) throw new Error(`Failed to fetch advanced viz kinds: ${res.status}`);
   return res.json();
 }
@@ -551,9 +559,7 @@ export async function fetchAdvancedVizKinds(): Promise<AdvancedVizKindDescriptor
  *  validate that the user's role→column binding matches the canonical
  *  schema declared in depictio/models/components/advanced_viz/schemas.py. */
 export async function fetchPolarsSchema(dcId: string): Promise<Record<string, string>> {
-  const res = await fetch(`${API_BASE}/datacollections/polars_schema/${dcId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/datacollections/polars_schema/${dcId}`);
   if (!res.ok) throw new Error(`Failed to fetch polars schema: ${res.status}`);
   return res.json();
 }
@@ -584,10 +590,7 @@ export interface VizSuggestionsResponse {
 export async function fetchVizSuggestions(
   dcId: string,
 ): Promise<VizSuggestionsResponse> {
-  const res = await fetch(
-    `${API_BASE}/datacollections/viz-suggestions/${dcId}`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/datacollections/viz-suggestions/${dcId}`);
   if (!res.ok) throw new Error(`Failed to fetch viz suggestions: ${res.status}`);
   return res.json();
 }
@@ -657,9 +660,8 @@ export async function fetchAdvancedVizData(
   // through. Bounding it keeps a dashboard's mount burst from saturating the
   // API pool ahead of the figures and tables the user is looking at.
   return enqueueFetch(async () => {
-    const res = await fetch(`${API_BASE}/advanced_viz/data`, {
+    const res = await authFetch(`${API_BASE}/advanced_viz/data`, {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({
         wf_id: req.wfId,
         dc_id: req.dcId,
@@ -721,9 +723,8 @@ export interface ComputeEmbeddingJob {
 export async function dispatchComputeEmbedding(
   payload: ComputeEmbeddingPayload,
 ): Promise<ComputeEmbeddingJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_embedding`, {
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_embedding`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) throw new Error(`Failed to dispatch compute_embedding: ${res.status}`);
@@ -732,9 +733,7 @@ export async function dispatchComputeEmbedding(
 
 /** Poll a previously-dispatched embedding compute. */
 export async function pollComputeEmbedding(jobId: string): Promise<ComputeEmbeddingJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_embedding/${jobId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_embedding/${jobId}`);
   if (!res.ok) throw new Error(`Failed to poll compute_embedding: ${res.status}`);
   return res.json();
 }
@@ -775,9 +774,8 @@ export interface ComplexHeatmapJob {
 export async function dispatchComplexHeatmap(
   payload: ComplexHeatmapPayload,
 ): Promise<ComplexHeatmapJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_complex_heatmap`, {
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_complex_heatmap`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) throw new Error(`Failed to dispatch compute_complex_heatmap: ${res.status}`);
@@ -786,9 +784,7 @@ export async function dispatchComplexHeatmap(
 
 /** Poll the ComplexHeatmap Celery task. */
 export async function pollComplexHeatmap(jobId: string): Promise<ComplexHeatmapJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_complex_heatmap/${jobId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_complex_heatmap/${jobId}`);
   if (!res.ok) throw new Error(`Failed to poll compute_complex_heatmap: ${res.status}`);
   return res.json();
 }
@@ -826,9 +822,8 @@ export interface UpsetJob {
 
 /** Dispatch an UpSet-plot Celery task. */
 export async function dispatchUpset(payload: UpsetPayload): Promise<UpsetJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_upset`, {
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_upset`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) throw new Error(`Failed to dispatch compute_upset: ${res.status}`);
@@ -837,9 +832,7 @@ export async function dispatchUpset(payload: UpsetPayload): Promise<UpsetJob> {
 
 /** Poll an UpSet-plot Celery task. */
 export async function pollUpset(jobId: string): Promise<UpsetJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_upset/${jobId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_upset/${jobId}`);
   if (!res.ok) throw new Error(`Failed to poll compute_upset: ${res.status}`);
   return res.json();
 }
@@ -896,9 +889,8 @@ export interface CoverageTrackJob {
 export async function dispatchCoverageTrack(
   payload: CoverageTrackPayload,
 ): Promise<CoverageTrackJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_coverage_track`, {
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_coverage_track`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) throw new Error(`Failed to dispatch compute_coverage_track: ${res.status}`);
@@ -907,9 +899,7 @@ export async function dispatchCoverageTrack(
 
 /** Poll a previously-dispatched coverage-track compute. */
 export async function pollCoverageTrack(jobId: string): Promise<CoverageTrackJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_coverage_track/${jobId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_coverage_track/${jobId}`);
   if (!res.ok) throw new Error(`Failed to poll compute_coverage_track: ${res.status}`);
   return res.json();
 }
@@ -953,9 +943,8 @@ export interface SankeyJob {
 
 /** Dispatch a Sankey / categorical-flow Celery task. */
 export async function dispatchSankey(payload: SankeyPayload): Promise<SankeyJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_sankey`, {
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_sankey`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) throw new Error(`Failed to dispatch compute_sankey: ${res.status}`);
@@ -964,9 +953,7 @@ export async function dispatchSankey(payload: SankeyPayload): Promise<SankeyJob>
 
 /** Poll a previously-dispatched Sankey compute. */
 export async function pollSankey(jobId: string): Promise<SankeyJob> {
-  const res = await fetch(`${API_BASE}/advanced_viz/compute_sankey/${jobId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/advanced_viz/compute_sankey/${jobId}`);
   if (!res.ok) throw new Error(`Failed to poll compute_sankey: ${res.status}`);
   return res.json();
 }
@@ -974,9 +961,7 @@ export async function pollSankey(jobId: string): Promise<SankeyJob> {
 
 /** Fetch the raw Newick string for a phylogeny-type DC. */
 export async function fetchPhylogenyNewick(dcId: string): Promise<string> {
-  const res = await fetch(`${API_BASE}/advanced_viz/phylogeny/${dcId}/newick`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/advanced_viz/phylogeny/${dcId}/newick`);
   if (!res.ok) throw new Error(`Failed to fetch phylogeny newick: ${res.status}`);
   return res.text();
 }
@@ -1011,11 +996,10 @@ export async function renderTable(
   sortDir: 'asc' | 'desc' = 'desc',
   signal?: AbortSignal,
 ): Promise<TableResponse> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/render_table/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({
         filters,
         start,
@@ -1062,11 +1046,10 @@ export async function fetchImagePaths(
   sortBy?: string | null,
   sortDir: 'asc' | 'desc' = 'desc',
 ): Promise<ImageGridResponse> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/render_image_paths/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters, max, sort_by: sortBy ?? null, sort_dir: sortDir }),
     },
   );
@@ -1081,11 +1064,10 @@ export async function renderMap(
   filters: InteractiveFilter[],
   theme: 'light' | 'dark' = 'light',
 ): Promise<FigureResponse> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/render_map/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters, theme }),
     },
   );
@@ -1112,11 +1094,10 @@ export async function fetchJBrowseSession(
   filters: InteractiveFilter[],
   theme: 'light' | 'dark' = 'light',
 ): Promise<JBrowseSessionResponse> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/render_jbrowse/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters, theme }),
     },
   );
@@ -1149,11 +1130,10 @@ export async function renderMultiQC(
   filters: InteractiveFilter[],
   theme: 'light' | 'dark' = 'light',
 ): Promise<MultiQCRenderResult> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/render_multiqc/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters, theme }),
     },
   );
@@ -1216,11 +1196,10 @@ export async function renderMultiQCGeneralStats(
   componentId: string,
   filters: InteractiveFilter[] = [],
 ): Promise<GeneralStatsPayload> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/render_multiqc_general_stats/${dashboardId}/${componentId}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify({ filters }),
     },
   );
@@ -1265,18 +1244,16 @@ export async function updateTab(
   dashboardId: string,
   payload: UpdateTabPayload,
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/dashboards/tab/${dashboardId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/tab/${dashboardId}`, {
     method: 'PATCH',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to update tab');
 }
 
 export async function deleteTab(dashboardId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/dashboards/tab/${dashboardId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/tab/${dashboardId}`, {
     method: 'DELETE',
-    headers: authHeaders(),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to delete tab');
 }
@@ -1290,9 +1267,8 @@ export async function reorderTabs(
   parentDashboardId: string,
   tabOrders: TabOrderEntry[],
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/dashboards/tabs/reorder`, {
+  const res = await authFetch(`${API_BASE}/dashboards/tabs/reorder`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({
       parent_dashboard_id: parentDashboardId,
       tab_orders: tabOrders,
@@ -1346,9 +1322,8 @@ export async function createTab(
     tab_icon_color: fields.tab_icon_color ?? null,
   };
 
-  const res = await fetch(`${API_BASE}/dashboards/save/${newId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/save/${newId}`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to create tab');
@@ -1379,9 +1354,7 @@ export interface WorkflowEntry {
  *  Mirrors GET /workflows/get_all_workflows. Note: requires a logged-in user;
  *  anonymous sessions get an empty list. */
 export async function fetchWorkflowsForUser(): Promise<WorkflowEntry[]> {
-  const res = await fetch(`${API_BASE}/workflows/get_all_workflows`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/workflows/get_all_workflows`);
   if (!res.ok) return [];
   const data = await res.json();
   return Array.isArray(data) ? data : [];
@@ -1408,10 +1381,7 @@ export async function fetchProjectFromDashboard(
   project: { _id: string; workflows: WorkflowEntry[]; [k: string]: unknown };
   delta_locations: Record<string, string>;
 }> {
-  const res = await fetch(
-    `${API_BASE}/projects/get/from_dashboard_id/${dashboardId}`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/projects/get/from_dashboard_id/${dashboardId}`);
   if (!res.ok) {
     throw new Error(
       `Failed to fetch project for dashboard ${dashboardId}: ${res.status}`,
@@ -1462,9 +1432,7 @@ export interface DcShapeResponse {
 
 /** Row/column counts for a delta table — for the step-one preview pane. */
 export async function fetchDeltaShape(dcId: string): Promise<DcShapeResponse> {
-  const res = await fetch(`${API_BASE}/deltatables/shape/${dcId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/deltatables/shape/${dcId}`);
   if (!res.ok) return {};
   return res.json();
 }
@@ -1482,10 +1450,7 @@ export async function fetchDataCollectionPreview(
   dcId: string,
   limit = 100,
 ): Promise<PreviewResult> {
-  const res = await fetch(
-    `${API_BASE}/deltatables/preview/${dcId}?limit=${limit}`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/deltatables/preview/${dcId}?limit=${limit}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch preview: ${res.status}`);
   }
@@ -1497,9 +1462,7 @@ export async function fetchDataCollectionPreview(
 export async function fetchDataCollectionConfig(
   dcId: string,
 ): Promise<Record<string, unknown>> {
-  const res = await fetch(`${API_BASE}/datacollections/specs/${dcId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/datacollections/specs/${dcId}`);
   if (!res.ok) return {};
   return res.json();
 }
@@ -1515,9 +1478,8 @@ export interface FigurePreviewRequest {
 export async function previewFigure(
   body: FigurePreviewRequest,
 ): Promise<FigureResponse> {
-  const res = await fetch(`${API_BASE}/figure/preview`, {
+  const res = await authFetch(`${API_BASE}/figure/preview`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({
       filters: [],
       theme: 'light',
@@ -1542,9 +1504,8 @@ export interface MultiQCPreviewRequest {
 export async function previewMultiQC(
   body: MultiQCPreviewRequest,
 ): Promise<FigureResponse> {
-  const res = await fetch(`${API_BASE}/multiqc/preview`, {
+  const res = await authFetch(`${API_BASE}/multiqc/preview`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({ theme: 'light', ...body }),
   });
   if (!res.ok) await throwHttpDetailError(res, 'MultiQC preview failed');
@@ -1566,10 +1527,7 @@ export interface MultiQCBuilderOptions {
 export async function fetchMultiQCBuilderOptions(
   dcId: string,
 ): Promise<MultiQCBuilderOptions> {
-  const res = await fetch(
-    `${API_BASE}/multiqc/builder_options?data_collection_id=${dcId}`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/multiqc/builder_options?data_collection_id=${dcId}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch MultiQC options: ${res.status}`);
   }
@@ -1590,9 +1548,8 @@ export async function analyzeFigureCode(
   code: string,
   visuTypeHint?: string,
 ): Promise<CodeAnalysis> {
-  const res = await fetch(`${API_BASE}/figure/analyze_code`, {
+  const res = await authFetch(`${API_BASE}/figure/analyze_code`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({ code, visu_type: visuTypeHint }),
   });
   if (!res.ok) {
@@ -1663,9 +1620,8 @@ export interface FigureVisualizationSummary {
 export async function fetchFigureParameterDiscovery(
   vizType: string,
 ): Promise<FigureVisualizationDefinition> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/figure/parameter-discovery/${encodeURIComponent(vizType)}`,
-    { headers: authHeaders() },
   );
   if (!res.ok) await throwHttpDetailError(res, 'Parameter discovery failed');
   return res.json();
@@ -1676,9 +1632,7 @@ export async function fetchFigureParameterDiscovery(
 export async function fetchFigureVisualizationList(): Promise<
   FigureVisualizationSummary[]
 > {
-  const res = await fetch(`${API_BASE}/figure/visualizations`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/figure/visualizations`);
   if (!res.ok) await throwHttpDetailError(res, 'Visualization list failed');
   return res.json();
 }
@@ -1785,9 +1739,8 @@ export async function upsertComponent(
     ];
   }
 
-  const res = await fetch(`${API_BASE}/dashboards/save/${dashboardId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/save/${dashboardId}`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to save component');
@@ -1805,16 +1758,15 @@ export async function saveDashboardNotes(
 ): Promise<void> {
   const dashboard = await fetchDashboard(dashboardId);
   const payload: DashboardData = { ...dashboard, notes_content: notesContent };
-  const res = await fetch(`${API_BASE}/dashboards/save/${dashboardId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/save/${dashboardId}`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to save dashboard notes');
 }
 
 export async function fetchCurrentUser(): Promise<CurrentUser | null> {
-  const res = await fetch(`${API_BASE}/auth/me/optional`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/auth/me/optional`);
   if (!res.ok) return null;
   // Endpoint returns `{auth_mode, user: {id, email, is_admin}, ...}`. Older
   // shape (flat user object) is tolerated for forward/backward compat.
@@ -1885,7 +1837,7 @@ export interface SessionPayload {
 
 /** Fetch the auth state + mode flags. Drives which UI the /auth page renders. */
 export async function fetchAuthStatus(): Promise<AuthStatusResponse> {
-  const res = await fetch(`${API_BASE}/auth/me/optional`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/auth/me/optional`);
   if (!res.ok) {
     return {
       auth_mode: 'standard',
@@ -2085,7 +2037,7 @@ export async function validateSession(): Promise<boolean> {
   return readStoredSession()?.access_token != null;
 }
 
-export { authFetch, refreshAccessToken };
+export { authFetch, ensureFreshAccessToken, refreshAccessToken };
 
 // ---- Dashboard management (list / create / edit / delete / import / export)
 //
@@ -2126,10 +2078,7 @@ export interface DashboardListEntry extends DashboardSummary {
 export async function listDashboards(
   includeChildTabs = true,
 ): Promise<DashboardListEntry[]> {
-  const res = await fetch(
-    `${API_BASE}/dashboards/list?include_child_tabs=${includeChildTabs}`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/dashboards/list?include_child_tabs=${includeChildTabs}`);
   if (!res.ok) await throwHttpError(res, 'Failed to list dashboards');
   const data = await res.json();
   return Array.isArray(data) ? data : (data?.dashboards ?? []);
@@ -2154,9 +2103,7 @@ export interface ProjectListEntry {
 }
 
 export async function listProjects(): Promise<ProjectListEntry[]> {
-  const res = await fetch(`${API_BASE}/projects/get/all`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/projects/get/all`);
   if (!res.ok) return [];
   const data = await res.json();
   return Array.isArray(data) ? data : [];
@@ -2171,9 +2118,7 @@ export async function fetchProject(
 ): Promise<{ project: ProjectListEntry; delta_locations: Record<string, string> }> {
   const params = new URLSearchParams({ project_id: projectId });
   if (options.skipEnrichment) params.set('skip_enrichment', 'true');
-  const res = await fetch(`${API_BASE}/projects/get/from_id?${params}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/projects/get/from_id?${params}`);
   if (!res.ok) await throwHttpError(res, `Failed to fetch project ${projectId}`);
   const data = await res.json();
   // skip_enrichment=true returns the project dict directly; the default
@@ -2254,9 +2199,7 @@ export interface IngestionReport {
 export async function fetchIngestionReport(
   projectId: string,
 ): Promise<IngestionReport> {
-  const res = await fetch(`${API_BASE}/projects/ingestion-report/${projectId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/projects/ingestion-report/${projectId}`);
   if (!res.ok) await throwHttpError(res, `Failed to fetch ingestion report ${projectId}`);
   return (await res.json()) as IngestionReport;
 }
@@ -2266,9 +2209,7 @@ export async function fetchIngestionReport(
 export async function fetchIngestionHealth(
   projectId: string,
 ): Promise<IngestionSummary> {
-  const res = await fetch(`${API_BASE}/projects/ingestion-health/${projectId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/projects/ingestion-health/${projectId}`);
   if (!res.ok) await throwHttpError(res, `Failed to fetch ingestion health ${projectId}`);
   return (await res.json()) as IngestionSummary;
 }
@@ -2287,9 +2228,7 @@ export interface RegisteredFile {
 export async function fetchDataCollectionFiles(
   dataCollectionId: string,
 ): Promise<RegisteredFile[]> {
-  const res = await fetch(`${API_BASE}/files/list/${dataCollectionId}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/files/list/${dataCollectionId}`);
   if (!res.ok) await throwHttpError(res, `Failed to list files for ${dataCollectionId}`);
   return (await res.json()) as RegisteredFile[];
 }
@@ -2336,9 +2275,8 @@ export async function createProject(
     permissions: { owners: [ownerEntry], editors: [], viewers: [] },
     workflows: [],
   };
-  const res = await fetch(`${API_BASE}/projects/create`, {
+  const res = await authFetch(`${API_BASE}/projects/create`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to create project');
@@ -2364,9 +2302,8 @@ export async function updateProject(
 ): Promise<void> {
   const { project } = await fetchProject(projectId, { skipEnrichment: true });
   const merged: Record<string, unknown> = { ...project, ...input };
-  const res = await fetch(`${API_BASE}/projects/update`, {
+  const res = await authFetch(`${API_BASE}/projects/update`, {
     method: 'PUT',
-    headers: authHeaders(),
     body: JSON.stringify(merged),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to update project');
@@ -2376,9 +2313,8 @@ export async function updateProject(
  *  data collections, runs, MultiQC, JBrowse refs, AND child dashboards. */
 export async function deleteProject(projectId: string): Promise<void> {
   const params = new URLSearchParams({ project_id: projectId });
-  const res = await fetch(`${API_BASE}/projects/delete?${params}`, {
+  const res = await authFetch(`${API_BASE}/projects/delete?${params}`, {
     method: 'DELETE',
-    headers: authHeaders(),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to delete project');
 }
@@ -2388,9 +2324,9 @@ export async function toggleProjectVisibility(
   isPublic: boolean,
 ): Promise<void> {
   const params = new URLSearchParams({ is_public: isPublic ? 'true' : 'false' });
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/projects/toggle_public_private/${projectId}?${params}`,
-    { method: 'POST', headers: authHeaders() },
+    { method: 'POST', },
   );
   if (!res.ok) await throwHttpError(res, 'Failed to toggle project visibility');
 }
@@ -2407,9 +2343,8 @@ export interface ProjectPermissionsInput {
 export async function updateProjectPermissions(
   input: ProjectPermissionsInput,
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/projects/update_project_permissions`, {
+  const res = await authFetch(`${API_BASE}/projects/update_project_permissions`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(input),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to update permissions');
@@ -2425,14 +2360,10 @@ export async function importProjectZip(
   const formData = new FormData();
   formData.append('file', file);
   const params = new URLSearchParams({ overwrite: overwrite ? 'true' : 'false' });
-  // Build headers WITHOUT Content-Type — the browser stamps the multipart
-  // boundary automatically when given a FormData body. Strip it from the
-  // shared authHeaders() to avoid corrupting the multipart frame.
-  const headers = { ...authHeaders() } as Record<string, string>;
-  delete headers['Content-Type'];
-  const res = await fetch(`${API_BASE}/migrate/import-project-zip?${params}`, {
+  // No Content-Type: the browser stamps the multipart boundary itself for a
+  // FormData body, and authFetch only defaults the header for string bodies.
+  const res = await authFetch(`${API_BASE}/migrate/import-project-zip?${params}`, {
     method: 'POST',
-    headers,
     body: formData,
   });
   if (!res.ok) await throwHttpError(res, 'Failed to import project');
@@ -2448,9 +2379,7 @@ export async function fetchUserByEmail(email: string): Promise<{
   is_admin?: boolean;
 } | null> {
   const params = new URLSearchParams({ email });
-  const res = await fetch(`${API_BASE}/auth/fetch_user/from_email?${params}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/auth/fetch_user/from_email?${params}`);
   if (res.status === 404) return null;
   if (!res.ok) await throwHttpError(res, 'User lookup failed');
   const data = await res.json();
@@ -2467,9 +2396,8 @@ export async function fetchUserByEmail(email: string): Promise<{
  *  wrap it in a Blob and trigger a browser download. Mirrors the Dash
  *  flow at projects.py:2360 (`/migrate/export-project`). */
 export async function exportProjectZip(projectId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/migrate/export-project`, {
+  const res = await authFetch(`${API_BASE}/migrate/export-project`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({ project_id: projectId, mode: 'all' }),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to export project');
@@ -2531,10 +2459,7 @@ export async function fetchMultiQCByDataCollection(
   dcId: string,
   limit = 50,
 ): Promise<MultiQCReportsList> {
-  const res = await fetch(
-    `${API_BASE}/multiqc/reports/data-collection/${dcId}?limit=${limit}`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/multiqc/reports/data-collection/${dcId}?limit=${limit}`);
   if (!res.ok) await throwHttpError(res, 'Failed to fetch MultiQC reports');
   return res.json();
 }
@@ -2544,9 +2469,8 @@ export async function renameDataCollection(
   dcId: string,
   newTag: string,
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/datacollections/${dcId}/name`, {
+  const res = await authFetch(`${API_BASE}/datacollections/${dcId}/name`, {
     method: 'PUT',
-    headers: authHeaders(),
     body: JSON.stringify({ new_name: newTag }),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to rename data collection');
@@ -2554,9 +2478,8 @@ export async function renameDataCollection(
 
 /** Delete a data collection by ID. Cascades to files, delta tables, runs. */
 export async function deleteDataCollection(dcId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/datacollections/${dcId}`, {
+  const res = await authFetch(`${API_BASE}/datacollections/${dcId}`, {
     method: 'DELETE',
-    headers: authHeaders(),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to delete data collection');
 }
@@ -2604,13 +2527,8 @@ export async function createDataCollectionFromUpload(
   if (input.lonColumn) fd.append('lon_column', input.lonColumn);
   fd.append('file', input.file, input.file.name);
 
-  // Strip Content-Type so the browser sets the multipart boundary itself.
-  const headers = authHeaders();
-  delete headers['Content-Type'];
-
-  const res = await fetch(`${API_BASE}/datacollections/create_from_upload`, {
+  const res = await authFetch(`${API_BASE}/datacollections/create_from_upload`, {
     method: 'POST',
-    headers,
     body: fd,
   });
   if (!res.ok) {
@@ -2665,9 +2583,8 @@ export async function createDashboard(input: CreateDashboardInput): Promise<stri
     is_main_tab: true,
     tab_order: 0,
   };
-  const res = await fetch(`${API_BASE}/dashboards/save/${newId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/save/${newId}`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to create dashboard');
@@ -2688,18 +2605,16 @@ export async function editDashboard(
   dashboardId: string,
   input: EditDashboardInput,
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/dashboards/edit/${dashboardId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/edit/${dashboardId}`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(input),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to edit dashboard');
 }
 
 export async function deleteDashboard(dashboardId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/dashboards/delete/${dashboardId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/delete/${dashboardId}`, {
     method: 'DELETE',
-    headers: authHeaders(),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to delete dashboard');
 }
@@ -2733,9 +2648,8 @@ export async function duplicateDashboard(sourceDashboardId: string): Promise<str
     last_saved_ts: '',
   };
 
-  const res = await fetch(`${API_BASE}/dashboards/save/${newId}`, {
+  const res = await authFetch(`${API_BASE}/dashboards/save/${newId}`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to duplicate dashboard');
@@ -2744,9 +2658,7 @@ export async function duplicateDashboard(sourceDashboardId: string): Promise<str
   // is itself a child tab — in that case there's nothing to enumerate, so we
   // silently swallow non-2xx responses.
   try {
-    const tabsRes = await fetch(`${API_BASE}/dashboards/tabs/${sourceDashboardId}`, {
-      headers: authHeaders(),
-    });
+    const tabsRes = await authFetch(`${API_BASE}/dashboards/tabs/${sourceDashboardId}`);
     if (tabsRes.ok) {
       const tabsData = (await tabsRes.json()) as {
         child_tabs?: Array<{ dashboard_id: string; tab_order?: number; title?: string }>;
@@ -2770,9 +2682,8 @@ export async function duplicateDashboard(sourceDashboardId: string): Promise<str
           tab_order: child.tab_order ?? (childSource.tab_order as number) ?? 0,
           last_saved_ts: '',
         };
-        const childRes = await fetch(`${API_BASE}/dashboards/save/${newChildId}`, {
+        const childRes = await authFetch(`${API_BASE}/dashboards/save/${newChildId}`, {
           method: 'POST',
-          headers: authHeaders(),
           body: JSON.stringify(childPayload),
         });
         if (!childRes.ok) {
@@ -2814,11 +2725,10 @@ export async function importDashboardJson(
     params.set('validate_integrity', String(opts.validateIntegrity));
   }
   const qs = params.toString();
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/import/json${qs ? `?${qs}` : ''}`,
     {
       method: 'POST',
-      headers: authHeaders(),
       body: JSON.stringify(jsonContent),
     },
   );
@@ -2835,10 +2745,11 @@ export async function importDashboardYaml(
   if (opts.projectId) params.set('project_id', opts.projectId);
   if (opts.overwrite !== undefined) params.set('overwrite', String(opts.overwrite));
   const qs = params.toString();
-  const headers: Record<string, string> = { ...authHeaders(), 'Content-Type': 'text/plain' };
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/dashboards/import/yaml${qs ? `?${qs}` : ''}`,
-    { method: 'POST', headers, body: yamlContent },
+    // Explicit Content-Type — the body is raw YAML, which authFetch would
+    // otherwise default to application/json.
+    { method: 'POST', headers: { 'Content-Type': 'text/plain' }, body: yamlContent },
   );
   if (!res.ok) await throwHttpDetailError(res, 'Failed to import YAML dashboard');
   return res.json();
@@ -2849,9 +2760,8 @@ export async function importDashboardYaml(
 export async function validateDashboardJson(
   jsonContent: Record<string, unknown>,
 ): Promise<{ valid: boolean; errors?: unknown[] }> {
-  const res = await fetch(`${API_BASE}/dashboards/json/validate`, {
+  const res = await authFetch(`${API_BASE}/dashboards/json/validate`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify(jsonContent),
   });
   if (!res.ok) return { valid: false, errors: [`HTTP ${res.status}`] };
@@ -2862,9 +2772,7 @@ export async function validateDashboardJson(
 export async function exportDashboardJson(
   dashboardId: string,
 ): Promise<Record<string, unknown>> {
-  const res = await fetch(`${API_BASE}/dashboards/${dashboardId}/json`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/dashboards/${dashboardId}/json`);
   if (!res.ok) await throwHttpError(res, 'Failed to export dashboard');
   return res.json();
 }
@@ -2890,16 +2798,15 @@ export interface AdminUser {
 }
 
 export async function listAllUsers(): Promise<AdminUser[]> {
-  const res = await fetch(`${API_BASE}/auth/list`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/auth/list`);
   if (!res.ok) await throwHttpError(res, 'Failed to list users');
   const data = await res.json();
   return Array.isArray(data) ? data : [];
 }
 
 export async function deleteUser(userId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/auth/delete/${userId}`, {
+  const res = await authFetch(`${API_BASE}/auth/delete/${userId}`, {
     method: 'DELETE',
-    headers: authHeaders(),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to delete user');
 }
@@ -2909,9 +2816,9 @@ export async function deleteUser(userId: string): Promise<void> {
  *  the Dash callback). We send the Python-style capitalized form for parity. */
 export async function setUserAdmin(userId: string, isAdmin: boolean): Promise<void> {
   const flag = isAdmin ? 'True' : 'False';
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE}/auth/turn_sysadmin/${userId}/${flag}`,
-    { method: 'POST', headers: authHeaders() },
+    { method: 'POST', },
   );
   if (!res.ok) await throwHttpError(res, 'Failed to update admin status');
 }
@@ -2931,7 +2838,7 @@ export interface AdminProject {
 }
 
 export async function listAllProjects(): Promise<AdminProject[]> {
-  const res = await fetch(`${API_BASE}/projects/get/all`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/projects/get/all`);
   if (!res.ok) await throwHttpError(res, 'Failed to list all projects');
   const data = await res.json();
   return Array.isArray(data) ? data : [];
@@ -2957,9 +2864,7 @@ export async function listAllDashboards(
   includeChildTabs = false,
 ): Promise<AdminDashboard[]> {
   const qs = includeChildTabs ? '?include_child_tabs=true' : '';
-  const res = await fetch(`${API_BASE}/dashboards/list_all${qs}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/dashboards/list_all${qs}`);
   if (!res.ok) await throwHttpError(res, 'Failed to list all dashboards');
   const data = await res.json();
   return Array.isArray(data) ? data : [];
@@ -2973,16 +2878,15 @@ export interface ExampleProject {
 }
 
 export async function listExampleProjects(): Promise<ExampleProject[]> {
-  const res = await fetch(`${API_BASE}/projects/admin/examples`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/projects/admin/examples`);
   if (!res.ok) await throwHttpError(res, 'Failed to list example projects');
   const data = await res.json();
   return Array.isArray(data) ? data : [];
 }
 
 export async function cleanExampleProjects(): Promise<{ deleted: ExampleProject[] }> {
-  const res = await fetch(`${API_BASE}/projects/admin/clean_examples`, {
+  const res = await authFetch(`${API_BASE}/projects/admin/clean_examples`, {
     method: 'POST',
-    headers: authHeaders(),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to clean example projects');
   const data = await res.json();
@@ -3099,14 +3003,14 @@ export async function fetchMonitoringTasks(opts: {
     limit: opts.limit,
     skip: opts.skip,
   });
-  const res = await fetch(`${API_BASE}/monitoring/tasks${qs}`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/monitoring/tasks${qs}`);
   if (!res.ok) await throwHttpDetailError(res, 'Failed to load tasks');
   const data = await res.json();
   return Array.isArray(data?.tasks) ? (data.tasks as MonitoringTaskEvent[]) : [];
 }
 
 export async function fetchMonitoringTask(taskId: string): Promise<MonitoringTaskEvent> {
-  const res = await fetch(`${API_BASE}/monitoring/tasks/${taskId}`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/monitoring/tasks/${taskId}`);
   if (!res.ok) await throwHttpDetailError(res, 'Failed to load task');
   return (await res.json()) as MonitoringTaskEvent;
 }
@@ -3125,14 +3029,14 @@ export async function fetchIngestionRuns(opts: {
     limit: opts.limit,
     skip: opts.skip,
   });
-  const res = await fetch(`${API_BASE}/monitoring/ingestion${qs}`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/monitoring/ingestion${qs}`);
   if (!res.ok) await throwHttpDetailError(res, 'Failed to load ingestion runs');
   const data = await res.json();
   return Array.isArray(data?.runs) ? (data.runs as MonitoringIngestionRun[]) : [];
 }
 
 export async function fetchIngestionRun(runId: string): Promise<MonitoringIngestionRun> {
-  const res = await fetch(`${API_BASE}/monitoring/ingestion/${runId}`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/monitoring/ingestion/${runId}`);
   if (!res.ok) await throwHttpDetailError(res, 'Failed to load ingestion run');
   return (await res.json()) as MonitoringIngestionRun;
 }
@@ -3143,21 +3047,21 @@ export async function fetchAppLogs(opts: {
   limit?: number;
 } = {}): Promise<MonitoringAppLog[]> {
   const qs = monitoringQuery({ level: opts.level, source: opts.source, limit: opts.limit });
-  const res = await fetch(`${API_BASE}/monitoring/logs${qs}`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/monitoring/logs${qs}`);
   if (!res.ok) await throwHttpDetailError(res, 'Failed to load logs');
   const data = await res.json();
   return Array.isArray(data?.logs) ? (data.logs as MonitoringAppLog[]) : [];
 }
 
 export async function fetchMonitoringHealth(): Promise<MonitoringHealth> {
-  const res = await fetch(`${API_BASE}/monitoring/health`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/monitoring/health`);
   if (!res.ok) await throwHttpDetailError(res, 'Failed to load monitoring health');
   return (await res.json()) as MonitoringHealth;
 }
 
 /** Read the current app-log capture floor (admin-only). */
 export async function fetchLogCaptureLevel(): Promise<string> {
-  const res = await fetch(`${API_BASE}/monitoring/logs/level`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/monitoring/logs/level`);
   if (!res.ok) await throwHttpDetailError(res, 'Failed to load log level');
   const data = await res.json();
   return typeof data?.level === 'string' ? data.level : 'WARNING';
@@ -3166,9 +3070,8 @@ export async function fetchLogCaptureLevel(): Promise<string> {
 /** Set the runtime app-log capture floor (admin-only). Applies live in the API
  *  process and is broadcast best-effort to Celery workers. */
 export async function setLogCaptureLevel(level: string): Promise<string> {
-  const res = await fetch(`${API_BASE}/monitoring/logs/level`, {
+  const res = await authFetch(`${API_BASE}/monitoring/logs/level`, {
     method: 'POST',
-    headers: { ...authHeaders(), 'Content-Type': 'application/json' },
     body: JSON.stringify({ level }),
   });
   if (!res.ok) await throwHttpDetailError(res, 'Failed to set log level');
@@ -3198,7 +3101,7 @@ export interface ProfileUser {
 }
 
 export async function fetchCurrentUserFull(): Promise<ProfileUser | null> {
-  const res = await fetch(`${API_BASE}/auth/me`, { headers: authHeaders() });
+  const res = await authFetch(`${API_BASE}/auth/me`);
   if (!res.ok) return null;
   const data = (await res.json()) as Record<string, unknown>;
   if (!data || typeof data.email !== 'string') return null;
@@ -3217,9 +3120,8 @@ export async function fetchCurrentUserFull(): Promise<ProfileUser | null> {
  *  server-side and rejects equal old/new. Throws Error(<detail>) on non-200
  *  so the caller can surface the message verbatim. */
 export async function editPassword(oldPassword: string, newPassword: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/auth/edit_password`, {
+  const res = await authFetch(`${API_BASE}/auth/edit_password`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({ old_password: oldPassword, new_password: newPassword }),
   });
   if (!res.ok) await throwHttpDetailError(res, 'Password update failed');
@@ -3238,9 +3140,7 @@ export interface CliToken {
 
 export async function listLongLivedTokens(): Promise<CliToken[]> {
   const params = new URLSearchParams({ token_lifetime: 'long-lived' });
-  const res = await fetch(`${API_BASE}/auth/list_tokens?${params.toString()}`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/auth/list_tokens?${params.toString()}`);
   if (!res.ok) await throwHttpError(res, 'Failed to list tokens');
   const data = await res.json();
   if (!Array.isArray(data)) return [];
@@ -3269,9 +3169,8 @@ export interface CreatedToken {
 }
 
 export async function createLongLivedToken(name: string): Promise<CreatedToken> {
-  const res = await fetch(`${API_BASE}/auth/me/tokens`, {
+  const res = await authFetch(`${API_BASE}/auth/me/tokens`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({ name }),
   });
   if (!res.ok) await throwHttpDetailError(res, 'Failed to create token');
@@ -3290,9 +3189,8 @@ export async function createLongLivedToken(name: string): Promise<CreatedToken> 
 }
 
 export async function deleteLongLivedToken(tokenId: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/auth/me/tokens/${encodeURIComponent(tokenId)}`, {
+  const res = await authFetch(`${API_BASE}/auth/me/tokens/${encodeURIComponent(tokenId)}`, {
     method: 'DELETE',
-    headers: authHeaders(),
   });
   if (!res.ok) await throwHttpDetailError(res, 'Failed to delete token');
 }
@@ -3303,9 +3201,8 @@ export async function deleteLongLivedToken(tokenId: string): Promise<void> {
 export type CliAgentConfig = Record<string, unknown>;
 
 export async function generateAgentConfig(token: CreatedToken): Promise<CliAgentConfig> {
-  const res = await fetch(`${API_BASE}/auth/generate_agent_config`, {
+  const res = await authFetch(`${API_BASE}/auth/generate_agent_config`, {
     method: 'POST',
-    headers: authHeaders(),
     body: JSON.stringify({
       user_id: token.user_id,
       access_token: token.access_token,
@@ -3377,10 +3274,6 @@ export interface ResolverInfo {
 }
 
 export async function listProjectLinks(projectId: string): Promise<DCLink[]> {
-  // Use authFetch (not raw fetch + authHeaders) so a stale access_token gets
-  // silently refreshed and retried instead of bubbling up as a 401 "Invalid
-  // token". The links endpoint uses strict get_current_user — there's no
-  // anonymous fallback to recover from a bad header.
   const res = await authFetch(`${API_BASE}/links/${projectId}`);
   if (!res.ok) await throwHttpError(res, 'Failed to list project links');
   const body = await res.json();
@@ -3468,9 +3361,7 @@ function normalizeResolver(item: unknown): ResolverInfo | null {
 }
 
 export async function listLinkResolvers(projectId: string): Promise<ResolverInfo[]> {
-  const res = await fetch(`${API_BASE}/links/${projectId}/resolvers`, {
-    headers: authHeaders(),
-  });
+  const res = await authFetch(`${API_BASE}/links/${projectId}/resolvers`);
   if (!res.ok) await throwHttpError(res, 'Failed to list resolvers');
   const body = await res.json();
   const raw: unknown[] = Array.isArray(body) ? body : (body?.resolvers ?? []);
@@ -3485,10 +3376,7 @@ export async function fetchMultiQCSampleMappings(
   projectId: string,
   dcId: string,
 ): Promise<Record<string, string[]>> {
-  const res = await fetch(
-    `${API_BASE}/links/${projectId}/multiqc/${dcId}/sample-mappings`,
-    { headers: authHeaders() },
-  );
+  const res = await authFetch(`${API_BASE}/links/${projectId}/multiqc/${dcId}/sample-mappings`);
   if (!res.ok) await throwHttpError(res, 'Failed to fetch sample mappings');
   const body = await res.json();
   if (body?.sample_mappings && typeof body.sample_mappings === 'object') {
@@ -3532,10 +3420,7 @@ async function postMultiQCUpload(
   for (const [key, value] of Object.entries(extraFields)) fd.append(key, value);
   for (const file of files) fd.append('files', file, file.name);
 
-  const headers = authHeaders();
-  delete headers['Content-Type'];
-
-  const res = await fetch(url, { method: 'POST', headers, body: fd });
+  const res = await authFetch(url, { method: 'POST', body: fd });
   if (!res.ok) await throwHttpDetailError(res, 'MultiQC upload failed');
   return (await res.json()) as MultiQCMutationResult;
 }
@@ -3570,11 +3455,8 @@ export async function checkMultiQCUniformity(
 ): Promise<MultiQCUniformityCheckResult> {
   const fd = new FormData();
   for (const file of files) fd.append('files', file, file.name);
-  const headers = authHeaders();
-  delete headers['Content-Type'];
-  const res = await fetch(`${API_BASE}/datacollections/multiqc_uniformity_check`, {
+  const res = await authFetch(`${API_BASE}/datacollections/multiqc_uniformity_check`, {
     method: 'POST',
-    headers,
     body: fd,
   });
   if (!res.ok) await throwHttpDetailError(res, 'MultiQC uniformity check failed');
@@ -3629,10 +3511,7 @@ async function postTableUpload(url: string, files: File[]): Promise<TableMutatio
   const fd = new FormData();
   for (const file of files) fd.append('files', file, file.name);
 
-  const headers = authHeaders();
-  delete headers['Content-Type'];
-
-  const res = await fetch(url, { method: 'POST', headers, body: fd });
+  const res = await authFetch(url, { method: 'POST', body: fd });
   if (!res.ok) await throwHttpDetailError(res, 'Table upload failed');
   return (await res.json()) as TableMutationResult;
 }

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -69,6 +69,34 @@ async function refreshAccessToken(refreshToken: string): Promise<{
  *  cache. Reset to null when the refresh resolves. */
 let pendingRefresh: Promise<string | null> | null = null;
 
+/** Incremented by ``clearSession``. A refresh started before a logout must not
+ *  write its result back afterwards.
+ *
+ *  Logout is client-side only: the refresh token stays valid server-side for 7
+ *  days, so a late write does not just restore stale bytes, it restores a
+ *  *working* session and the user is silently signed back in. The window is
+ *  real because every authenticated request now refreshes through here, and a
+ *  page like /profile has several in flight at the moment the button is
+ *  clicked. Writers capture the epoch before awaiting and drop their result if
+ *  it moved. */
+let sessionEpoch = 0;
+
+/** Persist a refreshed token, unless the session was cleared while we awaited.
+ *  Returns false when the write was dropped. */
+function persistRefreshedSession(
+  epoch: number,
+  base: Record<string, unknown> | null,
+  refreshed: { access_token: string; expire_datetime: string },
+): boolean {
+  if (epoch !== sessionEpoch) return false;
+  try {
+    localStorage.setItem(SESSION_KEY, JSON.stringify({ ...base, ...refreshed }));
+  } catch {
+    // ignore quota / private mode
+  }
+  return true;
+}
+
 /** Parse a timestamp the API produced, as UTC.
  *
  * The backend stamps expiries with a naive `datetime.now()` in a UTC container
@@ -101,23 +129,22 @@ async function ensureFreshAccessToken(): Promise<string | null> {
   }
 
   if (!pendingRefresh) {
+    const epoch = sessionEpoch;
     pendingRefresh = (async () => {
       try {
         const refreshed = await refreshAccessToken(refresh);
         if (!refreshed) return null;
-        const next = { ...session, ...refreshed };
-        try {
-          localStorage.setItem(SESSION_KEY, JSON.stringify(next));
-        } catch {
-          // ignore quota / private mode
-        }
+        if (!persistRefreshedSession(epoch, session, refreshed)) return null;
         return refreshed.access_token;
       } finally {
         pendingRefresh = null;
       }
     })();
   }
+  const epochBefore = sessionEpoch;
   const next = await pendingRefresh;
+  // Logged out mid-refresh: there is no current token to report.
+  if (epochBefore !== sessionEpoch) return null;
   return next ?? access;
 }
 
@@ -160,17 +187,16 @@ async function authFetch(url: string, init: RequestInit = {}): Promise<Response>
     redirectToAuth();
     return first;
   }
+  const epoch = sessionEpoch;
   const refreshed = await refreshAccessToken(refresh);
   if (!refreshed) {
     clearSession();
     redirectToAuth();
     return first;
   }
-  try {
-    localStorage.setItem(SESSION_KEY, JSON.stringify({ ...existing, ...refreshed }));
-  } catch {
-    // ignore
-  }
+  // Logged out while the retry was in flight — do not resurrect the session,
+  // and do not re-issue the request as the user who just signed out.
+  if (!persistRefreshedSession(epoch, existing, refreshed)) return first;
   const retryHeaders = new Headers(init.headers || {});
   retryHeaders.set('Authorization', `Bearer ${refreshed.access_token}`);
   if (!retryHeaders.has('Content-Type') && init.body && typeof init.body === 'string') {
@@ -1812,6 +1838,14 @@ export interface AuthStatusResponse {
    *  treat absent as `false`. */
   registration_disabled?: boolean;
   google_oauth_enabled: boolean;
+  /** Development mode (DEPICTIO_DEV_MODE). Suppresses the walkthrough. */
+  is_dev_mode?: boolean;
+  /** Explicit walkthrough kill switch (DEPICTIO_WALKTHROUGH_DISABLED). */
+  walkthrough_disabled?: boolean;
+  /** TTL of a temporary public-mode user. */
+  temporary_user_expiry_hours?: number;
+  /** Sub-hour component of the temporary-user TTL. */
+  temporary_user_expiry_minutes?: number;
 }
 
 /** Session payload persisted to localStorage['local-store'] on successful auth.
@@ -1835,9 +1869,31 @@ export interface SessionPayload {
   expiration_time?: string | null;
 }
 
-/** Fetch the auth state + mode flags. Drives which UI the /auth page renders. */
+/** Fetch the auth state + mode flags. Drives which UI the /auth page renders.
+ *
+ * Deliberately NOT routed through `authFetch`. This endpoint answers a
+ * question — "is the stored credential currently good?" — and `authFetch`
+ * would answer it by *making* it good: it refreshes a near-expiry or absent
+ * expiry token before sending, so the probe reports a healthy session it
+ * created itself.
+ *
+ * That is wrong everywhere, but it actively breaks logout. Signing out only
+ * clears the client's copy of the token; the refresh token stays valid
+ * server-side for 7 days. `/auth` then mounts, calls this to decide what to
+ * render, mints a fresh access token off that still-live refresh token, sees a
+ * logged-in user, and redirects straight back to `/dashboards`.
+ *
+ * Sending the stored bearer as-is gives the honest answer: the backend
+ * resolves the user when the token is genuinely live and returns
+ * `user: null` when it is not. Expiry recovery belongs to the requests that
+ * actually need a working credential, and they go through `authFetch`.
+ */
 export async function fetchAuthStatus(): Promise<AuthStatusResponse> {
-  const res = await authFetch(`${API_BASE}/auth/me/optional`);
+  const session = readStoredSession();
+  const token = typeof session?.access_token === 'string' ? session.access_token : null;
+  const res = await fetch(`${API_BASE}/auth/me/optional`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   if (!res.ok) {
     return {
       auth_mode: 'standard',
@@ -2016,8 +2072,14 @@ export function persistSession(session: SessionPayload): void {
   }
 }
 
-/** Clear the persisted session — used for logout. */
+/** Clear the persisted session — used for logout.
+ *
+ *  Also invalidates any refresh already in flight. Logout only removes the
+ *  client's copy of the credential (there is no server-side revocation), so a
+ *  refresh that resolved after this point would write back a *working* session
+ *  and sign the user straight back in. */
 export function clearSession(): void {
+  sessionEpoch += 1;
   try {
     localStorage.removeItem(SESSION_KEY);
   } catch {

--- a/packages/depictio-react-core/src/realtime.ts
+++ b/packages/depictio-react-core/src/realtime.ts
@@ -23,6 +23,8 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 
+import { ensureFreshAccessToken } from './api';
+
 export type RealtimeStatus = 'connecting' | 'connected' | 'disconnected';
 
 export type RealtimeMode = 'manual' | 'auto';
@@ -112,16 +114,11 @@ function buildWebSocketUrl(token: string | null, dashboardId: string): string {
   return `${proto}//${hostname}${portSuffix}/depictio/api/v1/events/ws?${params.toString()}`;
 }
 
-function readToken(): string | null {
-  try {
-    const raw = localStorage.getItem('local-store');
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    return typeof parsed?.access_token === 'string' ? parsed.access_token : null;
-  } catch {
-    return null;
-  }
-}
+// A WebSocket carries its credential in the URL, so these two connect paths
+// cannot ride `authFetch`. They resolve the token through
+// `ensureFreshAccessToken` instead, which matters most here: a dashboard left
+// open past the access token's 1 h life reconnects on its own, and would
+// otherwise reconnect with a token the backend has already stopped accepting.
 
 /** Subscribe to dashboard-scoped backend events. The hook owns one WebSocket
  *  for the current dashboard, reconnects with capped exponential backoff,
@@ -158,9 +155,11 @@ export function useDataCollectionUpdates(
 
     let disposed = false;
 
-    const connect = () => {
+    const connect = async () => {
       if (disposed) return;
-      const token = readToken();
+      const token = await ensureFreshAccessToken();
+      // Re-check: the effect can be torn down while the refresh is in flight.
+      if (disposed) return;
       const url = buildWebSocketUrl(token, dashboardId);
       setStatus('connecting');
 
@@ -308,9 +307,11 @@ export function useMonitoringEvents(
 
     let disposed = false;
 
-    const connect = () => {
+    const connect = async () => {
       if (disposed) return;
-      const token = readToken();
+      const token = await ensureFreshAccessToken();
+      // Re-check: the effect can be torn down while the refresh is in flight.
+      if (disposed) return;
       const url = buildWebSocketUrl(token, ADMIN_MONITORING_CHANNEL);
       setStatus('connecting');
 


### PR DESCRIPTION
## Problem

Deleting a project from the React viewer failed with:

```
Failed to delete project: 401 {"detail":"Invalid token"}
```

The session's access token had expired. A login mints a **1 hour** access token against a **7 day** refresh token (`_add_token`, `user_endpoints/core_functions.py:613-621`), and nothing on the delete path ever spent the refresh token.

`api.ts` has had `authFetch` for a while: it proactively refreshes a near-expiry token, retries once on a 401 with a freshly minted one, and redirects to `/auth` when the refresh token is dead too. Only 8 of the ~100 call sites used it. The other 94 attached the stored bearer by hand through a local `authHeaders()` helper, so an hour into any session they were sending a token the backend had already stopped accepting.

## Why only delete surfaced it

The failure mode splits on which auth dependency the endpoint uses.

Roughly 90 endpoints sit behind strict `get_current_user`, which has no fallback and raises `401 "Invalid token"` (`user_endpoints/routes.py:101`). `delete_project` (`projects_endpoints/routes.py:340`) is one, alongside `update_project`, the dashboard and data-collection mutations, and the MultiQC and workflow routes.

The larger set behind `get_user_or_anonymous` was quieter and, in a multi-user deployment, worse. In single-user and public mode an unusable token falls through to the anonymous user (`user_endpoints/routes.py:132-135`) and the request succeeds as somebody else. Nothing errors; a signed-in user's own projects simply stop appearing in the list.

That asymmetry is why the app looked healthy right up until a write was attempted.

Traced on a live instance: the only session token in `depictioDB.tokens` was created at `12:22:19` with `expire_datetime` `13:22:30`, while `refresh_expire_datetime` sat a week out at `2026-08-07`. The credential to recover was there the whole time, unused.

`listProjectLinks` already carried a comment describing exactly this bug and a local switch to `authFetch`. It was fixed one call site at a time.

## Second bug: the expiry comparison

Migrating everything to `authFetch` surfaced a latent bug that the 8-site minority had mostly hidden. On a single page load the client fired **4** `POST /auth/refresh` calls.

`ensureFreshAccessToken` compared `Date.parse(expire_datetime)` against `Date.now()`. The API stamps expiries with a naive `datetime.now()` in a UTC container and serialises them with no offset, and `Date.parse` reads an offset-less ISO string as *local* time. The comparison was skewed by the viewer's UTC offset:

- **East of UTC** (this repo's CEST dev box, UTC+2) every token looked already expired, so the client refreshed ahead of essentially every request. Harmless at 8 call sites, a refresh storm at 100.
- **West of UTC** a dead token looks live, the proactive refresh never fires, and the 401 retry has to catch it every time.

The admin and dashboard panels already pin these timestamps to UTC (`AdminUsersPanel.tsx:36`, `AdminMonitoringPanel.tsx:144`, `dashboards/lib/format.ts:32`). `api.ts` was the one place that did not.

## Changes

- **`packages/depictio-react-core/src/api.ts`** — 94 call sites moved from `fetch(..., { headers: authHeaders() })` to `authFetch`, and `authHeaders()` deleted. New `parseBackendTimestamp` reads the API's offset-less timestamps as UTC. `ensureFreshAccessToken` is exported for the one caller that cannot use `authFetch`.
- **`packages/depictio-react-core/src/realtime.ts`** — a WebSocket carries its credential in the URL, so the two `connect` paths resolve through `ensureFreshAccessToken` instead of reading `localStorage` directly. Both re-check `disposed` after the await, since the effect can tear down mid-refresh. This is what makes a dashboard left open past the 1 hour mark reconnect with a live token.
- **`depictio/viewer/src/EditorApp.tsx`**, **`depictio/viewer/src/hooks/useCurrentUser.ts`** — each had its own copy of `authHeaders()`. Both deleted in favour of the shared `authFetch`.

Six multipart upload sites got simpler: they were building headers and then deleting `Content-Type` so the browser could stamp the boundary. `authFetch` only defaults that header for string bodies, so the dance is gone. `importDashboardYaml` keeps an explicit `text/plain`, since its body is a raw string that would otherwise be typed as JSON.

The mechanical part of the migration was scripted rather than hand-edited, then reviewed as a diff. The invariant is easy to check: `authHeaders` and `local-store` now appear nowhere outside `api.ts`, and the only `Authorization` header construction left in the tree is inside `authFetch` itself.

## Verification

`npx tsc --noEmit` and `pnpm build` both clean.

Against a running dev stack holding the expired token from the original report:

**Strict auth recovers.** `/auth/me` uses the same `get_current_user` dependency as `/projects/delete`, so it exercises the exact path that was 401ing:

```
strict_auth_status: 200
body: {"id":"67658ba033c8b59ad489d7c7","email":"admin@example.com","is_admin":true,...}
```

**The refresh storm is gone.** Counting `POST /auth/refresh` on a `/dashboards` load, before and after the timestamp fix:

```
before parseBackendTimestamp:  4 refreshes per page load
after:                         0
```

with the session still valid throughout.

Not exercised: no project was actually deleted against the live instance, since that is destructive and irreversible. The auth dependency is identical, so the 401 cannot recur, but the cascade body itself is unchanged and untested by this PR.

## Notes

No image rebuild needed in dev, the React source trees are bind-mounted.

Two repo-wide pre-commit hooks fail identically on `main` and are untouched here: `ty check models` (2 diagnostics in `models/components/advanced_viz/catalog.py`) and `shellcheck` (ampliseq and viralrecon `generate_seeds.sh`, `scripts/security_audit_compose.sh`, `nfcore_megatests_showcase/scripts/upload.sh`). Every hook that applies to the four changed files passes.

Refresh-token rotation is still the open item flagged in `TODO(PR2)` at `user_endpoints/routes.py:384`. This PR makes the existing refresh token actually get used; it does not change its lifetime or add reuse detection.
