### PR TITLE
UX: font-size control, instance branding & per-dashboard plot theme

### DIFF
--- a/.github/workflows/minimal-deploy.yaml
+++ b/.github/workflows/minimal-deploy.yaml
@@ -323,4 +323,3 @@ jobs:
           depictio-cli config check \
             --project-config-path ../projects/init/iris/project.yaml \
             --CLI-config-path admin_config.yaml
-

--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,14 @@ depictio/dash/**/screenshots/**
 # copy-screenshot-files init container).
 depictio/api/static/screenshots/**
 
+# Dashboard logos are uploaded at runtime through the editor's Settings drawer
+# (POST /dashboards/upload_logo); the backend mkdir's the dir at boot.
+depictio/api/static/dashboard_logos/**
+
+# Instance branding logos are uploaded at runtime through the admin Branding
+# panel (POST /utils/branding/logo/{variant}); the backend mkdir's the dir.
+depictio/api/static/branding/**
+
 # Allow reference dashboard screenshots (iris, penguins, ampliseq)
 # Iris dashboard (6824cb3b89d2b72169309737)
 !depictio/dash/static/screenshots/6824cb3b89d2b72169309737.png

--- a/depictio/api/main.py
+++ b/depictio/api/main.py
@@ -267,6 +267,26 @@ app.mount(
     name="dashboard-screenshots",
 )
 
+# Dashboard logos — uploaded via /dashboards/upload_logo (editor Settings
+# drawer) and referenced by the dashboard's `logo_url` field.
+_DASHBOARD_LOGOS_DIR = Path(__file__).resolve().parent / "static" / "dashboard_logos"
+_DASHBOARD_LOGOS_DIR.mkdir(parents=True, exist_ok=True)
+app.mount(
+    "/static/dashboard_logos",
+    StaticFiles(directory=str(_DASHBOARD_LOGOS_DIR)),
+    name="dashboard-logos",
+)
+
+# Instance branding logos — uploaded via /utils/branding/logo/{variant} (admin
+# Branding panel) and referenced by the branding overrides' logo URLs.
+_BRANDING_DIR = Path(__file__).resolve().parent / "static" / "branding"
+_BRANDING_DIR.mkdir(parents=True, exist_ok=True)
+app.mount(
+    "/static/branding",
+    StaticFiles(directory=str(_BRANDING_DIR)),
+    name="instance-branding",
+)
+
 # Workflow logos / icons referenced by the React viewer as ``/assets/images/...``.
 # Relocated out of the deleted depictio/dash/assets/ tree.
 _STATIC_ASSETS_DIR = Path(__file__).resolve().parent / "static_assets"

--- a/depictio/api/v1/celery_tasks.py
+++ b/depictio/api/v1/celery_tasks.py
@@ -234,7 +234,17 @@ def build_figure_preview(payload: dict) -> dict:
                 select_columns=select_columns,
             )
             if scan is not None:
-                agg_fig = build_aggregated_figure(scan, agg_plan, theme, render_stats)
+                from depictio.api.v1.services.figure.figure_builder import (
+                    resolve_template_override,
+                )
+
+                agg_fig = build_aggregated_figure(
+                    scan,
+                    agg_plan,
+                    theme,
+                    render_stats,
+                    template_override=resolve_template_override(dict_kwargs.get("template")),
+                )
 
     df = None
     if agg_fig is None and code_sample_cap:

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -1274,15 +1274,13 @@ class BrandingConfig(BaseSettings):
     logo_url_dark: Optional[str] = Field(
         default=None,
         description=(
-            "Optional dark-mode variant of the custom logo. Falls back to "
-            "logo_url when unset."
+            "Optional dark-mode variant of the custom logo. Falls back to logo_url when unset."
         ),
     )
     app_name: Optional[str] = Field(
         default=None,
         description=(
-            "Instance display name, used for the browser tab title and the "
-            "login-page greeting."
+            "Instance display name, used for the browser tab title and the login-page greeting."
         ),
     )
     primary_color: Optional[str] = Field(

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from typing import Any, Literal, Optional
 
@@ -1252,6 +1253,72 @@ class GoogleAnalyticsConfig(BaseSettings):
         return self.enabled and self.tracking_id is not None
 
 
+class BrandingConfig(BaseSettings):
+    """Instance-level branding (issue #397).
+
+    Lets a deployment (e.g. a core facility) replace the depictio logo, name
+    the instance, and re-tint the UI and server-rendered Plotly figures —
+    all env-driven, exposed to the SPA through ``/utils/public-config``
+    (same channel as ``GoogleAnalyticsConfig``). The "Powered by Depictio"
+    header badge is not affected.
+    """
+
+    logo_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "URL of the custom logo shown in the sidebar and on the login page "
+            "(absolute https:// URL or a path served by this deployment). "
+            "Replaces the depictio logo when set."
+        ),
+    )
+    logo_url_dark: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional dark-mode variant of the custom logo. Falls back to "
+            "logo_url when unset."
+        ),
+    )
+    app_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Instance display name, used for the browser tab title and the "
+            "login-page greeting."
+        ),
+    )
+    primary_color: Optional[str] = Field(
+        default=None,
+        description=(
+            "Primary UI color: a Mantine palette name (e.g. 'teal') or a hex "
+            "color (e.g. '#0ca678') the viewer expands into a palette."
+        ),
+    )
+    colorway: Optional[str] = Field(
+        default=None,
+        description=(
+            "Comma-separated hex colors (e.g. '#1f77b4,#ff7f0e,...') used as "
+            "the categorical colorway of server-rendered Plotly figures."
+        ),
+    )
+
+    model_config = SettingsConfigDict(env_prefix="DEPICTIO_BRANDING_")
+
+    @property
+    def colorway_list(self) -> Optional[list[str]]:
+        """Parsed & validated colorway; None when unset or nothing valid remains."""
+        if not self.colorway:
+            return None
+        colors = [
+            color.strip()
+            for color in self.colorway.split(",")
+            if re.fullmatch(r"#[0-9a-fA-F]{6}", color.strip())
+        ]
+        return colors or None
+
+    @property
+    def is_configured(self) -> bool:
+        return any((self.logo_url, self.app_name, self.primary_color, self.colorway_list))
+
+
 class ProfilingConfig(BaseSettings):
     """Configuration for application profiling."""
 
@@ -1331,6 +1398,7 @@ class Settings(BaseSettings):
     analytics: AnalyticsConfig = Field(default_factory=AnalyticsConfig)
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
     google_analytics: GoogleAnalyticsConfig = Field(default_factory=GoogleAnalyticsConfig)
+    branding: BrandingConfig = Field(default_factory=BrandingConfig)
     profiling: ProfilingConfig = Field(default_factory=ProfilingConfig)
 
     disable_example_dashboards: bool = Field(

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -6,12 +6,13 @@ import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Annotated, Any
 from uuid import UUID
 
 import yaml
 from bson import ObjectId
-from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, File, HTTPException, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse, Response
 
@@ -712,6 +713,86 @@ async def save_dashboard(
         return {"message": message, "dashboard_id": dashboard_id_str}
     else:
         raise HTTPException(status_code=404, detail="Failed to insert or update dashboard data.")
+
+
+# Dashboard logos — uploaded through the editor's Settings drawer and served
+# by the /static/dashboard_logos mount (api/main.py). Derived from __file__ so
+# the path holds both in Docker (/app/depictio/...) and local runs.
+_DASHBOARD_LOGOS_DIR = Path(__file__).resolve().parents[3] / "static" / "dashboard_logos"
+# SVG is deliberately excluded: a stored SVG can carry scripts and is served
+# same-origin, which hands an XSS foothold to anyone navigating to it directly.
+# Extension + accepted magic-byte prefixes per declared content type.
+_LOGO_TYPES: dict[str, tuple[str, tuple[bytes, ...]]] = {
+    "image/png": (".png", (b"\x89PNG\r\n\x1a\n",)),
+    "image/jpeg": (".jpg", (b"\xff\xd8\xff",)),
+    "image/webp": (".webp", (b"RIFF",)),
+}
+_LOGO_MAX_BYTES = 2 * 1024 * 1024
+
+
+@dashboards_endpoint_router.post("/upload_logo/{dashboard_id}")
+async def upload_dashboard_logo(
+    dashboard_id: PyObjectId,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_user_or_anonymous),
+):
+    """Store a dashboard logo image and stamp `logo_url` on the document.
+
+    File write and field update happen in one ownership-checked call so the
+    stored URL can never point at a file that was rejected. Removal goes
+    through the regular save path (`logo_url: null`); the file on disk is
+    simply overwritten by the next upload for this dashboard.
+    """
+    if hasattr(current_user, "is_anonymous") and current_user.is_anonymous:
+        if not settings.auth.is_single_user_mode:
+            raise HTTPException(
+                status_code=403,
+                detail="Anonymous users cannot modify dashboards. Please login to continue.",
+            )
+
+    dashboard = dashboards_collection.find_one({"dashboard_id": dashboard_id})
+    if not dashboard:
+        raise HTTPException(status_code=404, detail="Dashboard not found.")
+    project_id = dashboard.get("project_id")
+    if not project_id or not check_project_permission(project_id, current_user, "editor"):
+        raise HTTPException(
+            status_code=403, detail="You don't have permission to update this dashboard."
+        )
+
+    spec = _LOGO_TYPES.get(file.content_type or "")
+    if not spec:
+        raise HTTPException(
+            status_code=415, detail="Unsupported image type — use PNG, JPEG or WebP."
+        )
+    ext, magic_prefixes = spec
+
+    content = await file.read()
+    if len(content) > _LOGO_MAX_BYTES:
+        raise HTTPException(status_code=413, detail="Logo file too large (max 2MB).")
+    # The declared content type decides the extension the static mount serves
+    # with, so make sure the bytes actually are that format.
+    valid_magic = content.startswith(magic_prefixes)
+    if valid_magic and ext == ".webp":
+        valid_magic = content[8:12] == b"WEBP"
+    if not valid_magic:
+        raise HTTPException(
+            status_code=415, detail="File content does not match the declared image type."
+        )
+
+    _DASHBOARD_LOGOS_DIR.mkdir(parents=True, exist_ok=True)
+    # One logo per dashboard — drop whatever extension the previous upload had.
+    for old in _DASHBOARD_LOGOS_DIR.glob(f"{dashboard_id}.*"):
+        old.unlink(missing_ok=True)
+    (_DASHBOARD_LOGOS_DIR / f"{dashboard_id}{ext}").write_bytes(content)
+
+    # `?v=` cache-busts the browser after a replacement (same idiom as the
+    # screenshot thumbnails' `screenshot_ts`).
+    logo_url = f"/static/dashboard_logos/{dashboard_id}{ext}?v={int(time.time())}"
+    dashboards_collection.update_one(
+        {"dashboard_id": dashboard_id}, {"$set": {"logo_url": logo_url}}
+    )
+    logger.info(f"Dashboard {dashboard_id} logo updated ({len(content)} bytes, {ext})")
+    return {"logo_url": logo_url}
 
 
 @dashboards_endpoint_router.delete("/delete/{dashboard_id}")

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -41,10 +41,10 @@ from depictio.api.v1.services.card_breakdown import (
 from depictio.api.v1.services.card_metrics import (
     NUMERIC_LAYOUTS,
 )
-from depictio.api.v1.services.figure.figure_builder import merge_dashboard_plot_theme
 from depictio.api.v1.services.card_metrics import (
     numeric_layout_payload as _numeric_layout_payload,
 )
+from depictio.api.v1.services.figure.figure_builder import merge_dashboard_plot_theme
 from depictio.models.models.base import PyObjectId, convert_objectid_to_str
 from depictio.models.models.dashboards import DashboardData, DashboardDataLite
 from depictio.models.models.users import User

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -41,6 +41,7 @@ from depictio.api.v1.services.card_breakdown import (
 from depictio.api.v1.services.card_metrics import (
     NUMERIC_LAYOUTS,
 )
+from depictio.api.v1.services.figure.figure_builder import merge_dashboard_plot_theme
 from depictio.api.v1.services.card_metrics import (
     numeric_layout_payload as _numeric_layout_payload,
 )
@@ -2604,7 +2605,9 @@ async def render_figure_endpoint(
         "dc_id": str(dc_id),
         "dc_config": convert_objectid_to_str(dc_config),
         "visu_type": component.get("visu_type", "scatter"),
-        "dict_kwargs": component.get("dict_kwargs") or {},
+        "dict_kwargs": merge_dashboard_plot_theme(
+            dashboard_data.get("plot_theme"), component.get("dict_kwargs") or {}
+        ),
         "mode": mode,
         "code_content": component.get("code_content", ""),
         "selection_enabled": bool(component.get("selection_enabled", False)),

--- a/depictio/api/v1/endpoints/figure_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/figure_endpoints/routes.py
@@ -121,15 +121,41 @@ async def preview_figure(
         {
           "metadata": { ...full figure stored_metadata shape... },
           "filters": [...] (optional),
-          "theme": "light" | "dark" (default "light")
+          "theme": "light" | "dark" (default "light"),
+          "dashboard_id": "..." (optional)
         }
+
+    ``dashboard_id``, when supplied, pulls that dashboard's ``plot_theme``
+    defaults into the preview so it matches what the saved component will
+    render (#397).
     """
     metadata = request.get("metadata") or {}
     filters = request.get("filters") or []
     theme = request.get("theme") or "light"
+    preview_dashboard_id = request.get("dashboard_id")
 
     if not metadata or metadata.get("component_type") != "figure":
         raise HTTPException(status_code=400, detail="metadata must be a figure component.")
+
+    if preview_dashboard_id:
+        from bson import ObjectId
+
+        from depictio.api.v1.db import dashboards_collection
+        from depictio.api.v1.services.figure.figure_builder import merge_dashboard_plot_theme
+
+        try:
+            dashboard_doc = dashboards_collection.find_one(
+                {"dashboard_id": ObjectId(str(preview_dashboard_id))}
+            )
+        except Exception:
+            dashboard_doc = None
+        if dashboard_doc and dashboard_doc.get("plot_theme"):
+            metadata = {
+                **metadata,
+                "dict_kwargs": merge_dashboard_plot_theme(
+                    dashboard_doc["plot_theme"], metadata.get("dict_kwargs") or {}
+                ),
+            }
 
     wf_id = metadata.get("wf_id")
     dc_id = metadata.get("dc_id")

--- a/depictio/api/v1/endpoints/utils_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/utils_endpoints/routes.py
@@ -1,7 +1,11 @@
 import asyncio
+import time
 from datetime import datetime
+from pathlib import Path
+from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Header, HTTPException, UploadFile
+from pydantic import BaseModel, Field
 
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
@@ -116,8 +120,9 @@ async def public_config():
     GA measurement ID is already visible in the page's network traffic once
     injected, so exposing it changes nothing.
     """
+    from depictio.api.v1.services.branding import get_effective_branding
+
     ga = settings.google_analytics
-    branding = settings.branding
     return {
         "google_analytics": {
             "enabled": ga.is_configured,
@@ -126,16 +131,146 @@ async def public_config():
             "tracking_id": ga.tracking_id if ga.is_configured else None,
         },
         # Instance branding (#397): custom logo / name / colors for e.g. a core
-        # facility deployment. Always emitted (nulls when unset) so the client
+        # facility deployment. Env defaults overridden by the admin panel's
+        # live settings. Always emitted (nulls when unset) so the client
         # contract stays shape-stable.
-        "branding": {
-            "logo_url": branding.logo_url,
-            "logo_url_dark": branding.logo_url_dark,
-            "app_name": branding.app_name,
-            "primary_color": branding.primary_color,
-            "colorway": branding.colorway_list,
-        },
+        "branding": get_effective_branding(),
     }
+
+
+# ── Admin branding (issue #397, admin UI) ────────────────────────────────────
+# Live overrides of the DEPICTIO_BRANDING_* env defaults, per field, persisted
+# in the `instance_settings` collection and served to every visitor through
+# /utils/public-config above. Admin only.
+
+# Uploaded branding logos; served by the /static/branding mount (api/main.py).
+_BRANDING_LOGOS_DIR = Path(__file__).resolve().parents[3] / "static" / "branding"
+
+_HEX_COLOR_RE_STR = r"^#[0-9a-fA-F]{6}$"
+
+
+class BrandingOverridesPayload(BaseModel):
+    """Full override set — PUT replaces; omitted/null fields fall back to env."""
+
+    logo_url: str | None = Field(default=None, max_length=2000)
+    logo_url_dark: str | None = Field(default=None, max_length=2000)
+    app_name: str | None = Field(default=None, max_length=120)
+    primary_color: str | None = Field(default=None, max_length=64)
+    colorway: list[str] | None = Field(default=None, max_length=24)
+
+
+def _require_admin(current_user) -> None:
+    if not getattr(current_user, "is_admin", False):
+        raise HTTPException(status_code=403, detail="User is not an admin.")
+
+
+def _validate_branding_payload(payload: BrandingOverridesPayload) -> dict:
+    """Cross-field validation the Pydantic shape can't express."""
+    import re as _re
+
+    from depictio.api.v1.services.branding import HEX_COLOR_RE, PALETTE_NAME_RE
+
+    overrides = payload.model_dump(exclude_none=True)
+
+    color = overrides.get("primary_color")
+    if color and not (HEX_COLOR_RE.match(color) or PALETTE_NAME_RE.match(color)):
+        raise HTTPException(
+            status_code=422,
+            detail="primary_color must be a hex color (#rrggbb) or a Mantine palette name.",
+        )
+    for hex_color in overrides.get("colorway") or []:
+        if not _re.match(_HEX_COLOR_RE_STR, hex_color):
+            raise HTTPException(
+                status_code=422, detail=f"colorway entries must be #rrggbb hex colors: {hex_color}"
+            )
+    if overrides.get("colorway") == []:
+        # An empty list means "no override" — store nothing so env applies.
+        overrides.pop("colorway")
+    for field in ("logo_url", "logo_url_dark"):
+        url = overrides.get(field)
+        # http(s) or a path this deployment serves — nothing else can end up
+        # in an <img src> the whole instance renders.
+        if url and not (
+            url.startswith("https://") or url.startswith("http://") or url.startswith("/")
+        ):
+            raise HTTPException(
+                status_code=422, detail=f"{field} must be an http(s) URL or an absolute path."
+            )
+    return overrides
+
+
+def _branding_admin_view() -> dict:
+    from depictio.api.v1.services.branding import (
+        env_branding_defaults,
+        get_branding_overrides,
+        get_effective_branding,
+    )
+
+    return {
+        "overrides": get_branding_overrides(),
+        "env_defaults": env_branding_defaults(),
+        "effective": get_effective_branding(use_cache=False),
+    }
+
+
+@utils_endpoint_router.get("/branding")
+async def get_branding_admin(current_user=Depends(get_current_user)):
+    """Current branding state for the admin panel: overrides, env, effective."""
+    _require_admin(current_user)
+    return _branding_admin_view()
+
+
+@utils_endpoint_router.put("/branding")
+async def put_branding_admin(
+    payload: BrandingOverridesPayload, current_user=Depends(get_current_user)
+):
+    """Replace the admin branding overrides. Null/omitted fields fall back to env."""
+    _require_admin(current_user)
+    from depictio.api.v1.services.branding import set_branding_overrides
+
+    overrides = _validate_branding_payload(payload)
+    set_branding_overrides(overrides)
+    logger.info(f"Branding overrides updated by {getattr(current_user, 'email', '?')}")
+    return _branding_admin_view()
+
+
+@utils_endpoint_router.delete("/branding")
+async def delete_branding_admin(current_user=Depends(get_current_user)):
+    """Clear every override — the deployment's env defaults apply again."""
+    _require_admin(current_user)
+    from depictio.api.v1.services.branding import set_branding_overrides
+
+    set_branding_overrides({})
+    logger.info(f"Branding overrides reset by {getattr(current_user, 'email', '?')}")
+    return _branding_admin_view()
+
+
+@utils_endpoint_router.post("/branding/logo/{variant}")
+async def upload_branding_logo(
+    variant: Literal["light", "dark"],
+    file: UploadFile = File(...),
+    current_user=Depends(get_current_user),
+):
+    """Store an instance logo (light or dark variant) and point the override at it."""
+    _require_admin(current_user)
+    from depictio.api.v1.services.branding import update_branding_override, validate_logo_upload
+
+    content = await file.read()
+    try:
+        ext = validate_logo_upload(file.content_type, content)
+    except ValueError as exc:
+        raise HTTPException(status_code=415, detail=str(exc))
+
+    _BRANDING_LOGOS_DIR.mkdir(parents=True, exist_ok=True)
+    for old in _BRANDING_LOGOS_DIR.glob(f"logo_{variant}.*"):
+        old.unlink(missing_ok=True)
+    (_BRANDING_LOGOS_DIR / f"logo_{variant}{ext}").write_bytes(content)
+
+    logo_url = f"/static/branding/logo_{variant}{ext}?v={int(time.time())}"
+    field = "logo_url" if variant == "light" else "logo_url_dark"
+    update_branding_override(field, logo_url)
+    logger.info(f"Branding logo ({variant}) updated by {getattr(current_user, 'email', '?')}")
+    return _branding_admin_view()
 
 
 @utils_endpoint_router.get("/telemetry/preview")

--- a/depictio/api/v1/endpoints/utils_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/utils_endpoints/routes.py
@@ -117,12 +117,23 @@ async def public_config():
     injected, so exposing it changes nothing.
     """
     ga = settings.google_analytics
+    branding = settings.branding
     return {
         "google_analytics": {
             "enabled": ga.is_configured,
             # Withheld unless actually enabled, so a half-configured deployment
             # does not leak a property ID it is not using.
             "tracking_id": ga.tracking_id if ga.is_configured else None,
+        },
+        # Instance branding (#397): custom logo / name / colors for e.g. a core
+        # facility deployment. Always emitted (nulls when unset) so the client
+        # contract stays shape-stable.
+        "branding": {
+            "logo_url": branding.logo_url,
+            "logo_url_dark": branding.logo_url_dark,
+            "app_name": branding.app_name,
+            "primary_color": branding.primary_color,
+            "colorway": branding.colorway_list,
         },
     }
 

--- a/depictio/api/v1/services/branding.py
+++ b/depictio/api/v1/services/branding.py
@@ -1,0 +1,164 @@
+"""Instance branding resolution (issue #397, admin UI follow-up).
+
+Two layers compose the effective branding:
+
+- **Deployment defaults** — the ``DEPICTIO_BRANDING_*`` env vars
+  (``settings.branding``), baked in by whoever operates the deployment
+  (helm values, compose env).
+- **Admin overrides** — a singleton document in ``instance_settings``,
+  edited live from the /admin Branding panel. Per-field: an override set to
+  ``None``/absent falls back to the env default, so a deployment configured
+  by env keeps working until an admin explicitly changes something.
+
+``get_effective_branding()`` is what every consumer reads: the
+``/utils/public-config`` channel (viewer logo/name/primary color) and the
+figure render paths (mantine template colorway) — API and Celery worker
+alike, both have DB access. Reads go through a short TTL cache so the
+per-figure template patch never adds a Mongo round-trip per render;
+``set_branding_overrides`` invalidates it in-process (other processes catch
+up within the TTL).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+import pymongo
+
+from depictio.api.v1.configs.config import MONGODB_URL, settings
+from depictio.api.v1.configs.logging_init import logger
+
+_DOC_ID = "branding"
+
+# Lazily-created handle on the `instance_settings` collection. Deliberately a
+# DEDICATED client with a short server-selection timeout rather than the
+# shared db.py client (30s): the effective branding is read on the figure
+# render path, and a Mongo hiccup must degrade to the env defaults in ~2s,
+# not stall every render for half a minute. Tests inject a fake here.
+instance_settings_collection: Any = None
+
+
+def _get_collection() -> Any:
+    global instance_settings_collection
+    if instance_settings_collection is None:
+        client: pymongo.MongoClient = pymongo.MongoClient(
+            MONGODB_URL, serverSelectionTimeoutMS=2000, connectTimeoutMS=2000
+        )
+        instance_settings_collection = client[settings.mongodb.db_name]["instance_settings"]
+    return instance_settings_collection
+
+
+#: Fields an admin can override. Mirrors BrandingConfig (settings_models.py),
+#: except colorway is stored as a list here rather than a comma-string.
+BRANDING_FIELDS = ("logo_url", "logo_url_dark", "app_name", "primary_color", "colorway")
+
+HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+#: Mantine palette name (e.g. "teal") — the other accepted primary_color form.
+PALETTE_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+# Render-path cache: get_effective_branding() runs for every server-rendered
+# figure (template colorway patch), so the singleton read is memoized briefly.
+_CACHE_TTL_SECONDS = 30.0
+_cache: tuple[float, dict[str, Any]] | None = None
+
+
+def get_branding_overrides() -> dict[str, Any]:
+    """The raw admin overrides document ({} when none saved yet)."""
+    doc = _get_collection().find_one({"_id": _DOC_ID}) or {}
+    return {field: doc.get(field) for field in BRANDING_FIELDS if doc.get(field) is not None}
+
+
+def set_branding_overrides(overrides: dict[str, Any]) -> dict[str, Any]:
+    """Replace the admin overrides with ``overrides`` (validated fields only).
+
+    ``None`` values are dropped — absence is what "fall back to the env
+    default" looks like. Returns the new effective branding.
+    """
+    doc = {field: overrides[field] for field in BRANDING_FIELDS if overrides.get(field) is not None}
+    if doc:
+        _get_collection().replace_one({"_id": _DOC_ID}, doc, upsert=True)
+    else:
+        _get_collection().delete_one({"_id": _DOC_ID})
+    invalidate_branding_cache()
+    return get_effective_branding()
+
+
+def update_branding_override(field: str, value: Any) -> dict[str, Any]:
+    """Set (or clear, with ``None``) a single override field in place."""
+    if field not in BRANDING_FIELDS:
+        raise ValueError(f"Unknown branding field: {field}")
+    if value is None:
+        _get_collection().update_one({"_id": _DOC_ID}, {"$unset": {field: ""}})
+    else:
+        _get_collection().update_one({"_id": _DOC_ID}, {"$set": {field: value}}, upsert=True)
+    invalidate_branding_cache()
+    return get_effective_branding()
+
+
+def env_branding_defaults() -> dict[str, Any]:
+    """The deployment-level (env var) branding, colorway already parsed."""
+    branding = settings.branding
+    return {
+        "logo_url": branding.logo_url,
+        "logo_url_dark": branding.logo_url_dark,
+        "app_name": branding.app_name,
+        "primary_color": branding.primary_color,
+        "colorway": branding.colorway_list,
+    }
+
+
+def get_effective_branding(use_cache: bool = True) -> dict[str, Any]:
+    """Env defaults overridden per-field by the admin document.
+
+    Never raises: an unreachable overrides store degrades to the env defaults
+    (cached like a successful read, so a Mongo outage costs one short
+    connection attempt per TTL window — not one per render).
+    """
+    global _cache
+    now = time.monotonic()
+    if use_cache and _cache and now - _cache[0] < _CACHE_TTL_SECONDS:
+        return _cache[1]
+
+    effective = env_branding_defaults()
+    try:
+        effective.update(get_branding_overrides())
+    except Exception as exc:
+        logger.warning(f"Branding overrides unavailable, using env defaults: {exc}")
+    _cache = (now, effective)
+    return effective
+
+
+def invalidate_branding_cache() -> None:
+    global _cache
+    _cache = None
+
+
+# ── Logo upload validation ────────────────────────────────────────────────────
+# Same rules as the per-dashboard logo endpoint: PNG/JPEG/WebP only (SVG can
+# carry scripts and is served same-origin), extension pinned by the declared
+# content type, magic bytes checked against it.
+
+LOGO_TYPES: dict[str, tuple[str, tuple[bytes, ...]]] = {
+    "image/png": (".png", (b"\x89PNG\r\n\x1a\n",)),
+    "image/jpeg": (".jpg", (b"\xff\xd8\xff",)),
+    "image/webp": (".webp", (b"RIFF",)),
+}
+LOGO_MAX_BYTES = 2 * 1024 * 1024
+
+
+def validate_logo_upload(content_type: str | None, content: bytes) -> str:
+    """Return the file extension for a valid logo upload, or raise ValueError."""
+    spec = LOGO_TYPES.get(content_type or "")
+    if not spec:
+        raise ValueError("Unsupported image type — use PNG, JPEG or WebP.")
+    ext, magic_prefixes = spec
+    if len(content) > LOGO_MAX_BYTES:
+        raise ValueError("Logo file too large (max 2MB).")
+    valid_magic = content.startswith(magic_prefixes)
+    if valid_magic and ext == ".webp":
+        valid_magic = content[8:12] == b"WEBP"
+    if not valid_magic:
+        raise ValueError("File content does not match the declared image type.")
+    return ext

--- a/depictio/api/v1/services/figure/aggregate.py
+++ b/depictio/api/v1/services/figure/aggregate.py
@@ -338,7 +338,13 @@ def _trace_colors(plan: AggPlan, names: list[str]) -> list[str | None]:
     mapping = _as_json(plan.style.get("color_discrete_map")) or {}
     sequence = _as_json(plan.style.get("color_discrete_sequence"))
     if not isinstance(sequence, list) or not sequence:
-        sequence = list(px.colors.qualitative.Plotly)
+        from depictio.api.v1.configs.config import settings
+
+        # A branded instance re-tints the mantine templates' colorway, which
+        # the px path picks up implicitly — mirror it here so graph_objects
+        # builders don't fall back to Plotly's default palette on those
+        # deployments.
+        sequence = settings.branding.colorway_list or list(px.colors.qualitative.Plotly)
     if not isinstance(mapping, dict):
         mapping = {}
     return [mapping.get(name) or sequence[i % len(sequence)] for i, name in enumerate(names)]

--- a/depictio/api/v1/services/figure/aggregate.py
+++ b/depictio/api/v1/services/figure/aggregate.py
@@ -228,6 +228,7 @@ def build_aggregated_figure(
     plan: AggPlan,
     theme: str = "light",
     render_stats: dict | None = None,
+    template_override: str | None = None,
 ) -> go.Figure | None:
     """Execute ``plan`` against ``scan`` and return the figure.
 
@@ -235,11 +236,14 @@ def build_aggregated_figure(
     at the data (missing column, cardinality blow-up); the caller then falls back
     to the px path. Never raises for data reasons — a fallback is always better
     than a failed render.
+
+    ``template_override`` pins an explicit Plotly template (component- or
+    dashboard-level choice); left ``None`` the figure follows the UI theme.
     """
     from depictio.api.v1.services.figure.mantine_templates import ensure_mantine_templates
 
     ensure_mantine_templates()
-    template = get_theme_template(theme)
+    template = template_override or get_theme_template(theme)
 
     try:
         available = set(scan.collect_schema().names())

--- a/depictio/api/v1/services/figure/aggregate.py
+++ b/depictio/api/v1/services/figure/aggregate.py
@@ -342,13 +342,13 @@ def _trace_colors(plan: AggPlan, names: list[str]) -> list[str | None]:
     mapping = _as_json(plan.style.get("color_discrete_map")) or {}
     sequence = _as_json(plan.style.get("color_discrete_sequence"))
     if not isinstance(sequence, list) or not sequence:
-        from depictio.api.v1.configs.config import settings
+        from depictio.api.v1.services.branding import get_effective_branding
 
         # A branded instance re-tints the mantine templates' colorway, which
         # the px path picks up implicitly — mirror it here so graph_objects
         # builders don't fall back to Plotly's default palette on those
-        # deployments.
-        sequence = settings.branding.colorway_list or list(px.colors.qualitative.Plotly)
+        # deployments. Effective branding = env defaults + admin overrides.
+        sequence = get_effective_branding().get("colorway") or list(px.colors.qualitative.Plotly)
     if not isinstance(mapping, dict):
         mapping = {}
     return [mapping.get(name) or sequence[i % len(sequence)] for i, name in enumerate(names)]

--- a/depictio/api/v1/services/figure/figure_builder.py
+++ b/depictio/api/v1/services/figure/figure_builder.py
@@ -21,6 +21,49 @@ from depictio.api.v1.services.multiqc.themes import get_theme_template
 # browser, and beyond ~50k markers the extra points are visually indistinguishable.
 FIGURE_MAX_POINTS = 50_000
 
+# Template names that mean "follow the UI theme" rather than an explicit style
+# choice. Legacy components carry `template: "mantine_light"` as a stamped
+# default, so honoring it literally would lock them to light mode.
+_THEME_FOLLOW_TEMPLATES = frozenset({"mantine_light", "mantine_dark"})
+
+
+def resolve_template_override(requested: str | None) -> str | None:
+    """The explicit Plotly template a component/dashboard picked, if any.
+
+    Returns ``None`` for unset values and for the mantine sentinels — both mean
+    "use the theme-matched mantine template".
+    """
+    if requested and requested not in _THEME_FOLLOW_TEMPLATES:
+        return requested
+    return None
+
+
+def merge_dashboard_plot_theme(plot_theme: dict | None, dict_kwargs: dict) -> dict:
+    """Apply the dashboard's ``plot_theme`` defaults to a figure's kwargs (#397).
+
+    Component-explicit choices always win:
+    - ``colorway`` fills ``color_discrete_sequence`` only when the component
+      sets neither a sequence nor a ``color_discrete_map``.
+    - ``template`` applies only when the component's own template is unset or a
+      mantine sentinel (i.e. "follow the UI theme" — see
+      ``resolve_template_override``).
+    """
+    if not plot_theme:
+        return dict_kwargs
+
+    merged = dict(dict_kwargs)
+    colorway = plot_theme.get("colorway")
+    if (
+        colorway
+        and not merged.get("color_discrete_sequence")
+        and not merged.get("color_discrete_map")
+    ):
+        merged["color_discrete_sequence"] = colorway
+    template = plot_theme.get("template")
+    if template and resolve_template_override(merged.get("template")) is None:
+        merged["template"] = template
+    return merged
+
 # Scatter-family plots — one marker per row, and the only types we force to WebGL.
 _POINT_PLOT_TYPES = frozenset(
     {"scatter", "scatter_3d", "scatter_ternary", "scatter_polar", "strip"}
@@ -334,7 +377,10 @@ def create_figure_from_data(
             elif v != "" and v != [] or (k in keep_empty_string_params and v == ""):
                 cleaned_kwargs[k] = v
 
-        cleaned_kwargs["template"] = template
+        # An explicit template choice (component picker or dashboard plot_theme)
+        # wins; otherwise follow the UI theme (see resolve_template_override).
+        if resolve_template_override(cleaned_kwargs.get("template")) is None:
+            cleaned_kwargs["template"] = template
 
         if selection_enabled and selection_column and selection_column in plot_df.columns:
             existing_custom_data = cleaned_kwargs.get("custom_data", [])

--- a/depictio/api/v1/services/figure/figure_builder.py
+++ b/depictio/api/v1/services/figure/figure_builder.py
@@ -64,6 +64,7 @@ def merge_dashboard_plot_theme(plot_theme: dict | None, dict_kwargs: dict) -> di
         merged["template"] = template
     return merged
 
+
 # Scatter-family plots — one marker per row, and the only types we force to WebGL.
 _POINT_PLOT_TYPES = frozenset(
     {"scatter", "scatter_3d", "scatter_ternary", "scatter_polar", "strip"}

--- a/depictio/api/v1/services/figure/mantine_templates.py
+++ b/depictio/api/v1/services/figure/mantine_templates.py
@@ -5,13 +5,16 @@ so that the CLI offline MultiQC figure prerender and the API render path share
 one source of truth (the CLI cannot import ``depictio.api.v1.services.*``).
 
 On the API/worker side this shim additionally applies the instance branding
-colorway (issue #397, ``DEPICTIO_BRANDING_COLORWAY``): after the CLI module
-registers the vanilla templates, their ``layout.colorway`` is overwritten from
-settings, once per process. The CLI module itself must stay settings-free —
-CLI-only installs don't ship the server settings machinery.
+colorway (issue #397): after the CLI module registers the vanilla templates,
+their ``layout.colorway`` is overwritten from the *effective* branding — the
+``DEPICTIO_BRANDING_COLORWAY`` env default overridden by the admin panel's
+live settings (services/branding.py). The CLI module itself must stay
+settings-free — CLI-only installs don't ship the server settings machinery.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import plotly.io as pio
 
@@ -19,27 +22,44 @@ from depictio.cli.cli.utils.mantine_templates import (
     ensure_mantine_templates as _ensure_base_templates,
 )
 
-_branding_applied = False
+_TEMPLATE_NAMES = ("mantine_light", "mantine_dark")
+
+# Applied-state guard: re-patching only when the effective colorway changed
+# keeps this callable per render. `_vanilla` remembers the unbranded colorways
+# so clearing the branding from the admin panel restores them without a
+# process restart.
+_UNSET = object()
+_applied_colorway: Any = _UNSET
+_vanilla: dict[str, Any] = {}
 
 
 def apply_branding_colorway() -> None:
-    """Overwrite the mantine templates' colorway from instance branding.
+    """Sync the mantine templates' colorway with the effective branding.
 
-    No-op when ``DEPICTIO_BRANDING_COLORWAY`` is unset/invalid. Idempotent —
-    guarded by a module flag so the settings lookup happens once per process.
+    Called on every render path (cheap: the branding read is TTL-cached, and
+    templates are only touched when the value actually changed). Falls back
+    to the env-var branding if the overrides store is unreachable, so a
+    Mongo hiccup can't take figure rendering down with it.
     """
-    global _branding_applied
-    if _branding_applied:
-        return
-    _branding_applied = True
+    global _applied_colorway
 
-    from depictio.api.v1.configs.config import settings
+    try:
+        from depictio.api.v1.services.branding import get_effective_branding
 
-    colorway = settings.branding.colorway_list
-    if not colorway:
+        colorway = get_effective_branding().get("colorway")
+    except Exception:
+        from depictio.api.v1.configs.config import settings
+
+        colorway = settings.branding.colorway_list
+
+    if colorway == _applied_colorway:
         return
-    for name in ("mantine_light", "mantine_dark"):
-        pio.templates[name].layout.colorway = colorway
+    if not _vanilla:
+        for name in _TEMPLATE_NAMES:
+            _vanilla[name] = pio.templates[name].layout.colorway
+    for name in _TEMPLATE_NAMES:
+        pio.templates[name].layout.colorway = colorway if colorway else _vanilla[name]
+    _applied_colorway = colorway
 
 
 def ensure_mantine_templates() -> None:

--- a/depictio/api/v1/services/figure/mantine_templates.py
+++ b/depictio/api/v1/services/figure/mantine_templates.py
@@ -1,15 +1,51 @@
 """Native Plotly ``mantine_light`` / ``mantine_dark`` templates.
 
-The implementation now lives in ``depictio.cli.cli.utils.mantine_templates`` so
-that the CLI offline MultiQC figure prerender and the API render path share one
-source of truth (the CLI cannot import ``depictio.api.v1.services.*``). This
-module is a thin re-export kept in place so every existing
-``from depictio.api.v1.services.figure.mantine_templates import
-ensure_mantine_templates`` import continues to work unchanged.
+The base implementation lives in ``depictio.cli.cli.utils.mantine_templates``
+so that the CLI offline MultiQC figure prerender and the API render path share
+one source of truth (the CLI cannot import ``depictio.api.v1.services.*``).
+
+On the API/worker side this shim additionally applies the instance branding
+colorway (issue #397, ``DEPICTIO_BRANDING_COLORWAY``): after the CLI module
+registers the vanilla templates, their ``layout.colorway`` is overwritten from
+settings, once per process. The CLI module itself must stay settings-free —
+CLI-only installs don't ship the server settings machinery.
 """
 
 from __future__ import annotations
 
-from depictio.cli.cli.utils.mantine_templates import ensure_mantine_templates
+import plotly.io as pio
 
-__all__ = ["ensure_mantine_templates"]
+from depictio.cli.cli.utils.mantine_templates import (
+    ensure_mantine_templates as _ensure_base_templates,
+)
+
+_branding_applied = False
+
+
+def apply_branding_colorway() -> None:
+    """Overwrite the mantine templates' colorway from instance branding.
+
+    No-op when ``DEPICTIO_BRANDING_COLORWAY`` is unset/invalid. Idempotent —
+    guarded by a module flag so the settings lookup happens once per process.
+    """
+    global _branding_applied
+    if _branding_applied:
+        return
+    _branding_applied = True
+
+    from depictio.api.v1.configs.config import settings
+
+    colorway = settings.branding.colorway_list
+    if not colorway:
+        return
+    for name in ("mantine_light", "mantine_dark"):
+        pio.templates[name].layout.colorway = colorway
+
+
+def ensure_mantine_templates() -> None:
+    """Register the mantine templates, branded when the instance is."""
+    _ensure_base_templates()
+    apply_branding_colorway()
+
+
+__all__ = ["ensure_mantine_templates", "apply_branding_colorway"]

--- a/depictio/api/v1/services/multiqc/themes.py
+++ b/depictio/api/v1/services/multiqc/themes.py
@@ -1,14 +1,28 @@
 """Plotly theme helpers.
 
-The implementation now lives in ``depictio.cli.cli.utils.mantine_templates`` so
+The implementation lives in ``depictio.cli.cli.utils.mantine_templates`` so
 that the CLI offline MultiQC figure prerender and the API render path share one
-``theme -> template name`` mapping. This module is a thin re-export kept in
-place so every existing ``from depictio.api.v1.services.multiqc.themes import
-get_theme_template`` import continues to work unchanged.
+``theme -> template name`` mapping. On the API/worker side this shim also
+applies the instance branding colorway (issue #397) to the registered
+templates — every server render path resolves its template name through here
+(or through ``figure/mantine_templates.py``), so branding can't be skipped by
+a path that never calls ``ensure_mantine_templates`` directly.
 """
 
 from __future__ import annotations
 
-from depictio.cli.cli.utils.mantine_templates import get_theme_template
+from depictio.cli.cli.utils.mantine_templates import (
+    get_theme_template as _get_theme_template_base,
+)
+
+from depictio.api.v1.services.figure.mantine_templates import apply_branding_colorway
+
+
+def get_theme_template(theme: str) -> str:
+    """Return the Plotly template name for the given UI theme (branded)."""
+    name = _get_theme_template_base(theme)
+    apply_branding_colorway()
+    return name
+
 
 __all__ = ["get_theme_template"]

--- a/depictio/api/v1/services/multiqc/themes.py
+++ b/depictio/api/v1/services/multiqc/themes.py
@@ -11,11 +11,10 @@ a path that never calls ``ensure_mantine_templates`` directly.
 
 from __future__ import annotations
 
+from depictio.api.v1.services.figure.mantine_templates import apply_branding_colorway
 from depictio.cli.cli.utils.mantine_templates import (
     get_theme_template as _get_theme_template_base,
 )
-
-from depictio.api.v1.services.figure.mantine_templates import apply_branding_colorway
 
 
 def get_theme_template(theme: str) -> str:

--- a/depictio/models/components/lite.py
+++ b/depictio/models/components/lite.py
@@ -135,6 +135,14 @@ class FigureLiteComponent(BaseLiteComponent):
         default=None, description="Column to extract from selected points"
     )
 
+    # Per-figure font emphasis (rendered client-side by FigureRenderer)
+    font_scale: float | None = Field(
+        default=None,
+        gt=0,
+        description="Font-size multiplier applied to the whole figure layout font "
+        "(axis labels, ticks, legend). Unset/1 = default size.",
+    )
+
     @model_validator(mode="after")
     def validate_figure_constraints(self) -> "FigureLiteComponent":
         """Validate figure-specific cross-field constraints."""

--- a/depictio/models/models/dashboards.py
+++ b/depictio/models/models/dashboards.py
@@ -293,6 +293,13 @@ class DashboardDataLite(BaseModel):
         "figure components of this dashboard.",
     )
 
+    # Dashboard logo, shown at the bottom of the dashboard sidebar. Uploaded
+    # through /dashboards/upload_logo and served from /static/dashboard_logos/.
+    logo_url: str | None = Field(
+        default=None,
+        description="URL of the dashboard logo image (uploaded server-side).",
+    )
+
     # Components using Lite models
     components: list[LiteComponent | dict[str, Any]] = Field(
         default_factory=list, description="List of dashboard components"
@@ -406,6 +413,7 @@ class DashboardDataLite(BaseModel):
         "filter_sections",
         "grid_sections",
         "plot_theme",
+        "logo_url",
     ]
 
     @staticmethod
@@ -779,6 +787,22 @@ class DashboardDataLite(BaseModel):
         except ValueError as e:
             return False, [{"type": "yaml_error", "msg": str(e)}]
 
+    @staticmethod
+    def _exportable_logo_url(logo_url: Any) -> str | None:
+        """Only external logo URLs survive an export.
+
+        Uploaded logos live under the instance-local ``/static/dashboard_logos/``
+        mount, named after this instance's ``dashboard_id`` (which imports
+        re-mint) and never shipped with the code — carrying the URL into a
+        YAML/seed would render a silently broken image on any other
+        deployment. Hand-written external URLs round-trip untouched.
+        """
+        if not logo_url or not isinstance(logo_url, str):
+            return None
+        if logo_url.startswith("/static/dashboard_logos/"):
+            return None
+        return logo_url
+
     @classmethod
     def from_full(cls, dashboard_data: dict[str, Any]) -> "DashboardDataLite":
         """Convert full dashboard dict to lite format.
@@ -933,6 +957,8 @@ class DashboardDataLite(BaseModel):
                     lite_comp["selection_enabled"] = comp["selection_enabled"]
                 if comp.get("max_points") is not None:
                     lite_comp["max_points"] = comp["max_points"]
+                if comp.get("font_scale") and comp["font_scale"] != 1:
+                    lite_comp["font_scale"] = comp["font_scale"]
 
             elif comp_type == "card":
                 lite_comp["aggregation"] = comp.get("aggregation", "")
@@ -1070,6 +1096,7 @@ class DashboardDataLite(BaseModel):
             filter_sections=dashboard_data.get("filter_sections") or [],
             grid_sections=dashboard_data.get("grid_sections") or [],
             plot_theme=dashboard_data.get("plot_theme") or None,
+            logo_url=cls._exportable_logo_url(dashboard_data.get("logo_url")),
             # Tab fields
             is_main_tab=dashboard_data.get("is_main_tab", True),
             tab_order=dashboard_data.get("tab_order", 0),
@@ -1139,6 +1166,7 @@ class DashboardDataLite(BaseModel):
             "filter_sections": [s.model_dump() for s in self.filter_sections],
             "grid_sections": [s.model_dump() for s in self.grid_sections],
             "plot_theme": self.plot_theme.model_dump() if self.plot_theme else None,
+            "logo_url": self.logo_url,
             # parent_dashboard_tag is resolved to parent_dashboard_id during import
         }
 
@@ -1185,6 +1213,7 @@ class DashboardDataLite(BaseModel):
                         # Selection filtering fields
                         "selection_enabled": comp_dict.get("selection_enabled", False),
                         "selection_column": comp_dict.get("selection_column"),
+                        "font_scale": comp_dict.get("font_scale"),
                     }
                 )
 
@@ -1468,6 +1497,8 @@ class DashboardData(MongoModel):
     # Dashboard-level figure theme defaults. None for dashboards saved before
     # the feature existed — figures then follow the UI theme exactly as before.
     plot_theme: DashboardThemeSpec | None = None
+    # Dashboard logo URL (uploaded via /dashboards/upload_logo). None hides it.
+    logo_url: str | None = None
     buttons_data: dict = {
         "unified_edit_mode": True,  # Default edit mode ON for dashboard owners
         "add_components_button": {"count": 0},

--- a/depictio/models/models/dashboards.py
+++ b/depictio/models/models/dashboards.py
@@ -156,6 +156,40 @@ class FilterSectionSpec(BaseModel):
     )
 
 
+class DashboardThemeSpec(BaseModel):
+    """Dashboard-level defaults for server-rendered Plotly figures (#397).
+
+    Applied to every figure component that doesn't set the corresponding
+    option itself — component-explicit values always win, and the instance
+    branding / mantine defaults apply when this is unset.
+
+    Example YAML:
+        plot_theme:
+          template: seaborn
+          colorway:
+            - "#0ca678"
+            - "#f76707"
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    template: str | None = Field(
+        default=None,
+        description="Plotly template name (e.g. 'seaborn', 'plotly_white') used by all "
+        "figures whose component doesn't pick one. Unset/`mantine_light`/`mantine_dark` "
+        "mean 'follow the UI theme'.",
+    )
+    colorway: list[str] | None = Field(
+        default=None,
+        description="Default categorical color sequence (hex list) for figures that set "
+        "neither `color_discrete_sequence` nor `color_discrete_map`.",
+    )
+
+    @property
+    def is_empty(self) -> bool:
+        return self.template is None and not self.colorway
+
+
 class DashboardDataLite(BaseModel):
     """Minimal dashboard format for YAML import/export.
 
@@ -250,6 +284,13 @@ class DashboardDataLite(BaseModel):
         default_factory=list,
         description="Optional presentation for the main grid's sections. Same shape "
         "as `filter_sections`, applied to non-interactive components.",
+    )
+
+    # Dashboard-level figure theme defaults (template + colorway)
+    plot_theme: DashboardThemeSpec | None = Field(
+        default=None,
+        description="Optional Plotly template/colorway applied as the default for all "
+        "figure components of this dashboard.",
     )
 
     # Components using Lite models
@@ -364,6 +405,7 @@ class DashboardDataLite(BaseModel):
         "workflow_system",
         "filter_sections",
         "grid_sections",
+        "plot_theme",
     ]
 
     @staticmethod
@@ -1027,6 +1069,7 @@ class DashboardDataLite(BaseModel):
             # "declared nowhere, sorted by first appearance".
             filter_sections=dashboard_data.get("filter_sections") or [],
             grid_sections=dashboard_data.get("grid_sections") or [],
+            plot_theme=dashboard_data.get("plot_theme") or None,
             # Tab fields
             is_main_tab=dashboard_data.get("is_main_tab", True),
             tab_order=dashboard_data.get("tab_order", 0),
@@ -1095,6 +1138,7 @@ class DashboardDataLite(BaseModel):
             # order sections and render their icons.
             "filter_sections": [s.model_dump() for s in self.filter_sections],
             "grid_sections": [s.model_dump() for s in self.grid_sections],
+            "plot_theme": self.plot_theme.model_dump() if self.plot_theme else None,
             # parent_dashboard_tag is resolved to parent_dashboard_id during import
         }
 
@@ -1421,6 +1465,9 @@ class DashboardData(MongoModel):
     # sections existed, which renders exactly as it did then.
     filter_sections: list[FilterSectionSpec] = []
     grid_sections: list[FilterSectionSpec] = []
+    # Dashboard-level figure theme defaults. None for dashboards saved before
+    # the feature existed — figures then follow the UI theme exactly as before.
+    plot_theme: DashboardThemeSpec | None = None
     buttons_data: dict = {
         "unified_edit_mode": True,  # Default edit mode ON for dashboard owners
         "add_components_button": {"count": 0},

--- a/depictio/tests/e2e-playwright/tests/ui/font-size-control.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/ui/font-size-control.spec.ts
@@ -1,20 +1,26 @@
 /**
- * Dashboard-wide font-size control (issue #854).
+ * Dashboard content font-size control (issue #854).
  *
- * The control lives in the dashboard viewer/editor header
- * (src/chrome/Header.tsx, data-testid="font-size-control"): A− / A+ step
- * through [0.85, 1, 1.15, 1.3]; the percent label appears when off 100% and
- * doubles as reset. The preference is persisted in the `depictio-ui-scale`
- * localStorage key and applied through Mantine's `theme.scale`
- * (`--mantine-scale` on :root).
+ * The control lives in the Settings drawer (src/chrome/SettingsDrawer.tsx,
+ * data-testid="font-size-control"): A− / A+ step through [0.85, 1, 1.15, 1.3];
+ * the preference is persisted in the `depictio-ui-scale` localStorage key.
+ * The scale applies to the dashboard content container only
+ * (data-testid="dashboard-content", via a `--mantine-scale` override plus
+ * re-scaled font-size tokens) — the app chrome (:root) stays at 1.
  */
 
 import { test, expect } from "@fixtures/auth";
 import { createDashboard, deleteDashboard } from "@fixtures/dashboard";
 
-async function mantineScale(page: import("@playwright/test").Page): Promise<string> {
-  return page.evaluate(() =>
-    getComputedStyle(document.documentElement).getPropertyValue("--mantine-scale").trim(),
+type Page = import("@playwright/test").Page;
+
+async function scaleVarOn(page: Page, selector: string): Promise<string> {
+  return page.evaluate(
+    (sel) =>
+      getComputedStyle(document.querySelector(sel) ?? document.documentElement)
+        .getPropertyValue("--mantine-scale")
+        .trim(),
+    selector,
   );
 }
 
@@ -24,7 +30,7 @@ test.describe("Font size control", () => {
     "Dashboard creation requires an authenticated user.",
   );
 
-  test("A+ / reset adjust the UI scale and persist across reloads", async ({
+  test("A+ in the Settings drawer scales the content only and persists", async ({
     loginAsAdmin,
     page,
   }) => {
@@ -45,27 +51,36 @@ test.describe("Font size control", () => {
       .click();
     await expect(page).toHaveURL(/\/dashboard\//, { timeout: 15_000 });
 
+    // The control moved out of the header into the Settings drawer.
+    await page.getByRole("button", { name: "Settings" }).click();
     const control = page.locator("[data-testid='font-size-control']");
-    await expect(control).toBeAttached({ timeout: 15_000 });
+    await expect(control).toBeVisible({ timeout: 15_000 });
 
-    // A+ → next step up (1 → 1.15), persisted and applied via --mantine-scale.
+    // A+ → next step up (1 → 1.15), persisted and applied to the content
+    // container — while the chrome (:root) stays at 1.
     await page.locator("[data-testid='font-size-increase']").click();
     expect(
       await page.evaluate(() => window.localStorage.getItem("depictio-ui-scale")),
     ).toBe("1.15");
-    expect(await mantineScale(page)).toBe("1.15");
+    expect(await scaleVarOn(page, "[data-testid='dashboard-content']")).toBe("1.15");
+    expect(await scaleVarOn(page, ":root")).toBe("1");
 
-    // Survives a reload.
+    // Survives a reload without reopening the drawer.
     await page.reload();
-    await expect(control).toBeAttached({ timeout: 15_000 });
-    expect(await mantineScale(page)).toBe("1.15");
+    await expect(page.locator("[data-testid='dashboard-content']")).toBeAttached({
+      timeout: 15_000,
+    });
+    expect(await scaleVarOn(page, "[data-testid='dashboard-content']")).toBe("1.15");
 
-    // The percent label doubles as reset.
+    // Reset from the drawer brings the content back to 100%.
+    await page.getByRole("button", { name: "Settings" }).click();
+    await expect(control).toBeVisible({ timeout: 15_000 });
     await page.locator("[data-testid='font-size-reset']").click();
     expect(
       await page.evaluate(() => window.localStorage.getItem("depictio-ui-scale")),
     ).toBe("1");
     await expect(page.locator("[data-testid='font-size-reset']")).toHaveCount(0);
+    expect(await scaleVarOn(page, "[data-testid='dashboard-content']")).toBe("1");
 
     // Cleanup.
     await page.goto("/dashboards");

--- a/depictio/tests/e2e-playwright/tests/ui/font-size-control.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/ui/font-size-control.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Dashboard-wide font-size control (issue #854).
+ *
+ * The control lives in the dashboard viewer/editor header
+ * (src/chrome/Header.tsx, data-testid="font-size-control"): A− / A+ step
+ * through [0.85, 1, 1.15, 1.3]; the percent label appears when off 100% and
+ * doubles as reset. The preference is persisted in the `depictio-ui-scale`
+ * localStorage key and applied through Mantine's `theme.scale`
+ * (`--mantine-scale` on :root).
+ */
+
+import { test, expect } from "@fixtures/auth";
+import { createDashboard, deleteDashboard } from "@fixtures/dashboard";
+
+async function mantineScale(page: import("@playwright/test").Page): Promise<string> {
+  return page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--mantine-scale").trim(),
+  );
+}
+
+test.describe("Font size control", () => {
+  test.skip(
+    process.env.UNAUTHENTICATED_MODE === "true",
+    "Dashboard creation requires an authenticated user.",
+  );
+
+  test("A+ / reset adjust the UI scale and persist across reloads", async ({
+    loginAsAdmin,
+    page,
+  }) => {
+    await loginAsAdmin();
+    await page.goto("/dashboards");
+    await expect(page).toHaveURL(/\/dashboards/);
+
+    const title = `Font Scale ${new Date().toISOString().replace(/:/g, "-")}`;
+    await createDashboard(page, title);
+
+    // Open the dashboard viewer via the card's link.
+    await page
+      .locator("[data-testid='dashboard-card']")
+      .filter({ hasText: title })
+      .first()
+      .locator("a[href*='/dashboard/']")
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/dashboard\//, { timeout: 15_000 });
+
+    const control = page.locator("[data-testid='font-size-control']");
+    await expect(control).toBeAttached({ timeout: 15_000 });
+
+    // A+ → next step up (1 → 1.15), persisted and applied via --mantine-scale.
+    await page.locator("[data-testid='font-size-increase']").click();
+    expect(
+      await page.evaluate(() => window.localStorage.getItem("depictio-ui-scale")),
+    ).toBe("1.15");
+    expect(await mantineScale(page)).toBe("1.15");
+
+    // Survives a reload.
+    await page.reload();
+    await expect(control).toBeAttached({ timeout: 15_000 });
+    expect(await mantineScale(page)).toBe("1.15");
+
+    // The percent label doubles as reset.
+    await page.locator("[data-testid='font-size-reset']").click();
+    expect(
+      await page.evaluate(() => window.localStorage.getItem("depictio-ui-scale")),
+    ).toBe("1");
+    await expect(page.locator("[data-testid='font-size-reset']")).toHaveCount(0);
+
+    // Cleanup.
+    await page.goto("/dashboards");
+    await deleteDashboard(page, title);
+  });
+});

--- a/depictio/tests/models/test_dashboard_logo.py
+++ b/depictio/tests/models/test_dashboard_logo.py
@@ -1,0 +1,76 @@
+"""Per-dashboard logo (`logo_url`): model shape and YAML round-trip.
+
+`logo_url` is an optional string on both DashboardDataLite and DashboardData,
+stamped by the /dashboards/upload_logo endpoint and rendered by the viewer
+header. Invariants:
+- absent everywhere by default, so pre-feature dashboards (and the shipped
+  `.db_seeds/*.json`) load unchanged;
+- external URLs survive the lite YAML round-trip and the lite ↔ full
+  conversions;
+- uploaded URLs (under the instance-local /static/dashboard_logos/ mount) are
+  dropped on export — the file never ships and imports re-mint the
+  dashboard_id the filename is keyed on, so carrying the URL would seed a
+  silently broken image on any other deployment.
+"""
+
+import json
+from pathlib import Path
+
+from depictio.models.models.dashboards import DashboardDataLite
+
+SEED_DIR = Path(__file__).parents[2] / "projects" / "init" / "iris" / ".db_seeds"
+
+EXTERNAL_LOGO_URL = "https://example.org/assets/facility-logo.png"
+UPLOADED_LOGO_URL = "/static/dashboard_logos/6824cb3b89d2b72169309737.png?v=1754550000"
+
+
+class TestLiteRoundTrip:
+    def test_default_is_none_and_absent_from_yaml(self):
+        dash = DashboardDataLite(title="Test", components=[])
+        assert dash.logo_url is None
+        assert "logo_url" not in dash.to_yaml()
+
+    def test_yaml_round_trip_external_url(self):
+        dash = DashboardDataLite(title="Test", components=[], logo_url=EXTERNAL_LOGO_URL)
+        yaml_str = dash.to_yaml()
+        assert "logo_url" in yaml_str
+
+        restored = DashboardDataLite.from_yaml(yaml_str)
+        assert restored.logo_url == EXTERNAL_LOGO_URL
+
+    def test_to_full_carries_logo_url(self):
+        dash = DashboardDataLite(title="Test", components=[], logo_url=EXTERNAL_LOGO_URL)
+        assert dash.to_full()["logo_url"] == EXTERNAL_LOGO_URL
+
+    def test_to_full_defaults_to_none(self):
+        dash = DashboardDataLite(title="Test", components=[])
+        assert dash.to_full()["logo_url"] is None
+
+    def test_from_full_restores_external_logo_url(self):
+        full = DashboardDataLite(title="Test", components=[], logo_url=EXTERNAL_LOGO_URL).to_full()
+        restored = DashboardDataLite.from_full(full)
+        assert restored.logo_url == EXTERNAL_LOGO_URL
+
+    def test_from_full_without_field_is_none(self):
+        # Pre-feature documents don't carry the key at all.
+        restored = DashboardDataLite.from_full({"title": "Legacy"})
+        assert restored.logo_url is None
+
+
+class TestUploadedLogoIsInstanceLocal:
+    def test_from_full_drops_uploaded_logo_url(self):
+        restored = DashboardDataLite.from_full({"title": "Test", "logo_url": UPLOADED_LOGO_URL})
+        assert restored.logo_url is None
+
+    def test_export_yaml_has_no_uploaded_logo(self):
+        lite = DashboardDataLite.from_full({"title": "Test", "logo_url": UPLOADED_LOGO_URL})
+        assert "logo_url" not in lite.to_yaml()
+
+
+class TestSeedCompatibility:
+    def test_shipped_seeds_have_no_logo(self):
+        # The reference seeds predate the feature; they must load with the
+        # default (no logo) rather than requiring a regeneration.
+        for seed in SEED_DIR.glob("*.json"):
+            data = json.loads(seed.read_text())
+            assert data.get("logo_url") is None

--- a/depictio/tests/models/test_figure_font_scale.py
+++ b/depictio/tests/models/test_figure_font_scale.py
@@ -1,0 +1,66 @@
+"""Per-figure font-size multiplier (`font_scale`): YAML round-trip.
+
+Stored on the figure component's metadata; the React FigureRenderer multiplies
+it into the Plotly layout font (axis labels, ticks, legend). Round-trip
+invariants:
+- absent by default (pre-feature components and seeds load unchanged);
+- survives lite YAML ↔ full conversions;
+- values equal to 1 are not exported (they're the default rendering).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from depictio.models.models.dashboards import DashboardDataLite
+
+FIGURE = {
+    "tag": "scatter-1",
+    "component_type": "figure",
+    "workflow_tag": "python/iris_workflow",
+    "data_collection_tag": "iris_table",
+    "visu_type": "scatter",
+}
+
+
+def _lite_with_figure(**extra) -> DashboardDataLite:
+    return DashboardDataLite(title="Test", components=[{**FIGURE, **extra}])
+
+
+class TestFontScaleRoundTrip:
+    def test_default_absent(self):
+        dash = _lite_with_figure()
+        assert "font_scale" not in dash.to_yaml()
+        assert dash.to_full()["stored_metadata"][0].get("font_scale") is None
+
+    def test_to_full_carries_font_scale(self):
+        dash = _lite_with_figure(font_scale=1.5)
+        assert dash.to_full()["stored_metadata"][0]["font_scale"] == 1.5
+
+    def test_yaml_round_trip(self):
+        dash = _lite_with_figure(font_scale=1.3)
+        yaml_str = dash.to_yaml()
+        assert "font_scale" in yaml_str
+        restored = DashboardDataLite.from_yaml(yaml_str)
+        comp = restored.components[0]
+        font_scale = comp["font_scale"] if isinstance(comp, dict) else comp.font_scale
+        assert font_scale == 1.3
+
+    def test_from_full_exports_only_non_default(self):
+        full_scaled = _lite_with_figure(font_scale=1.5).to_full()
+        lite = DashboardDataLite.from_full(
+            {**full_scaled, "title": "Test", "stored_layout_data": []}
+        )
+        comp = lite.components[0]
+        assert (comp["font_scale"] if isinstance(comp, dict) else comp.font_scale) == 1.5
+
+        full_default = _lite_with_figure().to_full()
+        lite_default = DashboardDataLite.from_full(
+            {**full_default, "title": "Test", "stored_layout_data": []}
+        )
+        comp_default = lite_default.components[0]
+        comp_dict = comp_default if isinstance(comp_default, dict) else comp_default.model_dump()
+        assert "font_scale" not in comp_dict or comp_dict["font_scale"] is None
+
+    def test_rejects_non_positive(self):
+        with pytest.raises(ValidationError):
+            _lite_with_figure(font_scale=0)

--- a/depictio/tests/models/test_plot_theme.py
+++ b/depictio/tests/models/test_plot_theme.py
@@ -1,0 +1,138 @@
+"""Dashboard-level plot theme (#397): model shape, YAML round-trip, precedence.
+
+`plot_theme` is an optional `DashboardThemeSpec` on both DashboardDataLite and
+DashboardData. The key invariants:
+- absent everywhere by default, so pre-feature dashboards (and the shipped
+  `.db_seeds/*.json`) load unchanged;
+- survives the lite YAML round-trip and the lite ↔ full conversions;
+- the template sentinel rule (`mantine_light`/`mantine_dark` = "follow the UI
+  theme") drives which template wins in the figure builder.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from depictio.models.models.dashboards import DashboardDataLite, DashboardThemeSpec
+
+SEED_DIR = Path(__file__).parents[2] / "projects" / "init" / "iris" / ".db_seeds"
+
+
+class TestDashboardThemeSpec:
+    def test_defaults_are_empty(self):
+        spec = DashboardThemeSpec()
+        assert spec.template is None
+        assert spec.colorway is None
+        assert spec.is_empty
+
+    def test_extra_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            DashboardThemeSpec(template="seaborn", font="Comic Sans")
+
+    def test_populated(self):
+        spec = DashboardThemeSpec(template="seaborn", colorway=["#111111", "#222222"])
+        assert not spec.is_empty
+
+
+class TestLiteRoundTrip:
+    def test_default_is_none_and_absent_from_yaml(self):
+        dash = DashboardDataLite(title="Test", components=[])
+        assert dash.plot_theme is None
+        assert "plot_theme" not in dash.to_yaml()
+
+    def test_yaml_round_trip(self):
+        dash = DashboardDataLite(
+            title="Test",
+            components=[],
+            plot_theme=DashboardThemeSpec(template="seaborn", colorway=["#0ca678", "#f76707"]),
+        )
+        yaml_str = dash.to_yaml()
+        assert "plot_theme" in yaml_str
+
+        restored = DashboardDataLite.from_yaml(yaml_str)
+        assert restored.plot_theme is not None
+        assert restored.plot_theme.template == "seaborn"
+        assert restored.plot_theme.colorway == ["#0ca678", "#f76707"]
+
+    def test_to_full_carries_plot_theme(self):
+        dash = DashboardDataLite(
+            title="Test",
+            components=[],
+            plot_theme=DashboardThemeSpec(template="ggplot2"),
+        )
+        full = dash.to_full()
+        assert full["plot_theme"] == {"template": "ggplot2", "colorway": None}
+
+    def test_to_full_without_plot_theme(self):
+        full = DashboardDataLite(title="Test", components=[]).to_full()
+        assert full["plot_theme"] is None
+
+    def test_from_full_restores_plot_theme(self):
+        dash = DashboardDataLite(
+            title="Test",
+            components=[],
+            plot_theme=DashboardThemeSpec(colorway=["#111111"]),
+        )
+        full = dash.to_full()
+        restored = DashboardDataLite.from_full(full)
+        assert restored.plot_theme is not None
+        assert restored.plot_theme.colorway == ["#111111"]
+
+
+class TestSeedCompatibility:
+    """Shipped seeds predate plot_theme — they must load with it defaulting off."""
+
+    @pytest.mark.skipif(not SEED_DIR.exists(), reason="iris seeds not present")
+    def test_existing_seed_parses_with_plot_theme_none(self):
+        seed_files = sorted(SEED_DIR.glob("dashboard*.json"))
+        assert seed_files, f"no dashboard seeds in {SEED_DIR}"
+        seed = json.loads(seed_files[0].read_text())
+        # Seeds are full-format dashboard dicts (DashboardData.mongo() shape);
+        # from_full is the lite view over the same shape and must tolerate the
+        # missing field.
+        lite = DashboardDataLite.from_full(seed)
+        assert lite.plot_theme is None
+
+
+class TestTemplatePrecedence:
+    """The sentinel rule shared by the render endpoint, px path and agg path."""
+
+    def test_resolve_template_override(self):
+        from depictio.api.v1.services.figure.figure_builder import resolve_template_override
+
+        assert resolve_template_override(None) is None
+        assert resolve_template_override("") is None
+        # Stamped legacy defaults mean "follow the UI theme".
+        assert resolve_template_override("mantine_light") is None
+        assert resolve_template_override("mantine_dark") is None
+        # An explicit pick wins.
+        assert resolve_template_override("seaborn") == "seaborn"
+
+    def test_merge_dashboard_plot_theme(self):
+        from depictio.api.v1.services.figure.figure_builder import merge_dashboard_plot_theme
+
+        # No dashboard theme → kwargs untouched (same object, no copy).
+        kwargs = {"x": "a", "template": "mantine_light"}
+        assert merge_dashboard_plot_theme(None, kwargs) is kwargs
+
+        # Dashboard template fills the sentinel slot…
+        merged = merge_dashboard_plot_theme({"template": "seaborn"}, kwargs)
+        assert merged["template"] == "seaborn"
+
+        # …but never overrides an explicit component pick.
+        merged = merge_dashboard_plot_theme({"template": "seaborn"}, {"template": "plotly_dark"})
+        assert merged["template"] == "plotly_dark"
+
+        # Colorway only fills when the component sets no colors of its own.
+        merged = merge_dashboard_plot_theme({"colorway": ["#111111"]}, {})
+        assert merged["color_discrete_sequence"] == ["#111111"]
+        merged = merge_dashboard_plot_theme(
+            {"colorway": ["#111111"]}, {"color_discrete_sequence": ["#eeeeee"]}
+        )
+        assert merged["color_discrete_sequence"] == ["#eeeeee"]
+        merged = merge_dashboard_plot_theme(
+            {"colorway": ["#111111"]}, {"color_discrete_map": {"A": "#eeeeee"}}
+        )
+        assert "color_discrete_sequence" not in merged

--- a/depictio/tests/unit/test_branding_service.py
+++ b/depictio/tests/unit/test_branding_service.py
@@ -1,0 +1,109 @@
+"""Instance branding service: env/DB merge, cache invalidation, upload rules."""
+
+import pytest
+
+from depictio.api.v1.services import branding as branding_svc
+
+
+class FakeCollection:
+    """Just enough of a pymongo collection for the singleton-document flows."""
+
+    def __init__(self):
+        self.docs: dict[str, dict] = {}
+
+    def find_one(self, query):
+        return self.docs.get(query["_id"])
+
+    def replace_one(self, query, doc, upsert=False):
+        self.docs[query["_id"]] = {"_id": query["_id"], **doc}
+
+    def delete_one(self, query):
+        self.docs.pop(query["_id"], None)
+
+    def update_one(self, query, update, upsert=False):
+        doc = self.docs.get(query["_id"])
+        if doc is None:
+            if not upsert and "$set" in update:
+                return
+            doc = {"_id": query["_id"]}
+            self.docs[query["_id"]] = doc
+        for key, value in update.get("$set", {}).items():
+            doc[key] = value
+        for key in update.get("$unset", {}):
+            doc.pop(key, None)
+
+
+@pytest.fixture()
+def fake_store(monkeypatch):
+    fake = FakeCollection()
+    monkeypatch.setattr(branding_svc, "instance_settings_collection", fake)
+    branding_svc.invalidate_branding_cache()
+    yield fake
+    branding_svc.invalidate_branding_cache()
+
+
+class TestEffectiveBranding:
+    def test_no_overrides_falls_back_to_env(self, fake_store):
+        effective = branding_svc.get_effective_branding(use_cache=False)
+        assert effective == branding_svc.env_branding_defaults()
+
+    def test_override_wins_per_field(self, fake_store):
+        branding_svc.set_branding_overrides({"app_name": "Core Facility"})
+        effective = branding_svc.get_effective_branding(use_cache=False)
+        assert effective["app_name"] == "Core Facility"
+        # Untouched fields keep the env defaults.
+        env = branding_svc.env_branding_defaults()
+        assert effective["primary_color"] == env["primary_color"]
+        assert effective["colorway"] == env["colorway"]
+
+    def test_none_values_are_not_stored(self, fake_store):
+        branding_svc.set_branding_overrides({"app_name": "X", "primary_color": None})
+        assert branding_svc.get_branding_overrides() == {"app_name": "X"}
+
+    def test_reset_clears_document(self, fake_store):
+        branding_svc.set_branding_overrides({"app_name": "X"})
+        branding_svc.set_branding_overrides({})
+        assert branding_svc.get_branding_overrides() == {}
+        assert fake_store.docs == {}
+
+    def test_set_invalidates_cache(self, fake_store):
+        # Prime the cache, then change the overrides: the cached value must
+        # not survive the write.
+        assert branding_svc.get_effective_branding()["app_name"] is None or True
+        branding_svc.set_branding_overrides({"app_name": "Fresh"})
+        assert branding_svc.get_effective_branding()["app_name"] == "Fresh"
+
+    def test_update_single_field(self, fake_store):
+        branding_svc.set_branding_overrides({"app_name": "X", "primary_color": "#0ca678"})
+        branding_svc.update_branding_override("app_name", None)
+        assert branding_svc.get_branding_overrides() == {"primary_color": "#0ca678"}
+        with pytest.raises(ValueError):
+            branding_svc.update_branding_override("nope", "x")
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"0" * 16
+JPEG = b"\xff\xd8\xff" + b"0" * 16
+WEBP = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"0" * 8
+
+
+class TestLogoUploadValidation:
+    def test_accepts_matching_content(self):
+        assert branding_svc.validate_logo_upload("image/png", PNG) == ".png"
+        assert branding_svc.validate_logo_upload("image/jpeg", JPEG) == ".jpg"
+        assert branding_svc.validate_logo_upload("image/webp", WEBP) == ".webp"
+
+    def test_rejects_svg(self):
+        with pytest.raises(ValueError, match="Unsupported"):
+            branding_svc.validate_logo_upload("image/svg+xml", b"<svg/>")
+
+    def test_rejects_mismatched_magic(self):
+        with pytest.raises(ValueError, match="does not match"):
+            branding_svc.validate_logo_upload("image/png", JPEG)
+        # RIFF container that is not WEBP (e.g. a WAV) is refused too.
+        with pytest.raises(ValueError, match="does not match"):
+            branding_svc.validate_logo_upload("image/webp", b"RIFF\x00\x00\x00\x00WAVE")
+
+    def test_rejects_oversize(self):
+        big = PNG + b"0" * branding_svc.LOGO_MAX_BYTES
+        with pytest.raises(ValueError, match="too large"):
+            branding_svc.validate_logo_upload("image/png", big)

--- a/depictio/viewer/package.json
+++ b/depictio/viewer/package.json
@@ -15,6 +15,7 @@
     "@iconify/react": "^5.0.2",
     "@mantine/carousel": "^7.14.0",
     "@mantine/code-highlight": "^7.14.0",
+    "@mantine/colors-generator": "^7.17.8",
     "@mantine/core": "^7.14.0",
     "@mantine/dates": "^7.14.0",
     "@mantine/hooks": "^7.14.0",

--- a/depictio/viewer/src/App.tsx
+++ b/depictio/viewer/src/App.tsx
@@ -71,6 +71,7 @@ const FILTER_DEBOUNCE_MS = 250;
 import { notifications } from '@mantine/notifications';
 import { Header, Sidebar, SettingsDrawer } from './chrome';
 import { useSidebarOpen } from './hooks/useSidebarOpen';
+import { useContentScaleStyle } from './hooks/useUiScalePref';
 import { useFilterPanelOpen } from './hooks/useFilterPanelOpen';
 import { FILTER_PANEL_WIDTH_VAR, useFilterPanelWidth } from './hooks/useFilterPanelWidth';
 import { useCurrentUser } from './hooks/useCurrentUser';
@@ -155,6 +156,7 @@ const App: React.FC = () => {
   // `sidebar-collapsed` localStorage key the Dash app writes.
   const [desktopOpened, toggleDesktop] = useSidebarOpen();
   const [settingsOpened, { open: openSettings, close: closeSettings }] = useDisclosure(false);
+  const contentScaleStyle = useContentScaleStyle();
   const { user: currentUser, inspectorEnabled } = useCurrentUser();
   const isOwner = isDashboardOwner(dashboard, currentUser?.email ?? null);
   // `control` is null while the flag is off, so no provider value reaches the
@@ -639,7 +641,7 @@ const App: React.FC = () => {
       </AppShell.Header>
 
       <AppShell.Navbar p="md" data-tour-id="sidebar">
-        <Sidebar tabs={tabSiblings} activeId={dashboardId} />
+        <Sidebar tabs={tabSiblings} activeId={dashboardId} logoUrl={dashboard?.logo_url} />
       </AppShell.Navbar>
 
       <AppShell.Main style={{ height: 'calc(100vh - 50px)' }}>
@@ -811,6 +813,7 @@ const App: React.FC = () => {
             <Box
               px={4}
               py={4}
+              data-testid="dashboard-content"
               style={{
                 height: '100%',
                 minWidth: 0,
@@ -818,6 +821,9 @@ const App: React.FC = () => {
                 overflowX: 'hidden',
                 display: 'flex',
                 flexDirection: 'column',
+                // Content font-size preference — scales the dashboard tiles
+                // below, never the surrounding chrome (header, sidebar, panel).
+                ...contentScaleStyle,
               }}
             >
               <Box style={{ flex: 1, minHeight: 0 }}>
@@ -895,12 +901,14 @@ const App: React.FC = () => {
                 background: 'var(--mantine-color-body)',
               }}
             >
-              <TopPanel
-                components={topComponents}
-                filters={filters}
-                onFilterChange={handleFilterChange}
-                refreshTick={refreshTick}
-              />
+              <Box style={contentScaleStyle}>
+                <TopPanel
+                  components={topComponents}
+                  filters={filters}
+                  onFilterChange={handleFilterChange}
+                  refreshTick={refreshTick}
+                />
+              </Box>
             </Box>
           )}
           </div>

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -44,6 +44,7 @@ import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { Icon } from '@iconify/react';
 import { useSidebarOpen } from './hooks/useSidebarOpen';
+import { useContentScaleStyle } from './hooks/useUiScalePref';
 import { useFilterPanelOpen } from './hooks/useFilterPanelOpen';
 import { FILTER_PANEL_WIDTH_VAR, useFilterPanelWidth } from './hooks/useFilterPanelWidth';
 import { useCurrentUser } from './hooks/useCurrentUser';
@@ -75,6 +76,7 @@ import {
   useRealtimeJournal,
   batchIdsFromPayload,
   authFetch,
+  uploadDashboardLogo,
   useMapPanel,
   MapPanelControl,
   MapPanelDock,
@@ -175,6 +177,7 @@ const EditorApp: React.FC = () => {
   // Persist across tab/page navigations (matches App.tsx + Dash app).
   const [desktopOpened, toggleDesktop] = useSidebarOpen();
   const [settingsOpened, { open: openSettings, close: closeSettings }] = useDisclosure(false);
+  const contentScaleStyle = useContentScaleStyle();
   // Bumped after a plot_theme save lands so figure components refetch and pick
   // up the new dashboard-level template/colorway (the server reads plot_theme
   // from the DB at render time, so the request body doesn't change).
@@ -370,6 +373,25 @@ const EditorApp: React.FC = () => {
     [handleSectionOp],
   );
 
+  /** Per-figure font-size multiplier, stored on the component's
+   *  stored_metadata entry so the viewer renders the same emphasis. Goes
+   *  through the debounced save like layout nudges — stepping A− / A+
+   *  repeatedly produces one POST. */
+  const handleComponentFontScale = useCallback(
+    (componentId: string, scale: number) => {
+      const cur = dashboardRef.current;
+      if (!cur) return;
+      const next = {
+        ...cur,
+        stored_metadata: (cur.stored_metadata || []).map((m) =>
+          m.index === componentId ? { ...m, font_scale: scale === 1 ? undefined : scale } : m,
+        ),
+      };
+      scheduleSave(next);
+    },
+    [scheduleSave],
+  );
+
   /** Dashboard-level plot theme (#397). Saved immediately (not debounced):
    *  the server resolves `plot_theme` from the DB at figure-render time, so
    *  figures can only refetch once the save has landed. */
@@ -392,6 +414,47 @@ const EditorApp: React.FC = () => {
     },
     [dashboardId, applyDashboard],
   );
+
+  /** Dashboard logo upload. The upload endpoint persists `logo_url` on the
+   *  dashboard document itself (file write + field update in one
+   *  ownership-checked call), so on success only the local state needs the
+   *  new URL. Errors propagate to the drawer, which displays them. */
+  const handleUploadLogo = useCallback(
+    async (file: File) => {
+      const cur = dashboardRef.current;
+      if (!cur || !dashboardId) return;
+      setSaveStatus('saving');
+      try {
+        const logoUrl = await uploadDashboardLogo(dashboardId, file);
+        // Re-read the ref: another action (plot theme, layout…) may have
+        // advanced the dashboard while the upload was in flight — merging
+        // into the pre-await snapshot would silently revert it.
+        applyDashboard({ ...(dashboardRef.current ?? cur), logo_url: logoUrl });
+        setSaveStatus('saved');
+      } catch (err) {
+        setSaveStatus('error');
+        throw err;
+      }
+    },
+    [dashboardId, applyDashboard],
+  );
+
+  /** Clears the logo through the regular save path (mirrors plot theme). The
+   *  uploaded file stays on disk — harmless, and overwritten by the next
+   *  upload for this dashboard. */
+  const handleRemoveLogo = useCallback(() => {
+    const cur = dashboardRef.current;
+    if (!cur || !dashboardId) return;
+    const next = { ...cur, logo_url: null };
+    applyDashboard(next);
+    setSaveStatus('saving');
+    saveDashboard(dashboardId, next)
+      .then(() => setSaveStatus('saved'))
+      .catch((err) => {
+        console.error('[EditorApp] logo removal save failed:', err);
+        setSaveStatus('error');
+      });
+  }, [dashboardId, applyDashboard]);
 
   const handleLeftLayoutChange = useCallback(
     (newLayout: Layout[]) => {
@@ -1193,6 +1256,7 @@ const EditorApp: React.FC = () => {
           onEditTab={openEditTabModal}
           onDeleteTab={handleDeleteTab}
           onMoveTab={handleMoveTab}
+          logoUrl={dashboard?.logo_url}
         />
       </AppShell.Navbar>
 
@@ -1299,11 +1363,15 @@ const EditorApp: React.FC = () => {
               px={4}
               py={4}
               data-tour-id="editor-grid"
+              data-testid="dashboard-content"
               style={{
                 height: '100%',
                 minWidth: 0,
                 overflowY: 'auto',
                 overflowX: 'hidden',
+                // Content font-size preference — scales the dashboard tiles
+                // below, never the surrounding chrome (header, sidebar, panel).
+                ...contentScaleStyle,
               }}
             >
               <RightComponentGrid
@@ -1323,6 +1391,7 @@ const EditorApp: React.FC = () => {
                 onAddComponent={handleAddComponent}
                 activeHighlight={activeHighlight}
                 onMoveToSection={handleMoveToSection}
+                onComponentFontScale={handleComponentFontScale}
                 refreshTick={plotThemeTick}
               />
             </Box>
@@ -1341,11 +1410,13 @@ const EditorApp: React.FC = () => {
                 background: 'var(--mantine-color-body)',
               }}
             >
-              <TopPanel
-                components={topComponents}
-                filters={filters}
-                onFilterChange={handleFilterChange}
-              />
+              <Box style={contentScaleStyle}>
+                <TopPanel
+                  components={topComponents}
+                  filters={filters}
+                  onFilterChange={handleFilterChange}
+                />
+              </Box>
             </Box>
           )}
           </div>
@@ -1402,6 +1473,8 @@ const EditorApp: React.FC = () => {
         onClose={closeSettings}
         dashboard={dashboard}
         onChangePlotTheme={handlePlotThemeChange}
+        onUploadLogo={handleUploadLogo}
+        onRemoveLogo={handleRemoveLogo}
       />
 
       <TabModal
@@ -1450,6 +1523,8 @@ interface RightComponentGridProps {
   /** Fired by each cell's "Move to section" action. The names on offer are
    *  derived from `gridSections`, which this component already receives. */
   onMoveToSection: (componentId: string, section: string | null) => void;
+  /** Fired by a figure cell's font-size control with the new multiplier. */
+  onComponentFontScale: (componentId: string, scale: number) => void;
   /** Bumped when the dashboard plot theme changes, so figures refetch. */
   refreshTick?: number;
 }
@@ -1479,6 +1554,7 @@ const RightComponentGrid: React.FC<RightComponentGridProps> = ({
   onAddComponent,
   activeHighlight,
   onMoveToSection,
+  onComponentFontScale,
   refreshTick,
 }) => {
   const allComponents = useMemo(
@@ -1551,6 +1627,8 @@ const RightComponentGrid: React.FC<RightComponentGridProps> = ({
           sections={gridSections}
           currentSection={metadata.section ?? null}
           onMoveToSection={onMoveToSection}
+          fontScale={typeof metadata.font_scale === 'number' ? metadata.font_scale : undefined}
+          onFontScale={onComponentFontScale}
         />
       )}
     />

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -86,6 +86,7 @@ import type {
   DashboardData,
   DashboardPermissions,
   DashboardSummary,
+  DashboardThemeSpec,
   FilterSectionSpec,
   InteractiveFilter,
   StoredMetadata,
@@ -174,6 +175,10 @@ const EditorApp: React.FC = () => {
   // Persist across tab/page navigations (matches App.tsx + Dash app).
   const [desktopOpened, toggleDesktop] = useSidebarOpen();
   const [settingsOpened, { open: openSettings, close: closeSettings }] = useDisclosure(false);
+  // Bumped after a plot_theme save lands so figure components refetch and pick
+  // up the new dashboard-level template/colorway (the server reads plot_theme
+  // from the DB at render time, so the request body doesn't change).
+  const [plotThemeTick, setPlotThemeTick] = useState(0);
   const [sectionsOpened, { open: openSections, close: closeSections }] = useDisclosure(false);
   const { user: currentUser, loading: userLoading, inspectorEnabled } = useCurrentUser();
   // `control` is null while the flag is off, so no provider value reaches the
@@ -363,6 +368,29 @@ const EditorApp: React.FC = () => {
     (componentId: string, section: string | null) =>
       handleSectionOp({ op: 'assign', componentId, section }),
     [handleSectionOp],
+  );
+
+  /** Dashboard-level plot theme (#397). Saved immediately (not debounced):
+   *  the server resolves `plot_theme` from the DB at figure-render time, so
+   *  figures can only refetch once the save has landed. */
+  const handlePlotThemeChange = useCallback(
+    (spec: DashboardThemeSpec | null) => {
+      const cur = dashboardRef.current;
+      if (!cur || !dashboardId) return;
+      const next = { ...cur, plot_theme: spec };
+      applyDashboard(next);
+      setSaveStatus('saving');
+      saveDashboard(dashboardId, next)
+        .then(() => {
+          setSaveStatus('saved');
+          setPlotThemeTick((t) => t + 1);
+        })
+        .catch((err) => {
+          console.error('[EditorApp] plot theme save failed:', err);
+          setSaveStatus('error');
+        });
+    },
+    [dashboardId, applyDashboard],
   );
 
   const handleLeftLayoutChange = useCallback(
@@ -1295,6 +1323,7 @@ const EditorApp: React.FC = () => {
                 onAddComponent={handleAddComponent}
                 activeHighlight={activeHighlight}
                 onMoveToSection={handleMoveToSection}
+                refreshTick={plotThemeTick}
               />
             </Box>
           </div>
@@ -1372,6 +1401,7 @@ const EditorApp: React.FC = () => {
         opened={settingsOpened}
         onClose={closeSettings}
         dashboard={dashboard}
+        onChangePlotTheme={handlePlotThemeChange}
       />
 
       <TabModal
@@ -1420,6 +1450,8 @@ interface RightComponentGridProps {
   /** Fired by each cell's "Move to section" action. The names on offer are
    *  derived from `gridSections`, which this component already receives. */
   onMoveToSection: (componentId: string, section: string | null) => void;
+  /** Bumped when the dashboard plot theme changes, so figures refetch. */
+  refreshTick?: number;
 }
 
 /**
@@ -1447,6 +1479,7 @@ const RightComponentGrid: React.FC<RightComponentGridProps> = ({
   onAddComponent,
   activeHighlight,
   onMoveToSection,
+  refreshTick,
 }) => {
   const allComponents = useMemo(
     () => [...cardComponents, ...otherComponents],
@@ -1502,6 +1535,7 @@ const RightComponentGrid: React.FC<RightComponentGridProps> = ({
       cardSecondaryValues={cardSecondaryValues}
       cardValuesLoading={cardsLoading}
       activeHighlight={activeHighlight}
+      refreshTick={refreshTick}
       isDraggable={true}
       isResizable={true}
       editMode={true}

--- a/depictio/viewer/src/admin/AdminApp.tsx
+++ b/depictio/viewer/src/admin/AdminApp.tsx
@@ -20,10 +20,11 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 import AdminUsersPanel from './AdminUsersPanel';
 import AdminProjectsPanel from './AdminProjectsPanel';
 import AdminDashboardsPanel from './AdminDashboardsPanel';
+import AdminBrandingPanel from './AdminBrandingPanel';
 import AdminMaintenancePanel from './AdminMaintenancePanel';
 import AdminMonitoringPanel from './AdminMonitoringPanel';
 
-type AdminTab = 'users' | 'projects' | 'dashboards' | 'monitoring' | 'maintenance';
+type AdminTab = 'users' | 'projects' | 'dashboards' | 'branding' | 'monitoring' | 'maintenance';
 
 /** Persist the active tab so a refresh keeps the admin where they left off. */
 const TAB_KEY = 'admin-active-tab';
@@ -35,6 +36,7 @@ function readInitialTab(): AdminTab {
       raw === 'users' ||
       raw === 'projects' ||
       raw === 'dashboards' ||
+      raw === 'branding' ||
       raw === 'monitoring' ||
       raw === 'maintenance'
     ) {
@@ -120,6 +122,9 @@ const AdminApp: React.FC = () => {
           >
             Dashboards
           </Tabs.Tab>
+          <Tabs.Tab value="branding" leftSection={<Icon icon="mdi:palette-outline" width={16} />}>
+            Branding
+          </Tabs.Tab>
           {showMonitoring && (
             <Tabs.Tab
               value="monitoring"
@@ -141,6 +146,9 @@ const AdminApp: React.FC = () => {
         </Tabs.Panel>
         <Tabs.Panel value="dashboards" pt="md">
           <AdminDashboardsPanel />
+        </Tabs.Panel>
+        <Tabs.Panel value="branding" pt="md">
+          <AdminBrandingPanel />
         </Tabs.Panel>
         {showMonitoring && (
           <Tabs.Panel value="monitoring" pt="md">

--- a/depictio/viewer/src/admin/AdminBrandingPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBrandingPanel.tsx
@@ -1,0 +1,370 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActionIcon,
+  Alert,
+  Button,
+  ColorInput,
+  Divider,
+  FileButton,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { Icon } from '@iconify/react';
+import { notifications } from '@mantine/notifications';
+
+import {
+  fetchBrandingAdmin,
+  resetBrandingAdmin,
+  updateBrandingAdmin,
+  uploadBrandingLogo,
+} from 'depictio-react-core';
+import type { AdminBrandingState, BrandingFields } from 'depictio-react-core';
+import { setBranding } from '../branding';
+
+const HEX_RE = /^#([0-9a-fA-F]{6})$/;
+/** Client-side mirror of the server's upload cap. */
+const LOGO_MAX_BYTES = 2 * 1024 * 1024;
+
+interface FormState {
+  app_name: string;
+  primary_color: string;
+  colorway: string[];
+  logo_url: string | null;
+  logo_url_dark: string | null;
+}
+
+function formFromOverrides(overrides: Partial<BrandingFields>): FormState {
+  return {
+    app_name: overrides.app_name ?? '',
+    primary_color: overrides.primary_color ?? '',
+    colorway: overrides.colorway ? [...overrides.colorway] : [],
+    logo_url: overrides.logo_url ?? null,
+    logo_url_dark: overrides.logo_url_dark ?? null,
+  };
+}
+
+function overridesFromForm(form: FormState): Partial<BrandingFields> {
+  return {
+    app_name: form.app_name.trim() || null,
+    primary_color: form.primary_color.trim() || null,
+    colorway: form.colorway.length ? form.colorway : null,
+    logo_url: form.logo_url,
+    logo_url_dark: form.logo_url_dark,
+  };
+}
+
+/** Push the saved branding into this tab's live theme + localStorage cache, so
+ *  the admin sees the result immediately; other visitors pick it up on their
+ *  next /utils/public-config fetch. */
+function applyEffective(state: AdminBrandingState) {
+  setBranding(state.effective);
+}
+
+const LogoField: React.FC<{
+  label: string;
+  hint: string;
+  value: string | null;
+  envDefault: string | null;
+  uploading: boolean;
+  onUpload: (file: File | null) => void;
+  onClear: () => void;
+}> = ({ label, hint, value, envDefault, uploading, onUpload, onClear }) => (
+  <Stack gap={6}>
+    <Text fw={500} size="sm">
+      {label}
+    </Text>
+    <Text size="xs" c="dimmed">
+      {hint}
+    </Text>
+    <Group gap="xs" align="center">
+      <FileButton onChange={onUpload} accept="image/png,image/jpeg,image/webp">
+        {(props) => (
+          <Button
+            {...props}
+            variant="default"
+            size="xs"
+            loading={uploading}
+            leftSection={<Icon icon="mdi:upload" width={14} />}
+          >
+            {value ? 'Replace' : 'Upload'}
+          </Button>
+        )}
+      </FileButton>
+      {value && (
+        <Tooltip label="Remove the override (deployment default applies)" withArrow>
+          <Button variant="subtle" color="red" size="xs" onClick={onClear}>
+            Clear
+          </Button>
+        </Tooltip>
+      )}
+      {(value ?? envDefault) && (
+        <img
+          src={value ?? envDefault ?? undefined}
+          alt=""
+          style={{ height: 32, maxWidth: 160, objectFit: 'contain' }}
+        />
+      )}
+      {!value && envDefault && (
+        <Text size="xs" c="dimmed">
+          (deployment default)
+        </Text>
+      )}
+    </Group>
+  </Stack>
+);
+
+/**
+ * Admin Branding panel (issue #397 follow-up): live, per-field overrides of
+ * the `DEPICTIO_BRANDING_*` env defaults — instance name, primary UI color,
+ * default figure colorway and logos — persisted server-side and served to
+ * every visitor through `/utils/public-config`. A cleared field falls back
+ * to the deployment default, and "Reset all" returns the whole instance to
+ * its env-var configuration.
+ */
+const AdminBrandingPanel: React.FC = () => {
+  const [state, setState] = useState<AdminBrandingState | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState<'light' | 'dark' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const adopt = useCallback((next: AdminBrandingState) => {
+    setState(next);
+    setForm(formFromOverrides(next.overrides));
+  }, []);
+
+  useEffect(() => {
+    fetchBrandingAdmin()
+      .then(adopt)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load branding.'))
+      .finally(() => setLoading(false));
+  }, [adopt]);
+
+  const patchForm = (patch: Partial<FormState>) =>
+    setForm((prev) => (prev ? { ...prev, ...patch } : prev));
+
+  const colorwayValid = !form || form.colorway.every((c) => HEX_RE.test(c));
+
+  const handleSave = async () => {
+    if (!form) return;
+    setSaving(true);
+    try {
+      const next = await updateBrandingAdmin(overridesFromForm(form));
+      adopt(next);
+      applyEffective(next);
+      notifications.show({ message: 'Branding saved.', color: 'teal' });
+    } catch (err) {
+      notifications.show({
+        message: err instanceof Error ? err.message : 'Failed to save branding.',
+        color: 'red',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setSaving(true);
+    try {
+      const next = await resetBrandingAdmin();
+      adopt(next);
+      applyEffective(next);
+      notifications.show({ message: 'Branding reset to deployment defaults.', color: 'teal' });
+    } catch (err) {
+      notifications.show({
+        message: err instanceof Error ? err.message : 'Failed to reset branding.',
+        color: 'red',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleLogoUpload = (variant: 'light' | 'dark') => async (file: File | null) => {
+    if (!file) return;
+    if (file.size > LOGO_MAX_BYTES) {
+      notifications.show({ message: 'File is too large (max 2MB).', color: 'red' });
+      return;
+    }
+    setUploading(variant);
+    try {
+      const next = await uploadBrandingLogo(variant, file);
+      adopt(next);
+      applyEffective(next);
+    } catch (err) {
+      notifications.show({
+        message: err instanceof Error ? err.message : 'Upload failed.',
+        color: 'red',
+      });
+    } finally {
+      setUploading(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Group justify="center" py="xl">
+        <Loader />
+      </Group>
+    );
+  }
+  if (error || !form || !state) {
+    return (
+      <Alert color="red" icon={<Icon icon="mdi:alert-circle-outline" width={18} />}>
+        {error ?? 'Failed to load branding.'}
+      </Alert>
+    );
+  }
+
+  const env = state.env_defaults;
+  const hasOverrides = Object.keys(state.overrides).length > 0;
+
+  return (
+    <Stack gap="md" maw={640} data-testid="admin-branding-panel">
+      <Stack gap={4}>
+        <Title order={4}>Instance branding</Title>
+        <Text size="sm" c="dimmed">
+          Rebrand this deployment (e.g. for a core facility) without touching its
+          configuration: name, logos and colors apply to every visitor. Cleared fields fall
+          back to the deployment&apos;s <code>DEPICTIO_BRANDING_*</code> defaults.
+        </Text>
+      </Stack>
+
+      <Paper withBorder p="md">
+        <Stack gap="md">
+          <TextInput
+            label="Instance name"
+            description="Browser tab title and login-page greeting."
+            placeholder={env.app_name ?? 'Depictio'}
+            value={form.app_name}
+            onChange={(e) => patchForm({ app_name: e.currentTarget.value })}
+            data-testid="branding-app-name"
+          />
+          <ColorInput
+            label="Primary UI color"
+            description="Buttons, links and accents across the whole app."
+            placeholder={env.primary_color ?? 'Default (blue)'}
+            value={form.primary_color}
+            onChange={(value) => patchForm({ primary_color: value })}
+            format="hex"
+            data-testid="branding-primary-color"
+          />
+
+          <Divider />
+
+          <LogoField
+            label="Logo"
+            hint="Replaces the depictio logo in the sidebar and on the login page. PNG, JPEG or WebP, up to 2MB."
+            value={form.logo_url}
+            envDefault={env.logo_url}
+            uploading={uploading === 'light'}
+            onUpload={handleLogoUpload('light')}
+            onClear={() => patchForm({ logo_url: null })}
+          />
+          <LogoField
+            label="Logo (dark mode)"
+            hint="Optional dark-mode variant; falls back to the logo above."
+            value={form.logo_url_dark}
+            envDefault={env.logo_url_dark}
+            uploading={uploading === 'dark'}
+            onUpload={handleLogoUpload('dark')}
+            onClear={() => patchForm({ logo_url_dark: null })}
+          />
+
+          <Divider />
+
+          <Stack gap={6}>
+            <Text fw={500} size="sm">
+              Figure color palette
+            </Text>
+            <Text size="xs" c="dimmed">
+              Default categorical colorway of server-rendered figures. Dashboards and
+              individual figures can still pick their own.
+            </Text>
+            {form.colorway.map((color, idx) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Group key={idx} gap="xs" wrap="nowrap">
+                <ColorInput
+                  size="xs"
+                  value={color}
+                  onChange={(value) =>
+                    patchForm({
+                      colorway: form.colorway.map((c, i) => (i === idx ? value : c)),
+                    })
+                  }
+                  format="hex"
+                  style={{ flex: 1 }}
+                />
+                <Tooltip label="Remove color" withArrow>
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    size="sm"
+                    onClick={() =>
+                      patchForm({ colorway: form.colorway.filter((_, i) => i !== idx) })
+                    }
+                    aria-label="Remove color"
+                  >
+                    <Icon icon="mdi:close" width={14} />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            ))}
+            <Group gap="xs">
+              <Button
+                variant="default"
+                size="compact-xs"
+                leftSection={<Icon icon="mdi:plus" width={14} />}
+                onClick={() =>
+                  patchForm({
+                    colorway: [
+                      ...form.colorway,
+                      form.colorway[form.colorway.length - 1] ?? '#636efa',
+                    ],
+                  })
+                }
+              >
+                Add color
+              </Button>
+              {form.colorway.length === 0 && (env.colorway?.length ?? 0) > 0 && (
+                <Text size="xs" c="dimmed">
+                  Deployment default in use ({env.colorway!.length} colors).
+                </Text>
+              )}
+            </Group>
+          </Stack>
+        </Stack>
+      </Paper>
+
+      <Group justify="space-between">
+        <Button
+          variant="subtle"
+          color="red"
+          disabled={!hasOverrides || saving}
+          onClick={handleReset}
+          leftSection={<Icon icon="mdi:restore" width={16} />}
+        >
+          Reset all to deployment defaults
+        </Button>
+        <Button
+          onClick={handleSave}
+          loading={saving}
+          disabled={!colorwayValid}
+          leftSection={<Icon icon="mdi:content-save" width={16} />}
+          data-testid="branding-save"
+        >
+          Save
+        </Button>
+      </Group>
+    </Stack>
+  );
+};
+
+export default AdminBrandingPanel;

--- a/depictio/viewer/src/auth/components/AuthCard.tsx
+++ b/depictio/viewer/src/auth/components/AuthCard.tsx
@@ -1,4 +1,7 @@
-import { Center, Image, Paper, Stack, Title, useMantineColorScheme } from '@mantine/core';
+import { Center, Paper, Stack, Title } from '@mantine/core';
+
+import BrandLogo from '../../chrome/BrandLogo';
+import { useBranding } from '../../branding';
 
 interface Props {
   heading: string;
@@ -11,12 +14,16 @@ interface Props {
  *
  * Mirrors render_login_form / render_register_form in users_management.py so
  * the React form sits in the same visual frame as the prior Dash version.
+ *
+ * On a branded instance (#397) the logo is the deployment's own and the
+ * literal "Depictio" in headings is swapped for the instance name — done here
+ * rather than at every call site so the greeting logic lives in one place.
  */
 export default function AuthCard({ heading, children }: Props) {
-  const { colorScheme } = useMantineColorScheme();
-  const logoSrc = colorScheme === 'dark'
-    ? '/dashboard/logos/logo_white.svg'
-    : '/dashboard/logos/logo_black.svg';
+  const branding = useBranding();
+  const resolvedHeading = branding?.app_name
+    ? heading.replace('Depictio', branding.app_name)
+    : heading;
 
   return (
     <Paper
@@ -28,7 +35,7 @@ export default function AuthCard({ heading, children }: Props) {
     >
       <Stack gap="md">
         <Center>
-          <Image src={logoSrc} alt="Depictio" h={60} w="auto" fit="contain" />
+          <BrandLogo height={60} />
         </Center>
         <Center>
           <Title
@@ -37,7 +44,7 @@ export default function AuthCard({ heading, children }: Props) {
             c="gray"
             style={{ fontFamily: 'Virgil' }}
           >
-            {heading}
+            {resolvedHeading}
           </Title>
         </Center>
         {children}

--- a/depictio/viewer/src/branding.ts
+++ b/depictio/viewer/src/branding.ts
@@ -1,0 +1,95 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Instance branding (issue #397): custom logo / name / colors for a
+ * deployment (e.g. a core facility), served by `/utils/public-config`.
+ *
+ * The config arrives over the network after first paint (the fetch is
+ * fire-and-forget, matching the Google Analytics bootstrap), so the last
+ * known branding is cached in localStorage: returning visitors get a branded
+ * first paint with no flash, and only the very first visit late-applies.
+ */
+
+export interface Branding {
+  logo_url: string | null;
+  logo_url_dark: string | null;
+  app_name: string | null;
+  primary_color: string | null;
+  colorway: string[] | null;
+}
+
+const STORAGE_KEY = 'depictio-branding-cache';
+const CACHE_VERSION = 1;
+
+export function readCachedBranding(): Branding | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || parsed.version !== CACHE_VERSION) return null;
+    const branding = parsed.branding;
+    if (!branding || typeof branding !== 'object') return null;
+    return branding as Branding;
+  } catch {
+    return null;
+  }
+}
+
+export function cacheBranding(branding: Branding | null): void {
+  try {
+    if (!branding || Object.values(branding).every((value) => value == null)) {
+      // Unbranded instance — drop any stale cache so a deployment that turns
+      // branding off doesn't keep showing the old logo forever.
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: CACHE_VERSION, branding }));
+    }
+  } catch {
+    // ignore quota / disabled storage
+  }
+}
+
+export const BrandingContext = createContext<Branding | null>(null);
+
+export function useBranding(): Branding | null {
+  return useContext(BrandingContext);
+}
+
+// ── Module-level store ────────────────────────────────────────────────────────
+// bootstrapPublicConfig() resolves before/after ThemeRoot mounts depending on
+// network timing, so the fetched branding flows through a tiny external store
+// (same pattern as the uiScale preference) instead of React state that might
+// not exist yet.
+
+let currentBranding: Branding | null = readCachedBranding();
+const subscribers = new Set<() => void>();
+
+export function getBranding(): Branding | null {
+  return currentBranding;
+}
+
+export function setBranding(branding: Branding | null): void {
+  cacheBranding(branding);
+  const normalized =
+    branding && Object.values(branding).some((value) => value != null) ? branding : null;
+  // Referential equality is what React's useSyncExternalStore checks — skip
+  // the notify when nothing changed to avoid a pointless theme rebuild.
+  if (JSON.stringify(normalized) === JSON.stringify(currentBranding)) return;
+  currentBranding = normalized;
+  subscribers.forEach((fn) => fn());
+}
+
+export function subscribeBranding(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+/** Hex colors are expanded into a Mantine palette under this name. */
+export const BRAND_PALETTE_NAME = 'brand';
+
+/** True when the value looks like a Mantine palette name rather than a hex color. */
+export function isMantinePaletteName(color: string): boolean {
+  return /^[a-z][a-z0-9-]*$/i.test(color) && !color.startsWith('#');
+}

--- a/depictio/viewer/src/builder/figure/FigurePreview.tsx
+++ b/depictio/viewer/src/builder/figure/FigurePreview.tsx
@@ -54,7 +54,12 @@ const FigurePreview: React.FC = () => {
       const id = ++reqId.current;
       setLoading(true);
       setError(null);
-      previewFigure({ metadata: buildMetadata(state) })
+      previewFigure({
+        metadata: buildMetadata(state),
+        // Fold the dashboard's plot_theme defaults into the preview so it
+        // matches what the saved component will render.
+        dashboard_id: state.dashboardId ?? undefined,
+      })
         .then((res) => {
           if (reqId.current !== id) return;
           setFigure(res);

--- a/depictio/viewer/src/chrome/AppSidebar.tsx
+++ b/depictio/viewer/src/chrome/AppSidebar.tsx
@@ -7,10 +7,10 @@ import {
   ScrollArea,
   Stack,
   Text,
-  useComputedColorScheme,
 } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
+import BrandLogo from './BrandLogo';
 import ThemeToggle from './ThemeToggle';
 import ServerStatusBadge from './ServerStatusBadge';
 import ProfileBadge from './ProfileBadge';
@@ -73,10 +73,6 @@ interface AppSidebarProps {
 }
 
 const AppSidebar: React.FC<AppSidebarProps> = ({ active }) => {
-  // useComputedColorScheme resolves 'auto' to the actual rendered scheme
-  // (dark/light) by reading prefers-color-scheme — useMantineColorScheme
-  // can return 'auto' which our equality check would never match.
-  const colorScheme = useComputedColorScheme('light', { getInitialValueInEffect: true });
   const { user } = useCurrentUser();
 
   // Show the Administration link only to admins (matches the Dash sidebar
@@ -90,21 +86,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ active }) => {
       <Stack gap="sm" align="stretch">
         <Center pt="md">
           <Anchor href="/" underline="never">
-            {/* Both `logo_black.svg` and `logo_white.svg` ship byte-identical
-                (base64-embedded PNG inside an SVG wrapper), so swapping `src`
-                does nothing. Apply a CSS filter in dark mode to invert the
-                raster while preserving brand hues — same trick as
-                `PoweredBy.tsx`. */}
-            <img
-              src="/dashboard/logos/logo_black.svg"
-              alt="depictio"
-              style={{
-                width: 185,
-                display: 'block',
-                filter:
-                  colorScheme === 'dark' ? 'invert(1) hue-rotate(180deg)' : undefined,
-              }}
-            />
+            <BrandLogo width={185} />
           </Anchor>
         </Center>
         <Divider />

--- a/depictio/viewer/src/chrome/BrandLogo.tsx
+++ b/depictio/viewer/src/chrome/BrandLogo.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useComputedColorScheme } from '@mantine/core';
+
+import { useBranding } from '../branding';
+
+interface BrandLogoProps {
+  width?: number | string;
+  height?: number | string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * The instance logo (issue #397): the deployment's custom logo when branding
+ * is configured (`DEPICTIO_BRANDING_LOGO_URL`), the depictio wordmark
+ * otherwise. Single source for the sidebar and the login card so the
+ * dark-mode handling lives in one place:
+ *
+ * - Custom logos pick `logo_url_dark` in dark mode (falling back to the light
+ *   one untouched — never CSS-inverted, the operator knows their own brand).
+ * - The default depictio logo ships as one raster for both themes
+ *   (`logo_black.svg` and `logo_white.svg` are byte-identical), so dark mode
+ *   applies the established `invert(1) hue-rotate(180deg)` filter instead of
+ *   swapping `src` — same trick as `PoweredBy.tsx`.
+ */
+export default function BrandLogo({ width, height, style }: BrandLogoProps) {
+  const branding = useBranding();
+  const colorScheme = useComputedColorScheme('light');
+  const isDark = colorScheme === 'dark';
+
+  const customSrc = branding?.logo_url
+    ? (isDark && branding.logo_url_dark) || branding.logo_url
+    : null;
+
+  return (
+    <img
+      src={customSrc ?? '/dashboard/logos/logo_black.svg'}
+      alt={branding?.app_name ?? 'depictio'}
+      style={{
+        width,
+        height,
+        maxWidth: '100%',
+        objectFit: 'contain',
+        display: 'block',
+        filter:
+          !customSrc && isDark ? 'invert(1) hue-rotate(180deg)' : undefined,
+        ...style,
+      }}
+    />
+  );
+}

--- a/depictio/viewer/src/chrome/Header.tsx
+++ b/depictio/viewer/src/chrome/Header.tsx
@@ -4,6 +4,56 @@ import { Icon } from '@iconify/react';
 
 import type { DashboardData, DashboardSummary } from 'depictio-react-core';
 import PoweredBy from './PoweredBy';
+import { useUiScalePref } from '../hooks/useUiScalePref';
+
+/** A− / percent / A+ control for the dashboard-wide font-size preference
+ *  (#854). The percent label doubles as a reset button and only appears when
+ *  the scale is off 100%, so the default header stays compact. */
+const FontSizeControl: React.FC = () => {
+  const { scale, increase, decrease, reset, canIncrease, canDecrease } = useUiScalePref();
+
+  return (
+    <ActionIcon.Group data-testid="font-size-control">
+      <Tooltip label="Decrease font size" withArrow>
+        <ActionIcon
+          variant="default"
+          size="input-xs"
+          onClick={decrease}
+          disabled={!canDecrease}
+          data-testid="font-size-decrease"
+          aria-label="Decrease font size"
+        >
+          <Icon icon="mdi:format-font-size-decrease" width={14} />
+        </ActionIcon>
+      </Tooltip>
+      {scale !== 1 && (
+        <Tooltip label="Reset font size" withArrow>
+          <Button
+            variant="default"
+            size="compact-xs"
+            h="var(--input-height-xs)"
+            onClick={reset}
+            data-testid="font-size-reset"
+          >
+            {Math.round(scale * 100)}%
+          </Button>
+        </Tooltip>
+      )}
+      <Tooltip label="Increase font size" withArrow>
+        <ActionIcon
+          variant="default"
+          size="input-xs"
+          onClick={increase}
+          disabled={!canIncrease}
+          data-testid="font-size-increase"
+          aria-label="Increase font size"
+        >
+          <Icon icon="mdi:format-font-size-increase" width={14} />
+        </ActionIcon>
+      </Tooltip>
+    </ActionIcon.Group>
+  );
+};
 
 /** True for path-like icon values (PNG/SVG file URLs) — these came from the
  *  Dash YAML and aren't valid Iconify names. */
@@ -334,6 +384,7 @@ const Header: React.FC<HeaderProps> = ({
             Exit Edit
           </Button>
         )}
+        <FontSizeControl />
         <Button
           leftSection={<Icon icon="ic:baseline-settings" width={14} />}
           color="gray"

--- a/depictio/viewer/src/chrome/Header.tsx
+++ b/depictio/viewer/src/chrome/Header.tsx
@@ -4,56 +4,6 @@ import { Icon } from '@iconify/react';
 
 import type { DashboardData, DashboardSummary } from 'depictio-react-core';
 import PoweredBy from './PoweredBy';
-import { useUiScalePref } from '../hooks/useUiScalePref';
-
-/** A− / percent / A+ control for the dashboard-wide font-size preference
- *  (#854). The percent label doubles as a reset button and only appears when
- *  the scale is off 100%, so the default header stays compact. */
-const FontSizeControl: React.FC = () => {
-  const { scale, increase, decrease, reset, canIncrease, canDecrease } = useUiScalePref();
-
-  return (
-    <ActionIcon.Group data-testid="font-size-control">
-      <Tooltip label="Decrease font size" withArrow>
-        <ActionIcon
-          variant="default"
-          size="input-xs"
-          onClick={decrease}
-          disabled={!canDecrease}
-          data-testid="font-size-decrease"
-          aria-label="Decrease font size"
-        >
-          <Icon icon="mdi:format-font-size-decrease" width={14} />
-        </ActionIcon>
-      </Tooltip>
-      {scale !== 1 && (
-        <Tooltip label="Reset font size" withArrow>
-          <Button
-            variant="default"
-            size="compact-xs"
-            h="var(--input-height-xs)"
-            onClick={reset}
-            data-testid="font-size-reset"
-          >
-            {Math.round(scale * 100)}%
-          </Button>
-        </Tooltip>
-      )}
-      <Tooltip label="Increase font size" withArrow>
-        <ActionIcon
-          variant="default"
-          size="input-xs"
-          onClick={increase}
-          disabled={!canIncrease}
-          data-testid="font-size-increase"
-          aria-label="Increase font size"
-        >
-          <Icon icon="mdi:format-font-size-increase" width={14} />
-        </ActionIcon>
-      </Tooltip>
-    </ActionIcon.Group>
-  );
-};
 
 /** True for path-like icon values (PNG/SVG file URLs) — these came from the
  *  Dash YAML and aren't valid Iconify names. */
@@ -384,7 +334,6 @@ const Header: React.FC<HeaderProps> = ({
             Exit Edit
           </Button>
         )}
-        <FontSizeControl />
         <Button
           leftSection={<Icon icon="ic:baseline-settings" width={14} />}
           color="gray"

--- a/depictio/viewer/src/chrome/SettingsDrawer.tsx
+++ b/depictio/viewer/src/chrome/SettingsDrawer.tsx
@@ -1,37 +1,163 @@
 import React from 'react';
-import { Drawer, Group, Text } from '@mantine/core';
+import { ColorSwatch, Divider, Drawer, Group, Select, Stack, Text } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
-import type { DashboardData } from 'depictio-react-core';
+import type { DashboardData, DashboardThemeSpec } from 'depictio-react-core';
 import DashboardInfoBody from './DashboardInfoBody';
+
+/** Plotly template choices offered at the dashboard level. Mirrors the
+ *  component-level "Theme" picker options (figure/models.py), minus the
+ *  mantine sentinels — "Default" already means "follow the UI theme". */
+const TEMPLATE_OPTIONS = [
+  { value: '', label: 'Default (follow UI theme)' },
+  { value: 'plotly', label: 'Plotly' },
+  { value: 'plotly_white', label: 'Plotly White' },
+  { value: 'plotly_dark', label: 'Plotly Dark' },
+  { value: 'ggplot2', label: 'ggplot2' },
+  { value: 'seaborn', label: 'Seaborn' },
+  { value: 'simple_white', label: 'Simple White' },
+  { value: 'presentation', label: 'Presentation' },
+];
+
+/** Preset categorical palettes (hex, what the server hands to Plotly). */
+const COLORWAY_PRESETS: { value: string; label: string; colors: string[] }[] = [
+  {
+    value: 'plotly',
+    label: 'Plotly',
+    colors: ['#636efa', '#EF553B', '#00cc96', '#ab63fa', '#FFA15A', '#19d3f3', '#FF6692', '#B6E880', '#FF97FF', '#FECB52'],
+  },
+  {
+    value: 'tab10',
+    label: 'Tab10',
+    colors: ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'],
+  },
+  {
+    value: 'set2',
+    label: 'Set2',
+    colors: ['#66c2a5', '#fc8d62', '#8da0cb', '#e78ac3', '#a6d854', '#ffd92f', '#e5c494', '#b3b3b3'],
+  },
+  {
+    value: 'dark2',
+    label: 'Dark2',
+    colors: ['#1b9e77', '#d95f02', '#7570b3', '#e7298a', '#66a61e', '#e6ab02', '#a6761d', '#666666'],
+  },
+  {
+    value: 'vivid',
+    label: 'Vivid',
+    colors: ['#E58606', '#5D69B1', '#52BCA3', '#99C945', '#CC61B0', '#24796C', '#DAA51B', '#2F8AC4', '#764E9F', '#ED645A'],
+  },
+];
+
+function presetForColorway(colorway: string[] | null | undefined): string {
+  if (!colorway || colorway.length === 0) return '';
+  const key = JSON.stringify(colorway);
+  const match = COLORWAY_PRESETS.find((preset) => JSON.stringify(preset.colors) === key);
+  // A colorway written by hand in YAML that matches no preset still renders —
+  // it just shows as "Custom" here.
+  return match ? match.value : 'custom';
+}
 
 interface SettingsDrawerProps {
   opened: boolean;
   onClose: () => void;
   dashboard: DashboardData | null;
+  /** Editor only: makes the "Plot theme" section editable. The viewer leaves
+   *  this unset and the drawer stays read-only metadata. */
+  onChangePlotTheme?: (spec: DashboardThemeSpec | null) => void;
 }
 
 /**
- * Right-side drawer with read-only metadata about the current dashboard.
+ * Right-side drawer with metadata about the current dashboard, plus — in the
+ * editor — the dashboard-level plot theme (#397): a Plotly template and/or
+ * colorway applied as the default for every figure component.
  *
- * The content lives in `DashboardInfoBody`, shared with the inspector's Info
- * tab — which is what the inspector replaces this drawer with when enabled.
+ * The metadata content lives in `DashboardInfoBody`, shared with the
+ * inspector's Info tab — which is what the inspector replaces this drawer
+ * with when enabled.
  */
-const SettingsDrawer: React.FC<SettingsDrawerProps> = ({ opened, onClose, dashboard }) => (
-  <Drawer
-    opened={opened}
-    onClose={onClose}
-    position="right"
-    size="md"
-    title={
-      <Group gap="xs">
-        <Icon icon="mdi:cog" width={20} />
-        <Text fw={600}>Dashboard settings</Text>
-      </Group>
-    }
-  >
-    <DashboardInfoBody dashboard={dashboard} active={opened} />
-  </Drawer>
-);
+const SettingsDrawer: React.FC<SettingsDrawerProps> = ({
+  opened,
+  onClose,
+  dashboard,
+  onChangePlotTheme,
+}) => {
+  const plotTheme = dashboard?.plot_theme ?? null;
+  const colorwayValue = presetForColorway(plotTheme?.colorway);
+
+  const emit = (template: string | null, colorway: string[] | null) => {
+    if (!onChangePlotTheme) return;
+    onChangePlotTheme(template || colorway ? { template, colorway } : null);
+  };
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size="md"
+      title={
+        <Group gap="xs">
+          <Icon icon="mdi:cog" width={20} />
+          <Text fw={600}>Dashboard settings</Text>
+        </Group>
+      }
+    >
+      <Stack gap="md">
+        {onChangePlotTheme && (
+          <>
+            <Stack gap="xs" data-testid="plot-theme-section">
+              <Group gap="xs">
+                <Icon icon="mdi:palette-outline" width={18} />
+                <Text fw={600} size="sm">
+                  Plot theme
+                </Text>
+              </Group>
+              <Text size="xs" c="dimmed">
+                Default template and color palette for every figure on this dashboard.
+                Options set on an individual figure still win.
+              </Text>
+              <Select
+                label="Template"
+                data={TEMPLATE_OPTIONS}
+                value={plotTheme?.template ?? ''}
+                onChange={(value) => emit(value || null, plotTheme?.colorway ?? null)}
+                allowDeselect={false}
+                data-testid="plot-theme-template"
+              />
+              <Select
+                label="Color palette"
+                data={[
+                  { value: '', label: 'Default (theme palette)' },
+                  ...COLORWAY_PRESETS.map(({ value, label }) => ({ value, label })),
+                  ...(colorwayValue === 'custom'
+                    ? [{ value: 'custom', label: 'Custom (from YAML)', disabled: true }]
+                    : []),
+                ]}
+                value={colorwayValue}
+                onChange={(value) => {
+                  const preset = COLORWAY_PRESETS.find((p) => p.value === value);
+                  emit(plotTheme?.template ?? null, preset ? preset.colors : null);
+                }}
+                allowDeselect={false}
+                data-testid="plot-theme-colorway"
+              />
+              {colorwayValue && colorwayValue !== 'custom' && (
+                <Group gap={4}>
+                  {(COLORWAY_PRESETS.find((p) => p.value === colorwayValue)?.colors ?? []).map(
+                    (color) => (
+                      <ColorSwatch key={color} color={color} size={16} radius="sm" />
+                    ),
+                  )}
+                </Group>
+              )}
+            </Stack>
+            <Divider />
+          </>
+        )}
+        <DashboardInfoBody dashboard={dashboard} active={opened} />
+      </Stack>
+    </Drawer>
+  );
+};
 
 export default SettingsDrawer;

--- a/depictio/viewer/src/chrome/SettingsDrawer.tsx
+++ b/depictio/viewer/src/chrome/SettingsDrawer.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
-import { ColorSwatch, Divider, Drawer, Group, Select, Stack, Text } from '@mantine/core';
+import {
+  ActionIcon,
+  Button,
+  ColorInput,
+  ColorSwatch,
+  Divider,
+  Drawer,
+  FileButton,
+  Grid,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
 import { Icon } from '@iconify/react';
 
 import type { DashboardData, DashboardThemeSpec } from 'depictio-react-core';
 import DashboardInfoBody from './DashboardInfoBody';
+import { useUiScalePref } from '../hooks/useUiScalePref';
 
 /** Plotly template choices offered at the dashboard level. Mirrors the
  *  component-level "Theme" picker options (figure/models.py), minus the
@@ -48,14 +64,126 @@ const COLORWAY_PRESETS: { value: string; label: string; colors: string[] }[] = [
   },
 ];
 
+const HEX_RE = /^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/;
+
+/** Client-side mirror of the server's upload cap (routes.py). */
+const LOGO_MAX_BYTES = 2 * 1024 * 1024;
+
+/** Mini bar chart previewing how the selected palette cycles over series. */
+const PREVIEW_BAR_HEIGHTS = [34, 52, 26, 44, 20, 48, 30, 40];
+
+const PalettePreview: React.FC<{ colors: string[]; caption: string }> = ({ colors, caption }) => (
+  <Paper withBorder radius="md" p="xs" data-testid="plot-theme-preview">
+    <svg
+      viewBox="0 0 168 64"
+      style={{ width: '100%', display: 'block' }}
+      role="img"
+      aria-label="Palette preview"
+    >
+      {PREVIEW_BAR_HEIGHTS.map((height, idx) => (
+        <rect
+          // eslint-disable-next-line react/no-array-index-key
+          key={idx}
+          x={4 + idx * 20}
+          y={58 - height}
+          width={14}
+          height={height}
+          rx={2}
+          fill={colors[idx % colors.length]}
+        />
+      ))}
+      <line
+        x1={2}
+        y1={58.5}
+        x2={166}
+        y2={58.5}
+        stroke="var(--mantine-color-default-border)"
+        strokeWidth={1}
+      />
+    </svg>
+    <Group gap={4} mt={6}>
+      {colors.map((color, idx) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <ColorSwatch key={idx} color={color} size={12} radius="sm" />
+      ))}
+    </Group>
+    <Text size="xs" c="dimmed" mt={4}>
+      {caption}
+    </Text>
+  </Paper>
+);
+
 function presetForColorway(colorway: string[] | null | undefined): string {
   if (!colorway || colorway.length === 0) return '';
   const key = JSON.stringify(colorway);
   const match = COLORWAY_PRESETS.find((preset) => JSON.stringify(preset.colors) === key);
-  // A colorway written by hand in YAML that matches no preset still renders —
-  // it just shows as "Custom" here.
+  // A colorway written by hand (YAML or the Custom editor) that matches no
+  // preset still renders — it shows as "Custom" here.
   return match ? match.value : 'custom';
 }
+
+/** A− / percent / A+ control for the dashboard content font-size preference
+ *  (#854). Scales figures, tables and the other dashboard tiles — never the
+ *  app chrome — and is a per-browser preference, so it renders in both the
+ *  viewer and the editor. */
+const FontSizeBlock: React.FC = () => {
+  const { scale, increase, decrease, reset, canIncrease, canDecrease } = useUiScalePref();
+
+  return (
+    <Stack gap={6} data-testid="font-size-section">
+      <Text fw={500} size="sm">
+        Font size
+      </Text>
+      <Text size="xs" c="dimmed">
+        Scales the dashboard components (figures, tables, cards…). Saved in this browser.
+        Each figure can also carry its own font size from its tile menu while editing.
+      </Text>
+      <Group gap="xs">
+        <ActionIcon.Group data-testid="font-size-control">
+          <Tooltip label="Decrease font size" withArrow>
+            <ActionIcon
+              variant="default"
+              size="input-xs"
+              onClick={decrease}
+              disabled={!canDecrease}
+              data-testid="font-size-decrease"
+              aria-label="Decrease font size"
+            >
+              <Icon icon="mdi:format-font-size-decrease" width={14} />
+            </ActionIcon>
+          </Tooltip>
+          <Button
+            variant="default"
+            size="compact-xs"
+            h="var(--input-height-xs)"
+            style={{ pointerEvents: 'none' }}
+            data-testid="font-size-value"
+            tabIndex={-1}
+          >
+            {Math.round(scale * 100)}%
+          </Button>
+          <Tooltip label="Increase font size" withArrow>
+            <ActionIcon
+              variant="default"
+              size="input-xs"
+              onClick={increase}
+              disabled={!canIncrease}
+              data-testid="font-size-increase"
+              aria-label="Increase font size"
+            >
+              <Icon icon="mdi:format-font-size-increase" width={14} />
+            </ActionIcon>
+          </Tooltip>
+        </ActionIcon.Group>
+        {scale !== 1 && (
+          <Button variant="subtle" size="compact-xs" onClick={reset} data-testid="font-size-reset">
+            Reset
+          </Button>
+        )}
+      </Group>
+    </Stack>
+  );
+};
 
 interface SettingsDrawerProps {
   opened: boolean;
@@ -64,12 +192,19 @@ interface SettingsDrawerProps {
   /** Editor only: makes the "Plot theme" section editable. The viewer leaves
    *  this unset and the drawer stays read-only metadata. */
   onChangePlotTheme?: (spec: DashboardThemeSpec | null) => void;
+  /** Editor only: enables the "Logo" section. Uploads the file (the server
+   *  persists `logo_url` on the dashboard) — reject to surface an error. */
+  onUploadLogo?: (file: File) => Promise<void>;
+  /** Editor only: clears the dashboard logo (saves `logo_url: null`). */
+  onRemoveLogo?: () => void;
 }
 
 /**
- * Right-side drawer with metadata about the current dashboard, plus — in the
- * editor — the dashboard-level plot theme (#397): a Plotly template and/or
- * colorway applied as the default for every figure component.
+ * Right-side drawer for the current dashboard: metadata on top, then an
+ * "Appearance" section grouping the content font-size preference (#854), the
+ * dashboard logo (editor only) and the dashboard-level plot theme (#397 —
+ * template plus a preset or fully custom colorway applied as the default for
+ * every figure component).
  *
  * The metadata content lives in `DashboardInfoBody`, shared with the
  * inspector's Info tab — which is what the inspector replaces this drawer
@@ -80,13 +215,92 @@ const SettingsDrawer: React.FC<SettingsDrawerProps> = ({
   onClose,
   dashboard,
   onChangePlotTheme,
+  onUploadLogo,
+  onRemoveLogo,
 }) => {
   const plotTheme = dashboard?.plot_theme ?? null;
-  const colorwayValue = presetForColorway(plotTheme?.colorway);
+  const savedColorway = plotTheme?.colorway ?? null;
+  const colorwayValue = presetForColorway(savedColorway);
+
+  // Custom-palette editor draft. Non-null while the user is editing — the
+  // palette only reaches the dashboard (and a save) on "Apply". Discarded on
+  // close so a half-edited palette never lingers into the next open.
+  const [customDraft, setCustomDraft] = React.useState<string[] | null>(null);
+  React.useEffect(() => {
+    if (!opened) setCustomDraft(null);
+  }, [opened]);
+
+  const [logoUploading, setLogoUploading] = React.useState(false);
+  const [logoError, setLogoError] = React.useState<string | null>(null);
 
   const emit = (template: string | null, colorway: string[] | null) => {
     if (!onChangePlotTheme) return;
     onChangePlotTheme(template || colorway ? { template, colorway } : null);
+  };
+
+  const selectValue = customDraft ? 'custom' : colorwayValue;
+  const customEditorOpen = customDraft !== null || colorwayValue === 'custom';
+  // What the custom editor rows show: the in-flight draft, else the saved
+  // custom palette (editing it lazily forks a draft).
+  const editingColors = customDraft ?? (colorwayValue === 'custom' ? (savedColorway ?? []) : []);
+
+  const updateDraft = (mutate: (colors: string[]) => string[]) => {
+    setCustomDraft(mutate([...editingColors]));
+  };
+
+  const draftValid = editingColors.length > 0 && editingColors.every((c) => HEX_RE.test(c));
+  const draftDirty =
+    customDraft !== null && JSON.stringify(customDraft) !== JSON.stringify(savedColorway);
+
+  // Right-column result preview. While editing a custom palette it follows
+  // the draft live (invalid/incomplete hex entries are skipped); otherwise it
+  // shows the saved colorway, falling back to the theme's default palette.
+  const validEditing = editingColors.filter((c) => HEX_RE.test(c));
+  const previewColors = customEditorOpen
+    ? validEditing.length
+      ? validEditing
+      : COLORWAY_PRESETS[0].colors
+    : savedColorway?.length
+      ? savedColorway
+      : COLORWAY_PRESETS[0].colors;
+  const templateLabel =
+    TEMPLATE_OPTIONS.find((o) => o.value === (plotTheme?.template ?? ''))?.label ??
+    plotTheme?.template ??
+    'Default';
+  const paletteLabel = customEditorOpen
+    ? 'Custom palette'
+    : colorwayValue
+      ? (COLORWAY_PRESETS.find((p) => p.value === colorwayValue)?.label ?? 'Custom palette')
+      : 'Theme default palette';
+  const previewCaption = `${templateLabel} · ${paletteLabel}`;
+
+  const handleColorwaySelect = (value: string | null) => {
+    if (value === 'custom') {
+      if (customEditorOpen) return;
+      // Seed from the saved palette when there is one, else the Plotly default.
+      setCustomDraft(savedColorway?.length ? [...savedColorway] : [...COLORWAY_PRESETS[0].colors]);
+      return;
+    }
+    setCustomDraft(null);
+    const preset = COLORWAY_PRESETS.find((p) => p.value === value);
+    emit(plotTheme?.template ?? null, preset ? preset.colors : null);
+  };
+
+  const handleLogoFile = async (file: File | null) => {
+    if (!file || !onUploadLogo) return;
+    if (file.size > LOGO_MAX_BYTES) {
+      setLogoError('File is too large (max 2MB).');
+      return;
+    }
+    setLogoError(null);
+    setLogoUploading(true);
+    try {
+      await onUploadLogo(file);
+    } catch (err) {
+      setLogoError(err instanceof Error ? err.message : 'Upload failed.');
+    } finally {
+      setLogoUploading(false);
+    }
   };
 
   return (
@@ -103,58 +317,186 @@ const SettingsDrawer: React.FC<SettingsDrawerProps> = ({
       }
     >
       <Stack gap="md">
-        {onChangePlotTheme && (
-          <>
-            <Stack gap="xs" data-testid="plot-theme-section">
-              <Group gap="xs">
-                <Icon icon="mdi:palette-outline" width={18} />
-                <Text fw={600} size="sm">
-                  Plot theme
-                </Text>
-              </Group>
-              <Text size="xs" c="dimmed">
-                Default template and color palette for every figure on this dashboard.
-                Options set on an individual figure still win.
+        <DashboardInfoBody dashboard={dashboard} active={opened} />
+        <Divider />
+        <Stack gap="sm" data-testid="appearance-section">
+          <Group gap="xs">
+            <Icon icon="mdi:palette-outline" width={18} />
+            <Text fw={600} size="sm">
+              Appearance
+            </Text>
+          </Group>
+          <FontSizeBlock />
+          {onUploadLogo && (
+            <Stack gap={6} data-testid="dashboard-logo-section">
+              <Text fw={500} size="sm">
+                Logo
               </Text>
-              <Select
-                label="Template"
-                data={TEMPLATE_OPTIONS}
-                value={plotTheme?.template ?? ''}
-                onChange={(value) => emit(value || null, plotTheme?.colorway ?? null)}
-                allowDeselect={false}
-                data-testid="plot-theme-template"
-              />
-              <Select
-                label="Color palette"
-                data={[
-                  { value: '', label: 'Default (theme palette)' },
-                  ...COLORWAY_PRESETS.map(({ value, label }) => ({ value, label })),
-                  ...(colorwayValue === 'custom'
-                    ? [{ value: 'custom', label: 'Custom (from YAML)', disabled: true }]
-                    : []),
-                ]}
-                value={colorwayValue}
-                onChange={(value) => {
-                  const preset = COLORWAY_PRESETS.find((p) => p.value === value);
-                  emit(plotTheme?.template ?? null, preset ? preset.colors : null);
-                }}
-                allowDeselect={false}
-                data-testid="plot-theme-colorway"
-              />
-              {colorwayValue && colorwayValue !== 'custom' && (
-                <Group gap={4}>
-                  {(COLORWAY_PRESETS.find((p) => p.value === colorwayValue)?.colors ?? []).map(
-                    (color) => (
-                      <ColorSwatch key={color} color={color} size={16} radius="sm" />
-                    ),
+              <Text size="xs" c="dimmed">
+                Shown at the bottom of the dashboard sidebar. PNG, JPEG or WebP, up to 2MB.
+              </Text>
+              <Group gap="xs">
+                <FileButton onChange={handleLogoFile} accept="image/png,image/jpeg,image/webp">
+                  {(props) => (
+                    <Button
+                      {...props}
+                      variant="default"
+                      size="xs"
+                      loading={logoUploading}
+                      leftSection={<Icon icon="mdi:upload" width={14} />}
+                      data-testid="dashboard-logo-upload"
+                    >
+                      {dashboard?.logo_url ? 'Replace logo' : 'Upload logo'}
+                    </Button>
                   )}
-                </Group>
+                </FileButton>
+                {dashboard?.logo_url && onRemoveLogo && (
+                  <Button
+                    variant="subtle"
+                    color="red"
+                    size="xs"
+                    onClick={onRemoveLogo}
+                    data-testid="dashboard-logo-remove"
+                  >
+                    Remove
+                  </Button>
+                )}
+              </Group>
+              {logoError && (
+                <Text size="xs" c="red">
+                  {logoError}
+                </Text>
+              )}
+              {/* Preview last, centered — it sits right above the divider that
+                  introduces the plot theme below. */}
+              {dashboard?.logo_url && (
+                <img
+                  src={dashboard.logo_url}
+                  alt="Dashboard logo"
+                  style={{
+                    height: 40,
+                    maxWidth: 220,
+                    objectFit: 'contain',
+                    alignSelf: 'center',
+                  }}
+                />
               )}
             </Stack>
-            <Divider />
-          </>
-        )}
-        <DashboardInfoBody dashboard={dashboard} active={opened} />
+          )}
+          {onChangePlotTheme && (
+            <>
+              <Divider />
+              <Stack gap={6} data-testid="plot-theme-section">
+                <Text fw={500} size="sm">
+                  Default plot theme
+                </Text>
+                <Text size="xs" c="dimmed">
+                  Default template and color palette for every figure on this dashboard.
+                  Options set on an individual figure still win.
+                </Text>
+                <Grid gutter="sm" align="stretch">
+                  {/* Left third: the pickers. Right two thirds: the result. */}
+                  <Grid.Col span={4}>
+                    <Stack gap="xs">
+                      <Select
+                        label="Template"
+                        size="xs"
+                        data={TEMPLATE_OPTIONS}
+                        value={plotTheme?.template ?? ''}
+                        onChange={(value) => emit(value || null, savedColorway)}
+                        allowDeselect={false}
+                        comboboxProps={{ withinPortal: true }}
+                        data-testid="plot-theme-template"
+                      />
+                      <Select
+                        label="Palette"
+                        size="xs"
+                        data={[
+                          { value: '', label: 'Default (theme palette)' },
+                          ...COLORWAY_PRESETS.map(({ value, label }) => ({ value, label })),
+                          { value: 'custom', label: 'Custom' },
+                        ]}
+                        value={selectValue}
+                        onChange={handleColorwaySelect}
+                        allowDeselect={false}
+                        comboboxProps={{ withinPortal: true }}
+                        data-testid="plot-theme-colorway"
+                      />
+                    </Stack>
+                  </Grid.Col>
+                  <Grid.Col span={8}>
+                    <PalettePreview colors={previewColors} caption={previewCaption} />
+                  </Grid.Col>
+                </Grid>
+                {customEditorOpen && (
+                  <Stack gap={6} data-testid="custom-colorway-editor">
+                    {editingColors.map((color, idx) => (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <Group key={idx} gap="xs" wrap="nowrap">
+                        <ColorInput
+                          size="xs"
+                          value={color}
+                          onChange={(value) =>
+                            updateDraft((colors) => {
+                              colors[idx] = value;
+                              return colors;
+                            })
+                          }
+                          format="hex"
+                          popoverProps={{ withinPortal: true }}
+                          style={{ flex: 1 }}
+                          data-testid={`custom-color-${idx}`}
+                        />
+                        <Tooltip label="Remove color" withArrow>
+                          <ActionIcon
+                            variant="subtle"
+                            color="red"
+                            size="sm"
+                            disabled={editingColors.length <= 1}
+                            onClick={() =>
+                              updateDraft((colors) => colors.filter((_, i) => i !== idx))
+                            }
+                            aria-label="Remove color"
+                          >
+                            <Icon icon="mdi:close" width={14} />
+                          </ActionIcon>
+                        </Tooltip>
+                      </Group>
+                    ))}
+                    <Group gap="xs">
+                      <Button
+                        variant="default"
+                        size="compact-xs"
+                        leftSection={<Icon icon="mdi:plus" width={14} />}
+                        onClick={() =>
+                          updateDraft((colors) => [
+                            ...colors,
+                            colors[colors.length - 1] ?? '#636efa',
+                          ])
+                        }
+                        data-testid="custom-color-add"
+                      >
+                        Add color
+                      </Button>
+                      <Button
+                        size="compact-xs"
+                        disabled={!draftDirty || !draftValid}
+                        onClick={() => {
+                          if (!customDraft) return;
+                          emit(plotTheme?.template ?? null, customDraft);
+                          setCustomDraft(null);
+                        }}
+                        data-testid="custom-color-apply"
+                      >
+                        Apply palette
+                      </Button>
+                    </Group>
+                  </Stack>
+                )}
+              </Stack>
+            </>
+          )}
+        </Stack>
       </Stack>
     </Drawer>
   );

--- a/depictio/viewer/src/chrome/Sidebar.tsx
+++ b/depictio/viewer/src/chrome/Sidebar.tsx
@@ -121,6 +121,9 @@ interface SidebarProps {
   onDeleteTab?: (tab: DashboardSummary) => void;
   onMoveTab?: (tab: DashboardSummary, direction: TabMoveDirection) => void;
   onAddTab?: () => void;
+  /** Dashboard logo (uploaded via the editor's Settings drawer). Rendered
+   *  centered at the bottom of the sidebar, just above the footer divider. */
+  logoUrl?: string | null;
 }
 
 /**
@@ -139,6 +142,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   onDeleteTab,
   onMoveTab,
   onAddTab,
+  logoUrl,
 }) => {
   const { colorScheme } = useMantineColorScheme();
   const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
@@ -367,6 +371,15 @@ const Sidebar: React.FC<SidebarProps> = ({
         active server mode (Demo / Public / Single User), matching
         `depictio/dash/layouts/sidebar.py:create_sidebar_footer`. */}
       <Stack gap="xs" align="center">
+        {/* Dashboard logo — centered, right above the footer divider. */}
+        {logoUrl && (
+          <img
+            src={logoUrl}
+            alt=""
+            data-testid="dashboard-logo"
+            style={{ maxWidth: '80%', maxHeight: 60, objectFit: 'contain', display: 'block' }}
+          />
+        )}
         <Divider w="100%" />
         <ThemeToggle />
         <ServerStatusBadge />

--- a/depictio/viewer/src/components/GridItemEditOverlay.tsx
+++ b/depictio/viewer/src/components/GridItemEditOverlay.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ActionIcon, Menu, ScrollArea } from '@mantine/core';
+import { ActionIcon, Group, Menu, ScrollArea, Text } from '@mantine/core';
 import { Icon } from '@iconify/react';
 import { SectionIcon } from 'depictio-react-core';
 import type { FilterSectionSpec } from 'depictio-react-core';
@@ -24,6 +24,24 @@ import type { FilterSectionSpec } from 'depictio-react-core';
  * read-only mode.
  */
 const DUPLICATABLE_COMPONENT_TYPES = new Set(['card', 'interactive', 'figure']);
+
+/** Steps for the per-figure font-size multiplier. Wider than the
+ *  dashboard-wide preference on purpose: axis labels on a dense figure are
+ *  the case that motivates going up to 2×. */
+const FONT_SCALE_STEPS = [0.7, 0.85, 1, 1.15, 1.3, 1.5, 1.75, 2];
+
+function nearestStepIndex(scale: number): number {
+  let best = FONT_SCALE_STEPS.indexOf(1);
+  let bestDist = Infinity;
+  FONT_SCALE_STEPS.forEach((step, idx) => {
+    const dist = Math.abs(step - scale);
+    if (dist < bestDist) {
+      best = idx;
+      bestDist = dist;
+    }
+  });
+  return best;
+}
 
 interface GridItemEditOverlayProps {
   dashboardId: string;
@@ -56,6 +74,12 @@ interface GridItemEditOverlayProps {
   /** Size of the group that would move with this component, when > 1. Shown so
    *  the user isn't surprised that three controls moved rather than one. */
   groupSize?: number;
+  /** Current per-component font-size multiplier (`font_scale` on the
+   *  component's stored_metadata). Defaults to 1. */
+  fontScale?: number;
+  /** Fires with the new multiplier when the user steps the font-size control.
+   *  Only rendered for figure components; omit to hide the control. */
+  onFontScale?: (componentId: string, scale: number) => void;
 }
 
 const GridItemEditOverlay: React.FC<GridItemEditOverlayProps> = ({
@@ -69,6 +93,8 @@ const GridItemEditOverlay: React.FC<GridItemEditOverlayProps> = ({
   currentSection,
   onMoveToSection,
   groupSize = 1,
+  fontScale,
+  onFontScale,
 }) => {
   // The dropdown shows one page at a time: the actions, or the section list.
   // A dashboard can declare any number of sections, and a flat list would grow
@@ -101,6 +127,14 @@ const GridItemEditOverlay: React.FC<GridItemEditOverlayProps> = ({
   // is where that starts, so offering only "No section" here would be a dead
   // end.
   const showMoveToSection = !!onMoveToSection && !!sections?.length;
+
+  // Per-figure font-size multiplier (#854 follow-up). Figures only: their
+  // whole Plotly layout font (axis labels, ticks, legend) follows it.
+  const showFontScale = !!onFontScale && componentType === 'figure';
+  const currentScale = fontScale && fontScale > 0 ? fontScale : 1;
+  const scaleIdx = nearestStepIndex(currentScale);
+  const canScaleDown = scaleIdx > 0;
+  const canScaleUp = scaleIdx < FONT_SCALE_STEPS.length - 1;
 
   // The tick goes on the right, so the section icons keep the left column and
   // every label starts at the same x — the icon is what identifies a section
@@ -153,6 +187,52 @@ const GridItemEditOverlay: React.FC<GridItemEditOverlayProps> = ({
               >
                 Move to section
               </Menu.Item>
+            )}
+            {showFontScale && (
+              <>
+                <Menu.Divider />
+                <Menu.Label>Font size</Menu.Label>
+                {/* Inline control rather than Menu.Items so stepping A− / A+
+                    doesn't close the menu between clicks. */}
+                <Group gap={6} px="sm" pb={6} wrap="nowrap" data-testid="figure-font-scale">
+                  <ActionIcon.Group>
+                    <ActionIcon
+                      variant="default"
+                      size="sm"
+                      disabled={!canScaleDown}
+                      onClick={() => onFontScale!(componentId, FONT_SCALE_STEPS[scaleIdx - 1])}
+                      data-testid="figure-font-scale-decrease"
+                      aria-label="Decrease figure font size"
+                    >
+                      <Icon icon="mdi:format-font-size-decrease" width={14} />
+                    </ActionIcon>
+                    <ActionIcon
+                      variant="default"
+                      size="sm"
+                      disabled={!canScaleUp}
+                      onClick={() => onFontScale!(componentId, FONT_SCALE_STEPS[scaleIdx + 1])}
+                      data-testid="figure-font-scale-increase"
+                      aria-label="Increase figure font size"
+                    >
+                      <Icon icon="mdi:format-font-size-increase" width={14} />
+                    </ActionIcon>
+                  </ActionIcon.Group>
+                  <Text size="xs" c={currentScale === 1 ? 'dimmed' : undefined} w={38} ta="center">
+                    {Math.round(currentScale * 100)}%
+                  </Text>
+                  {currentScale !== 1 && (
+                    <ActionIcon
+                      variant="subtle"
+                      size="sm"
+                      onClick={() => onFontScale!(componentId, 1)}
+                      data-testid="figure-font-scale-reset"
+                      aria-label="Reset figure font size"
+                    >
+                      <Icon icon="mdi:restore" width={14} />
+                    </ActionIcon>
+                  )}
+                </Group>
+              </>
             )}
             <Menu.Divider />
             <Menu.Item

--- a/depictio/viewer/src/hooks/useColorScheme.ts
+++ b/depictio/viewer/src/hooks/useColorScheme.ts
@@ -13,7 +13,7 @@ const STORAGE_KEY = 'theme-store';
 
 type Scheme = 'light' | 'dark';
 
-function readStoredScheme(): Scheme | null {
+export function readStoredScheme(): Scheme | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;

--- a/depictio/viewer/src/hooks/useUiScalePref.ts
+++ b/depictio/viewer/src/hooks/useUiScalePref.ts
@@ -1,11 +1,14 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { DEFAULT_THEME } from '@mantine/core';
 import { UI_SCALE_DEFAULT, UI_SCALE_STEPS } from 'depictio-react-core';
 
 /**
- * Dashboard-wide font-size preference (issue #854), persisted per browser like
- * the dark-mode toggle. Two independent consumers read it — the Header control
- * and ThemeRoot (which rebuilds the Mantine theme with `scale`) — so writes go
- * through a module-level subscriber list to keep both in sync within the tab.
+ * Dashboard font-size preference (issue #854), persisted per browser like the
+ * dark-mode toggle. It scales dashboard content only (figures, tables, cards,
+ * interactive tiles) — never the app chrome (header, sidebar, drawers).
+ * Several independent consumers read it — the SettingsDrawer control, the
+ * content containers (via useContentScaleStyle) and UiScaleContext — so writes
+ * go through a module-level subscriber list to keep them in sync within the tab.
  */
 
 const STORAGE_KEY = 'depictio-ui-scale';
@@ -87,4 +90,35 @@ export function useUiScalePref() {
   }, []);
 
   return { scale, increase, decrease, reset, canIncrease, canDecrease };
+}
+
+/**
+ * CSS custom properties applying the font-size preference to a dashboard
+ * content container (and nothing outside it).
+ *
+ * Two mechanisms compose:
+ * - `--mantine-scale` cascades into the `calc(<rem> * var(--mantine-scale))`
+ *   expressions Mantine emits per component (inline `rem()` conversions,
+ *   component-level size vars), which resolve at the component element and so
+ *   pick up the container override.
+ * - The font-size / heading tokens are *precomputed* at `:root` (a custom
+ *   property substitutes `var(--mantine-scale)` where it is declared, not
+ *   where it is consumed), so they must be re-declared here with the scale
+ *   baked in for `size="sm"` texts and `<Title>`s to follow.
+ *
+ * Returns `undefined` at 100% so the default renders untouched.
+ */
+export function useContentScaleStyle(): CSSProperties | undefined {
+  const { scale } = useUiScalePref();
+  return useMemo(() => {
+    if (scale === 1) return undefined;
+    const vars: Record<string, string> = { '--mantine-scale': String(scale) };
+    for (const [size, value] of Object.entries(DEFAULT_THEME.fontSizes)) {
+      vars[`--mantine-font-size-${size}`] = `calc(${value} * ${scale})`;
+    }
+    for (const [heading, spec] of Object.entries(DEFAULT_THEME.headings.sizes)) {
+      vars[`--mantine-${heading}-font-size`] = `calc(${spec.fontSize} * ${scale})`;
+    }
+    return vars as CSSProperties;
+  }, [scale]);
 }

--- a/depictio/viewer/src/hooks/useUiScalePref.ts
+++ b/depictio/viewer/src/hooks/useUiScalePref.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from 'react';
+import { UI_SCALE_DEFAULT, UI_SCALE_STEPS } from 'depictio-react-core';
+
+/**
+ * Dashboard-wide font-size preference (issue #854), persisted per browser like
+ * the dark-mode toggle. Two independent consumers read it — the Header control
+ * and ThemeRoot (which rebuilds the Mantine theme with `scale`) — so writes go
+ * through a module-level subscriber list to keep both in sync within the tab.
+ */
+
+const STORAGE_KEY = 'depictio-ui-scale';
+
+type Listener = (scale: number) => void;
+const listeners = new Set<Listener>();
+
+function clampToStep(value: number): number {
+  // Snap to the nearest allowed step so a hand-edited or stale stored value
+  // can't produce an off-scale UI.
+  let best: number = UI_SCALE_DEFAULT;
+  let bestDist = Infinity;
+  for (const step of UI_SCALE_STEPS) {
+    const dist = Math.abs(step - value);
+    if (dist < bestDist) {
+      best = step;
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
+export function readStoredUiScale(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return UI_SCALE_DEFAULT;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return UI_SCALE_DEFAULT;
+    return clampToStep(parsed);
+  } catch {
+    return UI_SCALE_DEFAULT;
+  }
+}
+
+function writeStoredUiScale(scale: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(scale));
+  } catch {
+    // ignore quota / disabled storage
+  }
+}
+
+function broadcast(scale: number): void {
+  writeStoredUiScale(scale);
+  listeners.forEach((fn) => fn(scale));
+  // Plotly and AG Grid size to their containers; a scale change moves text
+  // metrics without a window resize, so fire the established reflow signal
+  // (same idiom as the panel toggles — see DashboardGrid's resize dispatch).
+  window.dispatchEvent(new Event('resize'));
+}
+
+export function useUiScalePref() {
+  const [scale, setScale] = useState<number>(readStoredUiScale);
+
+  useEffect(() => {
+    const listener: Listener = (next) => setScale(next);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const stepIndex = UI_SCALE_STEPS.indexOf(scale as (typeof UI_SCALE_STEPS)[number]);
+  const canIncrease = stepIndex < UI_SCALE_STEPS.length - 1;
+  const canDecrease = stepIndex > 0;
+
+  const increase = useCallback(() => {
+    const idx = UI_SCALE_STEPS.indexOf(readStoredUiScale() as (typeof UI_SCALE_STEPS)[number]);
+    if (idx < UI_SCALE_STEPS.length - 1) broadcast(UI_SCALE_STEPS[idx + 1]);
+  }, []);
+
+  const decrease = useCallback(() => {
+    const idx = UI_SCALE_STEPS.indexOf(readStoredUiScale() as (typeof UI_SCALE_STEPS)[number]);
+    if (idx > 0) broadcast(UI_SCALE_STEPS[idx - 1]);
+  }, []);
+
+  const reset = useCallback(() => {
+    broadcast(UI_SCALE_DEFAULT);
+  }, []);
+
+  return { scale, increase, decrease, reset, canIncrease, canDecrease };
+}

--- a/depictio/viewer/src/main.tsx
+++ b/depictio/viewer/src/main.tsx
@@ -57,10 +57,20 @@ import {
   validateSession,
 } from 'depictio-react-core';
 import { UiScaleContext } from 'depictio-react-core';
+import { generateColors } from '@mantine/colors-generator';
 import BootSplash from './components/BootSplash';
 import { buildDepictioTheme } from './theme';
 import { readStoredScheme } from './hooks/useColorScheme';
 import { useUiScalePref } from './hooks/useUiScalePref';
+import {
+  BRAND_PALETTE_NAME,
+  Branding,
+  BrandingContext,
+  getBranding,
+  isMantinePaletteName,
+  setBranding,
+  subscribeBranding,
+} from './branding';
 import { initGoogleAnalytics } from './googleAnalytics';
 import { WalkthroughHost } from './walkthrough';
 
@@ -126,19 +136,48 @@ function readInitialColorScheme(): 'light' | 'dark' {
   return readStoredScheme() ?? 'light';
 }
 
+/** Mantine theme options derived from instance branding (#397). */
+function brandingThemeOptions(branding: Branding | null): {
+  primaryColor?: string;
+  colors?: Record<string, ReturnType<typeof generateColors>>;
+} {
+  const color = branding?.primary_color;
+  if (!color) return {};
+  if (isMantinePaletteName(color)) return { primaryColor: color };
+  if (/^#[0-9a-fA-F]{6}$/.test(color)) {
+    return {
+      primaryColor: BRAND_PALETTE_NAME,
+      colors: { [BRAND_PALETTE_NAME]: generateColors(color) },
+    };
+  }
+  return {};
+}
+
 /**
- * Theme + UI-scale root. Rebuilds the Mantine theme whenever the user's
- * font-size preference changes (Header's A−/A+ control writes it through
- * useUiScalePref's shared subscriber list), and exposes the numeric scale to
- * the non-Mantine surfaces (Plotly fonts, AG Grid row metrics) via
- * UiScaleContext.
+ * Theme + UI-scale + branding root. Rebuilds the Mantine theme whenever the
+ * user's font-size preference changes (Header's A−/A+ control writes it
+ * through useUiScalePref's shared subscriber list) or the instance branding
+ * resolves (cached in localStorage for a flash-free first paint on return
+ * visits; the /utils/public-config fetch updates it in-flight). The numeric
+ * scale reaches the non-Mantine surfaces (Plotly fonts, AG Grid row metrics)
+ * via UiScaleContext; the branding reaches logo/title consumers via
+ * BrandingContext.
  */
 function ThemeRoot({ children }: { children: React.ReactNode }) {
   const { scale } = useUiScalePref();
-  const theme = React.useMemo(() => buildDepictioTheme({ scale }), [scale]);
+  const branding = React.useSyncExternalStore(subscribeBranding, getBranding);
+  const theme = React.useMemo(
+    () => buildDepictioTheme({ scale, ...brandingThemeOptions(branding) }),
+    [scale, branding],
+  );
+
+  React.useEffect(() => {
+    if (branding?.app_name) document.title = branding.app_name;
+  }, [branding?.app_name]);
 
   return (
     <UiScaleContext.Provider value={scale}>
+      <BrandingContext.Provider value={branding}>
       <MantineProvider theme={theme} defaultColorScheme={readInitialColorScheme()}>
         {/* DatesProvider is required for @mantine/dates components to pick up
             locale + first-day-of-week settings. Matches what DMC does
@@ -151,6 +190,7 @@ function ThemeRoot({ children }: { children: React.ReactNode }) {
           <WalkthroughHost />
         </DatesProvider>
       </MantineProvider>
+      </BrandingContext.Provider>
     </UiScaleContext.Provider>
   );
 }
@@ -267,6 +307,12 @@ function bootstrapPublicConfig(): void {
       const ga = config.google_analytics;
       if (ga?.enabled && ga.tracking_id) {
         initGoogleAnalytics(ga.tracking_id);
+      }
+      // Instance branding: push into the theme root's store + localStorage
+      // cache. `undefined` means an older backend without the field — leave
+      // whatever the cache holds rather than un-branding a live UI.
+      if (config.branding !== undefined) {
+        setBranding(config.branding);
       }
     })
     .catch(() => undefined);

--- a/depictio/viewer/src/main.tsx
+++ b/depictio/viewer/src/main.tsx
@@ -155,20 +155,20 @@ function brandingThemeOptions(branding: Branding | null): {
 
 /**
  * Theme + UI-scale + branding root. Rebuilds the Mantine theme whenever the
- * user's font-size preference changes (Header's A−/A+ control writes it
- * through useUiScalePref's shared subscriber list) or the instance branding
- * resolves (cached in localStorage for a flash-free first paint on return
- * visits; the /utils/public-config fetch updates it in-flight). The numeric
- * scale reaches the non-Mantine surfaces (Plotly fonts, AG Grid row metrics)
- * via UiScaleContext; the branding reaches logo/title consumers via
- * BrandingContext.
+ * instance branding resolves (cached in localStorage for a flash-free first
+ * paint on return visits; the /utils/public-config fetch updates it
+ * in-flight). The font-size preference deliberately does NOT touch the theme:
+ * it scales dashboard content only (see useContentScaleStyle), never the app
+ * chrome. The numeric scale reaches the non-Mantine content surfaces (Plotly
+ * fonts, AG Grid row metrics) via UiScaleContext; the branding reaches
+ * logo/title consumers via BrandingContext.
  */
 function ThemeRoot({ children }: { children: React.ReactNode }) {
   const { scale } = useUiScalePref();
   const branding = React.useSyncExternalStore(subscribeBranding, getBranding);
   const theme = React.useMemo(
-    () => buildDepictioTheme({ scale, ...brandingThemeOptions(branding) }),
-    [scale, branding],
+    () => buildDepictioTheme(brandingThemeOptions(branding)),
+    [branding],
   );
 
   React.useEffect(() => {

--- a/depictio/viewer/src/main.tsx
+++ b/depictio/viewer/src/main.tsx
@@ -56,8 +56,11 @@ import {
   startSessionKeepAlive,
   validateSession,
 } from 'depictio-react-core';
+import { UiScaleContext } from 'depictio-react-core';
 import BootSplash from './components/BootSplash';
-import { depictioTheme } from './theme';
+import { buildDepictioTheme } from './theme';
+import { readStoredScheme } from './hooks/useColorScheme';
+import { useUiScalePref } from './hooks/useUiScalePref';
 import { initGoogleAnalytics } from './googleAnalytics';
 import { WalkthroughHost } from './walkthrough';
 
@@ -117,18 +120,39 @@ function resolveTree(): React.ReactElement {
 }
 
 // Mirrors depictio/dash/layouts/shared_app_shell.py:create_app_shell MantineProvider config.
-// forceColorScheme initial value comes from localStorage — same key as the Dash app writes.
-// Defensive parse: stale/invalid stored value must NOT crash the SPA on boot.
-function readInitialColorScheme(): 'light' | 'dark' | 'auto' {
-  try {
-    const raw = localStorage.getItem('theme-store');
-    if (!raw) return 'light';
-    const parsed = JSON.parse(raw);
-    const scheme = parsed?.colorScheme;
-    return scheme === 'dark' || scheme === 'auto' ? scheme : 'light';
-  } catch {
-    return 'light';
-  }
+// Initial value comes from localStorage — same key/parser as useColorScheme, so
+// the boot-time read and the hook's hydration can never disagree.
+function readInitialColorScheme(): 'light' | 'dark' {
+  return readStoredScheme() ?? 'light';
+}
+
+/**
+ * Theme + UI-scale root. Rebuilds the Mantine theme whenever the user's
+ * font-size preference changes (Header's A−/A+ control writes it through
+ * useUiScalePref's shared subscriber list), and exposes the numeric scale to
+ * the non-Mantine surfaces (Plotly fonts, AG Grid row metrics) via
+ * UiScaleContext.
+ */
+function ThemeRoot({ children }: { children: React.ReactNode }) {
+  const { scale } = useUiScalePref();
+  const theme = React.useMemo(() => buildDepictioTheme({ scale }), [scale]);
+
+  return (
+    <UiScaleContext.Provider value={scale}>
+      <MantineProvider theme={theme} defaultColorScheme={readInitialColorScheme()}>
+        {/* DatesProvider is required for @mantine/dates components to pick up
+            locale + first-day-of-week settings. Matches what DMC does
+            internally for ``dmc.DatePickerInput``. */}
+        <DatesProvider settings={{ locale: 'en', firstDayOfWeek: 1 }}>
+          <Notifications position="bottom-right" />
+          <ErrorBoundary>
+            <Suspense fallback={<BootSplash />}>{children}</Suspense>
+          </ErrorBoundary>
+          <WalkthroughHost />
+        </DatesProvider>
+      </MantineProvider>
+    </UiScaleContext.Provider>
+  );
 }
 
 // Boot-time session bootstrap. Four jobs:
@@ -266,20 +290,7 @@ if (isBareRoot) {
     startSessionKeepAlive();
     ReactDOM.createRoot(document.getElementById('root')!).render(
       <React.StrictMode>
-        <MantineProvider theme={depictioTheme} defaultColorScheme={readInitialColorScheme()}>
-          {/* DatesProvider is required for @mantine/dates components to pick up
-              locale + first-day-of-week settings. Matches what DMC does
-              internally for ``dmc.DatePickerInput``. */}
-          <DatesProvider settings={{ locale: 'en', firstDayOfWeek: 1 }}>
-            <Notifications position="bottom-right" />
-            <ErrorBoundary>
-              <Suspense fallback={<BootSplash />}>
-                {resolveTree()}
-              </Suspense>
-            </ErrorBoundary>
-            <WalkthroughHost />
-          </DatesProvider>
-        </MantineProvider>
+        <ThemeRoot>{resolveTree()}</ThemeRoot>
       </React.StrictMode>,
     );
   });

--- a/depictio/viewer/src/theme.ts
+++ b/depictio/viewer/src/theme.ts
@@ -4,17 +4,30 @@ import { createTheme, MantineColorsTuple } from '@mantine/core';
  * Depictio Mantine theme. Mirrors the Dash `MantineProvider` config in
  * depictio/dash/layouts/shared_app_shell.py:create_app_shell so the viewer
  * renders with identical tokens to the Dash app.
- *
- * TODO: if Depictio's Dash app customizes colors via an env-driven config,
- * read the same source here.
  */
-export const depictioTheme = createTheme({
-  fontFamily:
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif',
-  fontFamilyMonospace: 'Menlo, Monaco, Consolas, "Courier New", monospace',
-  defaultRadius: 'md',
-  primaryColor: 'blue',
-  // Headings use the normal sans stack — the Virgil hand-drawn font is opt-in
-  // per-place (e.g. AuthCard's "Welcome to Depictio") via inline style, not the
-  // global default.
-});
+
+export interface DepictioThemeOptions {
+  /** Global size multiplier (`theme.scale` → `--mantine-scale`). */
+  scale?: number;
+  /** Mantine palette name to use as the primary color. */
+  primaryColor?: string;
+  /** Extra palettes to register (e.g. a generated brand palette). */
+  colors?: Record<string, MantineColorsTuple>;
+}
+
+export function buildDepictioTheme(options: DepictioThemeOptions = {}) {
+  return createTheme({
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif',
+    fontFamilyMonospace: 'Menlo, Monaco, Consolas, "Courier New", monospace',
+    defaultRadius: 'md',
+    primaryColor: options.primaryColor ?? 'blue',
+    ...(options.colors ? { colors: options.colors } : {}),
+    ...(options.scale && options.scale !== 1 ? { scale: options.scale } : {}),
+    // Headings use the normal sans stack — the Virgil hand-drawn font is opt-in
+    // per-place (e.g. AuthCard's "Welcome to Depictio") via inline style, not the
+    // global default.
+  });
+}
+
+export const depictioTheme = buildDepictioTheme();

--- a/depictio/viewer/src/theme.ts
+++ b/depictio/viewer/src/theme.ts
@@ -7,8 +7,6 @@ import { createTheme, MantineColorsTuple } from '@mantine/core';
  */
 
 export interface DepictioThemeOptions {
-  /** Global size multiplier (`theme.scale` → `--mantine-scale`). */
-  scale?: number;
   /** Mantine palette name to use as the primary color. */
   primaryColor?: string;
   /** Extra palettes to register (e.g. a generated brand palette). */
@@ -23,7 +21,6 @@ export function buildDepictioTheme(options: DepictioThemeOptions = {}) {
     defaultRadius: 'md',
     primaryColor: options.primaryColor ?? 'blue',
     ...(options.colors ? { colors: options.colors } : {}),
-    ...(options.scale && options.scale !== 1 ? { scale: options.scale } : {}),
     // Headings use the normal sans stack — the Virgil hand-drawn font is opt-in
     // per-place (e.g. AuthCard's "Welcome to Depictio") via inline style, not the
     // global default.

--- a/helm-charts/depictio/examples/values-branding.yaml
+++ b/helm-charts/depictio/examples/values-branding.yaml
@@ -1,0 +1,46 @@
+# =====================================================
+# Instance Branding Configuration Example
+# =====================================================
+# This values file demonstrates how to brand a Depictio deployment for
+# your institute / core facility: your own logo, instance name, primary
+# UI color and Plotly figure colorway.
+#
+# Usage:
+#   helm upgrade depictio ./helm-charts/depictio \
+#     -f values.yaml \
+#     -f examples/values-branding.yaml
+
+# The BACKEND is the only place these belong. The viewer ships as a static,
+# pre-built bundle served by nginx, so it cannot read environment variables at
+# runtime — it fetches this configuration from the API at boot instead
+# (GET /depictio/api/v1/utils/public-config).
+backend:
+  env:
+    # Custom logo shown in the sidebar and on the login page, replacing the
+    # depictio logo. Absolute https:// URL, or a path served by this
+    # deployment. The "Powered by Depictio" header badge is unaffected.
+    DEPICTIO_BRANDING_LOGO_URL: "https://example.org/assets/facility-logo.svg"
+
+    # Optional dark-mode variant. Falls back to DEPICTIO_BRANDING_LOGO_URL
+    # when unset (no automatic color inversion is applied to custom logos).
+    # DEPICTIO_BRANDING_LOGO_URL_DARK: "https://example.org/assets/facility-logo-dark.svg"
+
+    # Instance display name — browser tab title and login-page greeting
+    # ("Welcome to <name> :").
+    DEPICTIO_BRANDING_APP_NAME: "My Core Facility"
+
+    # Primary UI color: a Mantine palette name (blue, teal, grape, ...) or a
+    # hex color the viewer expands into a full palette.
+    DEPICTIO_BRANDING_PRIMARY_COLOR: "#0ca678"
+
+    # Categorical colorway for server-rendered Plotly figures: comma-separated
+    # hex colors. Overrides the default Mantine colorway in both light and
+    # dark themes.
+    # DEPICTIO_BRANDING_COLORWAY: "#0ca678,#f76707,#7048e8,#1c7ed6,#e64980"
+
+# Notes:
+# - All keys are optional and independent — set only what you need.
+# - Remote logo URLs work out of the box (the viewer's CSP already allows
+#   https: images); host the files somewhere stable and CDN-cached.
+# - Component- and dashboard-level color settings still take precedence over
+#   the instance colorway for individual figures.

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -294,6 +294,10 @@ export interface StoredMetadata {
    *  When omitted, the renderer defaults to visible for ungrouped components and
    *  hidden for components inside a group (compact mode). */
   show_marks?: boolean;
+  /** Per-component font-size multiplier (figures: scales the whole Plotly
+   *  layout font — axis labels, ticks, legend). Multiplies the dashboard-wide
+   *  content scale; 1/undefined = no override. */
+  font_scale?: number;
   // Table
   /** Column allowlist for table components — when non-empty, only these
    *  columns are rendered (empty / undefined = show all columns). */
@@ -341,6 +345,9 @@ export interface DashboardData {
   grid_sections?: FilterSectionSpec[];
   /** Dashboard-level Plotly template/colorway defaults for figures. */
   plot_theme?: DashboardThemeSpec | null;
+  /** Dashboard logo (uploaded via /dashboards/upload_logo), shown at the
+   *  bottom of the dashboard sidebar. Served from /static/dashboard_logos/. */
+  logo_url?: string | null;
   /** Project-level realtime config — only when ``enabled === true`` should
    *  the viewer mount the WebSocket subscription / live-updates indicator. */
   project_realtime?: { enabled: boolean; debounce_ms: number };
@@ -2035,6 +2042,79 @@ export async function saveDashboardNotes(
     body: JSON.stringify(payload),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to save dashboard notes');
+}
+
+// ---- Instance branding (admin panel) --------------------------------------
+
+/** One branding value set: what /utils/public-config serves as `branding`. */
+export interface BrandingFields {
+  logo_url: string | null;
+  logo_url_dark: string | null;
+  app_name: string | null;
+  primary_color: string | null;
+  colorway: string[] | null;
+}
+
+/** Admin view: per-field overrides layered on the deployment env defaults. */
+export interface AdminBrandingState {
+  overrides: Partial<BrandingFields>;
+  env_defaults: BrandingFields;
+  effective: BrandingFields;
+}
+
+export async function fetchBrandingAdmin(): Promise<AdminBrandingState> {
+  const res = await authFetch(`${API_BASE}/utils/branding`);
+  if (!res.ok) await throwHttpError(res, 'Failed to load branding settings');
+  return res.json();
+}
+
+/** Replace the override set — omitted/null fields fall back to env defaults. */
+export async function updateBrandingAdmin(
+  overrides: Partial<BrandingFields>,
+): Promise<AdminBrandingState> {
+  const res = await authFetch(`${API_BASE}/utils/branding`, {
+    method: 'PUT',
+    body: JSON.stringify(overrides),
+  });
+  if (!res.ok) await throwHttpError(res, 'Failed to save branding settings');
+  return res.json();
+}
+
+export async function resetBrandingAdmin(): Promise<AdminBrandingState> {
+  const res = await authFetch(`${API_BASE}/utils/branding`, { method: 'DELETE' });
+  if (!res.ok) await throwHttpError(res, 'Failed to reset branding settings');
+  return res.json();
+}
+
+/** Upload an instance logo variant; the server stores it under
+ *  /static/branding/ and points the matching override at it. */
+export async function uploadBrandingLogo(
+  variant: 'light' | 'dark',
+  file: File,
+): Promise<AdminBrandingState> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await authFetch(`${API_BASE}/utils/branding/logo/${variant}`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) await throwHttpError(res, 'Failed to upload branding logo');
+  return res.json();
+}
+
+/** Upload a dashboard logo image. The server stores the file, sets
+ *  `logo_url` on the dashboard document (ownership-checked) and returns the
+ *  cache-busted URL. */
+export async function uploadDashboardLogo(dashboardId: string, file: File): Promise<string> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await authFetch(`${API_BASE}/dashboards/upload_logo/${dashboardId}`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) await throwHttpError(res, 'Failed to upload dashboard logo');
+  const data = (await res.json()) as { logo_url: string };
+  return data.logo_url;
 }
 
 export async function fetchCurrentUser(): Promise<CurrentUser | null> {

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -1455,6 +1455,14 @@ export interface PublicConfigResponse {
     enabled: boolean;
     tracking_id: string | null;
   };
+  /** Instance branding (#397): custom logo / name / colors. All-null when unset. */
+  branding?: {
+    logo_url: string | null;
+    logo_url_dark: string | null;
+    app_name: string | null;
+    primary_color: string | null;
+    colorway: string[] | null;
+  };
 }
 
 export async function fetchPublicConfig(): Promise<PublicConfigResponse> {

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -318,6 +318,15 @@ export interface FilterSectionSpec {
   collapsed?: boolean;
 }
 
+/** Dashboard-level Plotly defaults. Mirrors DashboardThemeSpec in
+ *  depictio/models/models/dashboards.py — component-explicit values win. */
+export interface DashboardThemeSpec {
+  /** Plotly template name; null/mantine_* mean "follow the UI theme". */
+  template?: string | null;
+  /** Default categorical color sequence (hex list). */
+  colorway?: string[] | null;
+}
+
 export interface DashboardData {
   _id?: string;
   dashboard_id?: string;
@@ -330,6 +339,8 @@ export interface DashboardData {
   /** Ordering + icons for the left panel's filter sections. */
   filter_sections?: FilterSectionSpec[];
   grid_sections?: FilterSectionSpec[];
+  /** Dashboard-level Plotly template/colorway defaults for figures. */
+  plot_theme?: DashboardThemeSpec | null;
   /** Project-level realtime config — only when ``enabled === true`` should
    *  the viewer mount the WebSocket subscription / live-updates indicator. */
   project_realtime?: { enabled: boolean; debounce_ms: number };
@@ -1731,6 +1742,9 @@ export interface FigurePreviewRequest {
   metadata: Record<string, unknown>;
   filters?: InteractiveFilter[];
   theme?: 'light' | 'dark';
+  /** Owning dashboard — lets the server fold the dashboard's `plot_theme`
+   *  defaults into the preview so it matches the saved render. */
+  dashboard_id?: string;
 }
 
 export async function previewFigure(

--- a/packages/depictio-react-core/src/components/FigureRenderer.tsx
+++ b/packages/depictio-react-core/src/components/FigureRenderer.tsx
@@ -23,6 +23,7 @@ import { useTransientFlag } from '../hooks/useTransientFlag';
 import { ActiveHighlight } from '../highlight';
 import { asNumberArray, extractCustomdataIds } from '../plotlyData';
 import { adaptGlTraces, PlotlyTrace, useWebglSlot } from '../webglBudget';
+import { useUiScale } from '../uiScale';
 import RefetchOverlay from './RefetchOverlay';
 import ComponentSkeleton from './ComponentSkeleton';
 import { useReportLoadStatus } from './DashboardLoadingProvider';
@@ -75,6 +76,7 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
   const [error, setError] = useState<string | null>(null);
   const { colorScheme } = useMantineColorScheme();
   const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
+  const uiScale = useUiScale();
   const [containerRef, inView] = useInView<HTMLDivElement>('200px');
 
   // Cross-filtering only fires meaningful events on scatter-like traces —
@@ -393,6 +395,15 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
         ...((figure?.layout?.margin as Record<string, unknown>) || {}),
       },
     };
+    if (uiScale !== 1) {
+      // The mantine templates set font family only, so server figures land at
+      // Plotly's default 12px base. Scale it with the dashboard-wide font
+      // preference; per-figure size overrides (if any) are preserved by
+      // scaling whatever base the server sent.
+      const serverFont = (figure?.layout?.font as Record<string, unknown>) || {};
+      const serverSize = typeof serverFont.size === 'number' ? serverFont.size : 12;
+      base.font = { ...serverFont, size: serverSize * uiScale };
+    }
     if (selectionEnabled && !base.dragmode) {
       const mode =
         typeof metadata.selection_mode === 'string' ? metadata.selection_mode : 'lasso';
@@ -407,7 +418,7 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
     // changes don't bump refreshTick, so zoom/pan still survive those.
     base.uirevision = `tick-${refreshTick ?? 0}`;
     return base;
-  }, [figure, selectionEnabled, metadata.selection_mode, refreshTick]);
+  }, [figure, selectionEnabled, metadata.selection_mode, refreshTick, uiScale]);
 
   // "N of M points" indicator. Passive/informational — the full-load toggle
   // itself lives in the component chrome (see the onLoadAllState effect below),

--- a/packages/depictio-react-core/src/components/FigureRenderer.tsx
+++ b/packages/depictio-react-core/src/components/FigureRenderer.tsx
@@ -77,6 +77,10 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
   const { colorScheme } = useMantineColorScheme();
   const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
   const uiScale = useUiScale();
+  // Per-figure font-size multiplier on top of the dashboard-wide preference.
+  const componentFontScale =
+    typeof metadata.font_scale === 'number' && metadata.font_scale > 0 ? metadata.font_scale : 1;
+  const effectiveFontScale = uiScale * componentFontScale;
   const [containerRef, inView] = useInView<HTMLDivElement>('200px');
 
   // Cross-filtering only fires meaningful events on scatter-like traces —
@@ -395,14 +399,15 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
         ...((figure?.layout?.margin as Record<string, unknown>) || {}),
       },
     };
-    if (uiScale !== 1) {
+    if (effectiveFontScale !== 1) {
       // The mantine templates set font family only, so server figures land at
       // Plotly's default 12px base. Scale it with the dashboard-wide font
-      // preference; per-figure size overrides (if any) are preserved by
-      // scaling whatever base the server sent.
+      // preference times this figure's own `font_scale` (labels, ticks and
+      // legend all inherit layout.font); per-figure size overrides (if any)
+      // are preserved by scaling whatever base the server sent.
       const serverFont = (figure?.layout?.font as Record<string, unknown>) || {};
       const serverSize = typeof serverFont.size === 'number' ? serverFont.size : 12;
-      base.font = { ...serverFont, size: serverSize * uiScale };
+      base.font = { ...serverFont, size: serverSize * effectiveFontScale };
     }
     if (selectionEnabled && !base.dragmode) {
       const mode =
@@ -418,7 +423,7 @@ const FigureRenderer: React.FC<FigureRendererProps> = ({
     // changes don't bump refreshTick, so zoom/pan still survive those.
     base.uirevision = `tick-${refreshTick ?? 0}`;
     return base;
-  }, [figure, selectionEnabled, metadata.selection_mode, refreshTick, uiScale]);
+  }, [figure, selectionEnabled, metadata.selection_mode, refreshTick, effectiveFontScale]);
 
   // "N of M points" indicator. Passive/informational — the full-load toggle
   // itself lives in the component chrome (see the onLoadAllState effect below),

--- a/packages/depictio-react-core/src/components/TableRenderer.tsx
+++ b/packages/depictio-react-core/src/components/TableRenderer.tsx
@@ -28,6 +28,7 @@ import { enqueueFetch, isStaleFetch } from '../fetchQueue';
 import { useNewItemIds } from '../hooks/useNewItemIds';
 import { useTransientFlag } from '../hooks/useTransientFlag';
 import { ActiveHighlight } from '../highlight';
+import { useUiScale } from '../uiScale';
 import RefetchOverlay from './RefetchOverlay';
 import ComponentSkeleton from './ComponentSkeleton';
 import { useReportLoadStatus } from './DashboardLoadingProvider';
@@ -104,6 +105,7 @@ const TableRenderer: React.FC<TableRendererProps> = ({
   const pageSize = clampPageSize(metadata.page_size);
   const { colorScheme } = useMantineColorScheme();
   const isDark = colorScheme === 'dark';
+  const uiScale = useUiScale();
   const [containerRef, inView] = useInView<HTMLDivElement>('200px');
 
   // The table must NOT filter itself by its own row-selection — otherwise
@@ -702,12 +704,31 @@ const TableRenderer: React.FC<TableRendererProps> = ({
           )}
           <div
             className={isDark ? 'ag-theme-alpine-dark' : 'ag-theme-alpine'}
-            style={{ width: '100%', flex: 1, minHeight: 0, position: 'relative' }}
+            style={
+              {
+                width: '100%',
+                flex: 1,
+                minHeight: 0,
+                position: 'relative',
+                // Scale the Alpine defaults (13px font, 42px rows, 48px header)
+                // with the dashboard-wide font preference. Compact mode sets
+                // explicit JS row/header props below, which win over these vars.
+                ...(uiScale !== 1
+                  ? {
+                      '--ag-font-size': `${Math.round(13 * uiScale)}px`,
+                      '--ag-row-height': `${Math.round(42 * uiScale)}px`,
+                      '--ag-header-height': `${Math.round(48 * uiScale)}px`,
+                    }
+                  : {}),
+              } as React.CSSProperties
+            }
           >
             <AgGridReact
               // Remount when switching row models — AG Grid can't swap
-              // infinite ↔ client-side on a live instance.
-              key={showAll ? 'client' : 'infinite'}
+              // infinite ↔ client-side on a live instance. uiScale is in the
+              // key too: rowHeight/headerHeight are initial-only grid options,
+              // so a font-size change needs a fresh grid to take effect.
+              key={`${showAll ? 'client' : 'infinite'}-${uiScale}`}
               columnDefs={colDefs}
               defaultColDef={defaultColDef}
               {...(showAll
@@ -723,8 +744,8 @@ const TableRenderer: React.FC<TableRendererProps> = ({
               // so a size selector (which changes page size) can't be offered
               // there — only in client-side "Show all" mode.
               paginationPageSizeSelector={showAll ? pageSizeSelector : false}
-              rowHeight={metadata.compact ? 28 : undefined}
-              headerHeight={metadata.compact ? 32 : undefined}
+              rowHeight={metadata.compact ? Math.round(28 * uiScale) : undefined}
+              headerHeight={metadata.compact ? Math.round(32 * uiScale) : undefined}
               onGridReady={onGridReady}
               getRowClass={getRowClass}
               getRowId={

--- a/packages/depictio-react-core/src/components/data/DataGridBody.tsx
+++ b/packages/depictio-react-core/src/components/data/DataGridBody.tsx
@@ -6,6 +6,7 @@ import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 
 import { extractRowSelection } from '../../selection';
+import { useUiScale } from '../../uiScale';
 
 /**
  * The "underlying data" grid, shared by every show-data popover.
@@ -84,6 +85,7 @@ const DataGridBody: React.FC<DataGridBodyProps> = ({
   onClose,
 }) => {
   const { colorScheme } = useMantineColorScheme();
+  const uiScale = useUiScale();
   const gridApiRef = useRef<GridApi | null>(null);
   const selectable = selection != null;
 
@@ -312,16 +314,19 @@ const DataGridBody: React.FC<DataGridBodyProps> = ({
             height,
             flex: height === '100%' ? 1 : undefined,
             minHeight: 0,
-            '--ag-font-size': '11px',
-            '--ag-row-height': '24px',
-            '--ag-header-height': '28px',
+            '--ag-font-size': `${Math.round(11 * uiScale)}px`,
+            '--ag-row-height': `${Math.round(24 * uiScale)}px`,
+            '--ag-header-height': `${Math.round(28 * uiScale)}px`,
             '--ag-cell-horizontal-padding': '6px',
             '--ag-grid-size': '4px',
-            '--ag-list-item-height': '20px',
+            '--ag-list-item-height': `${Math.round(20 * uiScale)}px`,
           } as React.CSSProperties
         }
       >
         <AgGridReact
+          // rowHeight/headerHeight are initial-only grid options — remount on
+          // font-scale change so the new metrics apply.
+          key={`scale-${uiScale}`}
           rowData={rowData}
           columnDefs={colDefs}
           // Stable row identity → AG Grid diffs rows instead of replacing
@@ -342,8 +347,8 @@ const DataGridBody: React.FC<DataGridBodyProps> = ({
           onSelectionChanged={selectable ? onSelectionChanged : undefined}
           animateRows={false}
           rowBuffer={25}
-          rowHeight={24}
-          headerHeight={28}
+          rowHeight={Math.round(24 * uiScale)}
+          headerHeight={Math.round(28 * uiScale)}
           pagination={paginated}
           paginationPageSize={100}
           paginationPageSizeSelector={[50, 100, 250, 500]}

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -359,6 +359,11 @@ export type { RealtimeJournalEntry } from './hooks/useRealtimeJournal';
 export { batchIdsFromPayload } from './highlight';
 export type { ActiveHighlight } from './highlight';
 
+// Dashboard-wide UI scale (font-size) preference. The viewer app owns the
+// provider; Plotly/AG Grid renderers consume the value for their non-Mantine
+// pixel metrics.
+export { UiScaleContext, useUiScale, UI_SCALE_STEPS, UI_SCALE_DEFAULT } from './uiScale';
+
 // Render-fetch queue. Apps that own the filter state call
 // ``bumpFetchGeneration`` when it changes, so requests queued for the previous
 // filter are dropped instead of running against a question nobody is asking.

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -380,6 +380,7 @@ export type {
   StoredMetadata,
   DashboardData,
   FilterSectionSpec,
+  DashboardThemeSpec,
   DashboardSummary,
   InteractiveFilter,
   InteractiveFilterSource,

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -179,6 +179,12 @@ export {
   fetchFigureVisualizationList,
   upsertComponent,
   saveDashboardNotes,
+  uploadDashboardLogo,
+  // Instance branding (admin panel)
+  fetchBrandingAdmin,
+  updateBrandingAdmin,
+  resetBrandingAdmin,
+  uploadBrandingLogo,
   // Auth helpers (React /auth page)
   fetchAuthStatus,
   loginUser,
@@ -281,6 +287,8 @@ export {
   fetchCatalogPreviewPayload,
 } from './api';
 export type {
+  BrandingFields,
+  AdminBrandingState,
   FloatingComponent,
   FloatingComponentsResponse,
   TableMutationResult,

--- a/packages/depictio-react-core/src/uiScale.ts
+++ b/packages/depictio-react-core/src/uiScale.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Dashboard-wide UI scale (font-size) preference, default 1.0.
+ *
+ * Mantine surfaces scale through `theme.scale` (the viewer rebuilds its theme
+ * from the same value), but Plotly figure fonts and AG Grid row metrics are
+ * plain pixel numbers that Mantine never touches — those renderers read this
+ * context instead. The provider lives in the viewer app; react-core only
+ * defines the channel so shared components stay host-agnostic.
+ */
+export const UI_SCALE_STEPS = [0.85, 1.0, 1.15, 1.3] as const;
+export const UI_SCALE_DEFAULT = 1.0;
+
+export const UiScaleContext = createContext<number>(UI_SCALE_DEFAULT);
+
+export function useUiScale(): number {
+  return useContext(UiScaleContext);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@mantine/code-highlight':
         specifier: ^7.14.0
         version: 7.17.8(@mantine/core@7.17.8(@mantine/hooks@7.17.8(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mantine/hooks@7.17.8(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mantine/colors-generator':
+        specifier: ^7.17.8
+        version: 7.17.8(chroma-js@3.2.0)
       '@mantine/core':
         specifier: ^7.14.0
         version: 7.17.8(@mantine/hooks@7.17.8(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1108,6 +1111,11 @@ packages:
       react: ^18.x || ^19.x
       react-dom: ^18.x || ^19.x
 
+  '@mantine/colors-generator@7.17.8':
+    resolution: {integrity: sha512-uLUYkmdwv2kQtoNTizBDyOeVLMuCIQfR7UdZDKAPJP921RUu+B8sbW7TAY6jAScDswqZNDZNLKdo5icYYBF/2g==}
+    peerDependencies:
+      chroma-js: '>=2.4.2'
+
   '@mantine/core@7.17.8':
     resolution: {integrity: sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==}
     peerDependencies:
@@ -1266,66 +1274,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1805,6 +1826,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chroma-js@3.2.0:
+    resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -4409,6 +4433,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@mantine/colors-generator@7.17.8(chroma-js@3.2.0)':
+    dependencies:
+      chroma-js: 3.2.0
+
   '@mantine/core@7.17.8(@mantine/hooks@7.17.8(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5166,6 +5194,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chroma-js@3.2.0: {}
 
   chrome-trace-event@1.0.4: {}
 


### PR DESCRIPTION
## Summary
Three appearance/UX features in one PR:

**Font-size control (#854)** — A−/A+ control in the dashboard viewer/editor header stepping the UI scale through 85%/100%/115%/130%, persisted per browser in localStorage (like the dark-mode toggle). Mantine `theme.scale` carries every token-driven surface; server-rendered Plotly figures scale their layout font client-side (no refetch) and AG Grid tables scale font + row/header metrics. Drive-by: the two divergent `theme-store` parsers (boot vs hook) are unified.

**Instance branding (#397, part 1)** — `DEPICTIO_BRANDING_*` env vars (logo light/dark, app name, primary color, Plotly colorway) exposed to the static viewer bundle through the existing unauthenticated `/utils/public-config` channel. A new `BrandLogo` component replaces the depictio logo in the sidebar and login card on branded deployments (core facility, TREC, …) — the "Powered by Depictio" header badge stays. The branding colorway re-tints the `mantine_light`/`mantine_dark` server templates in every render path (figures, maps, worker prerenders, screenshots). Branding is cached in localStorage for a flash-free first paint. Helm example: `helm-charts/depictio/examples/values-branding.yaml`.

**Per-dashboard plot theme (#397, part 2)** — optional `plot_theme` (Plotly template + colorway) on the dashboard model, editable in the editor's Settings drawer, with full lite-YAML round-trip. Applied as the default for every figure component that doesn't pick its own; builder previews fold in the same defaults. Precedence: component explicit > dashboard `plot_theme` > instance branding > mantine default.

This also fixes a latent bug: the per-component "Theme" picker was dead — `figure_builder` unconditionally overwrote the template. The new sentinel rule honors explicit templates while treating `mantine_light`/`mantine_dark` as "follow the UI theme", preserving dark mode for legacy components stamped with `template: "mantine_light"`.

**Deferred (follow-ups)**: advanced-viz renderer font scaling & palettes, admin UI for branding, full custom Plotly template JSON, free-form colorway editor.

## Type of change
- [x] Feature
- [ ] Bugfix
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
Closes #854
Closes #397

## How was this tested?
- New unit tests: `depictio/tests/models/test_plot_theme.py` (model shape, YAML round-trip, lite↔full conversion, seed compatibility, template precedence) — full suite: 771 passed (1 pre-existing S3/Docker-dependent integration error, environmental).
- New Playwright spec: `tests/ui/font-size-control.spec.ts` (apply, `--mantine-scale`, persistence across reload, reset), mirroring `theme-toggle.spec.ts`.
- `BrandingConfig` parsing and branded template colorway patch smoke-tested (light + dark templates, `get_theme_template` path).
- Viewer builds clean (`tsc` + `vite build`).

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh7D3fSyRsnmBrTHihqjkw)_