### PR TITLE
fix(telemetry): stop CI inflating the install count, and count CLI installs

### DIFF
--- a/depictio/cli/cli/utils/telemetry.py
+++ b/depictio/cli/cli/utils/telemetry.py
@@ -35,11 +35,18 @@ from depictio.telemetry.constants import (
 )
 from depictio.telemetry.env import detect_ci, detect_deployment_kind, platform_info
 from depictio.telemetry.gates import telemetry_allowed
-from depictio.telemetry.schema import EVENT_CLI_COMMAND, CliCommandProperties
+from depictio.telemetry.schema import (
+    EVENT_CLI_COMMAND,
+    EVENT_CLI_INSTALL,
+    CliCommandProperties,
+    CliInstallProperties,
+)
 from depictio.telemetry.state import (
     first_run_notice_shown,
     get_or_create_anonymous_id,
+    install_reported,
     mark_first_run_notice_shown,
+    mark_install_reported,
 )
 
 #: Opt-out, matching the server's variable name.
@@ -197,6 +204,56 @@ def build_properties(command: str, *, succeeded: bool, duration_seconds: float) 
         id_ephemeral=anon.ephemeral,
     )
     return properties.model_dump(mode="json")
+
+
+def maybe_send_install_event() -> None:
+    """Report this machine once, the first time the CLI runs. Never raises.
+
+    The counterpart of the server's ``server_install``. Sent from the same exit
+    path as the command event so a first run pays one round trip rather than two,
+    and so the notice is never delayed behind a network call.
+
+    Not gated on a terminal, unlike the first-run notice: a CLI first invoked from
+    a script is still an installation, even though there is nobody there to read a
+    disclosure. The flag is written only once the collector has accepted the
+    event, so a first run behind a firewall reports on the next run instead of
+    being lost.
+    """
+    try:
+        if suppression_reason() is not None:
+            return
+        if install_reported():
+            return
+
+        from depictio.telemetry.posthog import capture
+
+        anon = get_or_create_anonymous_id()
+        if anon.ephemeral:
+            # Nothing would remember that this was sent, so every later run would
+            # report another install from the same machine.
+            return
+
+        platform = platform_info()
+        properties = CliInstallProperties(
+            depictio_version=cli_version(),
+            deployment_kind=detect_deployment_kind(),
+            os=platform["os"],
+            arch=platform["arch"],
+            python_version=platform["python_version"],
+            is_ci=detect_ci(),
+        )
+        accepted = capture(
+            EVENT_CLI_INSTALL,
+            anon.value,
+            properties.model_dump(mode="json"),
+            api_key=os.getenv(API_KEY_ENV) or _DEFAULT_API_KEY,
+            endpoint=os.getenv(ENDPOINT_ENV) or DEFAULT_ENDPOINT,
+            timeout=CLI_TIMEOUT_SECONDS,
+        )
+        if accepted:
+            mark_install_reported()
+    except Exception as exc:
+        logger.debug(f"CLI telemetry install event failed: {exc}")
 
 
 def send_command_event(command: str, *, succeeded: bool, duration_seconds: float) -> None:

--- a/depictio/cli/depictio_cli.py
+++ b/depictio/cli/depictio_cli.py
@@ -198,6 +198,7 @@ def main():
     from depictio.cli.cli.utils.telemetry import (
         CommandTimer,
         maybe_print_first_run_notice,
+        maybe_send_install_event,
         resolve_command_path,
         send_command_event,
     )
@@ -232,4 +233,5 @@ def main():
         if not interrupted:
             # Fire-and-forget on the way out, under a 2s cap. A collector that is
             # slow or gone delays the shell prompt slightly, nothing more.
+            maybe_send_install_event()
             send_command_event(command, succeeded=succeeded, duration_seconds=timer.elapsed())

--- a/depictio/telemetry/posthog.py
+++ b/depictio/telemetry/posthog.py
@@ -72,6 +72,17 @@ def build_body(
     }
 
 
+def _headers() -> dict[str, str]:
+    """Headers for a capture request.
+
+    An explicit User-Agent because httpx's default (``python-httpx/x.y.z``) is
+    classified as bot traffic by PostHog, which flags every Depictio event as
+    ``Automation`` and hides it from any query that filters bots out. Data that is
+    ingested but invisible is indistinguishable from data that never arrived.
+    """
+    return {"User-Agent": "depictio-telemetry"}
+
+
 def _log_outcome(event: str, response_status: int | None, error: Exception | None) -> bool:
     """Log the result of a send at debug level and report success."""
     if error is not None:
@@ -104,7 +115,7 @@ def capture(
     body = build_body(event, distinct_id, properties, api_key=api_key)
     try:
         with httpx.Client(timeout=timeout) as client:
-            response = client.post(endpoint, json=body)
+            response = client.post(endpoint, json=body, headers=_headers())
         return _log_outcome(event, response.status_code, None)
     except Exception as exc:
         return _log_outcome(event, None, exc)
@@ -136,7 +147,7 @@ async def acapture(
     async with httpx.AsyncClient(timeout=timeout) as client:
         for attempt in range(retries + 1):
             try:
-                response = await client.post(endpoint, json=body)
+                response = await client.post(endpoint, json=body, headers=_headers())
                 last_status = response.status_code
                 if response.status_code < 400:
                     return _log_outcome(event, response.status_code, None)

--- a/depictio/telemetry/schema.py
+++ b/depictio/telemetry/schema.py
@@ -21,9 +21,15 @@ from pydantic import BaseModel, ConfigDict, Field
 #: call sites and in the collector's own dashboards.
 EVENT_INSTALL: Final[str] = "server_install"
 EVENT_HEARTBEAT: Final[str] = "server_heartbeat"
+EVENT_CLI_INSTALL: Final[str] = "cli_install"
 EVENT_CLI_COMMAND: Final[str] = "cli_command"
 
-ALL_EVENTS: Final[tuple[str, ...]] = (EVENT_INSTALL, EVENT_HEARTBEAT, EVENT_CLI_COMMAND)
+ALL_EVENTS: Final[tuple[str, ...]] = (
+    EVENT_INSTALL,
+    EVENT_HEARTBEAT,
+    EVENT_CLI_INSTALL,
+    EVENT_CLI_COMMAND,
+)
 
 
 class _StrictBase(BaseModel):
@@ -181,6 +187,27 @@ class ServerHeartbeatProperties(CommonProperties):
         description=(
             "Distinct `depictio-cli` versions that talked to this instance recently, "
             "read from the CLI's request headers. Versions only — no host or user."
+        ),
+    )
+
+
+class CliInstallProperties(CommonProperties):
+    """Payload for `cli_install`, emitted once per machine that runs the CLI.
+
+    The counterpart of `server_install`. Without it the CLI reports usage but
+    never installs, so the only way to count `depictio-cli` deployments is PyPI
+    downloads, which conflate CI runs, mirrors and re-installs.
+
+    "Install" here means the first run on a machine, not the `pip install`: a
+    package sitting unused in an environment is not a deployment, and nothing in
+    a wheel executes at install time anyway.
+    """
+
+    is_ci: bool = Field(
+        description=(
+            "Whether an automated environment was detected. Always false in practice, "
+            "since CI suppresses the send entirely; retained so the collector can "
+            "prove that."
         ),
     )
 

--- a/depictio/telemetry/state.py
+++ b/depictio/telemetry/state.py
@@ -49,6 +49,14 @@ _ID_KEY: Final[str] = "anonymous_id"
 #: exactly the users whose first contact with the CLI was automated.
 _NOTICE_KEY: Final[str] = "notice_shown"
 
+#: Key recording that the one-off ``cli_install`` event has been accepted.
+#:
+#: Written only after the collector takes the event, so a first run without
+#: network reports the install on the next run instead of losing it. Persisted
+#: rather than inferred from "the ID was created in this process", because the ID
+#: is created on the first run whether or not the send succeeds.
+_INSTALL_KEY: Final[str] = "install_reported"
+
 
 class AnonymousId(NamedTuple):
     """An anonymous CLI ID plus whether it survived to disk."""
@@ -156,6 +164,27 @@ def mark_first_run_notice_shown() -> None:
         _write_state(state_path(), {_NOTICE_KEY: True})
     except (OSError, RuntimeError) as exc:
         logger.debug("Could not record the telemetry notice as shown: %s", exc)
+
+
+def install_reported() -> bool:
+    """Whether this machine has already reported ``cli_install``.
+
+    True on any failure to find out, which is the direction that cannot corrupt
+    the metric: a missed install undercounts by one, a repeated one manufactures
+    installations that do not exist.
+    """
+    try:
+        return _read_state(state_path()).get(_INSTALL_KEY) is True
+    except (OSError, RuntimeError):
+        return True
+
+
+def mark_install_reported() -> None:
+    """Record that the install event was accepted by the collector. Never raises."""
+    try:
+        _write_state(state_path(), {_INSTALL_KEY: True})
+    except (OSError, RuntimeError) as exc:
+        logger.debug("Could not record the telemetry install as reported: %s", exc)
 
 
 def get_or_create_anonymous_id() -> AnonymousId:

--- a/depictio/tests/cli/utils/test_telemetry.py
+++ b/depictio/tests/cli/utils/test_telemetry.py
@@ -289,6 +289,84 @@ class TestFirstRunNotice:
             notice()
 
 
+class TestCliInstallEvent:
+    """The CLI counterpart of `server_install`.
+
+    Without it the CLI reports usage but never installs, leaving PyPI download
+    counts as the only way to count `depictio-cli` deployments — a number that
+    conflates CI runs, mirrors and re-installs.
+    """
+
+    @pytest.fixture
+    def send(self, monkeypatch, tmp_path):
+        """Run the install event against an empty state dir, return the send mock."""
+        from depictio.cli.cli.utils import telemetry as cli_telemetry
+
+        monkeypatch.setenv("DEPICTIO_TELEMETRY_STATE_DIR", str(tmp_path))
+
+        def run(*, accepted: bool = True):
+            with patch("depictio.telemetry.posthog.capture", return_value=accepted) as capture:
+                cli_telemetry.maybe_send_install_event()
+            return capture
+
+        return run
+
+    def test_reported_once_per_machine(self, send, allow_telemetry):
+        first = send()
+        assert first.call_count == 1
+        assert first.call_args.args[0] == "cli_install"
+
+        assert send().call_count == 0, "a second install from one machine is a phantom install"
+
+    def test_a_refused_send_is_retried_on_the_next_run(self, send, allow_telemetry):
+        """A first run behind a firewall must not cost the install permanently.
+
+        The flag is written only once the collector has taken the event, so an
+        offline first run reports later rather than never. This is the opposite
+        trade-off from the notice, which is marked shown even though nothing was
+        sent: a missed disclosure cannot be recovered, a missed count can.
+        """
+        assert send(accepted=False).call_count == 1
+        assert send().call_count == 1
+
+    def test_silent_when_telemetry_is_suppressed(self, send, monkeypatch):
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        assert send().call_count == 0
+
+    def test_reported_from_a_script_even_though_the_notice_is_not(
+        self, send, allow_telemetry, monkeypatch
+    ):
+        """An install is an install whether or not anyone is watching the terminal.
+
+        The first-run notice is gated on a TTY because there is nobody to read it
+        otherwise. Applying the same gate here would drop every installation whose
+        first contact with the CLI was a script, which is most of them on a
+        cluster.
+        """
+        monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+        assert send().call_count == 1
+
+    def test_not_reported_when_the_id_cannot_be_persisted(self, send, allow_telemetry):
+        """An ID that does not survive the process would report a new install each run."""
+        from depictio.cli.cli.utils import telemetry as cli_telemetry
+        from depictio.telemetry.state import AnonymousId
+
+        with patch.object(
+            cli_telemetry,
+            "get_or_create_anonymous_id",
+            return_value=AnonymousId(value="abc", ephemeral=True),
+        ):
+            assert send().call_count == 0
+
+    def test_never_raises(self, send, allow_telemetry):
+        from depictio.cli.cli.utils import telemetry as cli_telemetry
+
+        with patch.object(
+            cli_telemetry, "get_or_create_anonymous_id", side_effect=RuntimeError("boom")
+        ):
+            send()
+
+
 class TestCliVersion:
     def test_returns_a_string(self):
         assert isinstance(cli_version(), str)

--- a/depictio/tests/unit/test_telemetry_core.py
+++ b/depictio/tests/unit/test_telemetry_core.py
@@ -8,7 +8,7 @@ not a flaky test.
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -342,6 +342,39 @@ class TestPostHogBody:
         rendered = render_for_debug(build_body("e", "d", {}, api_key="phc_super_secret"))
         assert "phc_super_secret" not in rendered
         assert "<redacted>" in rendered
+
+
+class TestCaptureIdentifiesItself:
+    """Every send must carry a User-Agent that is not httpx's default.
+
+    PostHog classifies ``python-httpx/x.y.z`` as bot traffic. Every event Depictio
+    sent before this was flagged ``Automation``, which hides it from any query
+    that filters bots out — data that is ingested but invisible is
+    indistinguishable from data that never arrived.
+    """
+
+    def _sent_headers(self, sender):
+        client = MagicMock()
+        client.__enter__ = Mock(return_value=client)
+        client.__exit__ = Mock(return_value=False)
+        client.post.return_value = Mock(status_code=200)
+
+        with patch("depictio.telemetry.posthog.httpx.Client", return_value=client):
+            sender()
+        return client.post.call_args.kwargs["headers"]
+
+    def test_capture_sets_an_explicit_user_agent(self):
+        from depictio.telemetry.posthog import capture
+
+        headers = self._sent_headers(lambda: capture("e", "d", {}, api_key="phc_test"))
+        assert "httpx" not in headers["User-Agent"].lower()
+        assert "depictio" in headers["User-Agent"].lower()
+
+    def test_the_async_sender_agrees_with_the_sync_one(self):
+        """The server uses acapture; a header on only one path fixes only one channel."""
+        from depictio.telemetry.posthog import _headers
+
+        assert _headers()["User-Agent"] == "depictio-telemetry"
 
 
 class TestDocsStayInSyncWithTheSchema:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,14 @@ services:
       # look identical from the inside.
       DEPICTIO_TELEMETRY_ENABLED: "${DEPICTIO_TELEMETRY_ENABLED:-true}"
       DEPICTIO_TELEMETRY_DEPLOYMENT_KIND: "${DEPICTIO_TELEMETRY_DEPLOYMENT_KIND:-docker-compose}"
+      # Forwarded so the automatic CI suppression works through the container
+      # boundary. These are set on the machine running Compose, not inside the
+      # container, so without this a pipeline that brings Depictio up on every
+      # commit reports each run as a separate installation. Empty when unset,
+      # which detect_ci() reads as "not CI".
+      CI: "${CI:-}"
+      GITHUB_ACTIONS: "${GITHUB_ACTIONS:-}"
+      GITLAB_CI: "${GITLAB_CI:-}"
     command: ["/app/run_fastapi.sh"]
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8058/health > /dev/null"]

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -24,12 +24,13 @@ or know which versions still need support.
 
 ## What is sent
 
-Three events. Nothing else.
+Four events. Nothing else.
 
 | Event | When |
 | --- | --- |
 | `server_install` | Once per installation, ever. |
 | `server_heartbeat` | At most once per UTC day per installation — regardless of how many workers or replicas are running. |
+| `cli_install` | Once per machine that runs `depictio-cli`, ever. |
 | `cli_command` | Once per `depictio-cli` invocation. |
 
 Each event is identified by a random **installation ID** (server) or a random
@@ -117,6 +118,20 @@ than being sent as-is — see `depictio/telemetry/k8s_resources.py`.
 | `cpu_limit_millicores` | int, optional | Configured CPU limit, in millicores. |
 | `memory_request_mib` | int, optional | Configured memory request, in MiB. |
 | `memory_limit_mib` | int, optional | Configured memory limit, in MiB. |
+
+### `cli_install`
+
+Sent the first time the CLI runs on a machine, and never again. "Install" means
+that first run, not the `pip install`: nothing in a wheel executes at install
+time, and a package sitting unused in an environment is not a deployment.
+
+Unlike the first-run notice, this is not conditional on a terminal. A CLI first
+invoked from a job script is still an installation, and on a cluster that is the
+common case.
+
+| Field | Type | What it is |
+| --- | --- | --- |
+| `is_ci` | boolean | Whether an automated environment was detected. Always false in practice, since CI suppresses the send entirely; retained so the collector can prove that. |
 
 ### `cli_command`
 

--- a/helm-charts/depictio/values-gh-actions.yaml
+++ b/helm-charts/depictio/values-gh-actions.yaml
@@ -46,6 +46,16 @@ backend:
   env:
     DEPICTIO_LOGGING_VERBOSITY_LEVEL: "DEBUG"
     DEPICTIO_AUTH_SINGLE_USER_MODE: "true"
+    # This chart is installed into a throwaway minikube on every chart-touching
+    # run, with a fresh MongoDB each time. Left enabled it mints a new anonymous
+    # identity per run and reports a brand new installation, which is how the
+    # first four "installations" the project ever recorded came to be its own CI.
+    #
+    # The automatic CI suppression in depictio/telemetry/gates.py cannot catch
+    # this: it reads CI and GITHUB_ACTIONS from the environment, and those exist
+    # on the runner, not inside the pod. A container orchestrated by CI has to be
+    # told, so this file tells it.
+    DEPICTIO_TELEMETRY_ENABLED: "false"
 
 viewer:
   resources:

--- a/scripts/gen_telemetry_docs.py
+++ b/scripts/gen_telemetry_docs.py
@@ -28,9 +28,11 @@ from depictio.telemetry.buckets import LABELS  # noqa: E402
 from depictio.telemetry.constants import DEFAULT_ENDPOINT  # noqa: E402
 from depictio.telemetry.schema import (  # noqa: E402
     EVENT_CLI_COMMAND,
+    EVENT_CLI_INSTALL,
     EVENT_HEARTBEAT,
     EVENT_INSTALL,
     CliCommandProperties,
+    CliInstallProperties,
     CommonProperties,
     FeatureFlags,
     KubernetesResources,
@@ -119,12 +121,13 @@ or know which versions still need support.
 
 ## What is sent
 
-Three events. Nothing else.
+Four events. Nothing else.
 
 | Event | When |
 | --- | --- |
 | `{EVENT_INSTALL}` | Once per installation, ever. |
 | `{EVENT_HEARTBEAT}` | At most once per UTC day per installation — regardless of how many workers or replicas are running. |
+| `{EVENT_CLI_INSTALL}` | Once per machine that runs `depictio-cli`, ever. |
 | `{EVENT_CLI_COMMAND}` | Once per `depictio-cli` invocation. |
 
 Each event is identified by a random **installation ID** (server) or a random
@@ -169,6 +172,18 @@ reflected until the next Helm upgrade. A malformed value degrades to absent rath
 than being sent as-is — see `depictio/telemetry/k8s_resources.py`.
 
 {_field_table(KubernetesResources)}
+
+### `{EVENT_CLI_INSTALL}`
+
+Sent the first time the CLI runs on a machine, and never again. "Install" means
+that first run, not the `pip install`: nothing in a wheel executes at install
+time, and a package sitting unused in an environment is not a deployment.
+
+Unlike the first-run notice, this is not conditional on a terminal. A CLI first
+invoked from a job script is still an installation, and on a cluster that is the
+common case.
+
+{_field_table(CliInstallProperties, skip=common_fields)}
 
 ### `{EVENT_CLI_COMMAND}`
 

--- a/scripts/telemetry_cli_check.py
+++ b/scripts/telemetry_cli_check.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
@@ -31,6 +32,13 @@ os.environ.pop("DO_NOT_TRACK", None)
 os.environ.pop("PYTEST_CURRENT_TEST", None)
 for _ci_var in ("CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS", "GITLAB_CI"):
     os.environ.pop(_ci_var, None)
+
+# A throwaway state directory, so the run neither reads nor writes the developer's
+# real ``~/.depictio/telemetry.json``. Without this the script mutates the machine
+# it is run on, and the once-per-machine events (``cli_install``) fire on the first
+# run and never again, which makes the checks below pass or fail depending on
+# whether anyone has run the script here before.
+os.environ["DEPICTIO_TELEMETRY_STATE_DIR"] = tempfile.mkdtemp(prefix="depictio-cli-check-")
 
 RECEIVED: list[dict[str, Any]] = []
 
@@ -130,14 +138,28 @@ def main() -> int:
         ("misspelled sub-command", ["config", "shwo-nonsense", CANARIES[3]], "config"),
     ]
 
-    for label, argv, expected_command in invocations:
+    for index, (label, argv, expected_command) in enumerate(invocations):
         before = len(RECEIVED)
         run_cli(argv)
         sent = RECEIVED[before:]
-        if not check(f"{label}: emitted exactly one event", len(sent) == 1, f"got {len(sent)}"):
+        # The very first invocation on a fresh state directory also reports the
+        # one-off `cli_install`. Counted separately below rather than tolerated
+        # here, so "one command, one command event" stays an exact assertion.
+        commands = [event for event in sent if event.get("event") == "cli_command"]
+        installs = [event for event in sent if event.get("event") == "cli_install"]
+
+        expected_installs = 1 if index == 0 else 0
+        failures += not check(
+            f"{label}: emitted {expected_installs} install event(s)",
+            len(installs) == expected_installs,
+            f"got {len(installs)}",
+        )
+        if not check(
+            f"{label}: emitted exactly one command event", len(commands) == 1, f"got {len(commands)}"
+        ):
             failures += 1
             continue
-        actual = sent[0].get("properties", {}).get("command")
+        actual = commands[0].get("properties", {}).get("command")
         failures += not check(
             f"{label}: command == {expected_command!r}", actual == expected_command, repr(actual)
         )


### PR DESCRIPTION
## Summary

Telemetry shipped in v1.5.0 (#916). Within hours the collector held four `server_install` events, and all four were this repository's own CI. Four fixes.

**1. Our CI reported itself as an installation.** `test-and-package-helm-chart.yaml` installs the chart into a throwaway minikube with a fresh MongoDB on every chart-touching run, so each run minted a new identity and reported a new deployment. The automatic suppression could not catch it: `detect_ci()` reads `CI` / `GITHUB_ACTIONS`, which exist on the runner, not inside the pod. The chart's CI values now disable telemetry explicitly, and Compose forwards those variables into the container so a *user's* pipeline is suppressed by the mechanism `gates.py` already claims does it.

**2. Every event was filed as bot traffic.** No headers on the capture POST meant httpx's default User-Agent, which PostHog classifies as a bot. Events were ingested but hidden from any query filtering bots out, while the send reported success.

**3. The CLI counted usage but never installations.** `server_install` had no CLI counterpart, leaving PyPI downloads as the only proxy. `cli_install` now fires once per machine. Unlike the first-run notice next to it, it is not gated on a terminal (a scripted first run is still an install) and its flag is written only once the collector accepts, so an offline first run reports later rather than never.

**4. `telemetry_cli_check.py` used the real `~/.depictio`**, so it mutated the machine it ran on and passed or failed depending on whether it had run there before. It now uses a throwaway state directory.

### One note for reading the existing data

The server payload has no `is_ci` property, so the four recorded events cannot be filtered out by any property. What works without code: a CI deployment lives minutes and never reports a heartbeat on a second UTC day, so counting installs seen on two or more distinct days separates them.

## Type of change
- [x] Bug fix
- [x] Feature

## Related issue

Follow-up to #916. Does not close #959 or #960.

## How was this tested?

- 184 telemetry tests, up from 176: a refused `cli_install` retries on the next run, an accepted one does not, a non-interactive run still reports, an ephemeral ID reports nothing, both senders set a User-Agent.
- End to end against a loopback collector driving the real CLI: first run emits `cli_install` then `cli_command`, second emits `cli_command` alone.
- Full suite 2209 passed, 15 skipped (3 errors are `MinioContainer` tests needing Docker). `ruff`, `ty`, and `gen_telemetry_docs.py --check` clean.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [x] Docs updated if needed (`docs/telemetry.md` regenerated from the schema)
