### PR TITLE
Add SAML SSO (EMBL Keycloak) and fix OAuth state store for multi-worker deployments

### DIFF
--- a/.github/workflows/minimal-deploy.yaml
+++ b/.github/workflows/minimal-deploy.yaml
@@ -323,4 +323,3 @@ jobs:
           depictio-cli config check \
             --project-config-path ../projects/init/iris/project.yaml \
             --CLI-config-path admin_config.yaml
-

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -2,7 +2,14 @@ import os
 from pathlib import Path
 from typing import Any, Literal, Optional
 
-from pydantic import AliasChoices, Field, SecretStr, computed_field, model_validator
+from pydantic import (
+    AliasChoices,
+    Field,
+    SecretStr,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Import kept to the dependency-free constants module on purpose — this file is
@@ -331,6 +338,65 @@ class AuthConfig(BaseSettings):
     google_oauth_redirect_uri: Optional[str] = Field(
         default=None, description="Google OAuth redirect URI"
     )
+
+    # SAML SSO (SP-initiated, python3-saml). Designed for the EMBL Keycloak
+    # IdP but provider-agnostic.
+    saml_enabled: bool = Field(default=False, description="Enable SAML SSO authentication")
+    saml_idp_entity_id: Optional[str] = Field(
+        default=None,
+        description="IdP entityID, e.g. https://auth.ktest.embl.de/realms/EMBL-HD",
+    )
+    saml_idp_sso_url: Optional[str] = Field(
+        default=None,
+        description="IdP SSO endpoint (HTTP-Redirect binding), "
+        "e.g. https://auth.ktest.embl.de/realms/EMBL-HD/protocol/saml",
+    )
+    saml_idp_cert: Optional[str] = Field(
+        default=None,
+        description="IdP X.509 signing certificate: inline PEM "
+        "(-----BEGIN CERTIFICATE-----...) or a path to a PEM file",
+    )
+    saml_sp_entity_id: Optional[str] = Field(
+        default=None,
+        description="SP entityID / issuer registered with the IdP",
+    )
+    saml_sp_base_url: Optional[str] = Field(
+        default=None,
+        description="Public base URL of the API used to build the ACS URL; "
+        "defaults to the FastAPI service external URL",
+    )
+    saml_name_id_format: str = Field(
+        default="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+        description="Requested NameID format",
+    )
+    saml_attribute_email: Optional[str] = Field(
+        default=None,
+        description="SAML attribute name carrying the email; unset → use NameID",
+    )
+    saml_attribute_username: Optional[str] = Field(
+        default=None, description="SAML attribute name carrying the username (informational)"
+    )
+    saml_login_label: str = Field(
+        default="Sign in with SSO",
+        description="Label for the SSO button in the login form (e.g. 'Sign in with EMBL')",
+    )
+
+    @field_validator(
+        "saml_idp_entity_id",
+        "saml_idp_sso_url",
+        "saml_idp_cert",
+        "saml_sp_entity_id",
+        "saml_sp_base_url",
+        "saml_attribute_email",
+        "saml_attribute_username",
+        mode="before",
+    )
+    @classmethod
+    def _empty_saml_str_to_none(cls, v: Any) -> Any:
+        # Helm/compose render unset values as empty strings; treat them as unset.
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
 
     model_config = SettingsConfigDict(env_prefix="DEPICTIO_AUTH_", case_sensitive=False)
 

--- a/depictio/api/v1/endpoints/auth_endpoints/google_oauth_routes.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/google_oauth_routes.py
@@ -15,7 +15,6 @@ from fastapi import APIRouter, HTTPException, Query
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
 from depictio.api.v1.endpoints.auth_endpoints.utils import (
-    cleanup_expired_states,
     create_or_get_user,
     exchange_code_for_token,
     fetch_google_user_info,
@@ -55,9 +54,6 @@ async def google_oauth_login() -> GoogleOAuthLoginResponse:
         ]
     ):
         raise HTTPException(status_code=500, detail="Google OAuth configuration incomplete")
-
-    # Clean up expired states
-    cleanup_expired_states()
 
     # Generate state parameter for CSRF protection
     state = generate_oauth_state()

--- a/depictio/api/v1/endpoints/auth_endpoints/saml_routes.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/saml_routes.py
@@ -1,0 +1,157 @@
+"""SAML SSO endpoints (SP-initiated login against e.g. the EMBL Keycloak IdP).
+
+Flow:
+1. ``GET /auth/saml/login`` — build an AuthnRequest, remember its ID in the
+   shared state store, redirect the browser to the IdP.
+2. IdP authenticates the user and POSTs a SAMLResponse to
+   ``POST /auth/saml/callback`` (ACS). The response is validated
+   (signature, InResponseTo replay check), the email is mapped to a depictio
+   user, and the browser is redirected to the viewer's magic-link route with a
+   single-use ticket in the URL *fragment* (never query string / server logs).
+3. The viewer's existing MagicLinkCallback redeems the ticket for a session.
+"""
+
+from urllib.parse import quote
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi.responses import RedirectResponse
+
+from depictio.api.v1.configs.config import settings
+from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.endpoints.auth_endpoints.saml_utils import (
+    extract_in_response_to,
+    init_saml_auth,
+    resolve_email,
+    safe_relay_path,
+    saml_configured,
+)
+from depictio.api.v1.endpoints.auth_endpoints.state_store import (
+    consume_auth_state,
+    store_auth_state,
+)
+from depictio.api.v1.endpoints.auth_endpoints.utils import create_or_get_sso_user
+from depictio.api.v1.endpoints.user_endpoints.core_functions import (
+    _create_magic_link_ticket,
+)
+
+saml_router = APIRouter()
+
+
+def _require_saml() -> None:
+    if not settings.auth.saml_enabled:
+        raise HTTPException(status_code=403, detail="SAML SSO is not enabled")
+    if not saml_configured():
+        raise HTTPException(status_code=500, detail="SAML SSO configuration incomplete")
+
+
+def _error_redirect(reason: str) -> RedirectResponse:
+    """Send the browser back to the login page with a coarse error code.
+
+    Details stay in the server logs — the IdP error internals are not for the
+    URL bar, and the ACS must never answer a browser POST with raw JSON.
+    """
+    viewer = settings.viewer.external_url.rstrip("/")
+    return RedirectResponse(f"{viewer}/auth?error={quote(reason)}", status_code=303)
+
+
+@saml_router.get("/login")
+async def saml_login(
+    request: Request,
+    next: str | None = Query(default=None, description="Same-origin path to land on after login"),
+) -> RedirectResponse:
+    """Start an SP-initiated SAML login: redirect the browser to the IdP."""
+    _require_saml()
+    try:
+        auth = await init_saml_auth(request)
+    except ImportError as e:
+        logger.error(
+            f"SAML enabled but python3-saml is not installed ({e}); "
+            "install the 'saml' extra (pip install 'depictio[saml]')."
+        )
+        raise HTTPException(status_code=500, detail="SAML support is not installed on the server")
+
+    relay = safe_relay_path(next)
+    redirect_url = auth.login(return_to=relay)
+    request_id = auth.get_last_request_id()
+    # The relay path is stored server-side keyed by the AuthnRequest ID, so the
+    # ACS never has to trust the IdP-echoed RelayState.
+    store_auth_state("saml", request_id, value=relay)
+    logger.info(f"SAML login initiated (request_id={request_id}, relay={relay})")
+    return RedirectResponse(redirect_url, status_code=302)
+
+
+@saml_router.post("/callback")
+async def saml_acs(request: Request) -> RedirectResponse:
+    """Assertion Consumer Service: validate the IdP response, mint a session ticket."""
+    if not settings.auth.saml_enabled:
+        raise HTTPException(status_code=403, detail="SAML SSO is not enabled")
+
+    try:
+        form = await request.form()
+        saml_response = form.get("SAMLResponse")
+        if not isinstance(saml_response, str) or not saml_response:
+            logger.warning("SAML ACS called without a SAMLResponse")
+            return _error_redirect("saml_failed")
+
+        in_response_to = extract_in_response_to(saml_response)
+        relay = consume_auth_state("saml", in_response_to or "")
+        if relay is None:
+            logger.warning(f"SAML ACS with unknown/expired/replayed InResponseTo: {in_response_to}")
+            return _error_redirect("saml_failed")
+
+        auth = await init_saml_auth(request)
+        auth.process_response(request_id=in_response_to)
+        errors = auth.get_errors()
+        if errors:
+            logger.warning(
+                f"SAML response validation failed: {errors} — {auth.get_last_error_reason()}"
+            )
+            return _error_redirect("saml_failed")
+
+        logger.debug(f"SAML attributes: {auth.get_attributes()}")
+        email = resolve_email(auth.get_attributes(), auth.get_nameid())
+        if not email:
+            logger.warning("SAML response carried no usable email (attributes or NameID)")
+            return _error_redirect("saml_failed")
+
+        user, created = await create_or_get_sso_user(
+            email, allow_create=not settings.auth.registration_disabled
+        )
+        if user is None:
+            return _error_redirect("registration_disabled")
+
+        # Short expiry: the browser redeems the ticket immediately on landing.
+        ticket = await _create_magic_link_ticket(user.id, expiry_minutes=2)  # type: ignore[arg-type]
+        viewer = settings.viewer.external_url.rstrip("/")
+        logger.info(f"SAML login successful for {email} (created={created})")
+        # The ticket rides in the URL fragment: browsers apply fragments on
+        # Location headers but never send them to servers/proxies/logs.
+        return RedirectResponse(
+            f"{viewer}/auth/magic#ticket={ticket.ticket}&next={quote(safe_relay_path(relay))}",
+            status_code=303,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error in SAML ACS: {e}")
+        return _error_redirect("saml_failed")
+
+
+@saml_router.get("/metadata")
+async def saml_metadata() -> Response:
+    """Serve the SP metadata XML (import this in the IdP to register the client)."""
+    _require_saml()
+    try:
+        from onelogin.saml2.settings import OneLogin_Saml2_Settings
+
+        from depictio.api.v1.endpoints.auth_endpoints.saml_utils import get_saml_settings
+
+        saml_settings = OneLogin_Saml2_Settings(get_saml_settings(), sp_validation_only=True)
+        metadata = saml_settings.get_sp_metadata()
+        validation_errors = saml_settings.validate_metadata(metadata)
+        if validation_errors:
+            logger.error(f"SP metadata validation failed: {validation_errors}")
+            raise HTTPException(status_code=500, detail="Invalid SP metadata configuration")
+        return Response(content=metadata, media_type="text/xml")
+    except ImportError:
+        raise HTTPException(status_code=500, detail="SAML support is not installed on the server")

--- a/depictio/api/v1/endpoints/auth_endpoints/saml_utils.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/saml_utils.py
@@ -1,0 +1,157 @@
+"""Helpers for SAML SSO (SP-initiated, python3-saml).
+
+Ported from the validated prototype ``dev/dev_fastapi_saml/app.py`` and
+parameterized from ``settings.auth.saml_*``. ``onelogin`` imports are lazy so
+the optional ``saml`` extra is only required when the feature is enabled.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import Request
+
+from depictio.api.v1.configs.config import settings
+from depictio.api.v1.configs.logging_init import logger
+
+SAML_ACS_PATH = "/depictio/api/v1/auth/saml/callback"
+DEFAULT_RELAY_PATH = "/dashboards"
+
+
+def saml_configured() -> bool:
+    """True when SAML is enabled and every required setting is present."""
+    auth = settings.auth
+    return bool(
+        auth.saml_enabled
+        and auth.saml_idp_entity_id
+        and auth.saml_idp_sso_url
+        and auth.saml_idp_cert
+        and auth.saml_sp_entity_id
+    )
+
+
+def read_idp_cert(cert_value: str) -> str:
+    """Return the IdP certificate PEM, accepting inline PEM or a file path."""
+    if cert_value.lstrip().startswith("-----BEGIN"):
+        return cert_value
+    return Path(cert_value).read_text()
+
+
+def get_acs_url() -> str:
+    """Public Assertion Consumer Service URL (where the IdP POSTs responses)."""
+    base = settings.auth.saml_sp_base_url or settings.fastapi.external_url
+    return f"{base.rstrip('/')}{SAML_ACS_PATH}"
+
+
+def safe_relay_path(candidate: str | None) -> str:
+    """Constrain a post-login destination to a same-origin path (anti open-redirect)."""
+    if candidate and candidate.startswith("/") and not candidate.startswith("//"):
+        return candidate
+    return DEFAULT_RELAY_PATH
+
+
+def get_saml_settings() -> dict[str, Any]:
+    """Build the python3-saml settings dict from depictio settings."""
+    auth = settings.auth
+    import os
+
+    debug = os.getenv("DEPICTIO_DEV_MODE", "false").lower() == "true"
+    return {
+        "strict": True,
+        "debug": debug,
+        "sp": {
+            "entityId": auth.saml_sp_entity_id,
+            "assertionConsumerService": {
+                "url": get_acs_url(),
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            },
+            "NameIDFormat": auth.saml_name_id_format,
+            "x509cert": "",
+            "privateKey": "",
+        },
+        "idp": {
+            "entityId": auth.saml_idp_entity_id,
+            "singleSignOnService": {
+                "url": auth.saml_idp_sso_url,
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            "x509cert": read_idp_cert(auth.saml_idp_cert or ""),
+        },
+        "security": {
+            "authnRequestsSigned": False,
+            "wantAssertionsSigned": True,
+            "wantMessagesSigned": False,
+            "wantAttributeStatement": True,
+            "allowSingleLabelDomains": True,
+            "nameIdEncrypted": False,
+            "requestedAuthnContext": False,
+        },
+    }
+
+
+async def init_saml_auth(request: Request) -> Any:
+    """Adapt a Starlette request into a ``OneLogin_Saml2_Auth`` instance.
+
+    Honours ``X-Forwarded-Proto``/``X-Forwarded-Host`` so signature-relevant
+    URLs match what the browser saw when TLS terminates at nginx/the ingress.
+    """
+    from onelogin.saml2.auth import OneLogin_Saml2_Auth
+
+    url = request.url
+    scheme = request.headers.get("x-forwarded-proto", url.scheme)
+    host_header = request.headers.get("x-forwarded-host") or request.headers.get("host") or ""
+    if host_header:
+        host, _, port = host_header.partition(":")
+    else:
+        host, port = url.hostname or "", str(url.port or "")
+    if not port:
+        port = "443" if scheme == "https" else "80"
+
+    form_data: list[tuple[str, Any]] = []
+    if request.method == "POST":
+        form = await request.form()
+        form_data = [(k, v) for k, v in form.items()]
+
+    data = {
+        "https": "on" if scheme == "https" else "off",
+        "http_host": host,
+        "server_port": port,
+        "script_name": url.path,
+        "get_data": [(k, v) for k, v in request.query_params.items()],
+        "post_data": form_data,
+    }
+    logger.debug(f"SAML auth request data: {data}")
+    return OneLogin_Saml2_Auth(data, get_saml_settings())
+
+
+def extract_in_response_to(saml_response_b64: str) -> str | None:
+    """Read ``InResponseTo`` from a base64 SAMLResponse without validating it.
+
+    This is only a pre-crypto peek used to look up the pending AuthnRequest in
+    the shared state store; the actual signature/condition validation is done
+    by ``OneLogin_Saml2_Auth.process_response``.
+    """
+    import base64
+
+    from defusedxml import ElementTree
+
+    try:
+        xml = base64.b64decode(saml_response_b64)
+        root = ElementTree.fromstring(xml)
+        return root.attrib.get("InResponseTo")
+    except Exception as e:
+        logger.warning(f"Could not parse SAMLResponse for InResponseTo: {e}")
+        return None
+
+
+def resolve_email(attributes: dict[str, list[str]], nameid: str | None) -> str | None:
+    """Resolve the user email from SAML attributes, falling back to the NameID."""
+    attr_name = settings.auth.saml_attribute_email
+    email: str | None = None
+    if attr_name:
+        values = attributes.get(attr_name) or []
+        email = values[0] if values else None
+    if not email:
+        email = nameid
+    return email.strip().lower() if email else None

--- a/depictio/api/v1/endpoints/auth_endpoints/state_store.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/state_store.py
@@ -1,0 +1,82 @@
+"""Shared one-shot state store for browser SSO flows (OAuth state, SAML request IDs).
+
+The previous OAuth implementation kept the anti-CSRF ``state`` in a per-process
+dict, which breaks as soon as the login and the callback land on different
+gunicorn workers or replicas. This store is Redis-backed (shared across
+workers/pods) with an in-process fallback so single-worker dev setups and unit
+tests keep working without Redis.
+
+FALLBACK, NOT FAIL-CLOSED: if Redis is unreachable we log a warning and use the
+in-process dict — login then only succeeds when both legs of the flow hit the
+same worker, which mirrors the rate limiter's availability-over-strictness
+posture on auth paths.
+"""
+
+from __future__ import annotations
+
+import time
+
+from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.services.redis_client import get_shared_redis_client
+
+_STATE_TTL_SECONDS = 600  # 10 minutes, matches the historical OAuth state expiry
+_KEY_PREFIX = "depictio:authstate"
+
+# In-process fallback: {(kind, key): (value, expiry_monotonic)}
+_local_states: dict[tuple[str, str], tuple[str, float]] = {}
+
+
+def _redis_key(kind: str, key: str) -> str:
+    return f"{_KEY_PREFIX}:{kind}:{key}"
+
+
+def _prune_local() -> None:
+    now = time.monotonic()
+    for k in [k for k, (_, expiry) in _local_states.items() if expiry < now]:
+        del _local_states[k]
+
+
+def store_auth_state(
+    kind: str, key: str, value: str = "1", ttl_seconds: int = _STATE_TTL_SECONDS
+) -> None:
+    """Store a one-shot auth state (OAuth ``state``, SAML AuthnRequest ID)."""
+    client = get_shared_redis_client()
+    if client is not None:
+        try:
+            client.set(_redis_key(kind, key), value, ex=ttl_seconds, nx=True)
+            return
+        except Exception as e:
+            logger.warning(f"Auth state store Redis error ({e}); using in-process fallback.")
+    else:
+        logger.warning(
+            "Auth state store: Redis unavailable, using in-process fallback "
+            "(SSO logins only succeed when both flow legs hit the same worker)."
+        )
+    _prune_local()
+    _local_states[(kind, key)] = (value, time.monotonic() + ttl_seconds)
+
+
+def consume_auth_state(kind: str, key: str) -> str | None:
+    """Atomically fetch-and-delete a state; ``None`` if unknown, used, or expired.
+
+    Checks the in-process fallback too, so a state stored during a Redis outage
+    (or in tests) still redeems.
+    """
+    if not key:
+        return None
+
+    value: str | None = None
+    client = get_shared_redis_client()
+    if client is not None:
+        try:
+            value = client.getdel(_redis_key(kind, key))
+        except Exception as e:
+            logger.warning(f"Auth state store Redis error on consume ({e}).")
+
+    if value is None:
+        _prune_local()
+        local = _local_states.pop((kind, key), None)
+        if local is not None:
+            value = local[0]
+
+    return value

--- a/depictio/api/v1/endpoints/auth_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/utils.py
@@ -1,12 +1,11 @@
 """
-Utility functions for Google OAuth authentication.
+Utility functions for SSO authentication (Google OAuth, shared SSO user mapping).
 
 This module contains helper functions for managing OAuth state, token exchange,
-and user creation for Google OAuth 2.0 authentication flow.
+and user creation for browser SSO flows.
 """
 
 import secrets
-from datetime import datetime, timedelta
 from typing import Any
 
 import httpx
@@ -14,61 +13,29 @@ from fastapi import HTTPException
 
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.endpoints.auth_endpoints.state_store import (
+    consume_auth_state,
+    store_auth_state,
+)
 from depictio.models.models.google_oauth import GoogleUserInfo
 from depictio.models.models.users import UserBeanie
-
-# In-memory state storage (in production, use Redis or database)
-_oauth_states: dict[str, datetime] = {}
 
 
 def generate_oauth_state() -> str:
     """Generate a secure random state parameter for OAuth CSRF protection."""
-    from depictio.api.v1.configs.logging_init import logger
-
     state = secrets.token_urlsafe(32)
-    # Store state with expiration (10 minutes)
-    expiry = datetime.now() + timedelta(minutes=10)
-    _oauth_states[state] = expiry
-    logger.debug(f"Generated OAuth state: {state}, expires at: {expiry}")
+    store_auth_state("oauth", state)
+    logger.debug(f"Generated OAuth state: {state}")
     return state
 
 
 def validate_oauth_state(state: str) -> bool:
-    """Validate OAuth state parameter and remove if valid."""
-    import os
-
-    from depictio.api.v1.configs.logging_init import logger
-
-    # In development mode, skip state validation due to multi-worker issues
-    if os.getenv("DEPICTIO_DEV_MODE", "false").lower() == "true":
-        logger.debug(f"DEPICTIO_DEV_MODE: Skipping OAuth state validation for: {state}")
-        return True
-
-    logger.debug(f"Validating OAuth state: {state}")
-    logger.debug(f"Current stored states: {list(_oauth_states.keys())}")
-
-    if state not in _oauth_states:
-        logger.warning(f"State {state} not found in stored states")
+    """Validate an OAuth state parameter, consuming it so it cannot be replayed."""
+    if consume_auth_state("oauth", state) is None:
+        logger.warning(f"OAuth state unknown, already used, or expired: {state}")
         return False
-
-    # Check if state is expired
-    if _oauth_states[state] < datetime.now():
-        logger.warning(f"State {state} has expired")
-        del _oauth_states[state]
-        return False
-
-    # Remove used state
-    del _oauth_states[state]
     logger.debug(f"State {state} validated successfully")
     return True
-
-
-def cleanup_expired_states() -> None:
-    """Clean up expired OAuth states."""
-    now = datetime.now()
-    expired_states = [state for state, expiry in _oauth_states.items() if expiry < now]
-    for state in expired_states:
-        del _oauth_states[state]
 
 
 async def exchange_code_for_token(code: str) -> dict[str, Any]:
@@ -124,16 +91,16 @@ async def fetch_google_user_info(access_token: str) -> GoogleUserInfo:
         return GoogleUserInfo(**user_data)
 
 
-async def create_or_get_user(
-    google_user: GoogleUserInfo, *, allow_create: bool = True
+async def create_or_get_sso_user(
+    email: str, *, allow_create: bool = True
 ) -> tuple[UserBeanie | None, bool]:
-    """Create new user or get existing user from Google OAuth info.
+    """Create or fetch a user for an IdP-verified email (Google OAuth, SAML).
 
     Args:
-        google_user: Verified Google account info.
+        email: Email address already verified by the identity provider.
         allow_create: When False, never provision a new account — return
             ``(None, False)`` for an unknown email. Used to honour
-            ``registration_disabled`` so OAuth is a login-only door for
+            ``registration_disabled`` so SSO is a login-only door for
             pre-provisioned accounts, not a registration bypass.
 
     Returns:
@@ -141,32 +108,40 @@ async def create_or_get_user(
         created. ``user`` is None when the email is unknown and
         ``allow_create`` is False.
     """
-    # Check if user already exists
-    existing_user = await UserBeanie.find_one({"email": google_user.email})
+    from depictio.api.v1.endpoints.user_endpoints.core_functions import _hash_password
+
+    existing_user = await UserBeanie.find_one({"email": email})
 
     if existing_user:
-        logger.info(f"Existing user found for OAuth login: {google_user.email}")
+        logger.info(f"Existing user found for SSO login: {email}")
         return existing_user, False
 
     if not allow_create:
         logger.warning(
-            f"OAuth login rejected for unregistered email (registration disabled): "
-            f"{google_user.email}"
+            f"SSO login rejected for unregistered email (registration disabled): {email}"
         )
         return None, False
 
-    # Create new user
-    logger.info(f"Creating new user from OAuth: {google_user.email}")
+    logger.info(f"Creating new user from SSO: {email}")
 
     new_user = UserBeanie(
-        email=google_user.email,
-        password="$2b$12$oauth.user.no.password",  # OAuth users don't have passwords
+        email=email,
+        # SSO users have no usable password; a hash of an unguessable random
+        # secret keeps password login structurally valid but never satisfiable.
+        password=_hash_password(secrets.token_urlsafe(32)),
         is_admin=False,
         is_active=True,
-        is_verified=True,  # Google email is already verified
+        is_verified=True,  # Email is verified by the identity provider
     )
 
     await new_user.save()
-    logger.info(f"Created new OAuth user: {new_user.id}")
+    logger.info(f"Created new SSO user: {new_user.id}")
 
     return new_user, True
+
+
+async def create_or_get_user(
+    google_user: GoogleUserInfo, *, allow_create: bool = True
+) -> tuple[UserBeanie | None, bool]:
+    """Create new user or get existing user from Google OAuth info."""
+    return await create_or_get_sso_user(google_user.email, allow_create=allow_create)

--- a/depictio/api/v1/endpoints/routers.py
+++ b/depictio/api/v1/endpoints/routers.py
@@ -15,6 +15,7 @@ from depictio.api.v1.endpoints.analytics_data_endpoints.routes import (
 )
 from depictio.api.v1.endpoints.analytics_endpoints.routes import router as analytics_router
 from depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes import google_oauth_router
+from depictio.api.v1.endpoints.auth_endpoints.saml_routes import saml_router
 from depictio.api.v1.endpoints.backup_endpoints.routes import backup_endpoint_router
 from depictio.api.v1.endpoints.catalog_endpoints.routes import catalog_endpoint_router
 from depictio.api.v1.endpoints.celery_endpoints.routes import celery_endpoint_router
@@ -161,6 +162,12 @@ router.include_router(
     google_oauth_router,
     prefix="/auth/google",
     tags=["Google OAuth"],
+)
+
+router.include_router(
+    saml_router,
+    prefix="/auth/saml",
+    tags=["SAML SSO"],
 )
 
 # Include Analytics routes

--- a/depictio/api/v1/endpoints/user_endpoints/rate_limit.py
+++ b/depictio/api/v1/endpoints/user_endpoints/rate_limit.py
@@ -22,82 +22,18 @@ from typing import Any
 
 from fastapi import HTTPException, Request
 
-from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
-
-# Optional Redis import — graceful degradation if the package is missing.
-# Typed ``Any`` so the module alias can be None without a type-ignore.
-_redis: Any = None
-try:
-    import redis as _redis_module
-
-    _redis = _redis_module
-    _REDIS_AVAILABLE = True
-except ImportError:  # pragma: no cover - redis is a stack dependency
-    _REDIS_AVAILABLE = False
-    logger.warning("Redis package unavailable — auth rate limiting is disabled (fail-open).")
-
+from depictio.api.v1.services.redis_client import get_shared_redis_client
 
 # Fixed-window parameters. Kept conservative — these endpoints are
 # human-driven (login / register / temp-user mint), not high-throughput.
 _RATE_WINDOW_SECS = 60
 _RATE_MAX_CALLS = 10
 
-# How long to wait before re-trying a failed Redis connection. Without this a
-# worker that starts during a brief Redis bounce would lose rate limiting for
-# its entire process lifetime.
-_REDIS_RETRY_SECS = 60
-
-# Lazily-initialised shared Redis client (one per worker process).
-_redis_client: Any = None
-_redis_next_retry_at = 0.0
-
 
 def _get_redis_client() -> Any:
-    """Return a shared Redis client, or ``None`` if Redis is unavailable.
-
-    Reuses ``settings.cache`` connection details (same Redis instance used by
-    the DataFrame cache). Connection failures are swallowed here; callers must
-    treat ``None`` as "fail open". Failed connections are retried at most once
-    every ``_REDIS_RETRY_SECS`` so a Redis bounce doesn't permanently disable
-    rate limiting, while a hard outage isn't hammered on every request.
-    """
-    global _redis_client, _redis_next_retry_at
-
-    if _redis_client is not None:
-        return _redis_client
-
-    if not _REDIS_AVAILABLE:
-        return None
-
-    now = time.monotonic()
-    if now < _redis_next_retry_at:
-        # Recent attempt failed; wait out the backoff window.
-        return None
-    _redis_next_retry_at = now + _REDIS_RETRY_SECS
-
-    try:
-        cache_cfg = settings.cache
-        client = _redis.Redis(
-            host=cache_cfg.redis_host,
-            port=cache_cfg.redis_port,
-            password=cache_cfg.redis_password,
-            db=cache_cfg.redis_db,
-            ssl=cache_cfg.redis_ssl,
-            decode_responses=True,
-            socket_connect_timeout=1,
-            socket_timeout=1,
-        )
-        client.ping()
-        _redis_client = client
-        logger.debug("Auth rate limiter connected to Redis.")
-        return _redis_client
-    except Exception as e:
-        logger.warning(
-            f"Auth rate limiter could not connect to Redis ({e}); "
-            f"rate limiting disabled (fail-open), retrying in {_REDIS_RETRY_SECS}s."
-        )
-        return None
+    """Return the shared Redis client, or ``None`` (fail open) if unavailable."""
+    return get_shared_redis_client()
 
 
 def enforce_rate_limit(request: Request, endpoint: str) -> None:

--- a/depictio/api/v1/endpoints/user_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/user_endpoints/routes.py
@@ -629,9 +629,8 @@ async def get_current_user_info_optional(
     # walkthrough (and any other onboarding hints) during local development —
     # devs hot-reload the page constantly and don't need the tour popping back
     # up every time the auth-builder definition bumps its version. The env var
-    # already gates dev-only behavior elsewhere (Dash hot reload, OAuth state
-    # skip in `auth_endpoints/utils.py`), so we surface it here rather than
-    # adding a parallel knob.
+    # already gates dev-only behavior elsewhere, so we surface it here rather
+    # than adding a parallel knob.
     is_dev_mode = os.getenv("DEPICTIO_DEV_MODE", "false").lower() in ("true", "1", "yes")
     # DEPICTIO_WALKTHROUGH_DISABLED is the explicit kill switch for the
     # walkthrough independent of dev mode — useful for deployments that just
@@ -654,6 +653,8 @@ async def get_current_user_info_optional(
         "walkthrough_disabled": walkthrough_disabled,
         "unauthenticated_mode": getattr(settings.auth, "unauthenticated_mode", False),
         "google_oauth_enabled": settings.auth.google_oauth_enabled,
+        "saml_enabled": settings.auth.saml_enabled,
+        "saml_login_label": settings.auth.saml_login_label,
         "temporary_user_expiry_hours": settings.auth.temporary_user_expiry_hours,
         "temporary_user_expiry_minutes": settings.auth.temporary_user_expiry_minutes,
         # Viewer feature flags ride along here rather than on an endpoint of

--- a/depictio/api/v1/services/redis_client.py
+++ b/depictio/api/v1/services/redis_client.py
@@ -1,0 +1,93 @@
+"""Shared lazy Redis client for auth-adjacent features.
+
+Extracted from the rate limiter so other modules (OAuth/SAML state store) can
+reuse the same connection instead of each keeping a private one. Reuses
+``settings.cache`` connection details (same Redis instance as the DataFrame
+cache, celery broker and events pub/sub).
+
+Callers must treat ``None`` as "Redis unavailable" and degrade gracefully —
+this module never raises on connection failure.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from depictio.api.v1.configs.config import settings
+from depictio.api.v1.configs.logging_init import logger
+
+# Optional Redis import — graceful degradation if the package is missing.
+# Typed ``Any`` so the module alias can be None without a type-ignore.
+_redis: Any = None
+try:
+    import redis as _redis_module
+
+    _redis = _redis_module
+    _REDIS_AVAILABLE = True
+except ImportError:  # pragma: no cover - redis is a stack dependency
+    _REDIS_AVAILABLE = False
+    logger.warning("Redis package unavailable — Redis-backed auth features are degraded.")
+
+
+# How long to wait before re-trying a failed Redis connection. Without this a
+# worker that starts during a brief Redis bounce would lose Redis-backed
+# features for its entire process lifetime.
+_REDIS_RETRY_SECS = 60
+
+# Lazily-initialised shared Redis client (one per worker process).
+_redis_client: Any = None
+_redis_next_retry_at = 0.0
+
+
+def get_shared_redis_client() -> Any:
+    """Return a shared Redis client, or ``None`` if Redis is unavailable.
+
+    Connection failures are swallowed here; callers must treat ``None`` as
+    "degrade gracefully". Failed connections are retried at most once every
+    ``_REDIS_RETRY_SECS`` so a Redis bounce doesn't permanently disable
+    dependent features, while a hard outage isn't hammered on every request.
+    """
+    global _redis_client, _redis_next_retry_at
+
+    if _redis_client is not None:
+        return _redis_client
+
+    if not _REDIS_AVAILABLE:
+        return None
+
+    now = time.monotonic()
+    if now < _redis_next_retry_at:
+        # Recent attempt failed; wait out the backoff window.
+        return None
+    _redis_next_retry_at = now + _REDIS_RETRY_SECS
+
+    try:
+        cache_cfg = settings.cache
+        client = _redis.Redis(
+            host=cache_cfg.redis_host,
+            port=cache_cfg.redis_port,
+            password=cache_cfg.redis_password,
+            db=cache_cfg.redis_db,
+            ssl=cache_cfg.redis_ssl,
+            decode_responses=True,
+            socket_connect_timeout=1,
+            socket_timeout=1,
+        )
+        client.ping()
+        _redis_client = client
+        logger.debug("Shared auth Redis client connected.")
+        return _redis_client
+    except Exception as e:
+        logger.warning(
+            f"Could not connect to Redis ({e}); Redis-backed auth features degraded, "
+            f"retrying in {_REDIS_RETRY_SECS}s."
+        )
+        return None
+
+
+def reset_shared_redis_client() -> None:
+    """Drop the cached client and retry backoff (for tests)."""
+    global _redis_client, _redis_next_retry_at
+    _redis_client = None
+    _redis_next_retry_at = 0.0

--- a/depictio/tests/api/v1/endpoints/auth_endpoints/test_auth_state_store.py
+++ b/depictio/tests/api/v1/endpoints/auth_endpoints/test_auth_state_store.py
@@ -1,0 +1,112 @@
+"""Unit tests for the shared one-shot auth state store (OAuth state, SAML request IDs)."""
+
+from unittest.mock import MagicMock, patch
+
+from depictio.api.v1.endpoints.auth_endpoints import state_store
+from depictio.api.v1.endpoints.auth_endpoints.utils import (
+    generate_oauth_state,
+    validate_oauth_state,
+)
+
+_NO_REDIS = patch(
+    "depictio.api.v1.endpoints.auth_endpoints.state_store.get_shared_redis_client",
+    return_value=None,
+)
+
+
+class TestInMemoryFallback:
+    """Behavior when Redis is unavailable — in-process one-shot store."""
+
+    def setup_method(self):
+        state_store._local_states.clear()
+
+    def test_store_and_consume_round_trip(self):
+        with _NO_REDIS:
+            state_store.store_auth_state("oauth", "abc", value="/dashboards")
+            assert state_store.consume_auth_state("oauth", "abc") == "/dashboards"
+
+    def test_consume_is_one_shot(self):
+        with _NO_REDIS:
+            state_store.store_auth_state("oauth", "abc")
+            assert state_store.consume_auth_state("oauth", "abc") == "1"
+            assert state_store.consume_auth_state("oauth", "abc") is None
+
+    def test_unknown_key_returns_none(self):
+        with _NO_REDIS:
+            assert state_store.consume_auth_state("oauth", "never-stored") is None
+
+    def test_empty_key_returns_none(self):
+        with _NO_REDIS:
+            assert state_store.consume_auth_state("saml", "") is None
+
+    def test_kinds_are_isolated(self):
+        with _NO_REDIS:
+            state_store.store_auth_state("oauth", "abc")
+            assert state_store.consume_auth_state("saml", "abc") is None
+            assert state_store.consume_auth_state("oauth", "abc") == "1"
+
+    def test_expired_entry_returns_none(self):
+        with _NO_REDIS:
+            state_store.store_auth_state("oauth", "abc", ttl_seconds=600)
+            with patch(
+                "depictio.api.v1.endpoints.auth_endpoints.state_store.time.monotonic",
+                return_value=state_store._local_states[("oauth", "abc")][1] + 1,
+            ):
+                assert state_store.consume_auth_state("oauth", "abc") is None
+
+
+class TestRedisPath:
+    """Behavior with a (mocked) Redis client — shared across workers."""
+
+    def setup_method(self):
+        state_store._local_states.clear()
+
+    def test_store_uses_set_nx_ex(self):
+        client = MagicMock()
+        with patch(
+            "depictio.api.v1.endpoints.auth_endpoints.state_store.get_shared_redis_client",
+            return_value=client,
+        ):
+            state_store.store_auth_state("oauth", "abc", value="v", ttl_seconds=600)
+        client.set.assert_called_once_with("depictio:authstate:oauth:abc", "v", ex=600, nx=True)
+
+    def test_consume_uses_getdel(self):
+        client = MagicMock()
+        client.getdel.return_value = "v"
+        with patch(
+            "depictio.api.v1.endpoints.auth_endpoints.state_store.get_shared_redis_client",
+            return_value=client,
+        ):
+            assert state_store.consume_auth_state("saml", "id_1") == "v"
+        client.getdel.assert_called_once_with("depictio:authstate:saml:id_1")
+
+    def test_redis_error_falls_back_to_local(self):
+        client = MagicMock()
+        client.set.side_effect = ConnectionError("redis down")
+        client.getdel.side_effect = ConnectionError("redis down")
+        with patch(
+            "depictio.api.v1.endpoints.auth_endpoints.state_store.get_shared_redis_client",
+            return_value=client,
+        ):
+            state_store.store_auth_state("oauth", "abc", value="v")
+            assert state_store.consume_auth_state("oauth", "abc") == "v"
+
+
+class TestOAuthStateIntegration:
+    """The OAuth helpers ride on the shared store."""
+
+    def setup_method(self):
+        state_store._local_states.clear()
+
+    def test_generate_then_validate_round_trip(self):
+        with _NO_REDIS:
+            state = generate_oauth_state()
+            assert validate_oauth_state(state) is True
+            # One-shot: a replayed state must be rejected.
+            assert validate_oauth_state(state) is False
+
+    def test_unknown_state_rejected_even_in_dev_mode(self):
+        # The old implementation skipped validation under DEPICTIO_DEV_MODE to
+        # paper over the per-worker dict; that bypass must stay gone.
+        with _NO_REDIS, patch.dict("os.environ", {"DEPICTIO_DEV_MODE": "true"}):
+            assert validate_oauth_state("forged-state") is False

--- a/depictio/tests/api/v1/endpoints/auth_endpoints/test_saml.py
+++ b/depictio/tests/api/v1/endpoints/auth_endpoints/test_saml.py
@@ -1,0 +1,341 @@
+"""Unit tests for the SAML SSO endpoints (login, ACS callback, metadata).
+
+python3-saml is an optional extra, so ``OneLogin_Saml2_Auth`` is mocked
+throughout; tests that need the real library are guarded with importorskip.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from depictio.api.v1.configs.config import settings
+from depictio.api.v1.endpoints.auth_endpoints import state_store
+from depictio.api.v1.endpoints.auth_endpoints.saml_utils import (
+    get_acs_url,
+    resolve_email,
+    safe_relay_path,
+)
+
+_SAML_SETTINGS = {
+    "saml_enabled": True,
+    "saml_idp_entity_id": "https://auth.ktest.embl.de/realms/EMBL-HD",
+    "saml_idp_sso_url": "https://auth.ktest.embl.de/realms/EMBL-HD/protocol/saml",
+    "saml_idp_cert": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+    "saml_sp_entity_id": "https://api.example.org/depictio",
+}
+
+
+def _configure_saml(**overrides):
+    """Patch the real (shared) settings.auth SAML fields for one test."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    for field, value in {**_SAML_SETTINGS, **overrides}.items():
+        stack.enter_context(patch.object(settings.auth, field, value))
+    return stack
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    from depictio.api.v1.endpoints.auth_endpoints.saml_routes import saml_router
+
+    app.include_router(saml_router, prefix="/auth/saml")
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clean_state_store():
+    state_store._local_states.clear()
+    yield
+    state_store._local_states.clear()
+
+
+@pytest.fixture(autouse=True)
+def _no_redis():
+    with patch(
+        "depictio.api.v1.endpoints.auth_endpoints.state_store.get_shared_redis_client",
+        return_value=None,
+    ):
+        yield
+
+
+def _mock_auth(request_id="ONELOGIN_id_1", nameid="user@embl.de", errors=None, attributes=None):
+    auth = MagicMock()
+    auth.login.return_value = "https://auth.ktest.embl.de/sso?SAMLRequest=xyz"
+    auth.get_last_request_id.return_value = request_id
+    auth.process_response.return_value = None
+    auth.get_errors.return_value = errors or []
+    auth.get_last_error_reason.return_value = "reason"
+    auth.get_attributes.return_value = attributes or {}
+    auth.get_nameid.return_value = nameid
+    return auth
+
+
+class TestSamlLogin:
+    def test_login_disabled_returns_403(self, client):
+        with patch.object(settings.auth, "saml_enabled", False):
+            assert client.get("/auth/saml/login").status_code == 403
+
+    def test_login_enabled_but_unconfigured_returns_500(self, client):
+        with _configure_saml(saml_idp_sso_url=None):
+            assert client.get("/auth/saml/login").status_code == 500
+
+    def test_login_redirects_to_idp_and_stores_request_id(self, client):
+        auth = _mock_auth()
+        with (
+            _configure_saml(),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.init_saml_auth",
+                new=AsyncMock(return_value=auth),
+            ),
+        ):
+            response = client.get("/auth/saml/login", follow_redirects=False)
+
+        assert response.status_code == 302
+        assert response.headers["location"] == "https://auth.ktest.embl.de/sso?SAMLRequest=xyz"
+        auth.login.assert_called_once_with(return_to="/dashboards")
+        assert state_store.consume_auth_state("saml", "ONELOGIN_id_1") == "/dashboards"
+
+    @pytest.mark.parametrize("evil_next", ["//evil.com", "https://evil.com", "javascript:alert(1)"])
+    def test_login_rejects_non_relative_next(self, client, evil_next):
+        auth = _mock_auth()
+        with (
+            _configure_saml(),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.init_saml_auth",
+                new=AsyncMock(return_value=auth),
+            ),
+        ):
+            client.get("/auth/saml/login", params={"next": evil_next}, follow_redirects=False)
+
+        auth.login.assert_called_once_with(return_to="/dashboards")
+
+    def test_login_preserves_safe_next(self, client):
+        auth = _mock_auth()
+        with (
+            _configure_saml(),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.init_saml_auth",
+                new=AsyncMock(return_value=auth),
+            ),
+        ):
+            client.get("/auth/saml/login", params={"next": "/dashboard/42"}, follow_redirects=False)
+
+        auth.login.assert_called_once_with(return_to="/dashboard/42")
+        assert state_store.consume_auth_state("saml", "ONELOGIN_id_1") == "/dashboard/42"
+
+
+class TestSamlAcs:
+    def _post_acs(self, client, saml_response="ZmFrZQ=="):
+        return client.post(
+            "/auth/saml/callback",
+            data={"SAMLResponse": saml_response},
+            follow_redirects=False,
+        )
+
+    def test_acs_disabled_returns_403(self, client):
+        with patch.object(settings.auth, "saml_enabled", False):
+            assert self._post_acs(client).status_code == 403
+
+    def test_acs_without_samlresponse_redirects_to_error(self, client):
+        with _configure_saml():
+            response = client.post("/auth/saml/callback", data={}, follow_redirects=False)
+        assert response.status_code == 303
+        assert "/auth?error=saml_failed" in response.headers["location"]
+
+    def test_acs_unknown_in_response_to_redirects_to_error(self, client):
+        with (
+            _configure_saml(),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.extract_in_response_to",
+                return_value="ONELOGIN_unknown",
+            ),
+        ):
+            response = self._post_acs(client)
+        assert response.status_code == 303
+        assert "/auth?error=saml_failed" in response.headers["location"]
+
+    def test_acs_validation_errors_redirect_to_error(self, client):
+        state_store.store_auth_state("saml", "ONELOGIN_id_1", value="/dashboards")
+        auth = _mock_auth(errors=["invalid_response"])
+        with (
+            _configure_saml(),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.extract_in_response_to",
+                return_value="ONELOGIN_id_1",
+            ),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.init_saml_auth",
+                new=AsyncMock(return_value=auth),
+            ),
+        ):
+            response = self._post_acs(client)
+        assert response.status_code == 303
+        assert "/auth?error=saml_failed" in response.headers["location"]
+
+    def test_acs_success_mints_magic_ticket(self, client):
+        state_store.store_auth_state("saml", "ONELOGIN_id_1", value="/dashboard/42")
+        auth = _mock_auth(nameid="User@EMBL.de")
+
+        user = MagicMock()
+        user.id = "507f1f77bcf86cd799439011"
+        ticket = MagicMock()
+        ticket.ticket = "one-shot-secret"
+
+        create_user = AsyncMock(return_value=(user, True))
+        create_ticket = AsyncMock(return_value=ticket)
+        with (
+            _configure_saml(),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.extract_in_response_to",
+                return_value="ONELOGIN_id_1",
+            ),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.init_saml_auth",
+                new=AsyncMock(return_value=auth),
+            ),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.create_or_get_sso_user",
+                new=create_user,
+            ),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes._create_magic_link_ticket",
+                new=create_ticket,
+            ),
+        ):
+            response = self._post_acs(client)
+
+        assert response.status_code == 303
+        location = response.headers["location"]
+        assert "/auth/magic#ticket=one-shot-secret" in location
+        assert "next=/dashboard/42" in location
+        # InResponseTo replay protection: process_response pinned to the request id.
+        auth.process_response.assert_called_once_with(request_id="ONELOGIN_id_1")
+        # Email is lowercased before the user lookup.
+        create_user.assert_awaited_once()
+        assert create_user.await_args.args[0] == "user@embl.de"
+
+    def test_acs_replay_rejected(self, client):
+        """A second POST with the same InResponseTo must not mint a ticket."""
+        state_store.store_auth_state("saml", "ONELOGIN_id_1", value="/dashboards")
+        state_store.consume_auth_state("saml", "ONELOGIN_id_1")  # first (legit) use
+        with (
+            _configure_saml(),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.extract_in_response_to",
+                return_value="ONELOGIN_id_1",
+            ),
+        ):
+            response = self._post_acs(client)
+        assert response.status_code == 303
+        assert "/auth?error=saml_failed" in response.headers["location"]
+
+    def test_acs_registration_disabled_unknown_email(self, client):
+        state_store.store_auth_state("saml", "ONELOGIN_id_1", value="/dashboards")
+        auth = _mock_auth()
+        with (
+            _configure_saml(),
+            patch.object(settings.auth, "registration_disabled", True),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.extract_in_response_to",
+                return_value="ONELOGIN_id_1",
+            ),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.init_saml_auth",
+                new=AsyncMock(return_value=auth),
+            ),
+            patch(
+                "depictio.api.v1.endpoints.auth_endpoints.saml_routes.create_or_get_sso_user",
+                new=AsyncMock(return_value=(None, False)),
+            ) as create_user,
+        ):
+            response = self._post_acs(client)
+
+        assert response.status_code == 303
+        assert "/auth?error=registration_disabled" in response.headers["location"]
+        assert create_user.await_args.kwargs == {"allow_create": False}
+
+
+class TestSamlHelpers:
+    def test_safe_relay_path(self):
+        assert safe_relay_path("/dashboard/42") == "/dashboard/42"
+        assert safe_relay_path(None) == "/dashboards"
+        assert safe_relay_path("") == "/dashboards"
+        assert safe_relay_path("//evil.com") == "/dashboards"
+        assert safe_relay_path("https://evil.com") == "/dashboards"
+
+    def test_get_acs_url_strips_trailing_slash(self):
+        with patch.object(settings.auth, "saml_sp_base_url", "https://api.example.org/"):
+            assert get_acs_url() == "https://api.example.org/depictio/api/v1/auth/saml/callback"
+
+    def test_resolve_email_prefers_configured_attribute(self):
+        with patch.object(settings.auth, "saml_attribute_email", "urn:oid:mail"):
+            assert (
+                resolve_email({"urn:oid:mail": ["User@EMBL.de"]}, "fallback@x.y") == "user@embl.de"
+            )
+
+    def test_resolve_email_falls_back_to_nameid(self):
+        with patch.object(settings.auth, "saml_attribute_email", None):
+            assert resolve_email({}, "User@EMBL.de ") == "user@embl.de"
+        with patch.object(settings.auth, "saml_attribute_email", "urn:oid:mail"):
+            assert resolve_email({"urn:oid:mail": []}, "user@embl.de") == "user@embl.de"
+
+    def test_resolve_email_none_when_nothing_usable(self):
+        with patch.object(settings.auth, "saml_attribute_email", None):
+            assert resolve_email({}, None) is None
+
+    def test_extract_in_response_to(self):
+        pytest.importorskip("defusedxml")
+        import base64
+
+        from depictio.api.v1.endpoints.auth_endpoints.saml_utils import extract_in_response_to
+
+        xml = (
+            '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" '
+            'ID="_r1" InResponseTo="ONELOGIN_id_1" Version="2.0"/>'
+        )
+        encoded = base64.b64encode(xml.encode()).decode()
+        assert extract_in_response_to(encoded) == "ONELOGIN_id_1"
+        assert extract_in_response_to("not-base64!!") is None
+
+
+class TestSamlMetadata:
+    def test_metadata_disabled_returns_403(self, client):
+        with patch.object(settings.auth, "saml_enabled", False):
+            assert client.get("/auth/saml/metadata").status_code == 403
+
+    def test_metadata_with_real_library(self, client):
+        pytest.importorskip("onelogin")
+        # A real (self-signed, throwaway) cert so python3-saml settings validate.
+        pytest.importorskip("cryptography")
+        from datetime import datetime, timedelta, timezone
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-idp")])
+        now = datetime.now(timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=1))
+            .sign(key, hashes.SHA256())
+        )
+        pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+
+        with _configure_saml(saml_idp_cert=pem):
+            response = client.get("/auth/saml/metadata")
+
+        assert response.status_code == 200
+        assert "EntityDescriptor" in response.text
+        assert "https://api.example.org/depictio" in response.text

--- a/depictio/viewer/src/auth/AuthApp.tsx
+++ b/depictio/viewer/src/auth/AuthApp.tsx
@@ -122,6 +122,8 @@ export default function AuthApp() {
           <AuthCard heading="Welcome to Depictio :">
             <LoginForm
               googleEnabled={status?.google_oauth_enabled ?? false}
+              samlEnabled={status?.saml_enabled ?? false}
+              samlLabel={status?.saml_login_label}
               onSwitchToRegister={
                 status?.registration_disabled ? undefined : () => setView('register')
               }

--- a/depictio/viewer/src/auth/components/LoginForm.tsx
+++ b/depictio/viewer/src/auth/components/LoginForm.tsx
@@ -1,11 +1,15 @@
 import { Anchor, Button, Divider, Group, PasswordInput, Stack, Text, TextInput } from '@mantine/core';
 import { useState } from 'react';
-import { loginUser, persistSession, startGoogleOAuth } from 'depictio-react-core';
+import { loginUser, persistSession, samlLoginUrl, startGoogleOAuth } from 'depictio-react-core';
 
 const EMAIL_RE = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 
 interface Props {
   googleEnabled: boolean;
+  /** SAML SSO login enabled (e.g. EMBL Keycloak). */
+  samlEnabled?: boolean;
+  /** Label for the SAML button, e.g. "Sign in with EMBL". */
+  samlLabel?: string;
   /** Switch to the register view. Omit to hide the Register button entirely
    *  (e.g. when registration is disabled on this instance). */
   onSwitchToRegister?: () => void;
@@ -13,7 +17,7 @@ interface Props {
   onSuccess: () => void;
 }
 
-export default function LoginForm({ googleEnabled, onSwitchToRegister, onSuccess }: Props) {
+export default function LoginForm({ googleEnabled, samlEnabled, samlLabel, onSwitchToRegister, onSuccess }: Props) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -102,27 +106,40 @@ export default function LoginForm({ googleEnabled, onSwitchToRegister, onSuccess
           </Anchor>
         )}
       </Group>
-      {googleEnabled && (
+      {(googleEnabled || samlEnabled) && (
         <Stack gap="xs">
           <Divider label="Or" labelPosition="center" />
-          <Button
-            id="google-oauth-button"
-            variant="outline"
-            radius="md"
-            fullWidth
-            onClick={handleGoogleClick}
-            leftSection={
-              <img
-                src="https://www.google.com/favicon.ico"
-                alt=""
-                width={18}
-                height={18}
-                style={{ display: 'block' }}
-              />
-            }
-          >
-            Sign in with Google
-          </Button>
+          {googleEnabled && (
+            <Button
+              id="google-oauth-button"
+              variant="outline"
+              radius="md"
+              fullWidth
+              onClick={handleGoogleClick}
+              leftSection={
+                <img
+                  src="https://www.google.com/favicon.ico"
+                  alt=""
+                  width={18}
+                  height={18}
+                  style={{ display: 'block' }}
+                />
+              }
+            >
+              Sign in with Google
+            </Button>
+          )}
+          {samlEnabled && (
+            <Button
+              id="saml-login-button"
+              variant="outline"
+              radius="md"
+              fullWidth
+              onClick={() => window.location.assign(samlLoginUrl('/dashboards'))}
+            >
+              {samlLabel || 'Sign in with SSO'}
+            </Button>
+          )}
         </Stack>
       )}
     </Stack>

--- a/docker-images/Dockerfile.api
+++ b/docker-images/Dockerfile.api
@@ -17,10 +17,18 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
 
+# build-essential/pkg-config + libxml2/xmlsec dev headers are needed to build
+# the `xmlsec` dependency of python3-saml (the `saml` extra); libxmlsec1-openssl
+# is its runtime crypto backend.
 RUN apt-get update && apt-get install --no-install-recommends -y \
         curl \
         netcat-openbsd \
         ca-certificates \
+        build-essential \
+        pkg-config \
+        libxml2-dev \
+        libxmlsec1-dev \
+        libxmlsec1-openssl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,9 +45,13 @@ RUN groupadd -g ${GID} depictio && \
 # every dependency. packages/ rarely changes, so it stays cached too.
 COPY --chown=depictio:depictio pyproject.toml uv.lock* ./
 COPY --chown=depictio:depictio packages ./packages/
+# xmlsec is built from source so it links against the same apt libxml2 as the
+# system, avoiding the "lxml & xmlsec libxml2 library version mismatch" crash
+# that mixed binary wheels can produce at import time.
+ENV UV_NO_BINARY_PACKAGE="xmlsec"
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --no-dev \
-    || uv sync --no-install-project --no-dev
+    uv sync --frozen --no-install-project --no-dev --extra saml \
+    || uv sync --no-install-project --no-dev --extra saml
 
 # ---- Project layer (source + VERSION last) ----
 # Install the depictio project on top of the cached deps; cheap because every
@@ -48,7 +60,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY --chown=depictio:depictio VERSION ./
 COPY --chown=depictio:depictio depictio ./depictio/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev || uv sync --no-dev
+    uv sync --frozen --no-dev --extra saml || uv sync --no-dev --extra saml
 
 COPY --chown=depictio:depictio docker-images/run_fastapi.sh /app/run_fastapi.sh
 RUN chmod +x /app/run_fastapi.sh

--- a/helm-charts/depictio/templates/configmaps.yaml
+++ b/helm-charts/depictio/templates/configmaps.yaml
@@ -12,6 +12,9 @@ data:
   DEPICTIO_FASTAPI_PUBLIC_URL: {{ .Values.backend.env.DEPICTIO_FASTAPI_PUBLIC_URL | default (include "depictio.apiUrlWithProtocol" .) | quote }}
   DEPICTIO_VIEWER_SERVICE_PORT: {{ .Values.backend.env.DEPICTIO_VIEWER_SERVICE_PORT | quote }}
   DEPICTIO_VIEWER_SERVICE_NAME: {{ printf "%s-depictio-viewer" .Release.Name | quote }}
+  # Public viewer URL: the backend builds browser-facing redirect/link targets
+  # from it (magic-link login URLs, SAML ACS → /auth/magic hand-off).
+  DEPICTIO_VIEWER_PUBLIC_URL: {{ .Values.backend.env.DEPICTIO_VIEWER_PUBLIC_URL | default (include "depictio.frontendUrlWithProtocol" .) | quote }}
   {{- if .Values.mongo.useOperator }}
   DEPICTIO_MONGODB_SERVICE_NAME: {{ printf "%s-mongo-rs0" .Release.Name | quote }}
   DEPICTIO_MONGODB_SERVICE_PORT: "27017"
@@ -59,6 +62,21 @@ data:
   DEPICTIO_AUTH_GOOGLE_OAUTH_CLIENT_ID: ""
   DEPICTIO_AUTH_GOOGLE_OAUTH_CLIENT_SECRET: ""
   DEPICTIO_AUTH_GOOGLE_OAUTH_REDIRECT_URI: ""
+  {{- end }}
+
+  # SAML SSO Configuration (see helm-charts/depictio/values-embl-auth.yaml for
+  # a working EMBL Keycloak reference block). The IdP signing certificate is
+  # public X.509 material — a ConfigMap is fine; no key material rides here.
+  # Empty strings are coerced to "unset" by the backend settings model.
+  DEPICTIO_AUTH_SAML_ENABLED: {{ .Values.backend.env.DEPICTIO_AUTH_SAML_ENABLED | default "false" | quote }}
+  {{- if .Values.auth }}
+  DEPICTIO_AUTH_SAML_IDP_ENTITY_ID: {{ .Values.auth.DEPICTIO_AUTH_SAML_IDP_ENTITY_ID | default "" | quote }}
+  DEPICTIO_AUTH_SAML_IDP_SSO_URL: {{ .Values.auth.DEPICTIO_AUTH_SAML_IDP_SSO_URL | default "" | quote }}
+  DEPICTIO_AUTH_SAML_IDP_CERT: {{ .Values.auth.DEPICTIO_AUTH_SAML_IDP_CERT | default "" | quote }}
+  DEPICTIO_AUTH_SAML_SP_ENTITY_ID: {{ .Values.auth.DEPICTIO_AUTH_SAML_SP_ENTITY_ID | default "" | quote }}
+  DEPICTIO_AUTH_SAML_SP_BASE_URL: {{ .Values.auth.DEPICTIO_AUTH_SAML_SP_BASE_URL | default "" | quote }}
+  DEPICTIO_AUTH_SAML_ATTRIBUTE_EMAIL: {{ .Values.auth.DEPICTIO_AUTH_SAML_ATTRIBUTE_EMAIL | default "" | quote }}
+  DEPICTIO_AUTH_SAML_LOGIN_LABEL: {{ .Values.auth.DEPICTIO_AUTH_SAML_LOGIN_LABEL | default "Sign in with SSO" | quote }}
   {{- end }}
 
   # Performance

--- a/helm-charts/depictio/values-embl-auth.yaml
+++ b/helm-charts/depictio/values-embl-auth.yaml
@@ -65,8 +65,32 @@ backend:
     # Google OAuth Configuration
     DEPICTIO_AUTH_GOOGLE_OAUTH_ENABLED: "true"
 
+    # SAML SSO (EMBL Keycloak) — see the `auth:` block below for the IdP/SP
+    # settings. Flip to "true" once the SP is registered in the realm.
+    DEPICTIO_AUTH_SAML_ENABLED: "false"
+
     # Celery Configuration - Disabled for now
     # DEPICTIO_CELERY_ENABLED: "false"
+
+# SAML SSO reference configuration (EMBL Keycloak, ktest realm).
+# The IdP signing certificate is PUBLIC X.509 material (Keycloak → Realm
+# Settings → Keys → RS256 → Certificate, wrapped in PEM header/footer), so it
+# can live here — no secret rides in this block.
+#
+# IdP-side registration (Keycloak SAML client in the EMBL-HD realm):
+#   - Client ID            = DEPICTIO_AUTH_SAML_SP_ENTITY_ID below
+#   - ACS / redirect URL   = https://api.depictio.embl.org/depictio/api/v1/auth/saml/callback
+#   - Sign assertions: ON, Client signature required: OFF
+#   (or import GET https://api.depictio.embl.org/depictio/api/v1/auth/saml/metadata)
+auth:
+  DEPICTIO_AUTH_SAML_IDP_ENTITY_ID: "https://auth.ktest.embl.de/realms/EMBL-HD"
+  DEPICTIO_AUTH_SAML_IDP_SSO_URL: "https://auth.ktest.embl.de/realms/EMBL-HD/protocol/saml"
+  DEPICTIO_AUTH_SAML_SP_ENTITY_ID: "https://api.depictio.embl.org/depictio"
+  DEPICTIO_AUTH_SAML_LOGIN_LABEL: "Sign in with EMBL"
+  # DEPICTIO_AUTH_SAML_IDP_CERT: |
+  #   -----BEGIN CERTIFICATE-----
+  #   ...realm RS256 signing certificate...
+  #   -----END CERTIFICATE-----
 
 
 mongo:

--- a/helm-charts/depictio/values-embl-demo-base.yaml
+++ b/helm-charts/depictio/values-embl-demo-base.yaml
@@ -76,6 +76,11 @@ backend:
     # NOTE: DEPICTIO_FASTAPI_PUBLIC_URL must be set in environment-specific values files
     # (values-embl-demo.yaml, values-embl-demo-dev.yaml) to match the ingress host
 
+    # NOTE: To enable EMBL SSO (SAML via Keycloak), copy the
+    # DEPICTIO_AUTH_SAML_ENABLED env flag and the top-level `auth:` block from
+    # values-embl-auth.yaml into the environment-specific values file, adjusting
+    # the SP entity ID / ACS host to that environment's API hostname.
+
 
 mongo:
   useOperator: true     # Use Percona PSMDB Operator for HA replica set

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -2062,6 +2062,10 @@ export interface AuthStatusResponse {
    *  treat absent as `false`. */
   registration_disabled?: boolean;
   google_oauth_enabled: boolean;
+  /** SAML SSO login enabled. Older backends omit this — treat absent as `false`. */
+  saml_enabled?: boolean;
+  /** Label for the SAML login button (e.g. "Sign in with EMBL"). */
+  saml_login_label?: string;
   /** Development mode (DEPICTIO_DEV_MODE). Suppresses the walkthrough. */
   is_dev_mode?: boolean;
   /** Explicit walkthrough kill switch (DEPICTIO_WALKTHROUGH_DISABLED). */
@@ -2224,6 +2228,13 @@ export async function startGoogleOAuth(): Promise<{ authorization_url: string; s
   const res = await fetch(`${API_BASE}/auth/google/login`);
   if (!res.ok) await throwHttpError(res, 'Failed to start Google OAuth');
   return (await res.json()) as { authorization_url: string; state: string };
+}
+
+/** URL starting the SAML SP-initiated login. Use as a full-page navigation
+ *  (window.location.assign), NOT a fetch — the backend 302s to the IdP.
+ *  `next` must be a same-origin path; the backend re-validates it. */
+export function samlLoginUrl(next: string = '/dashboards'): string {
+  return `${API_BASE}/auth/saml/login?next=${encodeURIComponent(next)}`;
 }
 
 /** Complete the Google OAuth flow with the code/state from the redirect URL. */

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -187,6 +187,7 @@ export {
   getAnonymousSession,
   startGoogleOAuth,
   handleGoogleCallback,
+  samlLoginUrl,
   exchangeMagicToken,
   persistSession,
   clearSession,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,13 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+# SAML SSO support (python3-saml needs the native xmlsec/libxml2 toolchain at
+# build time — see docker-images/Dockerfile.api). Kept out of the base deps so
+# plain `pip install depictio` (CLI usage) needs no native libs.
+saml = [
+  "python3-saml==1.16.0",
+  "defusedxml==0.7.1",
+]
 dev = [
   "bandit==1.9.4",
   "ruff==0.16.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
@@ -981,6 +981,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deltalake"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1069,6 +1078,10 @@ dev = [
     { name = "types-bleach" },
     { name = "types-boto3" },
 ]
+saml = [
+    { name = "defusedxml" },
+    { name = "python3-saml" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1082,6 +1095,7 @@ requires-dist = [
     { name = "cloudpickle", specifier = "==3.1.2" },
     { name = "colorlog", specifier = "==6.12.0" },
     { name = "cryptography", specifier = "==49.0.0" },
+    { name = "defusedxml", marker = "extra == 'saml'", specifier = "==0.7.1" },
     { name = "deltalake", specifier = "==1.6.2" },
     { name = "devtools", specifier = "==0.12.2" },
     { name = "diskcache", specifier = "==5.6.3" },
@@ -1116,6 +1130,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-jose", specifier = "==3.5.0" },
     { name = "python-multipart", specifier = "==0.0.32" },
+    { name = "python3-saml", marker = "extra == 'saml'", specifier = "==1.16.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "redis", specifier = "==5.2.1" },
     { name = "restrictedpython", specifier = "==8.4" },
@@ -1134,7 +1149,7 @@ requires-dist = [
     { name = "watchdog", specifier = "==6.0.0" },
     { name = "websockets", specifier = "==17.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["saml", "dev"]
 
 [[package]]
 name = "deprecated"
@@ -1625,6 +1640,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1747,6 +1771,108 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
     { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
     { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/77/1bc7eeb0de4577d783fb625aa092cc9357883bba35845a3666bf1259f3dc/lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a", size = 5067921, upload-time = "2026-05-18T19:17:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3c/c0690d74bd2bc17bc03b5b0d093569ead597dd0bfa088bf99eef8c24e19c/lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d", size = 5002456, upload-time = "2026-05-18T19:17:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8d/d1b3271af0c0f1e27e8472a849e4d2c65bc7766884b9ad2da9e76e145c88/lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8", size = 5202776, upload-time = "2026-05-18T19:18:08.924Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/689824ffb237fd10125ad273f32b28ff04dc6203c2822c85ff65a93df65e/lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009", size = 5329945, upload-time = "2026-05-18T19:18:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c0/ef73af53767e958fd87d437c170f272e2f6e6c0f854939f133a895f1e711/lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6", size = 4659237, upload-time = "2026-05-18T19:18:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/e1158e40397585e91cb0472374a1f63d0926a1ddeaa92f13d1a1ffe306d5/lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8", size = 5265904, upload-time = "2026-05-18T19:18:24.883Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/8687e5d1400ed1c0bc41dace232ebb7553952b618ea1f2e5fb6e2cfbbe23/lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83", size = 5045225, upload-time = "2026-05-18T19:17:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/d877bd1ae2e5ffdfd4836565aba350db31feb2f2656d6ce70316ed66a05e/lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6", size = 4712721, upload-time = "2026-05-18T19:17:40.512Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4d/1f44fd1d770b10dacbf6b5c6e520f4d6e0708744930f719dc04e67cab981/lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c", size = 5252549, upload-time = "2026-05-18T19:17:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5d/1d66b84f850089254c230ef6ea6b267a5a54e2e179a5d960036a05d501d7/lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08", size = 5226877, upload-time = "2026-05-18T19:18:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/84c4b5302d42a2d0184f38d538c8a197f33b52a50bd4f7bcfe990bce3036/lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621", size = 3594072, upload-time = "2026-05-18T19:17:12.714Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9d/2e2f7d876349f45e0f3e29f72da311668853d59b58d473a2dea4f0160135/lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28", size = 4025469, upload-time = "2026-05-18T19:17:50.566Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/570e6390e4110331e6208b2ba83d1482cc9146808ee118b22824a34c1070/lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b", size = 3667640, upload-time = "2026-05-19T19:22:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/32/86a3f0f724a3a402d4627937a7fc27b160e45e7012b4adf47f6e1e844511/lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e", size = 3930127, upload-time = "2026-05-18T19:19:02.27Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/d832e82af08723761556d004b1d04d281c09f9a8cecd7d3148548c9941a3/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004", size = 4210769, upload-time = "2026-05-18T19:20:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/39/0dc5949f759ed7d951e0bb8c2f2d9d7aca1908d22352fa84a8afd2ea54af/lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e", size = 4318163, upload-time = "2026-05-18T19:20:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
 ]
 
 [[package]]
@@ -3241,6 +3367,20 @@ wheels = [
 ]
 
 [[package]]
+name = "python3-saml"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "lxml" },
+    { name = "xmlsec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/98/6e0268c3a9893af3d4c5cf670183e0314cd6b5cb034a612d6a7cc5060df8/python3-saml-1.16.0.tar.gz", hash = "sha256:97c9669aecabc283c6e5fb4eb264f446b6e006f5267d01c9734f9d8bffdac133", size = 83468, upload-time = "2023-10-09T10:37:43.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/14/49d9828443b58bd5cc80a454c91b0f867fbf36a24975d501945e6cb9e32f/python3_saml-1.16.0-py3-none-any.whl", hash = "sha256:20b97d11b04f01ee22e98f4a38242e2fea2e28fbc7fbc9bdd57cab5ac7fc2d0d", size = 76155, upload-time = "2023-10-09T10:40:34.001Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4461,6 +4601,53 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
+]
+
+[[package]]
+name = "xmlsec"
+version = "1.3.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/14/538b75379e6ab8f688f14d8663e2ab138d9c778bac4999d155b5f33c71c1/xmlsec-1.3.17.tar.gz", hash = "sha256:f3fac9ae679f66585925cc00c5f6839ae36c1d03157619571dee18acc05b9c01", size = 115637, upload-time = "2025-11-11T16:20:46.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/e4/970614d892749da00df253c370230fd24143028268923a1c35651fb3f962/xmlsec-1.3.17-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4a7ee007c6b55f7621330aee8330ef2dafa4225fce554064571ca826beafe7e", size = 3450577, upload-time = "2025-11-11T16:19:34.159Z" },
+    { url = "https://files.pythonhosted.org/packages/50/4a/2f48ad48fecbd49dbbc6f2a5b540cd65277089fd5b8b5d8c7e816c3625c2/xmlsec-1.3.17-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1ef656421d01851618d0fe5518e57469159c14a48e05125f7bd3225631952f9", size = 3846698, upload-time = "2025-11-11T16:19:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/07/0130e0b711f7443d0abdec403ea5128392cd5b241bb53f4ec41d144d94db/xmlsec-1.3.17-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80fff2251d0e73714435b5860ce200990dffe85466dd91d08d75c4d64ee9967d", size = 4423233, upload-time = "2025-11-11T16:19:37.129Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f7/a4e588d61f602f25a51b6004be9a162e36e746fa1cbeb12248794a96766b/xmlsec-1.3.17-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f2bf6bbf04f8a912483d268b4c2727d400d1806d054624da13bee4b9f6fa28a", size = 4163716, upload-time = "2025-11-11T16:19:38.365Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a2/f8c019445134dfc59afb5874d1fc4fe212ec2dc45a8c33806a15b5c0c119/xmlsec-1.3.17-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a603584ceee175036e1bccdbe65d551c0fff67343fd506bfa6cec52bc64d9a75", size = 3875404, upload-time = "2025-11-11T16:19:40.008Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c3/90c0e26bb9f95799c64874ebee0b43eaf7e5b5ba912bcd87ed4cc46ea514/xmlsec-1.3.17-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:26cc3d81437b51839946d2e93d09371dfd73ed2831dc7e37eff0fb52fc33747c", size = 4460640, upload-time = "2025-11-11T16:19:41.372Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/be/7b85b0ff4281779293d93a8bbef70a6b72ba60d8a80d15653bd4967d0c07/xmlsec-1.3.17-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d862f023f56a49c06576be41dfaf213c9ac77e7a344e7f204278c365bb36d00e", size = 4209625, upload-time = "2025-11-11T16:19:43.289Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6d/028472e523c2f667a4634881b65acfa939bc4902ed37e1e9fe1d55d45ec0/xmlsec-1.3.17-cp311-cp311-win_amd64.whl", hash = "sha256:9877303e8c72d7aa2467d1af12e56d67b8fb50d324eda5848e0ec5ee2176aac5", size = 2445935, upload-time = "2025-11-11T16:19:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/01/d36fd82b837167546951e7e088dbd2f0dacf553157d256b2a25802d28a95/xmlsec-1.3.17-cp311-cp311-win_arm64.whl", hash = "sha256:b3f306f5aef47336b8299d8dbee31fa0b2eba4579f9f41396070f7a97d0dcd49", size = 2261485, upload-time = "2025-11-11T16:19:46.212Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a5/d91216f7dbb85cb65cb7249fcc894f5389a8a4843857aff678646cab77fa/xmlsec-1.3.17-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df4a8d7fef3ffe90e572400d47392ea480120e339c292f802830ed09d449e622", size = 3450960, upload-time = "2025-11-11T16:19:47.794Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/38/c37bd4e164259e0b271fe4d17d054f31c7287a1e4c47d24ef77d723b3493/xmlsec-1.3.17-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed63cbd87dd69ebcf3a9f82d87b67818c9a7d656325dd4fb34d6c4dfbaa84017", size = 3846774, upload-time = "2025-11-11T16:19:49.636Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ff/83430c5df33c6ad402728a681998c5b2872c090b556a558d02f8cf1d2f24/xmlsec-1.3.17-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5c3008b32a15d24b6c9da39bf6ede8dc3122570a640a73795d763aea55a2193e", size = 4425910, upload-time = "2025-11-11T16:19:50.95Z" },
+    { url = "https://files.pythonhosted.org/packages/02/41/bb94c7a97ea613b3860f6152bb7efcf5be524d135592e094ecc64ff79228/xmlsec-1.3.17-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a0b9a1dcda547e0340eefa6f4a04b87dbd9e40cd514487f347934f94fd559ab", size = 4169038, upload-time = "2025-11-11T16:19:52.217Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4c/852ba0805df27b7bd1e88e9524d9573b076c3a126e936b1f18c6f22fb968/xmlsec-1.3.17-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3a53c14d4bc40b0f0fcc6d7908b88f3cbbcf36e25c392f796d88aee7dee5beea", size = 3876430, upload-time = "2025-11-11T16:19:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f0/08fec6adc65f6911b49b4fa71e920c8f6434f44fdc427c71360e6dd9e9ce/xmlsec-1.3.17-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5346616e1fe1015f7800698c15225c7902f45db199e217af2039a21989aff7e9", size = 4464419, upload-time = "2025-11-11T16:19:54.777Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ce/84789ba3929715806deae88f10bc31e1ff904aa735059ee3855c104a142d/xmlsec-1.3.17-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:64c1184d51c8a67e3d1eb3ac477e307a07e2b40fd03cd0c8084b147ea0f342db", size = 4215080, upload-time = "2025-11-11T16:19:56.293Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/57b5054187cd2b42e5310dc1f6d209fced456f93dae25345a422b3a290ef/xmlsec-1.3.17-cp312-cp312-win_amd64.whl", hash = "sha256:d360d4adfb53d3adeca398c225cb7e2a73a2246414455937082a1fa19bd8572b", size = 2445872, upload-time = "2025-11-11T16:19:57.713Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7b/f64c95df054dd793ae1925f04248abd359b1c26cc2320d67407e7fd26e4d/xmlsec-1.3.17-cp312-cp312-win_arm64.whl", hash = "sha256:eee89c268a35f8a08a8e9abef6f466b97577e94f5cac8bf32c25e97cd5020097", size = 2261464, upload-time = "2025-11-11T16:19:58.937Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/25/d0c03351bbf776f2272d602272ca9d759d48f0f4e90707987098abb48e14/xmlsec-1.3.17-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:672e41dc7962da4ce84b67aa1c3a008338e3b88332f5484b9911b91cee0997ed", size = 3450899, upload-time = "2025-11-11T16:20:00.29Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/00db758c40d42ae2d43603552262b1027c02bbac934be26425e820c63c0f/xmlsec-1.3.17-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:72fc6d336dd68d62822c6536ff4b2453fda94ea652eddb4a958ac97b16ac7001", size = 3846790, upload-time = "2025-11-11T16:20:01.515Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/91/00cd12243f5f8cccec23e0d9946379861b954bf98c52d3f68b9eb565ba76/xmlsec-1.3.17-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae88c3aaab5704adfdbce913b3a18db1eb96c49c970657cc01c0d1c420ffdec3", size = 4427662, upload-time = "2025-11-11T16:20:02.931Z" },
+    { url = "https://files.pythonhosted.org/packages/77/64/d198a8109c11124b01abbd34167dd951896b12392ccfc3f12c40eb3f0c35/xmlsec-1.3.17-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79b471fdd1d3a92b80907828eaa809f6e34023583488b1b8dc3f951529e7a2f8", size = 4170229, upload-time = "2025-11-11T16:20:04.244Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a9/3e061f10d0d921102a55b4c0442c8c5af4e01e175ea1584774eeef2e50aa/xmlsec-1.3.17-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:040f28a7aacfdb467df46d423e4af05569e9376bc8c7f6416b0761e16a0e3d0b", size = 3877622, upload-time = "2025-11-11T16:20:05.593Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1a/b8a71915bf1d59944d815c92e77a06e9c2dc4dc855a44a3127c86b0dd7f2/xmlsec-1.3.17-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67717fe5151df68987a1387cba11ba28ce19b3bb9a2d10d650277cd910e510e7", size = 4464934, upload-time = "2025-11-11T16:20:07.358Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/0f/4b9057c6049137256bb972d114d2858fc8b24e72c97e05e26a00d2db8ed2/xmlsec-1.3.17-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9bb6faa4ae0268204cfa6b0c0de1c9121eb606eea8c66c7d7ce62e89a17f9efa", size = 4215150, upload-time = "2025-11-11T16:20:10.008Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6b/a2e8bc2f94b90c2904007663c8162423fadd3cd98b7ca1632b66dcdc31cb/xmlsec-1.3.17-cp313-cp313-win_amd64.whl", hash = "sha256:66fe5aaccf68fb85fe0b64277e3f594d6b01ddefb98ef1ceb0a666652d6ec580", size = 2445890, upload-time = "2025-11-11T16:20:11.575Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/df/27210baa675eb9e5d80ed43e80d865be8fbf6148ea464d2b4d4ad1ba9f01/xmlsec-1.3.17-cp313-cp313-win_arm64.whl", hash = "sha256:5319d0bdaf9e597a0ba8dfb3840c4ae57e51f462e7620953f32b07df6267f2ba", size = 2261424, upload-time = "2025-11-11T16:20:12.88Z" },
+    { url = "https://files.pythonhosted.org/packages/77/2c/0169a383769d563f6582d5b3a2ccf7f612f4bf98cbd417a27287443b63c5/xmlsec-1.3.17-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:5d0e69291f90b28e9442d8e0e69d3e06cede8a3c44e856413fd284de81ce2888", size = 3450932, upload-time = "2025-11-11T16:20:14.334Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/be65923c5aa3097f422af3d917ffda15590ab0f4c9a5a5d78d520ae7fc9a/xmlsec-1.3.17-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5616ad5016794b0dd41d03eef5b721e31bb306353226b25fc88fedb7d4f7c37e", size = 3847248, upload-time = "2025-11-11T16:20:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/58/24e047e6a5f0c266e949c7c03c2770163038e7abd322c95bfbae021f9477/xmlsec-1.3.17-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4be73fbde421d6188300e02ad92d2d5435c708a35ede8124ebdf6b00330d7cb", size = 4428590, upload-time = "2025-11-11T16:20:18.012Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/23/e5212147d227da638311287045c90a47bb560b0552cc7daca0919a870220/xmlsec-1.3.17-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3961102a6ba8250670814bd1086139fb918e03bf146ef85dc8b6084a9b027d1", size = 4169645, upload-time = "2025-11-11T16:20:19.646Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/ed1f6d18f7c10dc61f791aade218b2271b4fc3092dd499036bc391a32945/xmlsec-1.3.17-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:728058a1623a620811a3cdf2dd4894b5d9413ede20c8ddddf98fdea5eafe9529", size = 3878531, upload-time = "2025-11-11T16:20:20.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/eb/09050fd1dc109ebe5bfefd0eab0829cab4fae51b3a244949e31dccf144e1/xmlsec-1.3.17-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:593264c192d1836162d75478c8b1cb5874f3b69dcc5bdfac642a0933abefa93a", size = 4464490, upload-time = "2025-11-11T16:20:22.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2e/52e9ef2b5c8ef2470e1e3ae3ef89f7ac45eecd267c7b3bab8a7ad7d68af1/xmlsec-1.3.17-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3d1fc1fbe2e8585a3f468cf4154d0ec36cd95a15e68429ad8cc8ccd7c04e84ae", size = 4214358, upload-time = "2025-11-11T16:20:24.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cd/5e9061027a203fd083b6058c2948ee1a16bd909d3a0e331e054362ca550e/xmlsec-1.3.17-cp314-cp314-win_amd64.whl", hash = "sha256:e2bf1d07c4f97afeb957f626b8c3ebb8cef300efa0cb95599e936c69a66a1b17", size = 2513252, upload-time = "2025-11-11T16:20:25.738Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e9/b2f4b9092434b854bcae0d901c10a7e96d2a12d03cc35dbf7a7b2c91502b/xmlsec-1.3.17-cp314-cp314-win_arm64.whl", hash = "sha256:3a6ced8c7744e896cb5a9fd0156d204df3143a62bae11be91cab8e9743d40eec", size = 2328451, upload-time = "2025-11-11T16:20:27.247Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds SP-initiated SAML SSO so the next EMBL deployment can log in against the EMBL Keycloak IdP, and fixes the Google OAuth anti-CSRF state store that made OAuth unreliable in multi-worker/multi-replica deployments.

**SAML (#562)** — based on the validated `dev/dev_fastapi_saml` prototype, integrated with depictio's own auth machinery:
- New `/auth/saml/{login,callback,metadata}` endpoints (`python3-saml` behind a new optional `saml` extra; xmlsec native deps added to `Dockerfile.api`).
- The ACS (POST callback) hands the browser off to the existing **magic-link flow**: a single-use ticket in the URL *fragment*, redeemed by the viewer's `MagicLinkCallback` — no JWT in query strings, no new frontend callback code.
- `InResponseTo` is tracked server-side (replay protection) and the IdP-echoed RelayState is never trusted; redirect targets are restricted to same-origin relative paths.
- `DEPICTIO_AUTH_SAML_*` settings on `AuthConfig` (IdP cert as inline PEM or file path; empty strings coerced to unset for Helm/compose).
- "Sign in with SSO" button (configurable label, e.g. "Sign in with EMBL") in the React login form, driven by `saml_enabled`/`saml_login_label` on `/auth/me/optional`.
- Helm plumbing: SAML env vars + `DEPICTIO_VIEWER_PUBLIC_URL` in the backend ConfigMap, EMBL Keycloak reference block in `values-embl-auth.yaml`.

**OAuth state fix (#561)** — the anti-CSRF `state` lived in a per-process dict, so with 4 workers × 2 replicas the callback usually hit a worker that had never seen it (~7/8 failures; the `DEPICTIO_DEV_MODE` bypass papered over it). States now live in a shared Redis-backed one-shot store (atomic GETDEL, in-process fallback when Redis is down), reused for SAML request tracking; the dev-mode bypass is removed. Also: OAuth-created users now get a real random bcrypt hash instead of the invalid sentinel that crashed password verification, and user mapping is shared between Google OAuth and SAML via `create_or_get_sso_user()`.

## Type of change
- [x] Bugfix
- [x] Feature
- [ ] Refactor / code style
- [x] Build / CI / deps
- [ ] Documentation

## Related issue
Closes #562, relates to #561

## How was this tested?
- 22 new unit tests for the SAML endpoints (`test_saml.py`): login gating/redirect, `next` open-redirect rejection, ACS success → magic-link ticket, InResponseTo replay rejection, validation-error and `registration_disabled` paths, helper functions, and real SP-metadata generation with `python3-saml` + a self-signed cert.
- New state-store tests (`test_auth_state_store.py`): one-shot semantics, TTL expiry, Redis `SET NX EX`/`GETDEL` calls, Redis-error fallback, and a regression test asserting the old dev-mode bypass stays gone.
- Full backend suite passes (888 passed; one pre-existing S3 integration test requires a Docker daemon unavailable in the sandbox).
- Viewer typechecks and production-builds; `helm lint` + `helm template` verified (including multi-line PEM quoting and the `DEPICTIO_VIEWER_PUBLIC_URL` default).

To enable at the next EMBL deployment: register the SP in the Keycloak realm (import `GET /auth/saml/metadata`), paste the realm RS256 signing cert into `DEPICTIO_AUTH_SAML_IDP_CERT`, copy the `auth:` block from `values-embl-auth.yaml` into the deployed values file, and set `DEPICTIO_AUTH_SAML_ENABLED: "true"`.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDZX8rReYKha1aRHRPFDmi)_