### PR TITLE
Migrate MongoDB driver from motor to pymongo AsyncMongoClient (unblocks beanie ≥ 2.1.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,10 @@
 #   - static-tooling : dev/test/lint tooling — safe, usually mergeable fast
 #   - runtime        : production dependencies — higher risk, isolated
 #
-# Known runtime deps that are currently pinned back on purpose (redis,
-# beanie — see the inline notes in pyproject.toml) are intentionally NOT
-# ignored here: the monthly runtime PR re-checks whether the upstream
-# blocker has been resolved. Expect that PR to stay red until it is.
+# Known runtime deps that are currently pinned back on purpose (redis —
+# see the inline notes in pyproject.toml) are intentionally NOT ignored
+# here: the monthly runtime PR re-checks whether the upstream blocker has
+# been resolved. Expect that PR to stay red until it is.
 #
 # Note: Dependabot does not update .pre-commit-config.yaml hook revs — run
 # `pre-commit autoupdate` manually (or via a separate job) for those.

--- a/.github/workflows/minimal-deploy.yaml
+++ b/.github/workflows/minimal-deploy.yaml
@@ -323,4 +323,3 @@ jobs:
           depictio-cli config check \
             --project-config-path ../projects/init/iris/project.yaml \
             --CLI-config-path admin_config.yaml
-

--- a/conda_envs/depictio.yaml
+++ b/conda_envs/depictio.yaml
@@ -24,7 +24,6 @@ dependencies:
   - flask-caching
   - gunicorn
   - httpx==0.28.1
-  - motor
   - mypy-boto3-s3
   - numpy==2.2.3
   - orjson

--- a/depictio/api/celery_app.py
+++ b/depictio/api/celery_app.py
@@ -103,7 +103,7 @@ def generate_dashboard_screenshot_dual(
 
     from beanie import init_beanie
     from celery.exceptions import Ignore
-    from motor.motor_asyncio import AsyncIOMotorClient
+    from pymongo import AsyncMongoClient
 
     from depictio.api.v1.configs.logging_init import logger
     from depictio.api.v1.services.screenshot_service import (
@@ -158,7 +158,7 @@ def generate_dashboard_screenshot_dual(
         """Async wrapper: initializes MongoDB and runs Playwright screenshot generation."""
         from depictio.api.v1.configs.config import MONGODB_URL
 
-        client = AsyncIOMotorClient(MONGODB_URL)
+        client: AsyncMongoClient = AsyncMongoClient(MONGODB_URL)
         try:
             await init_beanie(
                 database=client[settings.mongodb.db_name],
@@ -171,7 +171,7 @@ def generate_dashboard_screenshot_dual(
                 filename_prefix=filename_prefix,
             )
         finally:
-            client.close()
+            await client.close()
 
     try:
         result = asyncio.run(async_screenshot_task())

--- a/depictio/api/v1/monitoring/log_handler.py
+++ b/depictio/api/v1/monitoring/log_handler.py
@@ -16,7 +16,7 @@ from depictio.models.models.monitoring import AppLogRecord
 
 # Loggers whose records we never persist, to avoid recursion (the handler itself
 # talks to MongoDB through pymongo) and noise.
-_SKIP_LOGGER_PREFIXES = ("pymongo", "motor", "depictio.api.v1.monitoring.store")
+_SKIP_LOGGER_PREFIXES = ("pymongo", "depictio.api.v1.monitoring.store")
 
 _local = threading.local()
 

--- a/depictio/api/v1/services/events/mongodb_watcher.py
+++ b/depictio/api/v1/services/events/mongodb_watcher.py
@@ -10,7 +10,9 @@ from datetime import datetime
 from typing import Any
 
 from bson import ObjectId
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection, AsyncIOMotorDatabase
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.collection import AsyncCollection
+from pymongo.asynchronous.database import AsyncDatabase
 from pymongo.errors import OperationFailure
 
 from depictio.api.v1.configs.config import MONGODB_URL, settings
@@ -42,8 +44,8 @@ class MongoDBChangeWatcher:
                                Signature: async def callback(event: EventMessage, dashboard_ids: list[str])
         """
         self._on_change = on_change_callback
-        self._client: AsyncIOMotorClient | None = None
-        self._db: AsyncIOMotorDatabase | None = None
+        self._client: AsyncMongoClient | None = None
+        self._db: AsyncDatabase | None = None
         self._watch_task: asyncio.Task | None = None
         self._running = False
 
@@ -54,7 +56,7 @@ class MongoDBChangeWatcher:
             return
 
         try:
-            self._client = AsyncIOMotorClient(MONGODB_URL)
+            self._client = AsyncMongoClient(MONGODB_URL)
             self._db = self._client[settings.mongodb.db_name]
 
             # Verify connection
@@ -92,7 +94,7 @@ class MongoDBChangeWatcher:
             self._watch_task = None
 
         if self._client:
-            self._client.close()
+            await self._client.close()
             self._client = None
             self._db = None
 
@@ -103,7 +105,7 @@ class MongoDBChangeWatcher:
         if not self._db:
             return
 
-        collection: AsyncIOMotorCollection = self._db[settings.mongodb.collections.data_collection]
+        collection: AsyncCollection = self._db[settings.mongodb.collections.data_collection]
 
         # Pipeline to filter for relevant operations
         pipeline = [
@@ -117,7 +119,8 @@ class MongoDBChangeWatcher:
         try:
             logger.info("Starting MongoDB change stream on data_collections")
 
-            async with collection.watch(pipeline, full_document="updateLookup") as stream:
+            # pymongo's async watch() is a coroutine (unlike motor's), hence the await.
+            async with await collection.watch(pipeline, full_document="updateLookup") as stream:
                 async for change in stream:
                     if not self._running:
                         break
@@ -245,7 +248,7 @@ class MongoDBChangeWatcher:
                 {"$group": {"_id": "$_id"}},
             ]
 
-            cursor = dashboards_collection.aggregate(pipeline)
+            cursor = await dashboards_collection.aggregate(pipeline)
             dashboard_ids = [str(doc["_id"]) async for doc in cursor]
 
             return dashboard_ids

--- a/depictio/api/v1/services/lifespan.py
+++ b/depictio/api/v1/services/lifespan.py
@@ -8,13 +8,11 @@ background processing, and cleanup.
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import cast
 
 import pymongo
 from beanie import init_beanie
 from fastapi import FastAPI
-from motor.motor_asyncio import AsyncIOMotorClient
-from pymongo.asynchronous.database import AsyncDatabase
+from pymongo import AsyncMongoClient
 
 from depictio.api.v1.configs.config import MONGODB_URL, settings
 from depictio.api.v1.configs.logging_init import logger
@@ -46,15 +44,15 @@ from depictio.models.models.users import (
 WORKER_ID = os.getpid()
 
 
-async def init_motor_beanie() -> None:
-    """Initialize Motor (async MongoDB client) and Beanie ODM.
+async def init_pymongo_beanie() -> None:
+    """Initialize the async MongoDB client (pymongo) and Beanie ODM.
 
     Connection pool sizing:
     - maxPoolSize: 25 per worker (4 workers = ~100 total connections)
     - minPoolSize: 5 per worker (maintains 20 baseline connections)
     - Prevents connection exhaustion under load in K8s environment
     """
-    client = AsyncIOMotorClient(
+    client: AsyncMongoClient = AsyncMongoClient(
         MONGODB_URL,
         maxPoolSize=25,  # Limit per worker to prevent exhaustion
         minPoolSize=5,  # Maintain baseline connections
@@ -62,7 +60,7 @@ async def init_motor_beanie() -> None:
         waitQueueTimeoutMS=5000,  # Fail fast if pool exhausted
     )
     await init_beanie(
-        database=cast(AsyncDatabase, client[settings.mongodb.db_name]),
+        database=client[settings.mongodb.db_name],
         document_models=[
             TokenBeanie,
             GroupBeanie,
@@ -334,7 +332,7 @@ async def lifespan(_app: FastAPI):
     - Real-time event services
     """
     # Startup
-    await init_motor_beanie()
+    await init_pymongo_beanie()
     should_initialize = await handle_initialization()
     background_task = start_background_services(should_initialize)
     start_yaml_services(should_initialize)

--- a/depictio/cli/cli/utils/api_calls.py
+++ b/depictio/cli/cli/utils/api_calls.py
@@ -45,7 +45,7 @@ def api_login(yaml_config_path: str = "~/.depictio/CLI.yaml") -> dict:
     # than httpx's 5 s default. 120 s is well past any reasonable
     # cold-path; the call still returns as soon as the server responds.
     # 30 s wasn't enough in CI minikube/compose environments where the
-    # first Beanie query pays the full motor + driver init cost.
+    # first Beanie query pays the full async-driver init cost.
     response = get_http_client().post(
         f"{depictio_CLI_config['api_base_url']}/depictio/api/v1/cli/validate_cli_config",
         json=depictio_CLI_config,

--- a/depictio/cli/pyproject.toml
+++ b/depictio/cli/pyproject.toml
@@ -24,10 +24,7 @@ dependencies = [
   "rich==15.0.0",
   "pydantic[email]==2.13.4",
   "pydantic-settings==2.14.1",
-  # Held at 2.0.0: beanie 2.1.0 calls list_collection_names(authorizedCollections=
-  # True) during init, which the latest mongomock (4.3.0) test double doesn't
-  # accept, breaking the unit suite. Bump once mongomock supports the kwarg.
-  "beanie==2.0.0",
+  "beanie==2.2.0",
   "python-dotenv==1.2.2",
   "bleach==6.4.0",
   # Required by catalog recipes that build colour scales / hierarchical figures

--- a/depictio/dev_scripts/reseed_project.py
+++ b/depictio/dev_scripts/reseed_project.py
@@ -271,12 +271,12 @@ async def reseed(
     for name in dataset_names:
         _ = _resolve_static_ids(name)  # validate up-front
 
-    # Initialise Motor + Beanie ODM — required for UserBeanie/ProjectBeanie/
-    # TokenBeanie queries used downstream. The API process does this on
-    # startup; standalone scripts have to do it themselves.
-    from depictio.api.v1.services.lifespan import init_motor_beanie
+    # Initialise the async MongoDB client + Beanie ODM — required for
+    # UserBeanie/ProjectBeanie/TokenBeanie queries used downstream. The API
+    # process does this on startup; standalone scripts have to do it themselves.
+    from depictio.api.v1.services.lifespan import init_pymongo_beanie
 
-    await init_motor_beanie()
+    await init_pymongo_beanie()
 
     if dashboards_only:
         logger.info(f"reseed: dashboards-only refresh for {dataset_names}")

--- a/depictio/tests/conftest.py
+++ b/depictio/tests/conftest.py
@@ -29,3 +29,21 @@ _PYTEST_DEFAULTS = {
 
 for _k, _v in _PYTEST_DEFAULTS.items():
     os.environ.setdefault(_k, _v)
+
+
+# beanie >= 2.1 passes list_collection_names(nameOnly=True, authorizedCollections=True)
+# during init_beanie; mongomock 4.3.0 / mongomock-motor 0.0.36 accept neither kwarg.
+# Both are no-ops against a mock (privilege filtering and a projection hint), so drop
+# them before delegating. Remove once mongomock supports the kwargs upstream.
+import mongomock.database  # noqa: E402
+
+_orig_list_collection_names = mongomock.database.Database.list_collection_names
+
+
+def _list_collection_names_shim(self, filter=None, session=None, **kwargs):  # type: ignore[no-untyped-def]
+    kwargs.pop("nameOnly", None)
+    kwargs.pop("authorizedCollections", None)
+    return _orig_list_collection_names(self, filter=filter, session=session, **kwargs)
+
+
+mongomock.database.Database.list_collection_names = _list_collection_names_shim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,7 @@ dependencies = [
   # Core dependencies
   "bcrypt==5.0.0",
   "bleach==6.4.0",
-  # Held at 2.0.0: beanie 2.1.0 calls list_collection_names(authorizedCollections=
-  # True) during init, which the latest mongomock (4.3.0) test double doesn't
-  # accept, breaking the unit suite. Bump once mongomock supports the kwarg.
-  # Re-checked 2026-08 (dependabot runtime group): still blocked — mongomock
-  # 4.3.0 / mongomock-motor 0.0.36 are still the newest releases on PyPI, and
-  # beanie 2.1.0 fails 81 tests, all on the same TypeError.
-  "beanie==2.0.0",
+  "beanie==2.2.0",
   # Capped at 1.43.0: s3fs 2026.4.0 -> aiobotocore caps botocore<1.43.1, so this
   # is the highest boto3 compatible with the pinned s3fs/aiobotocore chain.
   "boto3==1.43.0",
@@ -45,7 +39,6 @@ dependencies = [
   "uvicorn==0.52.0",
   "websockets==17.0",
   # Database
-  "motor==3.7.1",
   "pymongo==4.17.0",
   # Authentication and security
   "pydantic[email]==2.13.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "beanie"
-version = "2.0.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -426,9 +426,9 @@ dependencies = [
     { name = "pymongo" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/c3/21152df5974f6b690a74a990a1b706102ad694b56bd2a59f7903b6424696/beanie-2.0.0.tar.gz", hash = "sha256:07982e42618cea01722f62d2b4028514a508a2c2c2c71ff85f07f6009112ffb3", size = 169854, upload-time = "2025-07-20T06:55:27.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/a1/4abc93d5437999c55465f68c3c81e4735cdfe22827072c0e9cab00f63d11/beanie-2.2.0.tar.gz", hash = "sha256:2dc116e7f4a6650f8066f95851d34d898983af6ffaf5366dcfef892993537a51", size = 70115, upload-time = "2026-08-07T17:15:24.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/36/c40577bc8e3564639b89db32aff1e9e8af14c990e3a7ed85a79b74ec4b78/beanie-2.0.0-py3-none-any.whl", hash = "sha256:0d5c0e0de09f2a316c74d17bbba1ceb68ebcbfd3046ae5be69038b2023682372", size = 87051, upload-time = "2025-07-20T06:55:25.944Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ae/2584fb9871b58f3c5334110f8ce00bd1421fe5fbda28eeac9a8d01d10ba6/beanie-2.2.0-py3-none-any.whl", hash = "sha256:4074f893ef00c52b8538b814c9dfd55130eea4ed0579abfae72853657c9029e4", size = 93116, upload-time = "2026-08-07T17:15:22.777Z" },
 ]
 
 [[package]]
@@ -1019,7 +1019,6 @@ dependencies = [
     { name = "fsspec" },
     { name = "gunicorn" },
     { name = "httpx" },
-    { name = "motor" },
     { name = "multiqc" },
     { name = "mypy-boto3-s3" },
     { name = "numpy" },
@@ -1074,7 +1073,7 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = "==1.9.4" },
     { name = "bcrypt", specifier = "==5.0.0" },
-    { name = "beanie", specifier = "==2.0.0" },
+    { name = "beanie", specifier = "==2.2.0" },
     { name = "bleach", specifier = "==6.4.0" },
     { name = "boto3", specifier = "==1.43.0" },
     { name = "bump2version", marker = "extra == 'dev'", specifier = "==1.0.1" },
@@ -1092,7 +1091,6 @@ requires-dist = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mongomock", marker = "extra == 'dev'", specifier = "==4.3.0" },
     { name = "mongomock-motor", marker = "extra == 'dev'", specifier = "==0.0.36" },
-    { name = "motor", specifier = "==3.7.1" },
     { name = "multiqc", specifier = "==1.35" },
     { name = "mypy-boto3-s3", specifier = "==1.43.50" },
     { name = "numpy", specifier = "==2.4.6" },
@@ -1711,14 +1709,14 @@ wheels = [
 
 [[package]]
 name = "lazy-model"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/fa/158a07f8c25c76568534328bf3ab8d16dba92abcb27cc9cfd84bbc652815/lazy-model-0.3.0.tar.gz", hash = "sha256:e425a189897dc926cc79af196a7cb385d1fd3ac7a7bccb4436fc93661f63b811", size = 8172, upload-time = "2025-04-22T17:03:33.923Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/85/e25dc36dee49cf0726c03a1558b5c311a17095bc9361bcbf47226cb3075a/lazy-model-0.4.0.tar.gz", hash = "sha256:a851d85d0b518b0b9c8e626bbee0feb0494c0e0cb5636550637f032dbbf9c55f", size = 8256, upload-time = "2025-08-07T20:05:34.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/a4/55bb305df9fe0d343ff8f0dd4da25b2cc33ba65f8596238aa7a4ecbe9777/lazy_model-0.3.0-py3-none-any.whl", hash = "sha256:67c112cad3fbc1816d32c070bf3b3ac1f48aefeb4e46e9eb70e12acc92c6859d", size = 13719, upload-time = "2025-04-22T17:03:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/54/653ea0d7c578741e9867ccf0cbf47b7eac09ff22e4238f311ac20671a911/lazy_model-0.4.0-py3-none-any.whl", hash = "sha256:95ea59551c1ac557a2c299f75803c56cc973923ef78c67ea4839a238142f7927", size = 13749, upload-time = "2025-08-07T20:05:36.303Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Migration du driver MongoDB async de `motor` (déprécié upstream) vers `pymongo.AsyncMongoClient` natif, ce qui débloque enfin le pin `beanie==2.0.0` (cause racine documentée dans #971 : le probe `callable(database.client.append_metadata)` de beanie ≥ 2.1 passait à tort avec motor à cause de `MotorDatabase.__call__`, et `init_beanie` mourait en `TypeError` au démarrage de l'API).

**Ce qui a été migré :**
- `depictio/api/v1/services/lifespan.py` — `init_motor_beanie()` → `init_pymongo_beanie()` ; mêmes réglages de pool (`maxPoolSize=25`, `minPoolSize=5`, `maxIdleTimeMS=45000`, `waitQueueTimeoutMS=5000`, kwargs identiques sur `AsyncMongoClient`) ; le `cast(AsyncDatabase, ...)` devient inutile.
- `depictio/api/celery_app.py` — `AsyncMongoClient(MONGODB_URL)` + `await client.close()` (`close()` est une coroutine sur le client async).
- `depictio/api/v1/services/events/mongodb_watcher.py` — le vrai delta d'API : `watch()` et `aggregate()` sont des coroutines sur pymongo async (contrairement à motor), donc `async with await collection.watch(...)` et `await ...aggregate(...)` ; `await client.close()` dans `stop()` ; type hints `AsyncMongoClient`/`AsyncDatabase`/`AsyncCollection`.
- `depictio/api/v1/monitoring/log_handler.py` — namespace logger `motor` retiré de `_SKIP_LOGGER_PREFIXES`.
- Commentaires : `depictio/cli/cli/utils/api_calls.py`, `depictio/dev_scripts/reseed_project.py`.

**Dépendances :** `beanie` 2.0.0 → **2.2.0** (dernière version, commentaires de pin supprimés dans les deux `pyproject.toml`), `motor==3.7.1` retiré des deps runtime (il ne subsiste dans `uv.lock` qu'en transitif de `mongomock-motor`, dépendance dev), `motor` retiré de `conda_envs/depictio.yaml`, note dependabot mise à jour. Les PR dependabot runtime mensuelles (#943, #955, #966) ne sont plus bloquées par beanie.

**Doubles de test — décision :** `mongomock-motor` est **conservé** comme double intentionnel (son client fait échouer le probe `callable(...)` de beanie, donc la branche `append_metadata` est sautée). Seul ajout : un shim dans `depictio/tests/conftest.py` qui retire les kwargs `nameOnly`/`authorizedCollections` de `list_collection_names` (beanie ≥ 2.1 les passe, mongomock 4.3.0 n'accepte ni l'un ni l'autre ; les deux sont des no-ops contre un mock). **Follow-up possible** : migrer ces ~80 sites de test vers testcontainers (déjà en dev deps) si mongomock-motor devient gênant.

## Type of change
- [ ] Bugfix
- [ ] Feature
- [x] Refactor / code style
- [x] Build / CI / deps
- [ ] Documentation

## Related issue
Closes #971

## How was this tested?

L'issue documente que la suite unitaire **ne peut pas** attraper ce bug (mongomock-motor est plus permissif que le vrai driver sur le probe `append_metadata`), donc la vérification a été faite contre un vrai MongoDB :

- **Démarrage réel de l'API** : mongo 8.0.14 (port 27018), redis et minio démarrés via `docker compose -f docker-compose.dev.yaml --env-file docker-compose/.env`, backend lancé avec l'environnement du compose sur le venv migré (beanie 2.2.0 + pymongo 4.17.0, sans motor) → `Application startup complete`, **aucun TypeError dans `init_beanie`**, initialisation complète (projets de référence seedés et traités via de vraies requêtes Beanie). `GET /depictio/api/v1/utils/status` → `{"status":"online","version":"1.5.1"}`.
- **Worker Celery réel** : `celery@… ready`, et des tâches screenshot en file ont exécuté le chemin migré (`AsyncMongoClient` → `init_beanie` → requêtes Beanie → `await client.close()`) sans erreur driver ni warning « coroutine never awaited » (l'échec Playwright observé est purement environnemental : binaire headless-shell absent du runner, sans lien avec la migration).
- **Suite unitaire** : 774 passed, 11 skipped (`pytest -x -n auto`), incluant les tests testcontainers S3.
- **Qualité** : `ruff format` + `ruff check` OK, `ty check depictio/models/` zéro erreur, `pre-commit run --all-files` OK (les hooks Helm Lint/shellcheck échouent déjà sur `main` dans cet environnement — binaire `helm` absent et warnings shellcheck préexistants sur des fichiers non touchés).
- **Hypothèses d'API vérifiées** : `AsyncCollection.watch`, `AsyncCollection.aggregate` et `AsyncMongoClient.close` sont bien des coroutines sur pymongo 4.17 ; `AsyncMongoClient.append_metadata` existe.
- Plus aucun import motor dans `depictio/` hors `mongomock_motor` dans les tests (les prototypes `dev/` sont hors périmètre).

Les jobs CI docker/e2e (`docker-system-init`, `cli-comprehensive-test`, `e2e-playwright`, `backup-s3-strategies`) restent la validation finale de la DoD sur cette PR.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeMKaTUm4xt49dy4LwrGKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeMKaTUm4xt49dy4LwrGKm)_