### PR TITLE
chore: automate the weekly repo audit (milestone epics + report generator)

### DIFF
--- a/.github/workflows/epic-on-milestone.yaml
+++ b/.github/workflows/epic-on-milestone.yaml
@@ -1,0 +1,51 @@
+name: open epic on milestone creation
+
+# Every milestone in this repo is meant to have one "[Epic] <milestone title>"
+# issue driving it, but that's been a manual step maintainers forget half the
+# time (see #842/#844, which shipped with no milestone attached at all). This
+# closes the gap: the moment a milestone is created, its epic exists too.
+on:
+  milestone:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  open-epic:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Create epic issue for the new milestone
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const milestone = context.payload.milestone;
+            const title = `[Epic] ${milestone.title}`;
+
+            // Idempotent: re-running (e.g. a milestone edited/recreated) must not
+            // spawn a second epic for the same milestone.
+            const { data: search } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue label:epic milestone:"${milestone.title}"`,
+            });
+            if (search.items.length > 0) {
+              core.info(`Epic already exists for "${milestone.title}": #${search.items[0].number}`);
+              return;
+            }
+
+            const body = [
+              `Tracking epic for milestone [${milestone.title}](${milestone.html_url}).`,
+              "",
+              milestone.description || "_No milestone description yet — fill in scope here._",
+            ].join("\n");
+
+            const { data: issue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ["epic"],
+              milestone: milestone.number,
+              assignees: milestone.creator ? [milestone.creator.login] : [],
+            });
+
+            core.info(`Opened epic #${issue.number} for milestone #${milestone.number}`);

--- a/dev/repo_audit/.gitignore
+++ b/dev/repo_audit/.gitignore
@@ -1,0 +1,2 @@
+audit.html
+__pycache__/

--- a/dev/repo_audit/README.md
+++ b/dev/repo_audit/README.md
@@ -1,0 +1,51 @@
+# Weekly repo audit
+
+Generates the milestone/epic/backlog hygiene report published as a Claude artifact
+each week.
+
+The design lives in `template.html`, committed once. `build.py` only fills slots in
+it, so the page looks identical week to week and differences you see reflect the
+repo rather than whoever generated the report.
+
+## Running it
+
+```bash
+python3 dev/repo_audit/build.py            # -> dev/repo_audit/audit.html
+python3 dev/repo_audit/build.py --raw /tmp/raw.json   # also dump the gh payload
+```
+
+Needs an authenticated `gh` CLI. No Python dependencies beyond the standard library.
+
+## What is mechanical vs. written
+
+`build.py` computes everything on the page except the Notes section. Its checks:
+
+- closed milestones still holding open issues or PRs
+- open milestones with no `epic`-labelled issue attached
+- epics whose title claims a version number another milestone owns
+- open issues with no assignee
+- open issues with no milestone and no `backlog` label
+- PR bodies carrying a `closes`/`fixes`/`resolves` keyword
+
+Judgment calls go in `notes.md`, which is injected into its own slot. Keep it to
+plain paragraphs separated by blank lines; `#123` is auto-linked. Rewrite it each
+week, or empty it and the section renders "No commentary this week."
+
+Anything you find yourself writing into `notes.md` every single week is a sign it
+should become a check in `build.py` instead.
+
+## Weekly routine
+
+The scheduled agent should do roughly this:
+
+1. `python3 dev/repo_audit/build.py`
+2. Rewrite `notes.md` with anything the mechanical checks cannot see
+3. Re-run the build so the notes land in the page
+4. Publish `dev/repo_audit/audit.html` with the Artifact tool, passing the existing
+   artifact URL as `url` so it updates in place instead of minting a new one
+
+Step 4 matters: without `url`, each week creates an orphaned page and the version
+history is lost.
+
+`audit.html` is gitignored. It is regenerated on every run and committing it would
+add churn to unrelated diffs.

--- a/dev/repo_audit/build.py
+++ b/dev/repo_audit/build.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Build the weekly depictio repo-audit page.
+
+Fetches issues, PRs and milestones via the `gh` CLI, runs a fixed set of
+mechanical hygiene checks over them, and renders `template.html`.
+
+The point of this script is that the *styling never drifts*: the design lives
+in template.html, committed once, and every weekly run fills the same slots.
+Nothing here makes a judgment call — anything requiring one goes in notes.md,
+which gets injected into its own bounded slot.
+
+Usage:
+    python3 dev/repo_audit/build.py                 # -> dev/repo_audit/audit.html
+    python3 dev/repo_audit/build.py --raw raw.json  # also dump what gh returned
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).parent
+VERSION_RE = re.compile(r"v?(\d+)\.(\d+)\.(\d+)")
+CLOSES_RE = re.compile(r"\b(?:closes?|fixes?|resolves?)\s+#(\d+)", re.I)
+
+
+# --------------------------------------------------------------------------- #
+# fetch
+# --------------------------------------------------------------------------- #
+def gh_json(path: str) -> list:
+    """Call `gh api <path> --paginate` and return the parsed array.
+
+    --paginate concatenates pages as separate JSON arrays when the response is
+    an array, so we ask gh to merge them into one via --slurp.
+    """
+    proc = subprocess.run(
+        ["gh", "api", path, "--paginate", "--slurp"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"gh api {path} failed:\n{proc.stderr}")
+    pages = json.loads(proc.stdout)
+    return [item for page in pages for item in page]
+
+
+def fetch(repo: str) -> dict:
+    return {
+        "milestones": gh_json(f"repos/{repo}/milestones?state=all&per_page=100"),
+        # This endpoint returns issues *and* PRs, with bodies — one call covers both.
+        "items": gh_json(f"repos/{repo}/issues?state=open&per_page=100"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def version_key(title: str) -> tuple:
+    """Sort key from a leading version, ignoring any `v` prefix.
+
+    Titles without a version sort last rather than crashing the sort.
+    """
+    m = VERSION_RE.match(title.strip())
+    return (0, *map(int, m.groups())) if m else (1, 0, 0, 0)
+
+
+def version_of(title: str) -> str | None:
+    m = VERSION_RE.match(title.strip())
+    return ".".join(m.groups()) if m else None
+
+
+def is_pr(item: dict) -> bool:
+    return "pull_request" in item
+
+
+def labels_of(item: dict) -> list[str]:
+    return [lbl["name"] for lbl in item.get("labels") or []]
+
+
+def esc(text: str) -> str:
+    return html.escape(str(text), quote=True)
+
+
+def ref(repo: str, item: dict) -> str:
+    """A linked #number that lands on the right issue/pull URL."""
+    kind = "pull" if is_pr(item) else "issues"
+    return (
+        f'<a class="ref" href="https://github.com/{repo}/{kind}/{item["number"]}">'
+        f'#{item["number"]}</a>'
+    )
+
+
+# --------------------------------------------------------------------------- #
+# checks — every one of these is mechanical, no judgment
+# --------------------------------------------------------------------------- #
+def run_checks(repo: str, milestones: list, items: list) -> list[dict]:
+    by_ms: dict[int, list] = {}
+    for it in items:
+        if it.get("milestone"):
+            by_ms.setdefault(it["milestone"]["number"], []).append(it)
+
+    epics = [i for i in items if "epic" in labels_of(i) and not is_pr(i)]
+    open_ms = [m for m in milestones if m["state"] == "open"]
+    alerts: list[dict] = []
+
+    # A closed milestone still holding open work means the release was cut
+    # before its scope finished, or something was filed against it afterwards.
+    for m in milestones:
+        if m["state"] == "closed" and by_ms.get(m["number"]):
+            leftovers = " ".join(ref(repo, i) for i in by_ms[m["number"]])
+            alerts.append(
+                {
+                    "level": "bad",
+                    "title": f'Closed milestone "{esc(m["title"])}" still holds open work',
+                    "body": f"{leftovers} — move them to the next release or reopen the milestone.",
+                }
+            )
+
+    # The auto-epic workflow guarantees this for new milestones; older ones
+    # predate it and have to be caught here.
+    for m in open_ms:
+        if not any(
+            e.get("milestone") and e["milestone"]["number"] == m["number"] for e in epics
+        ):
+            alerts.append(
+                {
+                    "level": "warn",
+                    "title": f'Milestone "{esc(m["title"])}" has no epic',
+                    "body": "Every milestone should have one tracking epic.",
+                }
+            )
+
+    # An epic whose title claims a version that belongs to a *different*
+    # milestone is the drift that produced #842 and #844.
+    ms_by_version = {version_of(m["title"]): m for m in milestones if version_of(m["title"])}
+    for e in epics:
+        claimed = version_of(re.sub(r"^\[Epic\]\s*", "", e["title"]))
+        if not claimed:
+            continue
+        owner = ms_by_version.get(claimed)
+        if owner and (not e.get("milestone") or e["milestone"]["number"] != owner["number"]):
+            alerts.append(
+                {
+                    "level": "warn",
+                    "title": f'Epic {ref(repo, e)} claims version {claimed}, which belongs to "{esc(owner["title"])}"',
+                    "body": "Renumber the epic, or attach it to that milestone.",
+                }
+            )
+
+    unassigned = [i for i in items if not i.get("assignees") and not is_pr(i)]
+    if unassigned:
+        alerts.append(
+            {
+                "level": "warn",
+                "title": f"{len(unassigned)} open issue(s) with no assignee",
+                "body": " ".join(ref(repo, i) for i in unassigned),
+            }
+        )
+
+    # "Unscheduled" is only a meaningful query if it is labelled, not merely
+    # milestone-less.
+    unlabelled = [
+        i
+        for i in items
+        if not is_pr(i) and not i.get("milestone") and "backlog" not in labels_of(i)
+    ]
+    if unlabelled:
+        alerts.append(
+            {
+                "level": "warn",
+                "title": f"{len(unlabelled)} open issue(s) with no milestone and no backlog label",
+                "body": " ".join(ref(repo, i) for i in unlabelled),
+            }
+        )
+
+    if not alerts:
+        alerts.append(
+            {"level": "good", "title": "No hygiene issues found", "body": "Everything checks out."}
+        )
+    return alerts
+
+
+def confirmed_links(repo: str, items: list) -> list[str]:
+    """PR -> issue links GitHub will action on merge (closing keyword present)."""
+    rows = []
+    for it in sorted((i for i in items if is_pr(i)), key=lambda x: -x["number"]):
+        found = sorted({int(n) for n in CLOSES_RE.findall(it.get("body") or "")})
+        if found:
+            issues = " ".join(
+                f'<a class="ref" href="https://github.com/{repo}/issues/{n}">#{n}</a>'
+                for n in found
+            )
+            rows.append(
+                f"<tr><td>{ref(repo, it)}</td><td>{issues}</td>"
+                f'<td><span class="pill good">auto-closes on merge</span></td></tr>'
+            )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# render
+# --------------------------------------------------------------------------- #
+def render(repo: str, data: dict, notes_html: str) -> str:
+    milestones, items = data["milestones"], data["items"]
+    open_ms = sorted(
+        (m for m in milestones if m["state"] == "open"), key=lambda m: version_key(m["title"])
+    )
+    issues = [i for i in items if not is_pr(i)]
+    prs = [i for i in items if is_pr(i)]
+    backlog = [i for i in issues if "backlog" in labels_of(i)]
+
+    by_ms: dict[int, list] = {}
+    for it in items:
+        if it.get("milestone"):
+            by_ms.setdefault(it["milestone"]["number"], []).append(it)
+
+    stats = [
+        (len(open_ms), "Open milestones"),
+        (len(issues), "Open issues"),
+        (len(prs), "Open PRs"),
+        (len(backlog), "In backlog"),
+        (sum(len(by_ms.get(m["number"], [])) for m in open_ms), "Items scheduled"),
+    ]
+    stat_html = "".join(
+        f'<div class="stat"><div class="n">{n}</div><div class="l">{esc(label)}</div></div>'
+        for n, label in stats
+    )
+
+    alert_html = "".join(
+        f'<div class="callout {a["level"]}"><strong>{a["title"]}</strong>{a["body"]}</div>'
+        for a in run_checks(repo, milestones, items)
+    )
+
+    roadmap = []
+    for m in open_ms:
+        contents = by_ms.get(m["number"], [])
+        refs = " ".join(ref(repo, i) for i in sorted(contents, key=lambda x: -x["number"]))
+        roadmap.append(
+            f'<div class="rcard"><span class="rver">{esc(version_of(m["title"]) or "—")}'
+            f'<span class="n">#{m["number"]}</span></span><div>'
+            f'<div class="rtitle"><a href="{m["html_url"]}">{esc(m["title"])}</a></div>'
+            f'<div class="rmeta">{len(contents)} open · {refs or "nothing attached"}</div>'
+            f'</div></div>'
+        )
+
+    backlog_rows = "".join(
+        f"<tr><td>{ref(repo, i)}</td>"
+        f'<td>{esc(re.sub(r"^\[[A-Za-z]+\]\s*", "", i["title"]))}</td>'
+        f'<td>{esc(", ".join(n for n in labels_of(i) if n != "backlog"))}</td></tr>'
+        for i in sorted(backlog, key=lambda x: -x["number"])
+    )
+
+    link_rows = "".join(confirmed_links(repo, items)) or (
+        '<tr><td colspan="3">No PR declares a closing keyword.</td></tr>'
+    )
+
+    template = (HERE / "template.html").read_text()
+    slots = {
+        "REPO": esc(repo),
+        "GENERATED_AT": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        "STATS": stat_html,
+        "ALERTS": alert_html,
+        "ROADMAP": "".join(roadmap),
+        "BACKLOG_ROWS": backlog_rows,
+        "BACKLOG_COUNT": str(len(backlog)),
+        "LINK_ROWS": link_rows,
+        "NOTES": notes_html,
+    }
+    for key, value in slots.items():
+        template = template.replace("{{" + key + "}}", value)
+    return template
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default="depictio/depictio")
+    ap.add_argument("--out", type=Path, default=HERE / "audit.html")
+    ap.add_argument("--raw", type=Path, help="also dump the raw gh payload here")
+    ap.add_argument(
+        "--notes",
+        type=Path,
+        default=HERE / "notes.md",
+        help="optional commentary injected into the Notes slot",
+    )
+    args = ap.parse_args()
+
+    data = fetch(args.repo)
+    if args.raw:
+        args.raw.write_text(json.dumps(data, indent=2))
+
+    if args.notes.exists() and args.notes.read_text().strip():
+        # Deliberately minimal: paragraphs and links only. The template owns
+        # every other visual decision so a week's notes cannot restyle the page.
+        body = args.notes.read_text().strip()
+        body = re.sub(r"#(\d+)", rf'<a class="ref" href="https://github.com/{args.repo}/issues/\1">#\1</a>', body)
+        notes_html = "".join(f"<p>{line}</p>" for line in body.split("\n\n") if line.strip())
+    else:
+        notes_html = '<p class="empty">No commentary this week.</p>'
+
+    args.out.write_text(render(args.repo, data, notes_html))
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/repo_audit/notes.md
+++ b/dev/repo_audit/notes.md
@@ -1,0 +1,10 @@
+Milestone 1.4.0 is titled "Telemetry & backup backward-compatibility", but six of its
+items (#361, #360, #327, #278, #196, #89) are figure and interactive-filter UX with no
+connection to either theme. Those six are the scope of epic #842, which currently sits
+in the backlog. Either pull them out to join the epic, or widen the milestone title.
+
+Issue #383 (per-project storage configuration) sits in 1.7.0 but is neither versioning
+nor ingestion.
+
+The auto-epic workflow in .github/workflows/epic-on-milestone.yaml is not on main yet,
+so newly created milestones will not get an epic until it lands.

--- a/dev/repo_audit/template.html
+++ b/dev/repo_audit/template.html
@@ -1,0 +1,168 @@
+<title>depictio — Weekly Repo Audit</title>
+<style>
+  :root{
+    --bg:#f5f6f5; --surface:#ffffff; --surface-2:#eef1ef; --ink:#1a2321; --muted:#5c6a65;
+    --line:#dde3e0; --accent:#2c6e63; --accent-soft:#e2efec;
+    --good:#2f8f5b; --good-soft:#e5f4ec; --warn:#a9760b; --warn-soft:#faf1de;
+    --bad:#c1443c; --bad-soft:#fbe9e7;
+    --shadow:0 1px 2px rgba(20,30,26,.06),0 8px 24px -16px rgba(20,30,26,.18);
+    --code-bg:rgba(0,0,0,.06);
+  }
+  @media (prefers-color-scheme: dark){
+    :root{
+      --bg:#121614; --surface:#181e1b; --surface-2:#1f2622; --ink:#e7ece9; --muted:#93a29c;
+      --line:#2b332f; --accent:#5fb3a1; --accent-soft:#1c2b27;
+      --good:#5fbf8b; --good-soft:#173226; --warn:#d8a548; --warn-soft:#332a15;
+      --bad:#e08079; --bad-soft:#391f1e;
+      --shadow:0 1px 2px rgba(0,0,0,.3),0 12px 32px -16px rgba(0,0,0,.5);
+      --code-bg:rgba(255,255,255,.08);
+    }
+  }
+  :root[data-theme="dark"]{
+    --bg:#121614; --surface:#181e1b; --surface-2:#1f2622; --ink:#e7ece9; --muted:#93a29c;
+    --line:#2b332f; --accent:#5fb3a1; --accent-soft:#1c2b27;
+    --good:#5fbf8b; --good-soft:#173226; --warn:#d8a548; --warn-soft:#332a15;
+    --bad:#e08079; --bad-soft:#391f1e;
+    --shadow:0 1px 2px rgba(0,0,0,.3),0 12px 32px -16px rgba(0,0,0,.5);
+    --code-bg:rgba(255,255,255,.08);
+  }
+  :root[data-theme="light"]{
+    --bg:#f5f6f5; --surface:#ffffff; --surface-2:#eef1ef; --ink:#1a2321; --muted:#5c6a65;
+    --line:#dde3e0; --accent:#2c6e63; --accent-soft:#e2efec;
+    --good:#2f8f5b; --good-soft:#e5f4ec; --warn:#a9760b; --warn-soft:#faf1de;
+    --bad:#c1443c; --bad-soft:#fbe9e7;
+    --shadow:0 1px 2px rgba(20,30,26,.06),0 8px 24px -16px rgba(20,30,26,.18);
+    --code-bg:rgba(0,0,0,.06);
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0; background:var(--bg); color:var(--ink);
+    font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    line-height:1.5; -webkit-font-smoothing:antialiased;
+  }
+  code,.mono{font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace; font-variant-numeric:tabular-nums;}
+  main{max-width:960px; margin:0 auto; padding:2.5rem 1.5rem 5rem;}
+  .eyebrow{
+    display:inline-block; font-size:.72rem; letter-spacing:.09em; text-transform:uppercase;
+    color:var(--accent); font-weight:700; margin-bottom:.6rem;
+  }
+  h1{font-size:1.9rem; margin:0 0 .35rem; letter-spacing:-.01em; text-wrap:balance;}
+  .sub{color:var(--muted); font-size:.95rem; max-width:64ch;}
+  h2{font-size:1.15rem; margin:0 0 .2rem; letter-spacing:-.005em;}
+  .section-head{margin:2.6rem 0 1rem;}
+  .section-head p{margin:.15rem 0 0; color:var(--muted); font-size:.88rem; max-width:62ch;}
+
+  .stats{display:grid; grid-template-columns:repeat(auto-fit,minmax(130px,1fr)); gap:.7rem; margin-top:1.4rem;}
+  .stat{background:var(--surface); border:1px solid var(--line); border-radius:10px; padding:.85rem 1rem; box-shadow:var(--shadow);}
+  .stat .n{font-size:1.5rem; font-weight:700; font-family:ui-monospace,monospace;}
+  .stat .l{font-size:.74rem; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; margin-top:.15rem;}
+
+  table{width:100%; border-collapse:collapse; font-size:.87rem;}
+  .twrap{overflow-x:auto; border:1px solid var(--line); border-radius:10px; background:var(--surface); box-shadow:var(--shadow);}
+  th,td{padding:.55rem .75rem; text-align:left; border-bottom:1px solid var(--line); vertical-align:top;}
+  th{font-size:.72rem; text-transform:uppercase; letter-spacing:.05em; color:var(--muted); background:var(--surface-2); font-weight:600;}
+  tr:last-child td{border-bottom:none;}
+
+  a{color:var(--accent);}
+  a.ref{
+    font-family:ui-monospace,monospace; color:var(--accent); text-decoration:none;
+    white-space:nowrap; border-bottom:1px solid transparent; margin-right:.35em;
+  }
+  a.ref:hover{border-bottom-color:var(--accent);}
+  a.ref:focus-visible{outline:2px solid var(--accent); outline-offset:2px; border-radius:2px;}
+
+  .pill{display:inline-flex; align-items:center; padding:.15em .6em; border-radius:99px; font-size:.72rem; font-weight:600; white-space:nowrap;}
+  .pill.good{background:var(--good-soft); color:var(--good);}
+
+  .callout{
+    border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--accent-soft);
+    border-radius:8px; padding:.9rem 1.1rem; font-size:.88rem; margin-bottom:.6rem;
+  }
+  .callout strong{display:block; margin-bottom:.25rem;}
+  .callout.warn{border-left-color:var(--warn); background:var(--warn-soft);}
+  .callout.bad{border-left-color:var(--bad); background:var(--bad-soft);}
+  .callout.good{border-left-color:var(--good); background:var(--good-soft);}
+  .callout code{background:var(--code-bg); padding:.05em .35em; border-radius:4px;}
+
+  .roadmap{display:grid; gap:.6rem; margin-top:1.4rem;}
+  .rcard{
+    background:var(--surface); border:1px solid var(--line); border-radius:10px; padding:.9rem 1.1rem;
+    box-shadow:var(--shadow); display:grid; grid-template-columns:5.5rem 1fr; gap:1rem; align-items:center;
+  }
+  .rver{font-family:ui-monospace,monospace; font-weight:700; font-size:.95rem; color:var(--accent);}
+  .rver .n{display:block; font-size:.68rem; color:var(--muted); font-weight:500; margin-top:.1rem;}
+  .rtitle{font-weight:600; font-size:.92rem;}
+  .rtitle a{text-decoration:none;}
+  .rtitle a:hover{text-decoration:underline;}
+  .rmeta{font-size:.78rem; color:var(--muted); margin-top:.25rem; line-height:1.7;}
+
+  .notes{background:var(--surface); border:1px solid var(--line); border-radius:10px; padding:.4rem 1.1rem; box-shadow:var(--shadow);}
+  .notes p{font-size:.88rem;}
+  .notes .empty{color:var(--muted); font-style:italic;}
+
+  footer{margin-top:3rem; padding-top:1.2rem; border-top:1px solid var(--line); font-size:.78rem; color:var(--muted);}
+</style>
+
+<main>
+  <header>
+    <span class="eyebrow">Weekly audit · {{REPO}}</span>
+    <h1>Repo Audit</h1>
+    <p class="sub">Generated {{GENERATED_AT}} by <code>dev/repo_audit/build.py</code>. Every figure below is computed from the GitHub API, so week-to-week differences reflect the repo, not the report.</p>
+  </header>
+
+  <div class="stats">{{STATS}}</div>
+
+  <section>
+    <div class="section-head">
+      <h2>Hygiene checks</h2>
+      <p>Mechanical checks only: closed milestones holding open work, milestones missing an epic, epics whose title claims a version another milestone owns, unassigned issues, and unscheduled issues missing the <code>backlog</code> label.</p>
+    </div>
+    {{ALERTS}}
+  </section>
+
+  <section>
+    <div class="section-head">
+      <h2>Active roadmap</h2>
+      <p>Open milestones only, sorted by version number regardless of any <code>v</code> prefix.</p>
+    </div>
+    <div class="roadmap">{{ROADMAP}}</div>
+  </section>
+
+  <section>
+    <div class="section-head">
+      <h2>Notes</h2>
+      <p>Written by hand into <code>dev/repo_audit/notes.md</code>. The only part of this page not derived mechanically.</p>
+    </div>
+    <div class="notes">{{NOTES}}</div>
+  </section>
+
+  <section>
+    <div class="section-head">
+      <h2>Confirmed issue ↔ PR links</h2>
+      <p>PRs whose body carries a <code>closes</code>/<code>fixes</code>/<code>resolves</code> keyword, so merging closes the issue automatically. Anything not listed needs the keyword added by hand.</p>
+    </div>
+    <div class="twrap">
+      <table>
+        <thead><tr><th>PR</th><th>Closes</th><th>Status</th></tr></thead>
+        <tbody>{{LINK_ROWS}}</tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="section-head">
+      <h2>Backlog ({{BACKLOG_COUNT}})</h2>
+      <p>Open issues labelled <code>backlog</code>: no milestone, not scheduled for a release.</p>
+    </div>
+    <div class="twrap">
+      <table>
+        <thead><tr><th>Issue</th><th>Title</th><th>Labels</th></tr></thead>
+        <tbody>{{BACKLOG_ROWS}}</tbody>
+      </table>
+    </div>
+  </section>
+
+  <footer>
+    Covers open issues, open PRs and all milestones. Closed history is not walked: it needs no scheduling and would only grow the page each week.
+  </footer>
+</main>


### PR DESCRIPTION
Two related pieces of repo-hygiene automation, from a milestone/epic audit that
turned up several drifted milestones.

## `ci: auto-open an epic issue when a milestone is created`

Every milestone here is meant to have one `[Epic] <title>` issue driving it, but
that was a manual step and it got skipped often enough to cause real drift: epics
#842 and #844 both ended up with version numbers in their titles that other
milestones already owned, and no milestone attached to either.

The workflow triggers on `milestone.created`, and opens a matching epic labelled
`epic`, attached to the new milestone, linking back to it, assigned to whoever
created the milestone. It searches for an existing epic first, so editing or
recreating a milestone will not spawn a duplicate.

## `chore(dev): add weekly repo-audit report generator`

`dev/repo_audit/` renders the milestone/epic/backlog hygiene report that gets
published weekly.

The design lives in `template.html`, committed once. `build.py` only fills slots
in it, so week-to-week differences in the report reflect the repo rather than
whoever generated it.

Checks computed from the GitHub API:

- closed milestones still holding open issues or PRs
- open milestones with no `epic`-labelled issue attached
- epics whose title claims a version number another milestone owns
- open issues with no assignee
- open issues with no milestone and no `backlog` label
- PR bodies carrying a `closes`/`fixes`/`resolves` keyword

Anything needing judgment goes in `notes.md`, injected into its own bounded slot
so it cannot restyle the page. `audit.html` is gitignored, since it is regenerated
on every run.

Stdlib only, needs an authenticated `gh` CLI. Run with:

```bash
python3 dev/repo_audit/build.py
```

## Testing

Checks were exercised against synthetic data covering every branch; all six fire
correctly. Version sorting ignores a leading `v` and compares numerically, so
`v0.9.0 < 1.3.2 < v1.3.10 < 1.10.0`. Against the current repo the report comes
back clean, which matches the state after this audit's fixes.