### PR TITLE
fix(helm): disable service link env vars on all pods

### DIFF
--- a/helm-charts/depictio/Chart.yaml
+++ b/helm-charts/depictio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: depictio
 description: A Helm chart for Depictio application
 type: application
-version: "20260730.1"
+version: "20260804.1"
 appVersion: "1.3.1"
 icon: https://github.com/depictio/depictio/raw/main/docs/images/logo.png
 maintainers:

--- a/helm-charts/depictio/README.md
+++ b/helm-charts/depictio/README.md
@@ -34,6 +34,7 @@ helm uninstall depictio
 |-----------|-------------|---------|
 | `nameOverride` | String to partially override the chart name | `""` |
 | `fullnameOverride` | String to fully override the chart name | `""` |
+| `enableServiceLinks` | Inject the legacy Docker-link service environment variables into every pod. Keep `false`: on clusters with many Services the injected block overflows the process argument limit and the viewer's nginx entrypoint crashloops with `envsubst: Argument list too long` | `false` |
 
 ### Namespace parameters
 

--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -24,6 +24,7 @@ spec:
         project: {{ .Values.project.slug }}
         type: app
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       {{- if gt (.Values.mongo.replicas | default 1 | int) 1 }}
       affinity:
         podAntiAffinity:
@@ -133,6 +134,7 @@ spec:
         project: {{ .Values.project.slug }}
         type: app
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
@@ -205,6 +207,7 @@ spec:
         project: {{ .Values.project.slug }}
         type: app
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       containers:
         - name: minio
           image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
@@ -268,6 +271,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       {{- if gt (.Values.backend.replicas | int) 1 }}
       affinity:
         podAntiAffinity:
@@ -571,6 +575,7 @@ spec:
         project: {{ .Values.project.slug }}
         type: app
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       {{- if gt (.Values.viewer.replicas | int) 1 }}
       affinity:
         podAntiAffinity:
@@ -666,6 +671,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       securityContext:
         {{- toYaml .Values.celery.podSecurityContext | nindent 8 }}
       initContainers:

--- a/helm-charts/depictio/templates/mongo-init-job.yaml
+++ b/helm-charts/depictio/templates/mongo-init-job.yaml
@@ -17,6 +17,7 @@ spec:
         app: mongo-init
         release: {{ .Release.Name }}
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       restartPolicy: OnFailure
       containers:
         - name: mongo-init

--- a/helm-charts/depictio/templates/wipe-job.yaml
+++ b/helm-charts/depictio/templates/wipe-job.yaml
@@ -67,6 +67,7 @@ spec:
     metadata:
       name: wipe-data
     spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks | default false }}
       restartPolicy: Never
       serviceAccountName: {{ .Release.Name }}-wipe-sa
       securityContext:

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -14,6 +14,16 @@ fullnameOverride: ""
 # some (e.g. EMBL ops-k1: ops-k1.embl.de) customise it.
 clusterDomain: "cluster.local"
 
+# Inject the legacy Docker-link service environment variables
+# (<SVC>_PORT_<port>_TCP_ADDR, ...) into every pod. Kubernetes defaults this to
+# true, which means each pod inherits one block of variables per Service in its
+# namespace. On busy clusters that environment grows large enough to break
+# execve's argument limit — the viewer's nginx entrypoint crashlooped on
+# `20-envsubst-on-templates.sh: envsubst: Argument list too long` — and Depictio
+# resolves every dependency through DNS anyway, so none of those variables are
+# read. Keep this false unless something in your deployment relies on them.
+enableServiceLinks: false
+
 # Application configuration
 appname: "depictio"
 


### PR DESCRIPTION
## Summary

Kubernetes defaults `enableServiceLinks` to `true`, injecting one block of legacy Docker-link variables (`<SVC>_PORT_<port>_TCP_ADDR`, …) per Service in the namespace into every pod. On a cluster with many Services that overflows `execve`'s argument limit and the viewer crashloops on SciLifeLab Serve:

```
/docker-entrypoint.d/20-envsubst-on-templates.sh: line 53: envsubst: Argument list too long
```

Depictio resolves everything through DNS, so none of those variables are read.

- New chart value `enableServiceLinks`, default `false`, templated into **every** pod spec — mongo, redis, minio, backend, viewer, celery worker, and the `mongo-init` / `wipe` jobs — so the overflow can't bite another workload later. Overridable with `--set enableServiceLinks=true`.
- Chart version `20260730.1` → `20260804.1`; value documented in the chart README.
- The Percona `PerconaServerMongoDB` CR is untouched — the operator owns those pod specs.

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue

None — reported by Hamza while deploying to SciLifeLab Serve.

## How was this tested?

`helm lint` clean; `helm template` renders against all 8 values files; with the jobs forced on (`--set demo.autoWipeOnUpgrade=true --set mongo.replicas=3 --set mongo.useOperator=false`) all 8 pod specs emit `enableServiceLinks: false`. `pre-commit run --all-files` passes apart from pre-existing `shellcheck` findings in untouched scripts. Not deployed to a live cluster — the minikube job in `test-and-package-helm-chart.yaml` covers that on this PR.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [ ] Tests added/updated and passing — chart-only change, covered by the existing helm workflow
- [x] Docs updated if needed