### PR TITLE
fix(multiqc)+feat(filters): sample-mapping fixes, mapping inspector, funnel filtering

### DIFF
--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -3698,54 +3698,66 @@ def _empty_gs_stub_figure(
     }
 
 
+MULTIQC_SAMPLE_FILTER_COLUMNS = {
+    "sample",
+    "sample_id",
+    "sample_name",
+    "sampleid",
+    "samplename",
+    "sample-id",
+    "sample-name",
+}
+
+
 def _resolve_multiqc_sample_filter(
     dashboard_data: dict,
     component: dict,
     filters: list[dict],
-) -> list[str]:
-    """Resolve a list of dashboard interactive filters into a sample-name list.
+) -> list[str] | None:
+    """Resolve dashboard interactive filters into the MultiQC sample-name set.
 
-    Mirrors the simple branch of ``patch_multiqc_plot_with_interactive_filtering``:
-      - filters on the MultiQC DC's own ``sample`` column → values used directly
-      - filters on a different metadata DC → load the metadata DC with the
-        filters applied, then extract the join column. The join column name is
-        looked up from the project's ``DCLink`` (``link.source_column``) when
-        defined; otherwise falls back to the first match in
-        (``sample``, ``sample_id``, ``sample_name``).
-      - if the link has resolver ``sample_mapping``, the canonical IDs from the
-        metadata DC are expanded into MultiQC sample variants using the live
-        ``sample_mappings`` from the multiqc reports.
+    Two kinds of filters contribute, and every active one is a *constraint*:
+      - filters on the MultiQC DC's own sample column (any spelling in
+        ``MULTIQC_SAMPLE_FILTER_COLUMNS``, matching the frontend allowlist)
+        -> the selected values, expanded to variants;
+      - filters on a linked metadata DC -> the metadata DC is loaded with that
+        DC's own filters applied, the link's ``source_column`` values are
+        extracted and expanded to variants. Every metadata DC with an enabled
+        link contributes, not just the first one seen.
 
-    Returns an empty list when no resolvable filters are present. Logs but does
-    not raise on metadata-DC load failures.
+    The result is the INTERSECTION of all constraint sets — each active filter
+    can only narrow the sample set further. (The previous implementation
+    unioned them, so adding a second filter *widened* the result, and dropped
+    filters from any metadata DC after the first, making the outcome depend on
+    filter ordering.)
+
+    Returns:
+        ``None`` when no applicable sample filters are active (render
+        unfiltered), or the sorted list of surviving sample names — possibly
+        empty, which means "active filters matched no sample" and must render
+        an empty figure rather than an unfiltered one.
+
+    Logs but does not raise on metadata-DC load failures; a DC whose filters
+    cannot be resolved is skipped (its constraint is dropped) rather than
+    silently matching nothing.
     """
     if not filters:
-        return []
+        return None
 
     wf_id = component.get("wf_id")
     if not wf_id:
-        return []
+        return None
 
     multiqc_dc_id_str = str(component.get("dc_id") or component.get("data_collection_id") or "")
     stored_meta_index = {
         str(m.get("index")): m for m in (dashboard_data.get("stored_metadata") or [])
     }
 
-    metadata_dc_id: str | None = None
-    # Track the metadata DC's own workflow id — load_deltatable_lite needs the
-    # workflow that owns the metadata DC, not the multiqc component's workflow,
-    # because real projects often have the metadata table on a different
-    # workflow than the multiqc report. Falls back to the multiqc component's
-    # `wf_id` only if the interactive component's stored_metadata doesn't
-    # carry one (legacy components).
-    metadata_wf_id: object | None = None
-    # The stored_metadata snapshot for the source interactive component — used
-    # to build the `init_data` for `load_deltatable_lite` so the metadata DC
-    # load doesn't fall back to an unauthenticated API hop (which 404/403's
-    # on non-public projects).
-    metadata_comp_meta: dict = {}
-    direct_sample_values: list[str] = []
-    indirect_filter_metadata: list[dict] = []
+    # One entry per direct sample filter (each is its own AND constraint).
+    direct_sample_filters: list[list[str]] = []
+    # Metadata DCs keyed by dc_id: each contributes one constraint computed
+    # from ALL of its own filters applied together.
+    indirect_by_dc: dict[str, dict] = {}
 
     for f in filters:
         value = f.get("value")
@@ -3756,30 +3768,38 @@ def _resolve_multiqc_sample_filter(
         comp_dc = str(comp_meta.get("dc_id") or comp_meta.get("data_collection_id") or "")
         column_name = f.get("column_name") or comp_meta.get("column_name")
 
-        if comp_dc == multiqc_dc_id_str and column_name == "sample":
+        if (
+            comp_dc == multiqc_dc_id_str
+            and str(column_name or "").lower() in MULTIQC_SAMPLE_FILTER_COLUMNS
+        ):
             values_list = value if isinstance(value, list) else [value]
-            direct_sample_values.extend(str(v) for v in values_list)
+            direct_sample_filters.append([str(v) for v in values_list])
             continue
 
         if comp_dc and comp_dc != multiqc_dc_id_str:
-            if metadata_dc_id is None:
-                metadata_dc_id = comp_dc
-                metadata_wf_id = comp_meta.get("wf_id") or comp_meta.get("workflow_id") or wf_id
-                metadata_comp_meta = comp_meta
-            if comp_dc == metadata_dc_id:
-                indirect_filter_metadata.append(
-                    {
-                        "interactive_component_type": f.get("interactive_component_type")
-                        or comp_meta.get("interactive_component_type"),
-                        "column_name": column_name,
-                        "value": value,
-                    }
-                )
+            entry = indirect_by_dc.setdefault(
+                comp_dc,
+                {
+                    "wf_id": comp_meta.get("wf_id") or comp_meta.get("workflow_id") or wf_id,
+                    "comp_meta": comp_meta,
+                    "filters": [],
+                },
+            )
+            entry["filters"].append(
+                {
+                    "interactive_component_type": f.get("interactive_component_type")
+                    or comp_meta.get("interactive_component_type"),
+                    "column_name": column_name,
+                    "value": value,
+                }
+            )
+
+    if not direct_sample_filters and not indirect_by_dc:
+        return None
 
     # Pull live sample_mappings from the MultiQC reports so canonical IDs
     # (e.g. ``NA12878``) get expanded into the variant names that actually
-    # appear in plot traces (``NA12878_R1``, ``NA12878_R2``). Mirrors the Dash
-    # flow which calls ``expand_canonical_samples_to_variants`` unconditionally.
+    # appear in plot traces (``NA12878_R1``, ``NA12878_R2``).
     sample_mappings: dict[str, list[str]] = {}
     try:
         from depictio.api.v1.db import multiqc_collection as _mc
@@ -3802,105 +3822,116 @@ def _resolve_multiqc_sample_filter(
         expand_canonical_samples_to_variants,
     )
 
-    selected_samples: list[str] = (
-        expand_canonical_samples_to_variants(
-            list(dict.fromkeys(direct_sample_values)), sample_mappings
-        )
-        if direct_sample_values
-        else []
-    )
+    # Each constraint is expressed in variant space so intersection is
+    # well-defined regardless of whether the filter emitted canonical IDs,
+    # variant names, or a mix.
+    constraint_sets: list[set[str]] = []
 
-    if metadata_dc_id and indirect_filter_metadata:
+    for values in direct_sample_filters:
+        expanded = expand_canonical_samples_to_variants(
+            list(dict.fromkeys(values)), sample_mappings
+        )
+        constraint_sets.append({str(s) for s in expanded})
+
+    if indirect_by_dc:
         from depictio.api.v1.db import projects_collection
         from depictio.api.v1.deltatables_utils import load_deltatable_lite
 
-        # Cross-DC filtering requires an explicit DCLink (metadata_dc_id →
+        # Cross-DC filtering requires an explicit DCLink (metadata_dc_id ->
         # multiqc_dc_id). Without one we don't guess at conventional join-
         # column names — silently auto-mapping `sample` / `sample_id` /
         # `sample_name` produced surprising filter behavior when the user
-        # hadn't declared the relationship. Bail with a clear log line so the
-        # user can see why filtering didn't apply and create a link.
-        link_source_column: str | None = None
+        # hadn't declared the relationship. Skip that DC with a clear log line
+        # so the user can see why filtering didn't apply and create a link.
+        links_by_source: dict[str, str] = {}
         try:
             project_id = dashboard_data.get("project_id")
             if project_id:
                 project_doc = projects_collection.find_one({"_id": ObjectId(str(project_id))})
                 for lk in (project_doc or {}).get("links", []) or []:
                     if (
-                        str(lk.get("source_dc_id")) == str(metadata_dc_id)
-                        and str(lk.get("target_dc_id")) == multiqc_dc_id_str
+                        str(lk.get("target_dc_id")) == multiqc_dc_id_str
                         and lk.get("enabled", True)
+                        and lk.get("source_column")
                     ):
-                        link_source_column = lk.get("source_column")
-                        break
+                        links_by_source.setdefault(
+                            str(lk.get("source_dc_id")), str(lk.get("source_column"))
+                        )
         except Exception as e:
             logger.debug(f"_resolve_multiqc_sample_filter: project link lookup failed: {e}")
 
-        if not link_source_column:
-            logger.info(
-                f"_resolve_multiqc_sample_filter: no enabled DCLink from "
-                f"{metadata_dc_id} → {multiqc_dc_id_str}; cross-DC filter ignored. "
-                f"Create a link with the correct source_column to enable filtering."
-            )
-            return list(dict.fromkeys(selected_samples))
+        for metadata_dc_id, entry in indirect_by_dc.items():
+            link_source_column = links_by_source.get(str(metadata_dc_id))
+            if not link_source_column:
+                logger.info(
+                    f"_resolve_multiqc_sample_filter: no enabled DCLink from "
+                    f"{metadata_dc_id} → {multiqc_dc_id_str}; cross-DC filter ignored. "
+                    f"Create a link with the correct source_column to enable filtering."
+                )
+                continue
 
-        # Build init_data so load_deltatable_lite reads the metadata DC's
-        # delta_location directly instead of falling back to an unauthenticated
-        # internal API hop (which returns 404 on non-public projects and
-        # silently drops the cross-DC filter — what made metadata→MultiQC
-        # filtering quietly stop working). Prefer the stored_metadata's
-        # dc_config snapshot; fall back to deltatables_collection if it's
-        # missing (legacy components saved before dc_config was attached).
-        init_data: dict[str, dict] = {}
-        dc_config = metadata_comp_meta.get("dc_config") or {}
-        delta_loc = dc_config.get("delta_location")
-        if not delta_loc:
-            from depictio.api.v1.db import deltatables_collection as _dt_coll
+            metadata_comp_meta: dict = entry["comp_meta"]
+            # Build init_data so load_deltatable_lite reads the metadata DC's
+            # delta_location directly instead of falling back to an
+            # unauthenticated internal API hop (which returns 404 on
+            # non-public projects and silently drops the cross-DC filter).
+            init_data: dict[str, dict] = {}
+            dc_config = metadata_comp_meta.get("dc_config") or {}
+            delta_loc = dc_config.get("delta_location")
+            if not delta_loc:
+                from depictio.api.v1.db import deltatables_collection as _dt_coll
 
-            dt = _dt_coll.find_one({"data_collection_id": ObjectId(str(metadata_dc_id))})
-            if dt:
-                delta_loc = dt.get("delta_table_location")
-        if delta_loc:
-            init_data[str(metadata_dc_id)] = {
-                "delta_location": delta_loc,
-                "dc_type": dc_config.get("type") or "table",
-                "size_bytes": dc_config.get("size_bytes", 0),
-            }
+                dt = _dt_coll.find_one({"data_collection_id": ObjectId(str(metadata_dc_id))})
+                if dt:
+                    delta_loc = dt.get("delta_table_location")
+            if delta_loc:
+                init_data[str(metadata_dc_id)] = {
+                    "delta_location": delta_loc,
+                    "dc_type": dc_config.get("type") or "table",
+                    "size_bytes": dc_config.get("size_bytes", 0),
+                }
 
-        try:
-            wfid = metadata_wf_id or wf_id
-            meta_df = load_deltatable_lite(
-                workflow_id=ObjectId(str(wfid)) if not isinstance(wfid, ObjectId) else wfid,
-                data_collection_id=str(metadata_dc_id),
-                metadata=indirect_filter_metadata,
-                init_data=init_data or None,
-            )
-            if meta_df is not None and not meta_df.is_empty():
+            try:
+                wfid = entry["wf_id"]
+                meta_df = load_deltatable_lite(
+                    workflow_id=ObjectId(str(wfid)) if not isinstance(wfid, ObjectId) else wfid,
+                    data_collection_id=str(metadata_dc_id),
+                    metadata=entry["filters"],
+                    init_data=init_data or None,
+                )
+                if meta_df is None:
+                    continue
                 if link_source_column not in meta_df.columns:
                     logger.warning(
                         f"_resolve_multiqc_sample_filter: link.source_column "
                         f"{link_source_column!r} not in metadata DC {metadata_dc_id}; "
                         f"available columns={meta_df.columns}"
                     )
-                else:
-                    canonical = [str(s) for s in meta_df[link_source_column].unique().to_list()]
-                    # Always run the canonical→variants expansion. When no
-                    # mappings are available, this returns canonical unchanged.
-                    expanded = expand_canonical_samples_to_variants(canonical, sample_mappings)
-                    logger.debug(
-                        f"_resolve_multiqc_sample_filter: dc={metadata_dc_id} "
-                        f"join_col={link_source_column!r} canonical={len(canonical)} "
-                        f"expanded={len(expanded)} mappings_keys={len(sample_mappings)}"
-                    )
-                    selected_samples.extend(expanded)
-        except Exception as e:
-            logger.warning(
-                f"_resolve_multiqc_sample_filter: filter resolution on DC {metadata_dc_id} "
-                f"failed: {e}",
-                exc_info=True,
-            )
+                    continue
+                canonical = [str(s) for s in meta_df[link_source_column].unique().to_list()]
+                # Always run the canonical→variants expansion. When no
+                # mappings are available, this returns canonical unchanged.
+                expanded = expand_canonical_samples_to_variants(canonical, sample_mappings)
+                logger.debug(
+                    f"_resolve_multiqc_sample_filter: dc={metadata_dc_id} "
+                    f"join_col={link_source_column!r} canonical={len(canonical)} "
+                    f"expanded={len(expanded)} mappings_keys={len(sample_mappings)}"
+                )
+                # An empty set here is a real answer: the metadata filters
+                # matched no row, so no sample survives this constraint.
+                constraint_sets.append({str(s) for s in expanded})
+            except Exception as e:
+                logger.warning(
+                    f"_resolve_multiqc_sample_filter: filter resolution on DC {metadata_dc_id} "
+                    f"failed: {e}",
+                    exc_info=True,
+                )
 
-    return list(dict.fromkeys(selected_samples))
+    if not constraint_sets:
+        return None
+
+    surviving = set.intersection(*constraint_sets)
+    return sorted(surviving)
 
 
 @dashboards_endpoint_router.post("/render_multiqc/{dashboard_id}/{component_id}")
@@ -4021,11 +4052,14 @@ def render_multiqc_endpoint(
     try:
         selected_samples = _resolve_multiqc_sample_filter(dashboard_data, component, filters)
         timings["resolve_filter_ms"] = (_time.perf_counter() - t0) * 1000
-        filter_applied = bool(selected_samples)
+        # ``None`` = no sample filter; ``[]`` = filters matched no sample and
+        # the figure must come back empty — a distinct cache signature keeps
+        # the two from sharing an entry.
+        filter_applied = selected_samples is not None
         filter_sig: str | None = None
-        if filter_applied:
+        if selected_samples is not None:
             sorted_samples = sorted({str(s) for s in selected_samples})
-            filter_sig = "|".join(sorted_samples)
+            filter_sig = "|".join(sorted_samples) if sorted_samples else "__no_match__"
 
         # Salt the cache key with the latest aggregation_version for this DC
         # so realtime updates (which bump the version after the CLI rewrites
@@ -4281,7 +4315,9 @@ def render_multiqc_endpoint(
                 "plot": selected_plot,
                 "dataset_id": selected_dataset,
                 "filter_applied": filter_applied,
-                "selected_sample_count": len(selected_samples) if filter_applied else None,
+                "selected_sample_count": (
+                    len(selected_samples) if selected_samples is not None else None
+                ),
             },
         }
     except HTTPException:
@@ -4396,7 +4432,14 @@ def render_multiqc_general_stats_endpoint(
         # Mtime stat removed — same rationale as the figure cache: it fired a
         # filesystem stat on every request (even cache hits) and any S3-cache
         # refresh cold-evicted the payload. TTL handles invalidation.
-        filter_sig = "|".join(sorted(selected_samples)) if selected_samples else "all"
+        # ``None`` = unfiltered; ``[]`` = filters matched no sample (empty
+        # table) — distinct cache signatures so the two never share an entry.
+        if selected_samples is None:
+            filter_sig = "all"
+        elif selected_samples:
+            filter_sig = "|".join(sorted(selected_samples))
+        else:
+            filter_sig = "__no_match__"
         # Cover the FULL sorted s3_locations set in the key, not just
         # `raw_path` (= s3_locations[0]). Append-only mutations can leave
         # `[0]` pointing at the same parquet → key wouldn't change → stale
@@ -4436,10 +4479,10 @@ def render_multiqc_general_stats_endpoint(
         payload = build_general_stats_payload(
             parquet_path=parquet_paths,
             show_hidden=show_hidden,
-            selected_samples=selected_samples or None,
+            selected_samples=selected_samples,
         )
         timings["build_payload_ms"] = (_time.perf_counter() - _t_build0) * 1000
-        if selected_samples:
+        if selected_samples is not None:
             payload["filter_applied"] = True
             payload["selected_sample_count"] = len(selected_samples)
 
@@ -6116,3 +6159,355 @@ async def validate_json_import(
             )
 
     return validation_result
+
+
+# ============================================================================
+# Funnel filtering (issue #939)
+# ============================================================================
+
+# Bounds for the funnel endpoint: it recomputes one distinct-values query per
+# interactive component and one count per (stage x DC), so both axes are
+# capped to keep a pathological dashboard from turning the toggle into a DoS.
+FUNNEL_MAX_TARGETS = 32
+FUNNEL_MAX_VALUES = 1000
+FUNNEL_MAX_STAGES = 12
+
+# Mirrors the frontend's isFilterActive: unset, empty and boolean-off values
+# are not constraints.
+_FUNNEL_INACTIVE_VALUES = (None, [], "", False)
+
+
+def _funnel_init_data(dashboard_data: dict, dc_id: str) -> dict[str, dict] | None:
+    """init_data for ``load_deltatable_lite`` — stored dc_config first, DB fallback."""
+    for m in dashboard_data.get("stored_metadata") or []:
+        if str(m.get("dc_id")) != str(dc_id):
+            continue
+        dc_config = m.get("dc_config") or {}
+        delta_loc = dc_config.get("delta_location")
+        if delta_loc:
+            return {
+                str(dc_id): {
+                    "delta_location": delta_loc,
+                    "dc_type": dc_config.get("type") or "table",
+                    "size_bytes": dc_config.get("size_bytes", 0),
+                }
+            }
+    from depictio.api.v1.db import deltatables_collection as _dt_coll
+
+    try:
+        dt = _dt_coll.find_one({"data_collection_id": ObjectId(str(dc_id))})
+    except Exception:
+        dt = None
+    if dt and dt.get("delta_table_location"):
+        return {
+            str(dc_id): {
+                "delta_location": dt["delta_table_location"],
+                "dc_type": "table",
+                "size_bytes": 0,
+            }
+        }
+    return None
+
+
+def _funnel_is_multiqc_dc(dashboard_data: dict, dc_id: str) -> bool:
+    for m in dashboard_data.get("stored_metadata") or []:
+        if str(m.get("dc_id")) == str(dc_id):
+            dc_type = ((m.get("dc_config") or {}).get("type") or "").lower()
+            if dc_type:
+                return dc_type == "multiqc"
+            if m.get("component_type") == "multiqc":
+                return True
+    return False
+
+
+def _funnel_multiqc_canonical_universe(dc_id: str) -> tuple[list[str], dict[str, list[str]]]:
+    """Canonical sample list + mappings for a MultiQC DC (option universe)."""
+    from depictio.api.v1.db import multiqc_collection as _mc
+
+    mappings: dict[str, list[str]] = {}
+    canonical: list[str] = []
+    seen: set[str] = set()
+    try:
+        for rep in _mc.find(
+            {"data_collection_id": {"$in": [str(dc_id), ObjectId(str(dc_id))]}},
+            {"metadata.sample_mappings": 1, "metadata.canonical_samples": 1},
+        ):
+            md = rep.get("metadata") or {}
+            for k, vlist in (md.get("sample_mappings") or {}).items():
+                bucket = mappings.setdefault(str(k), [])
+                for v in vlist or []:
+                    sv = str(v)
+                    if sv not in bucket:
+                        bucket.append(sv)
+                if str(k) not in seen:
+                    seen.add(str(k))
+                    canonical.append(str(k))
+            for s in md.get("canonical_samples") or []:
+                if str(s) not in seen:
+                    seen.add(str(s))
+                    canonical.append(str(s))
+    except Exception as e:
+        logger.debug(f"funnel: multiqc universe fetch failed for {dc_id}: {e}")
+    return canonical, mappings
+
+
+def _funnel_target_values(
+    dashboard_data: dict,
+    project_id: Any,
+    access_token: str | None,
+    target_meta: dict,
+    remaining_filters: list[dict],
+) -> dict:
+    """Available values of one interactive component's column under the
+    current filter state MINUS that component's own selection.
+
+    Returns a dict with ``status`` one of:
+      - ``unrestricted``: no other active filter reaches this DC — every value
+        is available, no query was run;
+      - ``ok``: ``values`` holds the surviving values (may be empty);
+      - ``unsupported`` / ``error``: no funnel information for this component.
+    """
+    dc_id = str(target_meta.get("dc_id") or "")
+    column = str(target_meta.get("column_name") or "")
+    if not dc_id or not column:
+        return {"status": "unsupported"}
+
+    if _funnel_is_multiqc_dc(dashboard_data, dc_id):
+        # MultiQC DCs have no Delta table; their sample filter options are the
+        # canonical sample IDs. Reuse the sample-filter resolution (which
+        # already intersects every other constraint) and map the surviving
+        # variants back onto the canonical option list.
+        pseudo_component = {
+            "index": target_meta.get("index"),
+            "dc_id": dc_id,
+            "wf_id": target_meta.get("wf_id"),
+        }
+        resolved = _resolve_multiqc_sample_filter(
+            dashboard_data, pseudo_component, remaining_filters
+        )
+        if resolved is None:
+            return {"status": "unrestricted"}
+        resolved_set = {str(s) for s in resolved}
+        canonical, mappings = _funnel_multiqc_canonical_universe(dc_id)
+        available = [c for c in canonical if ({c, *(mappings.get(c) or [])} & resolved_set)]
+        return {
+            "status": "ok",
+            "values": available[:FUNNEL_MAX_VALUES],
+            "truncated": len(available) > FUNNEL_MAX_VALUES,
+        }
+
+    merged = _resolve_link_filters_cached(
+        filters=remaining_filters,
+        target_dc_id=dc_id,
+        project_id=project_id,
+        access_token=access_token,
+        component_type="funnel",
+    )
+    filter_metadata = _build_filter_metadata(
+        [f for f in merged if str((f.get("metadata") or {}).get("dc_id") or "") == dc_id]
+    )
+    if not filter_metadata:
+        return {"status": "unrestricted"}
+
+    wf_id = target_meta.get("wf_id")
+    if not wf_id:
+        return {"status": "unsupported"}
+
+    from depictio.api.v1.deltatables_utils import load_deltatable_lite
+
+    try:
+        df = load_deltatable_lite(
+            workflow_id=wf_id if isinstance(wf_id, ObjectId) else ObjectId(str(wf_id)),
+            data_collection_id=dc_id,
+            metadata=filter_metadata,
+            init_data=_funnel_init_data(dashboard_data, dc_id),
+            select_columns=[column],
+        )
+    except Exception as e:
+        logger.warning(f"funnel: value computation failed for {dc_id}:{column}: {e}")
+        return {"status": "error"}
+
+    if column not in df.columns:
+        return {"status": "unsupported"}
+    values = sorted({str(v) for v in df[column].drop_nulls().unique().to_list()})
+    return {
+        "status": "ok",
+        "values": values[:FUNNEL_MAX_VALUES],
+        "truncated": len(values) > FUNNEL_MAX_VALUES,
+    }
+
+
+def _funnel_stage_counts(
+    dashboard_data: dict,
+    project_id: Any,
+    access_token: str | None,
+    active_filters: list[dict],
+    stage_dcs: list[str],
+) -> tuple[dict[str, int | None], list[dict]]:
+    """Cumulative row counts per DC as each active filter is applied in turn.
+
+    Returns ``(initial_rows_by_dc, stages)`` where each stage carries the
+    filter it added and the per-DC row counts after applying filters[0..k].
+    ``None`` counts mark DCs whose load failed at that stage.
+    """
+    from depictio.api.v1.deltatables_utils import load_deltatable_lite
+
+    stored_meta_index = {
+        str(m.get("index")): m for m in (dashboard_data.get("stored_metadata") or [])
+    }
+
+    def count_rows(dc_id: str, cumulative: list[dict]) -> int | None:
+        merged = _resolve_link_filters_cached(
+            filters=cumulative,
+            target_dc_id=dc_id,
+            project_id=project_id,
+            access_token=access_token,
+            component_type="funnel",
+        )
+        filter_metadata = _build_filter_metadata(
+            [f for f in merged if str((f.get("metadata") or {}).get("dc_id") or "") == dc_id]
+        )
+        wf_id = None
+        for m in dashboard_data.get("stored_metadata") or []:
+            if str(m.get("dc_id")) == dc_id and m.get("wf_id"):
+                wf_id = m.get("wf_id")
+                break
+        if not wf_id:
+            return None
+        try:
+            df = load_deltatable_lite(
+                workflow_id=wf_id if isinstance(wf_id, ObjectId) else ObjectId(str(wf_id)),
+                data_collection_id=dc_id,
+                metadata=filter_metadata,
+                init_data=_funnel_init_data(dashboard_data, dc_id),
+            )
+            return int(df.height)
+        except Exception as e:
+            logger.debug(f"funnel: stage count failed for {dc_id}: {e}")
+            return None
+
+    initial = {dc: count_rows(dc, []) for dc in stage_dcs}
+
+    stages: list[dict] = []
+    for k, f in enumerate(active_filters[:FUNNEL_MAX_STAGES]):
+        cumulative = active_filters[: k + 1]
+        meta = stored_meta_index.get(str(f.get("index") or "")) or {}
+        stages.append(
+            {
+                "index": f.get("index"),
+                "label": meta.get("title") or meta.get("column_name") or f.get("column_name"),
+                "column_name": f.get("column_name") or meta.get("column_name"),
+                "dc_id": str(meta.get("dc_id") or (f.get("metadata") or {}).get("dc_id") or ""),
+                "value": f.get("value"),
+                "rows_by_dc": {dc: count_rows(dc, cumulative) for dc in stage_dcs},
+            }
+        )
+    return initial, stages
+
+
+@dashboards_endpoint_router.post("/funnel_values/{dashboard_id}")
+def funnel_values_endpoint(
+    dashboard_id: PyObjectId,
+    request: dict,
+    current_user: User = Depends(get_user_or_anonymous),
+    access_token: Annotated[str | None, Depends(oauth2_scheme_optional)] = None,
+):
+    """Compute funnel-filtering data for the React viewer (issue #939).
+
+    For each requested interactive component, answers: given every OTHER
+    active filter (the component's own selection excluded — a value you
+    already picked must never grey itself out), which of this component's
+    values still lead to a non-empty result set? Cross-DC filters are
+    translated through the project's DC links exactly like figure/table
+    renders do (``_resolve_link_filters_cached``), so the funnel works across
+    linked data collections.
+
+    Request body:
+        {
+            "filters": [...],                # current filter list (viewer shape)
+            "target_indexes": ["...", ...],  # interactive components to compute
+            "include_stages": bool           # also compute the funnel overview
+        }
+
+    Response:
+        {
+            "targets": {"<index>": {"status": "ok"|"unrestricted"|"unsupported"|"error",
+                                     "column": str, "dc_id": str,
+                                     "values": [...], "truncated": bool}},
+            "stages": [...] | None,          # cumulative per-DC row counts
+            "initial_rows_by_dc": {...} | None,
+            "dc_labels": {"<dc_id>": str},
+            "filter_count": int
+        }
+    """
+    dashboard_data = dashboards_collection.find_one({"dashboard_id": dashboard_id})
+    if not dashboard_data:
+        raise HTTPException(status_code=404, detail=f"Dashboard '{dashboard_id}' not found.")
+
+    project_id = dashboard_data.get("project_id")
+    if not project_id or not check_project_permission(project_id, current_user, "viewer"):
+        raise HTTPException(status_code=403, detail="Permission denied.")
+
+    filters = request.get("filters") or []
+    target_indexes = [str(i) for i in (request.get("target_indexes") or [])][:FUNNEL_MAX_TARGETS]
+    include_stages = bool(request.get("include_stages", False))
+
+    active_filters = [f for f in filters if f.get("value") not in _FUNNEL_INACTIVE_VALUES]
+
+    stored_meta_index = {
+        str(m.get("index")): m for m in (dashboard_data.get("stored_metadata") or [])
+    }
+
+    targets: dict[str, dict] = {}
+    for index in target_indexes:
+        meta = stored_meta_index.get(index)
+        if not meta or meta.get("component_type") != "interactive":
+            targets[index] = {"status": "unsupported"}
+            continue
+        remaining = [f for f in active_filters if str(f.get("index") or "") != index]
+        result = _funnel_target_values(dashboard_data, project_id, access_token, meta, remaining)
+        result.setdefault("column", meta.get("column_name"))
+        result.setdefault("dc_id", str(meta.get("dc_id") or ""))
+        targets[index] = result
+
+    stages = None
+    initial_rows_by_dc = None
+    dc_labels: dict[str, str] = {}
+    if include_stages:
+        # The DCs worth charting: every delta-backed DC referenced by data
+        # components or active filters. MultiQC DCs are skipped — they have no
+        # row-level Delta table to count.
+        stage_dcs: list[str] = []
+        seen_dcs: set[str] = set()
+        data_types = {"figure", "table", "map", "image", "card", "interactive"}
+        for m in dashboard_data.get("stored_metadata") or []:
+            dc = str(m.get("dc_id") or "")
+            if not dc or dc in seen_dcs or m.get("component_type") not in data_types:
+                continue
+            if _funnel_is_multiqc_dc(dashboard_data, dc):
+                continue
+            seen_dcs.add(dc)
+            stage_dcs.append(dc)
+
+        initial_rows_by_dc, stages = _funnel_stage_counts(
+            dashboard_data, project_id, access_token, active_filters, stage_dcs
+        )
+
+        # Human-readable DC names for the funnel view.
+        try:
+            project_doc = projects_collection.find_one({"_id": ObjectId(str(project_id))})
+            for wf in (project_doc or {}).get("workflows", []) or []:
+                for dc in wf.get("data_collections", []) or []:
+                    dc_labels[str(dc.get("_id"))] = str(
+                        dc.get("data_collection_tag") or dc.get("tag") or dc.get("_id")
+                    )
+        except Exception as e:
+            logger.debug(f"funnel: dc label lookup failed: {e}")
+
+    return {
+        "targets": targets,
+        "stages": stages,
+        "initial_rows_by_dc": initial_rows_by_dc,
+        "dc_labels": dc_labels,
+        "filter_count": len(active_filters),
+    }

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -6172,9 +6172,23 @@ FUNNEL_MAX_TARGETS = 32
 FUNNEL_MAX_VALUES = 1000
 FUNNEL_MAX_STAGES = 12
 
-# Mirrors the frontend's isFilterActive: unset, empty and boolean-off values
-# are not constraints.
-_FUNNEL_INACTIVE_VALUES = (None, [], "", False)
+
+def _funnel_filter_is_active(f: dict) -> bool:
+    """Mirrors the frontend's ``isFilterActive``: only values that narrow data count.
+
+    Membership in a tuple of empties cannot express this: ``0 in (None, [], "",
+    False)`` is True in Python, so a slider parked at 0 would be dropped here
+    while ``clean_filter_payload`` still applies it downstream. The stage list
+    is zipped positionally against the client's own active list, so the two
+    must agree exactly or every reorder row past a divergence mislabels.
+    """
+    value = f.get("value")
+    if value is None or value == "":
+        return False
+    if isinstance(value, list):
+        # A range control that was reset emits [None, None].
+        return any(v is not None for v in value)
+    return True
 
 
 def _funnel_init_data(dashboard_data: dict, dc_id: str) -> dict[str, dict] | None:
@@ -6296,13 +6310,22 @@ def _funnel_target_values(
             "truncated": len(available) > FUNNEL_MAX_VALUES,
         }
 
-    merged = _resolve_link_filters_cached(
-        filters=remaining_filters,
-        target_dc_id=dc_id,
-        project_id=project_id,
-        access_token=access_token,
-        component_type="funnel",
-    )
+    # Link resolution can raise LinkResolutionError (timeout, upstream HTTP
+    # error). This endpoint answers every registered component in one batch, so
+    # letting it escape would 500 the whole batch over one slow link and blank
+    # a decorative feature dashboard-wide.
+    try:
+        merged = _resolve_link_filters_cached(
+            filters=remaining_filters,
+            target_dc_id=dc_id,
+            project_id=project_id,
+            access_token=access_token,
+            component_type="funnel",
+        )
+    except Exception as e:
+        logger.warning(f"funnel: link resolution failed for {dc_id}:{column}: {e}")
+        return {"status": "error"}
+
     filter_metadata = _build_filter_metadata(
         [f for f in merged if str((f.get("metadata") or {}).get("dc_id") or "") == dc_id]
     )
@@ -6357,13 +6380,20 @@ def _funnel_stage_counts(
     }
 
     def count_rows(dc_id: str, cumulative: list[dict]) -> int | None:
-        merged = _resolve_link_filters_cached(
-            filters=cumulative,
-            target_dc_id=dc_id,
-            project_id=project_id,
-            access_token=access_token,
-            component_type="funnel",
-        )
+        # As in _funnel_target_values: a raised LinkResolutionError here would
+        # abort the whole batch, so a failed stage degrades to an unknown count.
+        try:
+            merged = _resolve_link_filters_cached(
+                filters=cumulative,
+                target_dc_id=dc_id,
+                project_id=project_id,
+                access_token=access_token,
+                component_type="funnel",
+            )
+        except Exception as e:
+            logger.warning(f"funnel: link resolution failed for stage on {dc_id}: {e}")
+            return None
+
         filter_metadata = _build_filter_metadata(
             [f for f in merged if str((f.get("metadata") or {}).get("dc_id") or "") == dc_id]
         )
@@ -6452,7 +6482,7 @@ def funnel_values_endpoint(
     target_indexes = [str(i) for i in (request.get("target_indexes") or [])][:FUNNEL_MAX_TARGETS]
     include_stages = bool(request.get("include_stages", False))
 
-    active_filters = [f for f in filters if f.get("value") not in _FUNNEL_INACTIVE_VALUES]
+    active_filters = [f for f in filters if _funnel_filter_is_active(f)]
 
     stored_meta_index = {
         str(m.get("index")): m for m in (dashboard_data.get("stored_metadata") or [])

--- a/depictio/api/v1/endpoints/links_endpoints/resolvers.py
+++ b/depictio/api/v1/endpoints/links_endpoints/resolvers.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.services.multiqc.sample_matching import expand_samples
 from depictio.models.models.links import LinkConfig
 
 
@@ -120,8 +121,6 @@ class SampleMappingResolver(BaseLinkResolver):
         ``link_config.case_sensitive``. A key whose variant list is empty
         (canonical-only mapping) resolves to itself and counts as mapped.
         """
-        from depictio.api.v1.services.multiqc.sample_matching import expand_samples
-
         resolved, unmapped = expand_samples(
             source_values,
             link_config.mappings,

--- a/depictio/api/v1/endpoints/links_endpoints/resolvers.py
+++ b/depictio/api/v1/endpoints/links_endpoints/resolvers.py
@@ -104,23 +104,6 @@ class SampleMappingResolver(BaseLinkResolver):
     def name(self) -> str:
         return "sample_mapping"
 
-    # Common read-pair / replicate / lane suffixes that appear on canonical IDs
-    # in MultiQC's mapping but NOT on the source DC's sample column. Stripping
-    # them lets a source value like "HG001" match keys "HG001_R1" + "HG001_R2".
-    # Restricted to suffixes with an explicit prefix letter (R/L/REP/TECH) so
-    # we don't over-strip legit IDs ending in digits like "Sample_2024" or
-    # "Patient_42" — that would silently collapse unrelated samples onto
-    # the same base bucket.
-    _SAMPLE_SUFFIX_RE = re.compile(
-        r"_(?:R\d+|L\d+|REP\d+|TECH\d+)$",
-        re.IGNORECASE,
-    )
-
-    @classmethod
-    def _strip_sample_suffix(cls, name: str) -> str:
-        """Strip ``_R1`` / ``_R2`` / ``_REP1`` / ``_L001`` style suffixes."""
-        return cls._SAMPLE_SUFFIX_RE.sub("", name)
-
     def resolve(
         self,
         source_values: list[Any],
@@ -129,58 +112,21 @@ class SampleMappingResolver(BaseLinkResolver):
     ) -> tuple[list[str], list[str]]:
         """Expand canonical IDs to sample name variants.
 
-        Lookup tries (in order):
-        1. exact key match (honouring ``case_sensitive``)
-        2. base-name match — strips ``_R1`` / ``_R2`` / ``_1`` / ``_REP1`` from
-           every mapping key and aggregates variants from any keys whose base
-           equals the source value. Without this, a link source like ``"HG001"``
-           never matches MultiQC keys like ``"HG001_R1"`` / ``"HG001_R2"``.
+        Delegates to ``depictio.api.v1.services.multiqc.sample_matching`` (the
+        shared implementation with the MultiQC figure-patching path). Lookup
+        tries, in order: exact key, variant identity, suffix-stripped key base
+        (``_R1`` / ``_L001`` / ``_REP1`` / ``_TECH1``), suffix-stripped source
+        value. Whitespace is stripped on both sides; case folding follows
+        ``link_config.case_sensitive``. A key whose variant list is empty
+        (canonical-only mapping) resolves to itself and counts as mapped.
         """
-        resolved: list[str] = []
-        unmapped: list[str] = []
+        from depictio.api.v1.services.multiqc.sample_matching import expand_samples
 
-        mappings = link_config.mappings or {}
-        case_sensitive = bool(link_config.case_sensitive)
-
-        # Pre-bucket mapping keys by their stripped base so the per-value
-        # lookup is O(unique-bases) instead of O(keys × source_values).
-        base_to_variants: dict[str, list[str]] = {}
-        for key, variants in mappings.items():
-            base = self._strip_sample_suffix(key)
-            bucket_key = base if case_sensitive else base.lower()
-            base_to_variants.setdefault(bucket_key, []).extend(variants)
-
-        for val in source_values:
-            str_val = str(val)
-            lookup_val = str_val if case_sensitive else str_val.lower()
-
-            found_mapping: list[str] | None = None
-            if case_sensitive:
-                found_mapping = mappings.get(str_val)
-            else:
-                for key, variants in mappings.items():
-                    if key.lower() == lookup_val:
-                        found_mapping = variants
-                        break
-
-            # Fallback: match against suffix-stripped bases. Aggregates variants
-            # from every key sharing the same base (e.g. HG001_R1 + HG001_R2).
-            if not found_mapping:
-                fallback = base_to_variants.get(lookup_val)
-                if fallback:
-                    # Dedup while preserving order — the same variant can show up
-                    # from multiple keys (rare, but possible across reports).
-                    found_mapping = list(dict.fromkeys(fallback))
-
-            if found_mapping:
-                resolved.extend(found_mapping)
-                logger.debug(
-                    f"SampleMappingResolver: Expanded '{str_val}' to {len(found_mapping)} variants"
-                )
-            else:
-                resolved.append(str_val)
-                unmapped.append(str_val)
-                logger.debug(f"SampleMappingResolver: No mapping for '{str_val}' - using as-is")
+        resolved, unmapped = expand_samples(
+            source_values,
+            link_config.mappings,
+            case_sensitive=bool(link_config.case_sensitive),
+        )
 
         logger.info(
             f"SampleMappingResolver: Resolved {len(source_values)} source values "

--- a/depictio/api/v1/endpoints/links_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/links_endpoints/routes.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import polars as pl
 from bson import ObjectId
+from bson.errors import InvalidId
 from fastapi import APIRouter, Depends, HTTPException, Path
 
 from depictio.api.v1.configs.logging_init import logger
@@ -267,7 +268,7 @@ async def _translate_filter_values(
         )
 
 
-async def _get_multiqc_sample_mappings(target_dc_id: str) -> dict[str, list[str]]:
+def _get_multiqc_sample_mappings(target_dc_id: str) -> dict[str, list[str]]:
     """Fetch and aggregate sample mappings from ALL MultiQC reports for a DC.
 
     A single MultiQC data collection can have multiple reports (e.g., from different
@@ -723,7 +724,7 @@ async def resolve_link(
         and not link.link_config.mappings
     ):
         # Auto-fetch sample mappings from MultiQC report
-        sample_mappings = await _get_multiqc_sample_mappings(link.target_dc_id)
+        sample_mappings = _get_multiqc_sample_mappings(link.target_dc_id)
         if sample_mappings:
             # Create new config with fetched mappings
             effective_config = LinkConfig(
@@ -800,7 +801,16 @@ def _distinct_source_values(dc_id: str, column: str, cap: int) -> tuple[list[str
     """
     deltatable_doc = deltatables_collection.find_one({"data_collection_id": dc_id})
     if not deltatable_doc:
-        deltatable_doc = deltatables_collection.find_one({"data_collection_id": ObjectId(dc_id)})
+        # A link may legitimately carry a non-ObjectId dc id: DCLink permits an
+        # empty id when a tag is set, and the CLI writes a "tag:<tag>"
+        # placeholder for tags it could not resolve. Those must 404 like any
+        # other missing table, not raise InvalidId as a 500.
+        try:
+            dc_oid = ObjectId(dc_id)
+        except InvalidId:
+            dc_oid = None
+        if dc_oid is not None:
+            deltatable_doc = deltatables_collection.find_one({"data_collection_id": dc_oid})
     if not deltatable_doc or "delta_table_location" not in deltatable_doc:
         raise HTTPException(
             status_code=404,
@@ -830,7 +840,7 @@ def _distinct_source_values(dc_id: str, column: str, cap: int) -> tuple[list[str
     response_model=LinkMappingPreviewResponse,
     summary="Inspect how source values map through a link",
 )
-async def link_mapping_preview(
+def link_mapping_preview(
     project_id: str = Path(..., description="Project ID"),
     link_id: str = Path(..., description="Link ID to inspect"),
     limit: int = 500,
@@ -861,7 +871,7 @@ async def link_mapping_preview(
     mappings = link.link_config.mappings or {}
     mappings_source = "link_config" if mappings else "none"
     if not mappings and link.target_type == "multiqc":
-        mappings = await _get_multiqc_sample_mappings(str(link.target_dc_id))
+        mappings = _get_multiqc_sample_mappings(str(link.target_dc_id))
         if mappings:
             mappings_source = "multiqc_live"
 
@@ -988,7 +998,7 @@ async def get_multiqc_sample_mappings(
     _get_project_or_404(project_id, current_user)
 
     # Fetch aggregated sample mappings
-    mappings = await _get_multiqc_sample_mappings(dc_id)
+    mappings = _get_multiqc_sample_mappings(dc_id)
 
     logger.info(f"Returning {len(mappings)} aggregated sample mappings for MultiQC DC {dc_id}")
 

--- a/depictio/api/v1/endpoints/links_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/links_endpoints/routes.py
@@ -32,6 +32,8 @@ from depictio.models.models.links import (
     DCLink,
     LinkConfig,
     LinkCreateRequest,
+    LinkMappingPreviewResponse,
+    LinkMappingPreviewRow,
     LinkResolutionRequest,
     LinkResolutionResponse,
     LinkUpdateRequest,
@@ -785,6 +787,177 @@ async def list_available_resolvers(
     from depictio.api.v1.endpoints.links_endpoints.resolvers import list_resolvers
 
     return list_resolvers()
+
+
+def _distinct_source_values(dc_id: str, column: str, cap: int) -> tuple[list[str], int]:
+    """Distinct (stringified, sorted) values of ``column`` in a DC's Delta table.
+
+    Returns ``(values capped at cap, total distinct count)``.
+
+    Raises:
+        HTTPException: 404 when the DC has no Delta table, 400 when the column
+        is missing.
+    """
+    deltatable_doc = deltatables_collection.find_one({"data_collection_id": dc_id})
+    if not deltatable_doc:
+        deltatable_doc = deltatables_collection.find_one({"data_collection_id": ObjectId(dc_id)})
+    if not deltatable_doc or "delta_table_location" not in deltatable_doc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Delta table not found for DC {dc_id}",
+        )
+
+    from depictio.api.v1.s3 import polars_s3_config
+
+    lf = pl.scan_delta(deltatable_doc["delta_table_location"], storage_options=polars_s3_config)
+    schema = lf.collect_schema()
+    if column not in schema.names():
+        raise HTTPException(
+            status_code=400,
+            detail=f"Column '{column}' not found in DC {dc_id}. "
+            f"Available: {', '.join(schema.names())}",
+        )
+
+    series = lf.select(
+        pl.col(column).cast(pl.Utf8).drop_nulls().unique().sort().alias("_v")
+    ).collect()["_v"]
+    total = int(series.len())
+    return series.head(cap).to_list(), total
+
+
+@links_endpoint_router.get(
+    "/{project_id}/{link_id}/mapping-preview",
+    response_model=LinkMappingPreviewResponse,
+    summary="Inspect how source values map through a link",
+)
+async def link_mapping_preview(
+    project_id: str = Path(..., description="Project ID"),
+    link_id: str = Path(..., description="Link ID to inspect"),
+    limit: int = 500,
+    current_user: User = Depends(get_current_user),
+) -> LinkMappingPreviewResponse:
+    """Full sample ↔ link mapping table for one link — the debug/inspect view.
+
+    Loads the distinct values of ``link.source_column`` from the source DC,
+    resolves each one through the link's actual resolver (with the same
+    effective mappings the ``/resolve`` endpoint would use, fetched live from
+    MultiQC reports when the link doesn't freeze its own), and reports per
+    value whether and how it matched. Also lists the target-side sample names
+    no source value reaches, so mismatches are visible from both directions.
+    """
+    project = _get_project_or_404(project_id, current_user)
+
+    link, _ = _find_link_by_id(project, link_id)
+    if link is None:
+        raise HTTPException(status_code=404, detail=f"Link not found: {link_id}")
+
+    limit = max(1, min(int(limit), 2000))
+    source_values, source_total = _distinct_source_values(
+        str(link.source_dc_id), link.source_column, limit
+    )
+    truncated = source_total > len(source_values)
+
+    # Effective mappings — same precedence as the /resolve endpoint.
+    mappings = link.link_config.mappings or {}
+    mappings_source = "link_config" if mappings else "none"
+    if not mappings and link.target_type == "multiqc":
+        mappings = await _get_multiqc_sample_mappings(str(link.target_dc_id))
+        if mappings:
+            mappings_source = "multiqc_live"
+
+    rows: list[LinkMappingPreviewRow] = []
+    reached_targets: set[str] = set()
+
+    if link.link_config.resolver == "sample_mapping":
+        from depictio.api.v1.services.multiqc.sample_matching import match_samples
+
+        for m in match_samples(
+            source_values, mappings, case_sensitive=bool(link.link_config.case_sensitive)
+        ):
+            rows.append(
+                LinkMappingPreviewRow(
+                    source_value=m.source,
+                    matched=m.matched,
+                    via=m.via,
+                    resolved=m.targets,
+                )
+            )
+            if m.matched:
+                reached_targets.update(m.targets)
+    else:
+        resolver = get_resolver(link.link_config.resolver)
+        effective_config = LinkConfig(
+            resolver=link.link_config.resolver,
+            mappings=mappings or None,
+            pattern=link.link_config.pattern,
+            target_field=link.link_config.target_field,
+            case_sensitive=link.link_config.case_sensitive,
+        )
+        # regex / wildcard need the target's known values to match against.
+        target_known_values: list[str] | None = None
+        if link.link_config.resolver in ("regex", "wildcard"):
+            if link.target_type == "multiqc":
+                known: set[str] = set()
+                for canonical, variants in (mappings or {}).items():
+                    known.add(canonical)
+                    known.update(variants or [])
+                target_known_values = sorted(known)
+            elif link.link_config.target_field:
+                try:
+                    target_known_values, _ = _distinct_source_values(
+                        str(link.target_dc_id), link.link_config.target_field, 10000
+                    )
+                except HTTPException:
+                    target_known_values = None
+
+        for value in source_values:
+            resolved, unmapped = resolver.resolve([value], effective_config, target_known_values)
+            matched = value not in unmapped
+            rows.append(
+                LinkMappingPreviewRow(
+                    source_value=str(value),
+                    matched=matched,
+                    via=link.link_config.resolver if matched else "passthrough",
+                    resolved=resolved,
+                )
+            )
+            if matched:
+                reached_targets.update(resolved)
+
+    # Target-side orphans: canonical mapping entries none of the listed source
+    # values reach. Only meaningful when mappings exist; capped like the rows.
+    orphan_targets: list[str] = []
+    for canonical, variants in (mappings or {}).items():
+        names = {canonical, *(variants or [])}
+        if not (names & reached_targets):
+            orphan_targets.append(canonical)
+            if len(orphan_targets) >= limit:
+                break
+    orphan_targets.sort()
+
+    matched_count = sum(1 for r in rows if r.matched)
+    response = LinkMappingPreviewResponse(
+        link_id=str(link.id),
+        resolver=link.link_config.resolver,
+        source_dc_id=str(link.source_dc_id),
+        source_column=link.source_column,
+        target_dc_id=str(link.target_dc_id),
+        target_type=link.target_type,
+        case_sensitive=bool(link.link_config.case_sensitive),
+        mappings_source=mappings_source,  # type: ignore[arg-type]
+        source_values_total=source_total,
+        truncated=truncated,
+        matched_count=matched_count,
+        unmapped_count=len(rows) - matched_count,
+        rows=rows,
+        orphan_targets=orphan_targets,
+    )
+
+    logger.info(
+        f"Mapping preview for link {link_id}: {matched_count}/{len(rows)} matched, "
+        f"{len(orphan_targets)} orphan targets"
+    )
+    return response
 
 
 @links_endpoint_router.get(

--- a/depictio/api/v1/services/multiqc/general_stats_payload.py
+++ b/depictio/api/v1/services/multiqc/general_stats_payload.py
@@ -759,7 +759,9 @@ def _build_mode_payload(
         _sample_groups,
     ) = result
 
-    if selected_samples:
+    # ``None`` = no filter; ``[]`` = active filters matched no sample and the
+    # table must come back empty rather than unfiltered.
+    if selected_samples is not None:
         df_for_display = df_for_display[
             df_for_display["Sample Name"].astype(str).isin([str(s) for s in selected_samples])
         ].reset_index(drop=True)

--- a/depictio/api/v1/services/multiqc/patching.py
+++ b/depictio/api/v1/services/multiqc/patching.py
@@ -6,12 +6,8 @@ without dragging in Dash callback machinery.
 """
 
 import copy
-import re
 
-# Strip read-pair / lane / replicate suffixes (HG001_R1 -> HG001) so a base
-# sample name selected in an interactive component still matches MultiQC's
-# suffixed mapping keys.
-_SAMPLE_SUFFIX_RE = re.compile(r"_(?:R\d+|L\d+|REP\d+|TECH\d+)$", re.IGNORECASE)
+from depictio.api.v1.services.multiqc.sample_matching import expand_samples
 
 
 def expand_canonical_samples_to_variants(
@@ -19,52 +15,38 @@ def expand_canonical_samples_to_variants(
 ) -> list[str]:
     """Expand canonical sample IDs to all their MultiQC variants using stored mappings.
 
-    Lookup tries exact key first, then falls back to base-name match
-    (stripping ``_R1`` / ``_R2`` / ``_REP1`` / ``_L001`` style suffixes from
-    the mapping keys). Without the fallback, an interactive MultiSelect on
-    a sample column emitting a base name like ``HG001`` matches nothing in
-    a mapping keyed by ``HG001_R1`` / ``HG001_R2`` (MultiQC's own keying
-    when read-pair suffixes are present), so plot patching shows nothing.
+    Delegates to ``sample_matching.expand_samples`` — the shared, direction-
+    agnostic lookup (exact key, variant identity, suffix-stripped key base,
+    suffix-stripped source value; whitespace-stripped and case-insensitive
+    throughout). Without the fallbacks, an interactive MultiSelect emitting a
+    base name like ``HG001`` matches nothing in a mapping keyed by
+    ``HG001_R1`` / ``HG001_R2``, so plot patching shows nothing.
 
     When no mappings are available, returns canonical samples unchanged.
     """
     if not sample_mappings:
         return canonical_samples
 
-    # Pre-bucket keys by suffix-stripped base. Mappings come pre-aggregated
-    # across reports, so the same base can show up in multiple suffixed
-    # keys (HG001_R1 + HG001_R2) — union their variants.
-    base_to_variants: dict[str, list[str]] = {}
-    for key, variants in sample_mappings.items():
-        base = _SAMPLE_SUFFIX_RE.sub("", key).lower()
-        base_to_variants.setdefault(base, []).extend(variants)
-
-    expanded_samples: list[str] = []
-    for canonical_id in canonical_samples:
-        variants = sample_mappings.get(canonical_id)
-        if variants:
-            expanded_samples.extend(variants)
-            continue
-
-        fallback = base_to_variants.get(canonical_id.lower())
-        if fallback:
-            expanded_samples.extend(dict.fromkeys(fallback))
-            continue
-
-        expanded_samples.append(canonical_id)
-
-    return expanded_samples
+    resolved, _unmapped = expand_samples(canonical_samples, sample_mappings, case_sensitive=False)
+    return resolved
 
 
 def patch_multiqc_figures(
     figures: list[dict],
-    selected_samples: list[str],
+    selected_samples: list[str] | None,
     metadata: dict | None = None,
     trace_metadata: dict | None = None,
 ) -> list[dict]:
-    """Apply sample filtering to MultiQC figures based on interactive selections."""
-    if not figures or not selected_samples:
+    """Apply sample filtering to MultiQC figures based on interactive selections.
+
+    ``selected_samples`` semantics: ``None`` means "no sample filter" (figures
+    returned untouched); an empty list means "active filters matched no
+    sample" and every sample is filtered out — the two must not be conflated,
+    or a filter that narrows to nothing silently renders everything.
+    """
+    if not figures or selected_samples is None:
         return figures
+    selected_set = {str(s) for s in selected_samples}
 
     patched_figures = []
 
@@ -106,7 +88,7 @@ def patch_multiqc_figures(
                 filtered_samples = []
                 filtered_values = []
                 for j, sample in enumerate(sample_axis):
-                    if sample in selected_samples:
+                    if sample in selected_set:
                         filtered_samples.append(sample)
                         if j < len(value_axis):
                             filtered_values.append(value_axis[j])
@@ -116,9 +98,9 @@ def patch_multiqc_figures(
 
             elif trace_type == "heatmap":
                 if original_x and original_z:
-                    x_indices = [j for j, x in enumerate(original_x) if str(x) in selected_samples]
+                    x_indices = [j for j, x in enumerate(original_x) if str(x) in selected_set]
                     y_indices = (
-                        [j for j, y in enumerate(original_y) if str(y) in selected_samples]
+                        [j for j, y in enumerate(original_y) if str(y) in selected_set]
                         if original_y
                         else []
                     )
@@ -127,7 +109,11 @@ def patch_multiqc_figures(
                         trace["y"] = [original_y[j] for j in y_indices]
                         if isinstance(original_z, list) and original_z:
                             trace["z"] = [original_z[j] for j in y_indices if j < len(original_z)]
-                    elif x_indices:
+                    else:
+                        # Assign even when nothing matched — a selection that
+                        # matches no sample must blank the heatmap, exactly
+                        # like the bar/box/violin branches, not silently
+                        # render the full matrix.
                         trace["x"] = [original_x[j] for j in x_indices]
                         if isinstance(original_z, list) and original_z:
                             trace["z"] = [
@@ -136,14 +122,14 @@ def patch_multiqc_figures(
 
             elif trace_type in ["scatter", "scattergl"]:
                 if trace_name:
-                    trace["visible"] = trace_name in selected_samples
+                    trace["visible"] = trace_name in selected_set
                 else:
                     filtered_x = []
                     filtered_y = []
                     for j, x_val in enumerate(original_x):
                         if (
-                            str(x_val) in selected_samples
-                            or str(original_y[j] if j < len(original_y) else "") in selected_samples
+                            str(x_val) in selected_set
+                            or str(original_y[j] if j < len(original_y) else "") in selected_set
                         ):
                             filtered_x.append(x_val)
                             if j < len(original_y):

--- a/depictio/api/v1/services/multiqc/sample_matching.py
+++ b/depictio/api/v1/services/multiqc/sample_matching.py
@@ -1,0 +1,185 @@
+"""Single source of truth for matching sample identifiers against MultiQC mappings.
+
+Sample ``mappings`` come from ``build_sample_mapping`` at ingest time
+(``depictio/cli/cli/utils/sample_mapping.py``): canonical IDs mapped to the
+variant names MultiQC actually uses in plot traces. The matching problem is
+the reverse direction — given a value from a *source* data collection (a
+metadata table column, an interactive selection), find the variant names it
+corresponds to.
+
+Historically this logic existed in three diverging copies
+(``SampleMappingResolver``, ``patching.expand_canonical_samples_to_variants``
+and the frontend's ``availableValues.tsx``), each with different
+normalization; this module is the one implementation the backend copies now
+delegate to.
+
+Matching tries, in order (first hit wins):
+
+1. **exact** — the value is a mapping key. A key with an empty variant list
+   (synthesized from ``canonical_samples`` when no explicit mapping exists)
+   still counts as matched: the sample is known, its only "variant" is itself.
+2. **variant** — the value is itself one of the variant names (e.g. the
+   metadata table stores read-level ids like ``SRR001_1`` while the mapping
+   is keyed by the canonical ``SRR001``). Resolves to the variant itself.
+3. **base** — the value equals a mapping key once read-pair / lane /
+   replicate suffixes (``_R1`` / ``_L001`` / ``_REP1`` / ``_TECH1``) are
+   stripped from the *keys*; variants from every key sharing the base are
+   aggregated.
+4. **source-suffix** — same stripping applied to the *value* (``HG001_R1``
+   selected against a mapping keyed ``HG001``), then retried as exact/base.
+5. **passthrough** — nothing matched; the (whitespace-stripped) value is
+   returned as-is and reported unmapped.
+
+All lookups strip surrounding whitespace on both sides; case folding is
+applied on both sides when ``case_sensitive`` is False. The restricted
+suffix pattern is deliberate — bare ``_<digits>`` endings like
+``Sample_2024`` / ``Patient_42`` are legitimate IDs and must not collapse
+onto a shared base.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# Read-pair / lane / replicate / technical-replicate suffixes. Kept in sync
+# with the frontend copy in ``packages/depictio-react-core/src/availableValues.tsx``.
+SAMPLE_SUFFIX_RE = re.compile(r"_(?:R\d+|L\d+|REP\d+|TECH\d+)$", re.IGNORECASE)
+
+
+def strip_sample_suffix(name: str) -> str:
+    """Strip a trailing ``_R1`` / ``_L001`` / ``_REP1`` / ``_TECH1`` style suffix."""
+    return SAMPLE_SUFFIX_RE.sub("", name)
+
+
+@dataclass
+class SampleMatch:
+    """Outcome of matching one source value against the mappings."""
+
+    source: str
+    matched: bool
+    via: str  # "exact" | "variant" | "base" | "source-suffix" | "passthrough"
+    targets: list[str] = field(default_factory=list)
+
+
+class SampleLookup:
+    """Pre-indexed view of a ``{canonical: [variants]}`` mapping dict.
+
+    Build once per mapping dict, then match any number of values against it.
+    Indexes are deterministic: keys are processed in dict order and variant
+    lists are merged in encounter order, so two processes holding the same
+    mapping produce identical answers.
+    """
+
+    def __init__(self, mappings: dict[str, list[str]] | None, case_sensitive: bool = False):
+        self.case_sensitive = bool(case_sensitive)
+        # normalized key -> (canonical key, merged variants)
+        self._exact: dict[str, tuple[str, list[str]]] = {}
+        # normalized variant -> variant (identity lookup)
+        self._variants: dict[str, str] = {}
+        # normalized suffix-stripped base -> (keys sharing it, merged variants)
+        self._base: dict[str, tuple[list[str], list[str]]] = {}
+
+        for raw_key, raw_variants in (mappings or {}).items():
+            key = str(raw_key).strip()
+            if not key:
+                continue
+            variants = [str(v).strip() for v in (raw_variants or []) if str(v).strip()]
+
+            nk = self._norm(key)
+            if nk in self._exact:
+                merged = self._exact[nk][1]
+                for v in variants:
+                    if v not in merged:
+                        merged.append(v)
+            else:
+                self._exact[nk] = (key, list(variants))
+
+            for v in variants:
+                self._variants.setdefault(self._norm(v), v)
+
+            base = self._norm(strip_sample_suffix(key))
+            keys, bucket = self._base.setdefault(base, ([], []))
+            keys.append(key)
+            for v in variants:
+                if v not in bucket:
+                    bucket.append(v)
+
+    def _norm(self, value: str) -> str:
+        return value if self.case_sensitive else value.lower()
+
+    def _targets_for_key(self, entry: tuple[str, list[str]]) -> list[str]:
+        # The canonical key is itself a target alongside its variants: plot
+        # traces use variant names, but General-Stats-style tables keyed by
+        # the canonical ID must also keep matching. A key with no recorded
+        # variants (canonical-only mapping) resolves to just itself.
+        key, variants = entry
+        return list(dict.fromkeys([key, *variants]))
+
+    def _targets_for_base(self, entry: tuple[list[str], list[str]]) -> list[str]:
+        keys, variants = entry
+        return list(dict.fromkeys([*keys, *variants]))
+
+    def match(self, value: Any) -> SampleMatch:
+        """Match one source value; see the module docstring for the try order."""
+        source = str(value).strip()
+        nv = self._norm(source)
+
+        exact = self._exact.get(nv)
+        if exact is not None:
+            return SampleMatch(source, True, "exact", self._targets_for_key(exact))
+
+        variant = self._variants.get(nv)
+        if variant is not None:
+            return SampleMatch(source, True, "variant", [variant])
+
+        base_hit = self._base.get(nv)
+        if base_hit is not None:
+            return SampleMatch(source, True, "base", self._targets_for_base(base_hit))
+
+        stripped = self._norm(strip_sample_suffix(source))
+        if stripped != nv:
+            exact = self._exact.get(stripped)
+            if exact is not None:
+                return SampleMatch(source, True, "source-suffix", self._targets_for_key(exact))
+            base_hit = self._base.get(stripped)
+            if base_hit is not None:
+                return SampleMatch(source, True, "source-suffix", self._targets_for_base(base_hit))
+
+        return SampleMatch(source, False, "passthrough", [source])
+
+
+def match_samples(
+    values: list[Any],
+    mappings: dict[str, list[str]] | None,
+    case_sensitive: bool = False,
+) -> list[SampleMatch]:
+    """Match every value, returning per-value detail (for debug/inspect UIs)."""
+    lookup = SampleLookup(mappings, case_sensitive=case_sensitive)
+    return [lookup.match(v) for v in values]
+
+
+def expand_samples(
+    values: list[Any],
+    mappings: dict[str, list[str]] | None,
+    case_sensitive: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Expand source values to target identifiers.
+
+    Returns ``(resolved, unmapped)`` — ``resolved`` is order-preserving and
+    deduplicated; unmapped values pass through into ``resolved`` so a filter
+    on the target still sees them (they may be literal target names the
+    mapping simply doesn't know about).
+    """
+    resolved: list[str] = []
+    unmapped: list[str] = []
+    seen: set[str] = set()
+    for m in match_samples(values, mappings, case_sensitive=case_sensitive):
+        if not m.matched:
+            unmapped.append(m.source)
+        for t in m.targets:
+            if t not in seen:
+                seen.add(t)
+                resolved.append(t)
+    return resolved, unmapped

--- a/depictio/models/models/dashboards.py
+++ b/depictio/models/models/dashboards.py
@@ -252,10 +252,12 @@ class DashboardDataLite(BaseModel):
         default=None, description="Workflow system (e.g., 'nf-core', 'snakemake')"
     )
 
-    # Funnel filtering (issue #939). Opt-in and default-off on purpose: it
-    # recomputes availability on every filter change, which has a real cost.
+    # Funnel filtering (issue #939). On by default: knowing which values still
+    # lead somewhere is the point of a filter panel, so authors should have to
+    # opt *out*, not in. The cost is one extra availability query per filter
+    # change, which the author can turn off in the dashboard settings.
     funnel_filtering: bool = Field(
-        default=False,
+        default=True,
         description="Enable funnel filtering: values in other interactive "
         "components that no longer lead to a non-empty result set are "
         "visually distinguished, and the cascading restriction can be "
@@ -1080,7 +1082,7 @@ class DashboardDataLite(BaseModel):
             # "declared nowhere, sorted by first appearance".
             filter_sections=dashboard_data.get("filter_sections") or [],
             grid_sections=dashboard_data.get("grid_sections") or [],
-            funnel_filtering=bool(dashboard_data.get("funnel_filtering", False)),
+            funnel_filtering=bool(dashboard_data.get("funnel_filtering", True)),
             # Tab fields
             is_main_tab=dashboard_data.get("is_main_tab", True),
             tab_order=dashboard_data.get("tab_order", 0),
@@ -1476,8 +1478,9 @@ class DashboardData(MongoModel):
     # sections existed, which renders exactly as it did then.
     filter_sections: list[FilterSectionSpec] = []
     grid_sections: list[FilterSectionSpec] = []
-    # Funnel filtering (issue #939) — author-level opt-in, off by default.
-    funnel_filtering: bool = False
+    # Funnel filtering (issue #939). On by default; authors opt out per
+    # dashboard from the settings drawer.
+    funnel_filtering: bool = True
     buttons_data: dict = {
         "unified_edit_mode": True,  # Default edit mode ON for dashboard owners
         "add_components_button": {"count": 0},

--- a/depictio/models/models/dashboards.py
+++ b/depictio/models/models/dashboards.py
@@ -252,6 +252,16 @@ class DashboardDataLite(BaseModel):
         default=None, description="Workflow system (e.g., 'nf-core', 'snakemake')"
     )
 
+    # Funnel filtering (issue #939). Opt-in and default-off on purpose: it
+    # recomputes availability on every filter change, which has a real cost.
+    funnel_filtering: bool = Field(
+        default=False,
+        description="Enable funnel filtering: values in other interactive "
+        "components that no longer lead to a non-empty result set are "
+        "visually distinguished, and the cascading restriction can be "
+        "inspected in a funnel overview.",
+    )
+
     # Left filter panel presentation (ordering + icons for named sections)
     filter_sections: list[FilterSectionSpec] = Field(
         default_factory=list,
@@ -378,6 +388,7 @@ class DashboardDataLite(BaseModel):
         "icon_color",
         "icon_variant",
         "workflow_system",
+        "funnel_filtering",
         "filter_sections",
         "grid_sections",
     ]
@@ -1069,6 +1080,7 @@ class DashboardDataLite(BaseModel):
             # "declared nowhere, sorted by first appearance".
             filter_sections=dashboard_data.get("filter_sections") or [],
             grid_sections=dashboard_data.get("grid_sections") or [],
+            funnel_filtering=bool(dashboard_data.get("funnel_filtering", False)),
             # Tab fields
             is_main_tab=dashboard_data.get("is_main_tab", True),
             tab_order=dashboard_data.get("tab_order", 0),
@@ -1137,6 +1149,7 @@ class DashboardDataLite(BaseModel):
             # order sections and render their icons.
             "filter_sections": [s.model_dump() for s in self.filter_sections],
             "grid_sections": [s.model_dump() for s in self.grid_sections],
+            "funnel_filtering": self.funnel_filtering,
             # parent_dashboard_tag is resolved to parent_dashboard_id during import
         }
 
@@ -1463,6 +1476,8 @@ class DashboardData(MongoModel):
     # sections existed, which renders exactly as it did then.
     filter_sections: list[FilterSectionSpec] = []
     grid_sections: list[FilterSectionSpec] = []
+    # Funnel filtering (issue #939) — author-level opt-in, off by default.
+    funnel_filtering: bool = False
     buttons_data: dict = {
         "unified_edit_mode": True,  # Default edit mode ON for dashboard owners
         "add_components_button": {"count": 0},

--- a/depictio/models/models/links.py
+++ b/depictio/models/models/links.py
@@ -334,3 +334,57 @@ class LinkUpdateRequest(BaseModel):
     enabled: bool | None = Field(default=None)
 
     model_config = ConfigDict(extra="forbid")
+
+
+class LinkMappingPreviewRow(BaseModel):
+    """One source value's resolution outcome, for the mapping-inspection UI."""
+
+    source_value: str = Field(..., description="Distinct value from the source DC's link column")
+    matched: bool = Field(..., description="Whether the value resolved through the link")
+    via: str = Field(
+        ...,
+        description="How it matched: exact | variant | base | source-suffix | "
+        "passthrough, or the resolver name for non-sample_mapping resolvers",
+    )
+    resolved: list[str] = Field(
+        default_factory=list,
+        description="Target identifiers this value resolves to",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class LinkMappingPreviewResponse(BaseModel):
+    """Full sample ↔ link mapping table for one DC link.
+
+    Backs the debug/inspection view: every distinct source value with its
+    resolution outcome, plus the target-side names no source value reaches
+    (orphans) so mismatches are visible from both directions.
+    """
+
+    link_id: str = Field(...)
+    resolver: str = Field(...)
+    source_dc_id: str = Field(...)
+    source_column: str = Field(...)
+    target_dc_id: str = Field(...)
+    target_type: str = Field(...)
+    case_sensitive: bool = Field(...)
+    mappings_source: Literal["link_config", "multiqc_live", "none"] = Field(
+        ...,
+        description="Where the effective mappings came from: frozen on the link, "
+        "fetched live from MultiQC reports, or absent",
+    )
+    source_values_total: int = Field(..., description="Distinct source values in the DC")
+    truncated: bool = Field(
+        default=False,
+        description="True when rows were capped by the request limit",
+    )
+    matched_count: int = Field(default=0)
+    unmapped_count: int = Field(default=0)
+    rows: list[LinkMappingPreviewRow] = Field(default_factory=list)
+    orphan_targets: list[str] = Field(
+        default_factory=list,
+        description="Target-side sample names not reached by any listed source value",
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/depictio/tests/api/v1/endpoints/dashboards_endpoints/test_funnel_values.py
+++ b/depictio/tests/api/v1/endpoints/dashboards_endpoints/test_funnel_values.py
@@ -180,3 +180,37 @@ def test_inactive_filters_are_ignored(patched_env):
     result = _call(filters, [], include_stages=True)
     assert result["filter_count"] == 1
     assert len(result["stages"]) == 1
+
+
+@pytest.mark.parametrize("falsy_value", [0, 0.0, False])
+def test_falsy_scalar_filters_still_count_as_stages(patched_env, falsy_value):
+    """A slider parked at 0 is a real constraint, not an empty filter.
+
+    Regression: the active-filter test used ``value not in (None, [], "",
+    False)``. ``0 == False`` in Python, so 0 and 0.0 were silently dropped
+    here while ``clean_filter_payload`` still applied them downstream. The
+    client zips its own active list against ``stages`` positionally, so the
+    drop mislabelled every reorder row after it.
+    """
+    filters = [
+        _filter("comp-habitat", "habitat", falsy_value),
+        _filter("comp-depth", "depth", ["3"]),
+    ]
+    result = _call(filters, [], include_stages=True)
+    assert result["filter_count"] == 2
+    assert len(result["stages"]) == 2
+
+
+def test_reset_range_filter_is_not_a_stage(patched_env):
+    """``[None, None]`` is what a reset RangeSlider emits — not a constraint.
+
+    The frontend's ``isFilterActive`` has always ignored it; the server used to
+    count it, which inflated the stage list in the other direction.
+    """
+    filters = [
+        _filter("comp-habitat", "habitat", [None, None]),
+        _filter("comp-depth", "depth", ["3"]),
+    ]
+    result = _call(filters, [], include_stages=True)
+    assert result["filter_count"] == 1
+    assert len(result["stages"]) == 1

--- a/depictio/tests/api/v1/endpoints/dashboards_endpoints/test_funnel_values.py
+++ b/depictio/tests/api/v1/endpoints/dashboards_endpoints/test_funnel_values.py
@@ -1,0 +1,182 @@
+"""Tests for the funnel-filtering endpoint (issue #939).
+
+Pins the core contract:
+- each target's available values are computed under the current filters MINUS
+  that target's own selection (a picked value must never grey itself out);
+- a target reached by no other active filter is reported ``unrestricted``
+  (and no query runs for it);
+- ``include_stages`` returns the cumulative per-DC row counts that back the
+  funnel overview;
+- unknown targets are ``unsupported``.
+"""
+
+from unittest.mock import patch
+
+import mongomock
+import polars as pl
+import pytest
+from bson import ObjectId
+
+from depictio.api.v1.endpoints.dashboards_endpoints.routes import funnel_values_endpoint
+
+DC1 = str(ObjectId())
+PROJECT_ID = ObjectId()
+WF_ID = str(ObjectId())
+DASHBOARD_ID = str(ObjectId())
+
+BASE_DF = pl.DataFrame(
+    {
+        "habitat": ["Groundwater", "Groundwater", "Riverwater"],
+        "depth": ["1", "2", "3"],
+    }
+)
+
+
+def _dashboard_doc() -> dict:
+    def interactive(index: str, column: str) -> dict:
+        return {
+            "index": index,
+            "component_type": "interactive",
+            "interactive_component_type": "MultiSelect",
+            "dc_id": DC1,
+            "wf_id": WF_ID,
+            "column_name": column,
+            "dc_config": {"delta_location": f"memory://{DC1}", "type": "table"},
+        }
+
+    return {
+        "dashboard_id": DASHBOARD_ID,
+        "project_id": PROJECT_ID,
+        "stored_metadata": [
+            interactive("comp-habitat", "habitat"),
+            interactive("comp-depth", "depth"),
+            {
+                "index": "fig-1",
+                "component_type": "figure",
+                "dc_id": DC1,
+                "wf_id": WF_ID,
+                "dc_config": {"delta_location": f"memory://{DC1}", "type": "table"},
+            },
+        ],
+    }
+
+
+def _fake_load(workflow_id, data_collection_id, metadata=None, init_data=None, **kwargs):
+    df = BASE_DF
+    for f in metadata or []:
+        column = f.get("column_name")
+        value = f.get("value")
+        values = value if isinstance(value, list) else [value]
+        if column in df.columns:
+            df = df.filter(pl.col(column).is_in([str(v) for v in values]))
+    select_columns = kwargs.get("select_columns")
+    if select_columns:
+        df = df.select([c for c in select_columns if c in df.columns])
+    return df
+
+
+def _filter(index: str, column: str, value) -> dict:
+    return {
+        "index": index,
+        "value": value,
+        "column_name": column,
+        "interactive_component_type": "MultiSelect",
+        "metadata": {"dc_id": DC1, "column_name": column},
+    }
+
+
+@pytest.fixture
+def patched_env():
+    client = mongomock.MongoClient()
+    db = client.test_db
+    db.dashboards.insert_one(_dashboard_doc())
+    db.projects.insert_one({"_id": PROJECT_ID, "workflows": []})
+
+    routes_mod = "depictio.api.v1.endpoints.dashboards_endpoints.routes"
+    with (
+        patch(f"{routes_mod}.dashboards_collection", db.dashboards),
+        patch(f"{routes_mod}.projects_collection", db.projects),
+        patch(f"{routes_mod}.check_project_permission", lambda *a, **k: True),
+        patch(
+            f"{routes_mod}._resolve_link_filters_cached",
+            lambda **kw: list(kw["filters"]),
+        ),
+        patch("depictio.api.v1.deltatables_utils.load_deltatable_lite", _fake_load),
+    ):
+        yield
+        client.close()
+
+
+def _call(filters, target_indexes, include_stages=False):
+    return funnel_values_endpoint(
+        dashboard_id=DASHBOARD_ID,  # type: ignore[arg-type]
+        request={
+            "filters": filters,
+            "target_indexes": target_indexes,
+            "include_stages": include_stages,
+        },
+        current_user=object(),  # permission check is patched out
+        access_token=None,
+    )
+
+
+def test_own_selection_is_excluded(patched_env):
+    """comp-habitat's availability reflects only the depth filter — its own
+    habitat selection must not restrict itself."""
+    filters = [
+        _filter("comp-habitat", "habitat", ["Groundwater"]),
+        _filter("comp-depth", "depth", ["3"]),
+    ]
+    result = _call(filters, ["comp-habitat"])
+    target = result["targets"]["comp-habitat"]
+    assert target["status"] == "ok"
+    # depth == 3 → only the Riverwater row survives, even though the user's
+    # own habitat selection is Groundwater.
+    assert target["values"] == ["Riverwater"]
+
+
+def test_other_component_sees_narrowed_values(patched_env):
+    filters = [
+        _filter("comp-habitat", "habitat", ["Groundwater"]),
+        _filter("comp-depth", "depth", ["3"]),
+    ]
+    result = _call(filters, ["comp-depth"])
+    target = result["targets"]["comp-depth"]
+    assert target["status"] == "ok"
+    assert target["values"] == ["1", "2"]
+
+
+def test_unrestricted_when_no_other_filter(patched_env):
+    """With only its own filter active, a component is unrestricted."""
+    filters = [_filter("comp-habitat", "habitat", ["Groundwater"])]
+    result = _call(filters, ["comp-habitat"])
+    assert result["targets"]["comp-habitat"]["status"] == "unrestricted"
+
+
+def test_unknown_target_is_unsupported(patched_env):
+    result = _call([], ["nope"])
+    assert result["targets"]["nope"]["status"] == "unsupported"
+
+
+def test_stages_report_cumulative_counts(patched_env):
+    filters = [
+        _filter("comp-habitat", "habitat", ["Groundwater"]),
+        _filter("comp-depth", "depth", ["3"]),
+    ]
+    result = _call(filters, [], include_stages=True)
+    assert result["initial_rows_by_dc"] == {DC1: 3}
+    stages = result["stages"]
+    assert len(stages) == 2
+    assert stages[0]["rows_by_dc"] == {DC1: 2}  # habitat=Groundwater
+    assert stages[1]["rows_by_dc"] == {DC1: 0}  # + depth=3 → nothing left
+    assert result["filter_count"] == 2
+
+
+def test_inactive_filters_are_ignored(patched_env):
+    filters = [
+        _filter("comp-habitat", "habitat", []),
+        _filter("comp-depth", "depth", ["3"]),
+    ]
+    result = _call(filters, [], include_stages=True)
+    assert result["filter_count"] == 1
+    assert len(result["stages"]) == 1

--- a/depictio/tests/api/v1/endpoints/dashboards_endpoints/test_multiqc_sample_filter.py
+++ b/depictio/tests/api/v1/endpoints/dashboards_endpoints/test_multiqc_sample_filter.py
@@ -1,0 +1,226 @@
+"""Tests for ``_resolve_multiqc_sample_filter`` (issue #938).
+
+Pins the corrected semantics:
+- every active filter is an AND constraint — the result is the INTERSECTION
+  of the per-filter sample sets, not their union;
+- filters from *every* linked metadata DC contribute, not just the first one
+  seen (the old behavior silently dropped later DCs, so the outcome depended
+  on filter ordering);
+- direct filters on the MultiQC DC are honored for any sample-column spelling
+  (``sample``, ``sample_id``, ``sample_name``, ...), matching the frontend;
+- return value distinguishes "no applicable filter" (``None``) from "active
+  filters matched no sample" (``[]``).
+"""
+
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+from bson import ObjectId
+
+from depictio.api.v1.endpoints.dashboards_endpoints.routes import (
+    _resolve_multiqc_sample_filter,
+)
+
+MULTIQC_DC = str(ObjectId())
+META_DC_A = str(ObjectId())
+META_DC_B = str(ObjectId())
+PROJECT_ID = ObjectId()
+WF_ID = str(ObjectId())
+
+MAPPINGS = {
+    "S1": ["S1_R1"],
+    "S2": ["S2_R1"],
+    "S3": ["S3_R1"],
+}
+
+
+def _dashboard_data() -> dict:
+    def meta(index: str, dc_id: str, column: str) -> dict:
+        return {
+            "index": index,
+            "component_type": "interactive",
+            "dc_id": dc_id,
+            "wf_id": WF_ID,
+            "column_name": column,
+            "interactive_component_type": "MultiSelect",
+            "dc_config": {"delta_location": f"memory://{dc_id}", "type": "table"},
+        }
+
+    return {
+        "project_id": PROJECT_ID,
+        "stored_metadata": [
+            meta("direct-sample", MULTIQC_DC, "sample_name"),
+            meta("habitat-a", META_DC_A, "habitat"),
+            meta("depth-b", META_DC_B, "depth_zone"),
+            {
+                "index": "mqc-comp",
+                "component_type": "multiqc",
+                "dc_id": MULTIQC_DC,
+                "wf_id": WF_ID,
+            },
+        ],
+    }
+
+
+def _component() -> dict:
+    return {"index": "mqc-comp", "dc_id": MULTIQC_DC, "wf_id": WF_ID}
+
+
+def _link(source_dc: str) -> dict:
+    return {
+        "id": str(ObjectId()),
+        "source_dc_id": source_dc,
+        "source_column": "sample",
+        "target_dc_id": MULTIQC_DC,
+        "target_type": "multiqc",
+        "enabled": True,
+        "link_config": {"resolver": "sample_mapping", "target_field": "sample_name"},
+    }
+
+
+@pytest.fixture
+def patched_db():
+    """Patch the DB collections and the Delta loader used by the resolver."""
+    import mongomock
+
+    client = mongomock.MongoClient()
+    db = client.test_db
+    db.multiqc.insert_one(
+        {
+            "data_collection_id": MULTIQC_DC,
+            "metadata": {"sample_mappings": MAPPINGS},
+        }
+    )
+    db.projects.insert_one(
+        {
+            "_id": PROJECT_ID,
+            "links": [_link(META_DC_A), _link(META_DC_B)],
+        }
+    )
+
+    # One frame per metadata DC: DC A narrows to S2+S3, DC B narrows to S1+S2.
+    frames = {
+        META_DC_A: pl.DataFrame({"sample": ["S2", "S3"], "habitat": ["w", "w"]}),
+        META_DC_B: pl.DataFrame({"sample": ["S1", "S2"], "depth_zone": ["d", "d"]}),
+    }
+
+    def fake_load(workflow_id, data_collection_id, metadata=None, init_data=None, **kwargs):
+        return frames[str(data_collection_id)]
+
+    with (
+        patch("depictio.api.v1.db.multiqc_collection", db.multiqc),
+        patch("depictio.api.v1.db.projects_collection", db.projects),
+        patch("depictio.api.v1.deltatables_utils.load_deltatable_lite", side_effect=fake_load),
+    ):
+        yield frames
+        client.close()
+
+
+def _filter(index: str, column: str, value) -> dict:
+    return {
+        "index": index,
+        "value": value,
+        "column_name": column,
+        "interactive_component_type": "MultiSelect",
+    }
+
+
+def test_no_filters_returns_none(patched_db):
+    assert _resolve_multiqc_sample_filter(_dashboard_data(), _component(), []) is None
+
+
+def test_inapplicable_filters_return_none(patched_db):
+    # A filter on the MultiQC DC but not on a sample-like column contributes
+    # nothing — there is no sample filter to apply.
+    dashboard = _dashboard_data()
+    dashboard["stored_metadata"].append(
+        {
+            "index": "not-sample",
+            "component_type": "interactive",
+            "dc_id": MULTIQC_DC,
+            "wf_id": WF_ID,
+            "column_name": "module",
+        }
+    )
+    filters = [_filter("not-sample", "module", ["fastqc"])]
+    assert _resolve_multiqc_sample_filter(dashboard, _component(), filters) is None
+
+
+def test_direct_filter_accepts_sample_name_spelling(patched_db):
+    """The direct branch matches any allow-listed sample column, not just ``sample``."""
+    filters = [_filter("direct-sample", "sample_name", ["S1"])]
+    result = _resolve_multiqc_sample_filter(_dashboard_data(), _component(), filters)
+    assert result is not None
+    assert set(result) == {"S1", "S1_R1"}
+
+
+def test_direct_and_indirect_filters_intersect(patched_db):
+    """Direct S1+S2 ∩ metadata-A (S2+S3) must keep only S2 — never the union."""
+    filters = [
+        _filter("direct-sample", "sample_name", ["S1", "S2"]),
+        _filter("habitat-a", "habitat", ["w"]),
+    ]
+    result = _resolve_multiqc_sample_filter(_dashboard_data(), _component(), filters)
+    assert result is not None
+    assert set(result) == {"S2", "S2_R1"}
+
+
+def test_every_metadata_dc_contributes(patched_db):
+    """DC A (S2+S3) ∩ DC B (S1+S2) = S2 — the second DC must not be dropped."""
+    filters = [
+        _filter("habitat-a", "habitat", ["w"]),
+        _filter("depth-b", "depth_zone", ["d"]),
+    ]
+    result = _resolve_multiqc_sample_filter(_dashboard_data(), _component(), filters)
+    assert result is not None
+    assert set(result) == {"S2", "S2_R1"}
+
+
+def test_metadata_dc_order_does_not_change_result(patched_db):
+    filters_ab = [
+        _filter("habitat-a", "habitat", ["w"]),
+        _filter("depth-b", "depth_zone", ["d"]),
+    ]
+    filters_ba = list(reversed(filters_ab))
+    dashboard = _dashboard_data()
+    component = _component()
+    assert _resolve_multiqc_sample_filter(
+        dashboard, component, filters_ab
+    ) == _resolve_multiqc_sample_filter(dashboard, component, filters_ba)
+
+
+def test_empty_intersection_returns_empty_list_not_none(patched_db, monkeypatch):
+    """Filters that match no sample must yield ``[]`` (render nothing)."""
+    import depictio.api.v1.deltatables_utils as dtu
+
+    monkeypatch.setattr(
+        dtu,
+        "load_deltatable_lite",
+        lambda *a, **k: pl.DataFrame({"sample": [], "habitat": []}),
+    )
+    filters = [_filter("habitat-a", "habitat", ["nope"])]
+    result = _resolve_multiqc_sample_filter(_dashboard_data(), _component(), filters)
+    assert result == []
+
+
+def test_unlinked_metadata_dc_is_skipped(patched_db):
+    """A metadata DC without an enabled link is ignored, direct filters kept."""
+    dashboard = _dashboard_data()
+    unlinked_dc = str(ObjectId())
+    dashboard["stored_metadata"].append(
+        {
+            "index": "unlinked",
+            "component_type": "interactive",
+            "dc_id": unlinked_dc,
+            "wf_id": WF_ID,
+            "column_name": "foo",
+        }
+    )
+    filters = [
+        _filter("direct-sample", "sample_name", ["S1"]),
+        _filter("unlinked", "foo", ["bar"]),
+    ]
+    result = _resolve_multiqc_sample_filter(dashboard, _component(), filters)
+    assert result is not None
+    assert set(result) == {"S1", "S1_R1"}

--- a/depictio/tests/api/v1/endpoints/links_endpoints/test_mapping_preview.py
+++ b/depictio/tests/api/v1/endpoints/links_endpoints/test_mapping_preview.py
@@ -89,9 +89,8 @@ def patched_env():
         client.close()
 
 
-@pytest.mark.asyncio
-async def test_mapping_preview_reports_matches_and_orphans(patched_env):
-    response = await link_mapping_preview(
+def test_mapping_preview_reports_matches_and_orphans(patched_env):
+    response = link_mapping_preview(
         project_id=str(PROJECT_ID),
         link_id=LINK_ID,
         limit=500,
@@ -115,9 +114,8 @@ async def test_mapping_preview_reports_matches_and_orphans(patched_env):
     assert response.orphan_targets == ["ORPHAN"]
 
 
-@pytest.mark.asyncio
-async def test_mapping_preview_respects_limit(patched_env):
-    response = await link_mapping_preview(
+def test_mapping_preview_respects_limit(patched_env):
+    response = link_mapping_preview(
         project_id=str(PROJECT_ID),
         link_id=LINK_ID,
         limit=2,
@@ -128,12 +126,11 @@ async def test_mapping_preview_respects_limit(patched_env):
     assert response.source_values_total == 3
 
 
-@pytest.mark.asyncio
-async def test_mapping_preview_unknown_link_404(patched_env):
+def test_mapping_preview_unknown_link_404(patched_env):
     from fastapi import HTTPException
 
     with pytest.raises(HTTPException) as exc:
-        await link_mapping_preview(
+        link_mapping_preview(
             project_id=str(PROJECT_ID),
             link_id=str(ObjectId()),
             limit=10,

--- a/depictio/tests/api/v1/endpoints/links_endpoints/test_mapping_preview.py
+++ b/depictio/tests/api/v1/endpoints/links_endpoints/test_mapping_preview.py
@@ -1,0 +1,142 @@
+"""Tests for the link mapping-preview endpoint (issue #938 debug/inspect view)."""
+
+from unittest.mock import patch
+
+import mongomock
+import polars as pl
+import pytest
+from bson import ObjectId
+
+from depictio.api.v1.endpoints.links_endpoints.routes import link_mapping_preview
+from depictio.api.v1.endpoints.user_endpoints.core_functions import _hash_password
+from depictio.models.models.base import PyObjectId
+from depictio.models.models.users import User
+
+SOURCE_DC = str(ObjectId())
+TARGET_DC = str(ObjectId())
+PROJECT_ID = ObjectId()
+LINK_ID = str(ObjectId())
+
+MAPPINGS = {
+    "HG001": ["HG001_R1", "HG001_R2"],
+    "HG002": ["HG002_R1"],
+    "ORPHAN": ["ORPHAN_R1"],
+}
+
+
+def _admin_user() -> User:
+    return User(
+        id=PyObjectId(),
+        email="admin@example.com",
+        password=_hash_password("test_password"),
+        is_admin=True,
+    )
+
+
+@pytest.fixture
+def patched_env():
+    client = mongomock.MongoClient()
+    db = client.test_db
+    db.projects.insert_one(
+        {
+            "_id": PROJECT_ID,
+            "permissions": {"owners": [], "editors": [], "viewers": []},
+            "links": [
+                {
+                    "id": LINK_ID,
+                    "source_dc_id": SOURCE_DC,
+                    "source_column": "sample",
+                    "target_dc_id": TARGET_DC,
+                    "target_type": "multiqc",
+                    "enabled": True,
+                    "link_config": {
+                        "resolver": "sample_mapping",
+                        "target_field": "sample_name",
+                        "case_sensitive": False,
+                    },
+                }
+            ],
+        }
+    )
+    db.deltatables.insert_one(
+        {
+            "data_collection_id": SOURCE_DC,
+            "delta_table_location": "memory://source",
+        }
+    )
+    db.multiqc.insert_one(
+        {
+            "data_collection_id": TARGET_DC,
+            "metadata": {"sample_mappings": MAPPINGS},
+        }
+    )
+
+    source_frame = pl.DataFrame({"sample": ["HG001", "HG002", "UNKNOWN"]}).lazy()
+
+    with (
+        patch("depictio.api.v1.endpoints.links_endpoints.routes.projects_collection", db.projects),
+        patch(
+            "depictio.api.v1.endpoints.links_endpoints.routes.deltatables_collection",
+            db.deltatables,
+        ),
+        patch("depictio.api.v1.endpoints.links_endpoints.routes.multiqc_collection", db.multiqc),
+        patch(
+            "depictio.api.v1.endpoints.links_endpoints.routes.pl.scan_delta",
+            return_value=source_frame,
+        ),
+    ):
+        yield
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_mapping_preview_reports_matches_and_orphans(patched_env):
+    response = await link_mapping_preview(
+        project_id=str(PROJECT_ID),
+        link_id=LINK_ID,
+        limit=500,
+        current_user=_admin_user(),
+    )
+
+    assert response.resolver == "sample_mapping"
+    assert response.mappings_source == "multiqc_live"
+    assert response.source_values_total == 3
+    assert response.truncated is False
+    assert response.matched_count == 2
+    assert response.unmapped_count == 1
+
+    by_source = {r.source_value: r for r in response.rows}
+    assert by_source["HG001"].matched and by_source["HG001"].via == "exact"
+    assert set(by_source["HG001"].resolved) == {"HG001", "HG001_R1", "HG001_R2"}
+    assert not by_source["UNKNOWN"].matched
+    assert by_source["UNKNOWN"].via == "passthrough"
+
+    # ORPHAN's variants are reached by no source value.
+    assert response.orphan_targets == ["ORPHAN"]
+
+
+@pytest.mark.asyncio
+async def test_mapping_preview_respects_limit(patched_env):
+    response = await link_mapping_preview(
+        project_id=str(PROJECT_ID),
+        link_id=LINK_ID,
+        limit=2,
+        current_user=_admin_user(),
+    )
+    assert len(response.rows) == 2
+    assert response.truncated is True
+    assert response.source_values_total == 3
+
+
+@pytest.mark.asyncio
+async def test_mapping_preview_unknown_link_404(patched_env):
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await link_mapping_preview(
+            project_id=str(PROJECT_ID),
+            link_id=str(ObjectId()),
+            limit=10,
+            current_user=_admin_user(),
+        )
+    assert exc.value.status_code == 404

--- a/depictio/tests/api/v1/endpoints/links_endpoints/test_sample_mapping_resolver.py
+++ b/depictio/tests/api/v1/endpoints/links_endpoints/test_sample_mapping_resolver.py
@@ -149,3 +149,50 @@ def test_mixed_exact_and_fallback_in_one_call():
     assert "DONOR_A_R1" in resolved
     assert "MISSING" in resolved
     assert unmapped == ["MISSING"]
+
+
+# --- Regression tests for issue #938 -----------------------------------------
+
+
+def test_canonical_only_mapping_is_matched_not_unmapped():
+    """``{sample: []}`` (synthesized from canonical_samples) counts as mapped."""
+    resolver = SampleMappingResolver()
+    resolved, unmapped = resolver.resolve(["HG001"], _config({"HG001": []}))
+    assert resolved == ["HG001"]
+    assert unmapped == []
+
+
+def test_variant_name_as_source_value_matches():
+    """Metadata tables can carry read-level ids that ARE the variants."""
+    resolver = SampleMappingResolver()
+    mappings = {"SRR001": ["SRR001_1", "SRR001_2"]}
+    resolved, unmapped = resolver.resolve(["SRR001_1"], _config(mappings))
+    assert resolved == ["SRR001_1"]
+    assert unmapped == []
+
+
+def test_suffixed_source_value_matches_base_key():
+    """``HG001_R1`` from the source DC against a mapping keyed ``HG001``."""
+    resolver = SampleMappingResolver()
+    mappings = {"HG001": ["HG001 - adapter"]}
+    resolved, unmapped = resolver.resolve(["HG001_R1"], _config(mappings))
+    assert unmapped == []
+    assert "HG001 - adapter" in resolved
+
+
+def test_surrounding_whitespace_does_not_break_matching():
+    resolver = SampleMappingResolver()
+    mappings = {"HG001": ["HG001_R1"]}
+    resolved, unmapped = resolver.resolve([" HG001 "], _config(mappings))
+    assert unmapped == []
+    assert "HG001_R1" in resolved
+
+
+def test_global_dedup_across_source_values():
+    resolver = SampleMappingResolver()
+    mappings = {
+        "HG001_R1": ["HG001_R1", "shared_variant"],
+        "HG001_R2": ["HG001_R2", "shared_variant"],
+    }
+    resolved, _ = resolver.resolve(["HG001_R1", "HG001_R2"], _config(mappings))
+    assert resolved.count("shared_variant") == 1

--- a/depictio/tests/api/v1/test_sample_matching.py
+++ b/depictio/tests/api/v1/test_sample_matching.py
@@ -1,0 +1,91 @@
+"""Tests for the shared sample-matching module (issue #938 regression suite).
+
+These pin the fixes for the MultiQC sample-mapping bugs:
+- a canonical-only mapping (``{sample: []}``, synthesized when no explicit
+  mapping exists) must count as *matched*, not unmapped;
+- a source value that is itself a variant name must match (reverse lookup);
+- suffix stripping must also apply to the source value, not only the keys;
+- surrounding whitespace must never break a match;
+- resolved lists are deduplicated while preserving order;
+- the canonical key stays among the targets alongside its variants (General
+  Stats tables key rows by the canonical ID while plot traces use variants).
+"""
+
+from depictio.api.v1.services.multiqc.sample_matching import (
+    SampleLookup,
+    expand_samples,
+    match_samples,
+)
+
+
+def test_canonical_only_mapping_counts_as_matched():
+    """``{sample: []}`` fallback mappings: the sample is known, not unmapped."""
+    resolved, unmapped = expand_samples(["S1"], {"S1": []})
+    assert resolved == ["S1"]
+    assert unmapped == []
+
+
+def test_variant_identity_lookup():
+    """A source value that IS a variant resolves to itself (mapped)."""
+    mappings = {"SRR001": ["SRR001_1", "SRR001_2"]}
+    resolved, unmapped = expand_samples(["SRR001_1"], mappings)
+    assert resolved == ["SRR001_1"]
+    assert unmapped == []
+
+
+def test_source_suffix_stripped():
+    """``HG001_R1`` selected against a mapping keyed by the base ``HG001``."""
+    mappings = {"HG001": ["HG001 - adapter"]}
+    resolved, unmapped = expand_samples(["HG001_R1"], mappings)
+    assert unmapped == []
+    assert "HG001 - adapter" in resolved
+
+
+def test_whitespace_stripped_on_both_sides():
+    mappings = {" HG001 ": ["HG001_R1"]}
+    resolved, unmapped = expand_samples(["HG001  "], mappings)
+    assert unmapped == []
+    assert "HG001_R1" in resolved
+
+
+def test_resolved_deduplicated_across_source_values():
+    """Two source values expanding to the same variant emit it once."""
+    mappings = {
+        "HG001": ["shared", "HG001_R1"],
+        "HG002": ["shared", "HG002_R1"],
+    }
+    resolved, unmapped = expand_samples(["HG001", "HG002"], mappings)
+    assert unmapped == []
+    assert resolved.count("shared") == 1
+
+
+def test_canonical_key_kept_among_targets():
+    """The canonical ID must survive expansion for GS-style exact matching."""
+    mappings = {"S1": ["S1_1", "S1_2"]}
+    resolved, _ = expand_samples(["S1"], mappings)
+    assert set(resolved) == {"S1", "S1_1", "S1_2"}
+
+
+def test_match_detail_reports_via():
+    mappings = {"HG001_R1": ["HG001_R1"], "S1": ["S1_1"]}
+    details = {m.source: m for m in match_samples(["HG001_R1", "HG001", "S1_1", "NOPE"], mappings)}
+    assert details["HG001_R1"].via == "exact"
+    assert details["HG001"].via == "base"
+    assert details["S1_1"].via == "variant"
+    assert details["NOPE"].via == "passthrough"
+    assert not details["NOPE"].matched
+    assert details["NOPE"].targets == ["NOPE"]
+
+
+def test_case_sensitive_lookup_is_strict():
+    lookup = SampleLookup({"HG001": ["HG001_R1"]}, case_sensitive=True)
+    assert lookup.match("hg001").matched is False
+    assert lookup.match("HG001").matched is True
+
+
+def test_no_overstrip_of_plain_digit_suffixes():
+    """``Sample_2024`` must not collapse onto a ``Sample`` base bucket."""
+    mappings = {"Sample_2024": ["Sample_2024"], "Sample_2025": ["Sample_2025"]}
+    resolved, unmapped = expand_samples(["Sample"], mappings)
+    assert resolved == ["Sample"]
+    assert unmapped == ["Sample"]

--- a/depictio/viewer/src/App.tsx
+++ b/depictio/viewer/src/App.tsx
@@ -23,6 +23,7 @@ import {
   AvailableFilterValuesProvider,
   DashboardGrid,
   FilterPanel,
+  FunnelView,
   TopPanel,
   mergeFiltersBySource,
   enrichFilterWithDcId,
@@ -133,6 +134,16 @@ const App: React.FC = () => {
   // this, picking three values in a MultiSelect fires three full rounds of
   // renders and the first two are obsolete before they land.
   const [deferredFilters] = useDebouncedValue(filters, FILTER_DEBOUNCE_MS);
+
+  // Funnel filtering (issue #939). The dashboard's `funnel_filtering` field is
+  // the author's default; the panel button flips it for this page view only
+  // (viewers may lack edit rights, so the button never writes back).
+  const [funnelEnabled, setFunnelEnabled] = useState(false);
+  const [funnelViewOpen, setFunnelViewOpen] = useState(false);
+  const funnelDefault = Boolean(dashboard?.funnel_filtering);
+  useEffect(() => {
+    setFunnelEnabled(funnelDefault);
+  }, [funnelDefault]);
 
   // Invalidate whatever the previous filter left queued.
   //
@@ -673,6 +684,11 @@ const App: React.FC = () => {
     <AvailableFilterValuesProvider
       dashboardMetadata={summaryMetadata}
       projectId={dashboard?.project_id}
+      funnel={
+        dashboardId
+          ? { enabled: funnelEnabled, dashboardId, filters: deferredFilters }
+          : undefined
+      }
     >
       <DashboardLoadingProvider>
       <InspectorProviders control={inspectorControl}>
@@ -889,6 +905,11 @@ const App: React.FC = () => {
                   refreshTick={refreshTick}
                   collapsed={!filterPanelOpened}
                   onToggleCollapsed={toggleFilterPanel}
+                  funnel={{
+                    enabled: funnelEnabled,
+                    onToggle: () => setFunnelEnabled((v) => !v),
+                    onOpenView: () => setFunnelViewOpen(true),
+                  }}
                   footer={
                     <MapPanelDock
                       panel={mapPanel}
@@ -1054,8 +1075,21 @@ const App: React.FC = () => {
               filterSections={panelFilterSections}
               dashboardId={dashboardId}
               refreshTick={refreshTick}
+              funnel={{
+                enabled: funnelEnabled,
+                onToggle: () => setFunnelEnabled((v) => !v),
+                onOpenView: () => setFunnelViewOpen(true),
+              }}
             />
           </Drawer>
+        )}
+        {dashboardId && (
+          <FunnelView
+            opened={funnelViewOpen}
+            onClose={() => setFunnelViewOpen(false)}
+            dashboardId={dashboardId}
+            filters={deferredFilters}
+          />
         )}
         {dashboard && dashboardId && !inspectorEnabled && (
           <NotesFooter

--- a/depictio/viewer/src/App.tsx
+++ b/depictio/viewer/src/App.tsx
@@ -137,10 +137,12 @@ const App: React.FC = () => {
 
   // Funnel filtering (issue #939). The dashboard's `funnel_filtering` field is
   // the author's default; the panel button flips it for this page view only
-  // (viewers may lack edit rights, so the button never writes back).
-  const [funnelEnabled, setFunnelEnabled] = useState(false);
+  // (viewers may lack edit rights, so the button never writes back). The field
+  // defaults to on, so only an explicit `false` disables it: a dashboard saved
+  // before the field existed has no value and must still get the funnel.
+  const [funnelEnabled, setFunnelEnabled] = useState(true);
   const [funnelViewOpen, setFunnelViewOpen] = useState(false);
-  const funnelDefault = Boolean(dashboard?.funnel_filtering);
+  const funnelDefault = dashboard?.funnel_filtering !== false;
   useEffect(() => {
     setFunnelEnabled(funnelDefault);
   }, [funnelDefault]);

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -549,6 +549,33 @@ const EditorApp: React.FC = () => {
   );
 
   /**
+   * Persist the dashboard-level funnel-filtering default (issue #939). Same
+   * save-now pattern as delete: apply optimistically, POST the full document.
+   */
+  const handleToggleFunnelFiltering = useCallback(
+    async (enabled: boolean) => {
+      if (!dashboardId) return;
+      const cur = dashboardRef.current;
+      if (!cur) return;
+      const next = { ...cur, funnel_filtering: enabled };
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        saveTimer.current = null;
+      }
+      applyDashboard(next);
+      setSaveStatus('saving');
+      try {
+        await saveDashboard(dashboardId, next);
+        setSaveStatus('saved');
+      } catch (err) {
+        console.error('[EditorApp] funnel toggle save failed:', err);
+        setSaveStatus('error');
+      }
+    },
+    [dashboardId, applyDashboard],
+  );
+
+  /**
    * Duplicate: deep-clone the source component's stored_metadata entry, give
    * it a fresh UUID, and stack a layout entry directly below the source in
    * whichever panel (left/right) the source lives in. POSTs the full
@@ -1677,6 +1704,7 @@ const EditorApp: React.FC = () => {
         opened={settingsOpened}
         onClose={closeSettings}
         dashboard={dashboard}
+        onToggleFunnelFiltering={handleToggleFunnelFiltering}
       />
 
       <TabModal

--- a/depictio/viewer/src/chrome/SettingsDrawer.tsx
+++ b/depictio/viewer/src/chrome/SettingsDrawer.tsx
@@ -44,7 +44,7 @@ const SettingsDrawer: React.FC<SettingsDrawerProps> = ({
         <Switch
           label="Funnel filtering by default"
           description="Highlight, in every other filter, the values that still lead to a non-empty result set. Viewers can still turn it off from the filter panel."
-          checked={Boolean(dashboard?.funnel_filtering)}
+          checked={dashboard?.funnel_filtering !== false}
           onChange={(e) => onToggleFunnelFiltering(e.currentTarget.checked)}
           color="teal"
         />

--- a/depictio/viewer/src/chrome/SettingsDrawer.tsx
+++ b/depictio/viewer/src/chrome/SettingsDrawer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Drawer, Group, Text } from '@mantine/core';
+import { Divider, Drawer, Group, Stack, Switch, Text } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
 import type { DashboardData } from 'depictio-react-core';
@@ -9,15 +9,24 @@ interface SettingsDrawerProps {
   opened: boolean;
   onClose: () => void;
   dashboard: DashboardData | null;
+  /** Editor-only: persists the dashboard's `funnel_filtering` field (issue
+   *  #939). Omitted in the viewer, where the drawer stays read-only. */
+  onToggleFunnelFiltering?: (enabled: boolean) => void;
 }
 
 /**
- * Right-side drawer with read-only metadata about the current dashboard.
+ * Right-side drawer with metadata about the current dashboard.
  *
  * The content lives in `DashboardInfoBody`, shared with the inspector's Info
  * tab — which is what the inspector replaces this drawer with when enabled.
+ * The editor adds one writable control on top: the funnel-filtering default.
  */
-const SettingsDrawer: React.FC<SettingsDrawerProps> = ({ opened, onClose, dashboard }) => (
+const SettingsDrawer: React.FC<SettingsDrawerProps> = ({
+  opened,
+  onClose,
+  dashboard,
+  onToggleFunnelFiltering,
+}) => (
   <Drawer
     opened={opened}
     onClose={onClose}
@@ -30,6 +39,18 @@ const SettingsDrawer: React.FC<SettingsDrawerProps> = ({ opened, onClose, dashbo
       </Group>
     }
   >
+    {onToggleFunnelFiltering && (
+      <Stack gap="xs" mb="md">
+        <Switch
+          label="Funnel filtering by default"
+          description="Highlight, in every other filter, the values that still lead to a non-empty result set. Viewers can still turn it off from the filter panel."
+          checked={Boolean(dashboard?.funnel_filtering)}
+          onChange={(e) => onToggleFunnelFiltering(e.currentTarget.checked)}
+          color="teal"
+        />
+        <Divider />
+      </Stack>
+    )}
     <DashboardInfoBody dashboard={dashboard} active={opened} />
   </Drawer>
 );

--- a/depictio/viewer/src/projects/detail/LinkEditModal.tsx
+++ b/depictio/viewer/src/projects/detail/LinkEditModal.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
+  Badge,
   Box,
   Button,
   Code,
+  Collapse,
   Group,
+  Loader,
   Modal,
   ScrollArea,
   Select,
@@ -15,11 +18,18 @@ import {
   Textarea,
   TextInput,
   Title,
+  Tooltip,
+  useMantineColorScheme,
 } from '@mantine/core';
 import { Icon } from '@iconify/react';
+import { AgGridReact } from 'ag-grid-react';
+import type { ColDef, ICellRendererParams } from 'ag-grid-community';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
 
 import {
   createProjectLink,
+  fetchLinkMappingPreview,
   fetchMultiQCSampleMappings,
   fetchSpecs,
   updateProjectLink,
@@ -28,6 +38,8 @@ import type {
   CreateLinkInput,
   DCLink,
   DCLinkConfig,
+  LinkMappingPreviewResponse,
+  LinkMappingPreviewRow,
   LinkResolverName,
   LinkTargetType,
   ResolverInfo,
@@ -276,11 +288,14 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
       };
     }
     if (resolver === 'sample_mapping') {
-      // Prefer the auto-loaded MultiQC mappings; otherwise parse JSON textarea.
+      // MultiQC targets: do NOT freeze the auto-loaded mappings into the
+      // link. The server re-fetches live mappings at resolution time when
+      // the link carries none — persisting a snapshot here meant a MultiQC
+      // re-ingest kept resolving against stale samples forever (#938). The
+      // table shown in the editor is a preview, not the stored config.
+      // Non-MultiQC targets keep the manual JSON path.
       let mappings: Record<string, string[]> | undefined;
-      if (autoMappings) {
-        mappings = autoMappings;
-      } else if (mappingsJson.trim()) {
+      if (targetType !== 'multiqc' && mappingsJson.trim()) {
         try {
           mappings = JSON.parse(mappingsJson);
         } catch (err) {
@@ -292,6 +307,10 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
         resolver,
         mappings,
         target_field: targetField || undefined,
+        // Sample names are matched case-insensitively in practice (MultiQC
+        // tools freely re-case names); the model default of `true` was never
+        // surfaced by this UI and silently made real-world links strict.
+        case_sensitive: false,
       };
     }
     return { resolver };
@@ -510,6 +529,10 @@ const LinkEditModal: React.FC<LinkEditModalProps> = ({
           />
         )}
 
+        {editing && link && (
+          <LinkMappingInspector projectId={projectId} linkId={link.id} />
+        )}
+
         <Textarea
           label="Description (optional)"
           value={description}
@@ -638,6 +661,230 @@ const SampleMappingEditor: React.FC<SampleMappingEditorProps> = ({
         value={targetField}
         onChange={(e) => onTargetFieldChange(e.currentTarget.value)}
       />
+    </Stack>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Mapping inspection (issue #938)
+// ---------------------------------------------------------------------------
+
+const VIA_LABELS: Record<string, string> = {
+  exact: 'Exact key',
+  variant: 'Variant name',
+  base: 'Suffix-stripped key',
+  'source-suffix': 'Suffix-stripped value',
+  passthrough: 'No match',
+};
+
+interface LinkMappingInspectorProps {
+  projectId: string;
+  linkId: string;
+}
+
+/**
+ * Debug/inspect view for one link's sample ↔ target mapping.
+ *
+ * Fetches `/links/{project}/{link}/mapping-preview` lazily on expand and
+ * renders every distinct source value with its resolution outcome in an AG
+ * Grid (quick-filterable, sortable), plus the target-side orphans — so a
+ * mismatch is visible from both directions instead of silently matching
+ * nothing at render time.
+ */
+const LinkMappingInspector: React.FC<LinkMappingInspectorProps> = ({ projectId, linkId }) => {
+  const { colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const [expanded, setExpanded] = useState(false);
+  const [data, setData] = useState<LinkMappingPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [unmappedOnly, setUnmappedOnly] = useState(false);
+
+  useEffect(() => {
+    if (!expanded || data || loading) return;
+    setLoading(true);
+    setError(null);
+    fetchLinkMappingPreview(projectId, linkId)
+      .then(setData)
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setLoading(false));
+  }, [expanded, data, loading, projectId, linkId]);
+
+  const rows = useMemo(() => {
+    const all = data?.rows ?? [];
+    return unmappedOnly ? all.filter((r) => !r.matched) : all;
+  }, [data, unmappedOnly]);
+
+  const colDefs = useMemo<ColDef<LinkMappingPreviewRow>[]>(
+    () => [
+      {
+        headerName: 'Source value',
+        field: 'source_value',
+        flex: 1,
+        minWidth: 140,
+        sortable: true,
+      },
+      {
+        headerName: 'Status',
+        field: 'matched',
+        width: 120,
+        sortable: true,
+        cellRenderer: (p: ICellRendererParams<LinkMappingPreviewRow>) =>
+          p.value ? (
+            <Badge size="sm" variant="light" color="teal" style={{ textTransform: 'none' }}>
+              matched
+            </Badge>
+          ) : (
+            <Badge size="sm" variant="light" color="orange" style={{ textTransform: 'none' }}>
+              unmapped
+            </Badge>
+          ),
+      },
+      {
+        headerName: 'Via',
+        field: 'via',
+        width: 170,
+        sortable: true,
+        valueFormatter: (p) => VIA_LABELS[p.value as string] ?? String(p.value ?? ''),
+      },
+      {
+        headerName: 'Resolves to',
+        field: 'resolved',
+        flex: 2,
+        minWidth: 200,
+        sortable: false,
+        valueFormatter: (p) => (Array.isArray(p.value) ? p.value.join(', ') : ''),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Stack gap="xs">
+      <Group justify="space-between" wrap="nowrap">
+        <Group gap="xs">
+          <Icon icon="mdi:magnify-scan" width={18} color="var(--mantine-color-teal-6)" />
+          <Text size="sm" fw={600}>
+            Inspect mapping
+          </Text>
+          {data && (
+            <>
+              <Tooltip label="Source values that resolve through the link" withArrow>
+                <Badge size="sm" variant="light" color="teal" style={{ textTransform: 'none' }}>
+                  {data.matched_count} matched
+                </Badge>
+              </Tooltip>
+              <Tooltip label="Source values the link cannot map" withArrow>
+                <Badge size="sm" variant="light" color="orange" style={{ textTransform: 'none' }}>
+                  {data.unmapped_count} unmapped
+                </Badge>
+              </Tooltip>
+              {data.orphan_targets.length > 0 && (
+                <Tooltip
+                  label="Target-side samples no source value reaches"
+                  withArrow
+                >
+                  <Badge size="sm" variant="light" color="gray" style={{ textTransform: 'none' }}>
+                    {data.orphan_targets.length} orphan targets
+                  </Badge>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Group>
+        <Button
+          size="compact-xs"
+          variant="subtle"
+          color="teal"
+          onClick={() => setExpanded((v) => !v)}
+          rightSection={
+            <Icon icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'} width={14} />
+          }
+          data-testid="mapping-inspector-toggle"
+        >
+          {expanded ? 'Hide' : 'Show'}
+        </Button>
+      </Group>
+      <Collapse in={expanded}>
+        <Stack gap="xs">
+          {loading && (
+            <Group gap="xs">
+              <Loader size="xs" />
+              <Text size="sm" c="dimmed">
+                Resolving every source value through the link…
+              </Text>
+            </Group>
+          )}
+          {error && (
+            <Alert color="orange" variant="light">
+              {error}
+            </Alert>
+          )}
+          {data && (
+            <>
+              <Group gap="xs" wrap="nowrap">
+                <TextInput
+                  size="xs"
+                  flex={1}
+                  placeholder="Search values…"
+                  leftSection={<Icon icon="mdi:magnify" width={14} />}
+                  value={search}
+                  onChange={(e) => setSearch(e.currentTarget.value)}
+                />
+                <Switch
+                  size="xs"
+                  label="Unmapped only"
+                  checked={unmappedOnly}
+                  onChange={(e) => setUnmappedOnly(e.currentTarget.checked)}
+                />
+              </Group>
+              <Box
+                className={isDark ? 'ag-theme-alpine-dark' : 'ag-theme-alpine'}
+                style={{ height: 280, width: '100%' }}
+                data-testid="mapping-inspector-grid"
+              >
+                <AgGridReact<LinkMappingPreviewRow>
+                  rowData={rows}
+                  columnDefs={colDefs}
+                  headerHeight={32}
+                  rowHeight={32}
+                  suppressCellFocus
+                  quickFilterText={search}
+                  overlayNoRowsTemplate={
+                    '<span style="color:var(--mantine-color-dimmed);font-size:12px">No source values to inspect.</span>'
+                  }
+                />
+              </Box>
+              <Text size="xs" c="dimmed">
+                {data.source_values_total} distinct source values in{' '}
+                <Code>{data.source_column}</Code>
+                {data.truncated ? ` — showing the first ${data.rows.length}` : ''}. Mappings:{' '}
+                {data.mappings_source === 'multiqc_live'
+                  ? 'fetched live from the MultiQC reports'
+                  : data.mappings_source === 'link_config'
+                    ? 'frozen on the link'
+                    : 'none'}
+                {data.case_sensitive ? ' · case-sensitive' : ' · case-insensitive'}.
+              </Text>
+              {data.orphan_targets.length > 0 && (
+                <Text size="xs" c="dimmed">
+                  Orphan targets:{' '}
+                  {data.orphan_targets.slice(0, 12).map((t) => (
+                    <Code key={t} mr={4}>
+                      {t}
+                    </Code>
+                  ))}
+                  {data.orphan_targets.length > 12
+                    ? `… +${data.orphan_targets.length - 12} more`
+                    : ''}
+                </Text>
+              )}
+            </>
+          )}
+        </Stack>
+      </Collapse>
     </Stack>
   );
 };

--- a/depictio/viewer/src/projects/detail/LinkEditModal.tsx
+++ b/depictio/viewer/src/projects/detail/LinkEditModal.tsx
@@ -1,13 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
-  Badge,
   Box,
   Button,
   Code,
-  Collapse,
   Group,
-  Loader,
   Modal,
   ScrollArea,
   Select,
@@ -18,18 +15,11 @@ import {
   Textarea,
   TextInput,
   Title,
-  Tooltip,
-  useMantineColorScheme,
 } from '@mantine/core';
 import { Icon } from '@iconify/react';
-import { AgGridReact } from 'ag-grid-react';
-import type { ColDef, ICellRendererParams } from 'ag-grid-community';
-import 'ag-grid-community/styles/ag-grid.css';
-import 'ag-grid-community/styles/ag-theme-alpine.css';
 
 import {
   createProjectLink,
-  fetchLinkMappingPreview,
   fetchMultiQCSampleMappings,
   fetchSpecs,
   updateProjectLink,
@@ -38,13 +28,13 @@ import type {
   CreateLinkInput,
   DCLink,
   DCLinkConfig,
-  LinkMappingPreviewResponse,
-  LinkMappingPreviewRow,
   LinkResolverName,
   LinkTargetType,
   ResolverInfo,
   UpdateLinkInput,
 } from 'depictio-react-core';
+
+import { LinkMappingInspector } from './LinkMappingInspector';
 
 interface DataCollectionOption {
   id: string;
@@ -661,230 +651,6 @@ const SampleMappingEditor: React.FC<SampleMappingEditorProps> = ({
         value={targetField}
         onChange={(e) => onTargetFieldChange(e.currentTarget.value)}
       />
-    </Stack>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Mapping inspection (issue #938)
-// ---------------------------------------------------------------------------
-
-const VIA_LABELS: Record<string, string> = {
-  exact: 'Exact key',
-  variant: 'Variant name',
-  base: 'Suffix-stripped key',
-  'source-suffix': 'Suffix-stripped value',
-  passthrough: 'No match',
-};
-
-interface LinkMappingInspectorProps {
-  projectId: string;
-  linkId: string;
-}
-
-/**
- * Debug/inspect view for one link's sample ↔ target mapping.
- *
- * Fetches `/links/{project}/{link}/mapping-preview` lazily on expand and
- * renders every distinct source value with its resolution outcome in an AG
- * Grid (quick-filterable, sortable), plus the target-side orphans — so a
- * mismatch is visible from both directions instead of silently matching
- * nothing at render time.
- */
-const LinkMappingInspector: React.FC<LinkMappingInspectorProps> = ({ projectId, linkId }) => {
-  const { colorScheme } = useMantineColorScheme();
-  const isDark = colorScheme === 'dark';
-
-  const [expanded, setExpanded] = useState(false);
-  const [data, setData] = useState<LinkMappingPreviewResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
-  const [unmappedOnly, setUnmappedOnly] = useState(false);
-
-  useEffect(() => {
-    if (!expanded || data || loading) return;
-    setLoading(true);
-    setError(null);
-    fetchLinkMappingPreview(projectId, linkId)
-      .then(setData)
-      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
-      .finally(() => setLoading(false));
-  }, [expanded, data, loading, projectId, linkId]);
-
-  const rows = useMemo(() => {
-    const all = data?.rows ?? [];
-    return unmappedOnly ? all.filter((r) => !r.matched) : all;
-  }, [data, unmappedOnly]);
-
-  const colDefs = useMemo<ColDef<LinkMappingPreviewRow>[]>(
-    () => [
-      {
-        headerName: 'Source value',
-        field: 'source_value',
-        flex: 1,
-        minWidth: 140,
-        sortable: true,
-      },
-      {
-        headerName: 'Status',
-        field: 'matched',
-        width: 120,
-        sortable: true,
-        cellRenderer: (p: ICellRendererParams<LinkMappingPreviewRow>) =>
-          p.value ? (
-            <Badge size="sm" variant="light" color="teal" style={{ textTransform: 'none' }}>
-              matched
-            </Badge>
-          ) : (
-            <Badge size="sm" variant="light" color="orange" style={{ textTransform: 'none' }}>
-              unmapped
-            </Badge>
-          ),
-      },
-      {
-        headerName: 'Via',
-        field: 'via',
-        width: 170,
-        sortable: true,
-        valueFormatter: (p) => VIA_LABELS[p.value as string] ?? String(p.value ?? ''),
-      },
-      {
-        headerName: 'Resolves to',
-        field: 'resolved',
-        flex: 2,
-        minWidth: 200,
-        sortable: false,
-        valueFormatter: (p) => (Array.isArray(p.value) ? p.value.join(', ') : ''),
-      },
-    ],
-    [],
-  );
-
-  return (
-    <Stack gap="xs">
-      <Group justify="space-between" wrap="nowrap">
-        <Group gap="xs">
-          <Icon icon="mdi:magnify-scan" width={18} color="var(--mantine-color-teal-6)" />
-          <Text size="sm" fw={600}>
-            Inspect mapping
-          </Text>
-          {data && (
-            <>
-              <Tooltip label="Source values that resolve through the link" withArrow>
-                <Badge size="sm" variant="light" color="teal" style={{ textTransform: 'none' }}>
-                  {data.matched_count} matched
-                </Badge>
-              </Tooltip>
-              <Tooltip label="Source values the link cannot map" withArrow>
-                <Badge size="sm" variant="light" color="orange" style={{ textTransform: 'none' }}>
-                  {data.unmapped_count} unmapped
-                </Badge>
-              </Tooltip>
-              {data.orphan_targets.length > 0 && (
-                <Tooltip
-                  label="Target-side samples no source value reaches"
-                  withArrow
-                >
-                  <Badge size="sm" variant="light" color="gray" style={{ textTransform: 'none' }}>
-                    {data.orphan_targets.length} orphan targets
-                  </Badge>
-                </Tooltip>
-              )}
-            </>
-          )}
-        </Group>
-        <Button
-          size="compact-xs"
-          variant="subtle"
-          color="teal"
-          onClick={() => setExpanded((v) => !v)}
-          rightSection={
-            <Icon icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'} width={14} />
-          }
-          data-testid="mapping-inspector-toggle"
-        >
-          {expanded ? 'Hide' : 'Show'}
-        </Button>
-      </Group>
-      <Collapse in={expanded}>
-        <Stack gap="xs">
-          {loading && (
-            <Group gap="xs">
-              <Loader size="xs" />
-              <Text size="sm" c="dimmed">
-                Resolving every source value through the link…
-              </Text>
-            </Group>
-          )}
-          {error && (
-            <Alert color="orange" variant="light">
-              {error}
-            </Alert>
-          )}
-          {data && (
-            <>
-              <Group gap="xs" wrap="nowrap">
-                <TextInput
-                  size="xs"
-                  flex={1}
-                  placeholder="Search values…"
-                  leftSection={<Icon icon="mdi:magnify" width={14} />}
-                  value={search}
-                  onChange={(e) => setSearch(e.currentTarget.value)}
-                />
-                <Switch
-                  size="xs"
-                  label="Unmapped only"
-                  checked={unmappedOnly}
-                  onChange={(e) => setUnmappedOnly(e.currentTarget.checked)}
-                />
-              </Group>
-              <Box
-                className={isDark ? 'ag-theme-alpine-dark' : 'ag-theme-alpine'}
-                style={{ height: 280, width: '100%' }}
-                data-testid="mapping-inspector-grid"
-              >
-                <AgGridReact<LinkMappingPreviewRow>
-                  rowData={rows}
-                  columnDefs={colDefs}
-                  headerHeight={32}
-                  rowHeight={32}
-                  suppressCellFocus
-                  quickFilterText={search}
-                  overlayNoRowsTemplate={
-                    '<span style="color:var(--mantine-color-dimmed);font-size:12px">No source values to inspect.</span>'
-                  }
-                />
-              </Box>
-              <Text size="xs" c="dimmed">
-                {data.source_values_total} distinct source values in{' '}
-                <Code>{data.source_column}</Code>
-                {data.truncated ? ` — showing the first ${data.rows.length}` : ''}. Mappings:{' '}
-                {data.mappings_source === 'multiqc_live'
-                  ? 'fetched live from the MultiQC reports'
-                  : data.mappings_source === 'link_config'
-                    ? 'frozen on the link'
-                    : 'none'}
-                {data.case_sensitive ? ' · case-sensitive' : ' · case-insensitive'}.
-              </Text>
-              {data.orphan_targets.length > 0 && (
-                <Text size="xs" c="dimmed">
-                  Orphan targets:{' '}
-                  {data.orphan_targets.slice(0, 12).map((t) => (
-                    <Code key={t} mr={4}>
-                      {t}
-                    </Code>
-                  ))}
-                  {data.orphan_targets.length > 12
-                    ? `… +${data.orphan_targets.length - 12} more`
-                    : ''}
-                </Text>
-              )}
-            </>
-          )}
-        </Stack>
-      </Collapse>
     </Stack>
   );
 };

--- a/depictio/viewer/src/projects/detail/LinkMappingInspector.tsx
+++ b/depictio/viewer/src/projects/detail/LinkMappingInspector.tsx
@@ -1,0 +1,393 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Code,
+  Collapse,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+  Title,
+  Tooltip,
+  useMantineColorScheme,
+} from '@mantine/core';
+import { Icon } from '@iconify/react';
+import { AgGridReact } from 'ag-grid-react';
+import type { ColDef, ICellRendererParams } from 'ag-grid-community';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+
+import { fetchLinkMappingPreview } from 'depictio-react-core';
+import type {
+  DCLink,
+  LinkMappingPreviewResponse,
+  LinkMappingPreviewRow,
+} from 'depictio-react-core';
+
+// ---------------------------------------------------------------------------
+// Mapping inspection (issue #938)
+// ---------------------------------------------------------------------------
+
+/** How the source value was matched — not how the resolved names relate to
+ *  it. `exact` in particular expands the canonical ID to every MultiQC
+ *  variant recorded for it (`S1`, `S1 - First read`, …), so the label names
+ *  the *lookup rule* and the tooltip spells out the expansion.
+ *
+ *  Keys cover both vocabularies the endpoint emits: the sample-matching ones
+ *  (`exact` / `variant` / `base` / `source-suffix`) for `sample_mapping`
+ *  links, and the resolver's own name for every other resolver. */
+const VIA_LABELS: Record<string, { label: string; help: string }> = {
+  exact: {
+    label: 'Canonical ID',
+    help: 'The value is a mapping key. It resolves to the canonical ID plus every MultiQC variant name recorded for it.',
+  },
+  variant: {
+    label: 'Variant name',
+    help: 'The value is itself one of the MultiQC variant names. It resolves to that variant only.',
+  },
+  base: {
+    label: 'Shared base ID',
+    help: 'The value matches mapping keys once read-pair / lane / replicate suffixes (_R1, _L001, _REP1…) are stripped from the keys. It resolves to every key sharing that base plus their variants.',
+  },
+  'source-suffix': {
+    label: 'Suffix-stripped value',
+    help: 'The value matched only after stripping its own read-pair / lane / replicate suffix (_R1, _L001, _REP1…).',
+  },
+  direct: {
+    label: 'Direct',
+    help: 'Passed through unchanged and matched against the target field as-is.',
+  },
+  pattern: {
+    label: 'Pattern',
+    help: "The value was substituted into the link's pattern template (e.g. {sample}.bam) to build the target name.",
+  },
+  regex: {
+    label: 'Regex',
+    help: "The value was used as a regular expression against the target field; it resolves to every target name that matched.",
+  },
+  wildcard: {
+    label: 'Wildcard',
+    help: 'The value was glob-matched (* / ?) against the target field; it resolves to every target name that matched.',
+  },
+  passthrough: {
+    label: 'No match',
+    help: 'Nothing matched. The value is passed through unchanged, so it only filters the target if that name exists there literally.',
+  },
+};
+
+/** Every column drag-resizable, sortable and column-menu filterable — the
+ *  grid is a debugging surface, so reading long variant lists must not
+ *  require leaving it. */
+const DEFAULT_COL_DEF: ColDef<LinkMappingPreviewRow> = {
+  resizable: true,
+  sortable: true,
+  filter: true,
+};
+
+interface LinkMappingInspectorProps {
+  projectId: string;
+  linkId: string;
+  /** Collapsed-by-default section with a Show/Hide toggle (the edit-modal
+   *  layout). When false the grid loads immediately and fills the host —
+   *  used by the standalone inspect modal, where the toggle is pure noise. */
+  collapsible?: boolean;
+}
+
+/**
+ * Debug/inspect view for one link's sample ↔ target mapping.
+ *
+ * Fetches `/links/{project}/{link}/mapping-preview` lazily on expand and
+ * renders every distinct source value with its resolution outcome in an AG
+ * Grid (quick-filterable, sortable), plus the target-side orphans — so a
+ * mismatch is visible from both directions instead of silently matching
+ * nothing at render time.
+ */
+export const LinkMappingInspector: React.FC<LinkMappingInspectorProps> = ({
+  projectId,
+  linkId,
+  collapsible = true,
+}) => {
+  const { colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const [expanded, setExpanded] = useState(!collapsible);
+  const [data, setData] = useState<LinkMappingPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [unmappedOnly, setUnmappedOnly] = useState(false);
+
+  useEffect(() => {
+    if (!expanded || data || loading) return;
+    setLoading(true);
+    setError(null);
+    fetchLinkMappingPreview(projectId, linkId)
+      .then(setData)
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setLoading(false));
+  }, [expanded, data, loading, projectId, linkId]);
+
+  const rows = useMemo(() => {
+    const all = data?.rows ?? [];
+    return unmappedOnly ? all.filter((r) => !r.matched) : all;
+  }, [data, unmappedOnly]);
+
+  const colDefs = useMemo<ColDef<LinkMappingPreviewRow>[]>(
+    () => [
+      {
+        headerName: 'Source value',
+        field: 'source_value',
+        flex: 1,
+        minWidth: 160,
+        tooltipField: 'source_value',
+      },
+      {
+        headerName: 'Status',
+        field: 'matched',
+        width: 120,
+        cellRenderer: (p: ICellRendererParams<LinkMappingPreviewRow>) =>
+          p.value ? (
+            <Badge size="sm" variant="light" color="teal" style={{ textTransform: 'none' }}>
+              matched
+            </Badge>
+          ) : (
+            <Badge size="sm" variant="light" color="orange" style={{ textTransform: 'none' }}>
+              unmapped
+            </Badge>
+          ),
+      },
+      {
+        headerName: 'Matched via',
+        field: 'via',
+        width: 180,
+        valueFormatter: (p) => VIA_LABELS[p.value as string]?.label ?? String(p.value ?? ''),
+        cellRenderer: (p: ICellRendererParams<LinkMappingPreviewRow>) => {
+          const via = VIA_LABELS[p.value as string];
+          if (!via) return String(p.value ?? '');
+          return (
+            <Tooltip label={via.help} withArrow multiline w={320} openDelay={200}>
+              <Text size="sm" style={{ borderBottom: '1px dotted currentColor' }} span>
+                {via.label}
+              </Text>
+            </Tooltip>
+          );
+        },
+      },
+      {
+        headerName: 'Resolves to',
+        field: 'resolved',
+        flex: 2,
+        minWidth: 220,
+        sortable: false,
+        // Variant lists routinely run past one line ("S1", "S1 - First
+        // read", …); wrapping beats a clipped single line the user can only
+        // read by dragging the column wider.
+        wrapText: true,
+        autoHeight: true,
+        cellStyle: { lineHeight: '20px', paddingTop: 6, paddingBottom: 6 },
+        valueFormatter: (p) => (Array.isArray(p.value) ? p.value.join(', ') : ''),
+        tooltipValueGetter: (p) => (Array.isArray(p.value) ? p.value.join(', ') : ''),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Stack gap="xs">
+      <Group justify="space-between" wrap="nowrap">
+        <Group gap="xs">
+          {collapsible && (
+            <>
+              <Icon icon="mdi:magnify-scan" width={18} color="var(--mantine-color-teal-6)" />
+              <Text size="sm" fw={600}>
+                Inspect mapping
+              </Text>
+            </>
+          )}
+          {data && (
+            <>
+              <Tooltip label="Source values that resolve through the link" withArrow>
+                <Badge size="sm" variant="light" color="teal" style={{ textTransform: 'none' }}>
+                  {data.matched_count} matched
+                </Badge>
+              </Tooltip>
+              <Tooltip label="Source values the link cannot map" withArrow>
+                <Badge size="sm" variant="light" color="orange" style={{ textTransform: 'none' }}>
+                  {data.unmapped_count} unmapped
+                </Badge>
+              </Tooltip>
+              {data.orphan_targets.length > 0 && (
+                <Tooltip
+                  label="Target-side samples no source value reaches"
+                  withArrow
+                >
+                  <Badge size="sm" variant="light" color="gray" style={{ textTransform: 'none' }}>
+                    {data.orphan_targets.length} orphan targets
+                  </Badge>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Group>
+        {collapsible && (
+          <Button
+            size="compact-xs"
+            variant="subtle"
+            color="teal"
+            onClick={() => setExpanded((v) => !v)}
+            rightSection={
+              <Icon icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'} width={14} />
+            }
+            data-testid="mapping-inspector-toggle"
+          >
+            {expanded ? 'Hide' : 'Show'}
+          </Button>
+        )}
+      </Group>
+      <Collapse in={expanded}>
+        <Stack gap="xs">
+          {loading && (
+            <Group gap="xs">
+              <Loader size="xs" />
+              <Text size="sm" c="dimmed">
+                Resolving every source value through the link…
+              </Text>
+            </Group>
+          )}
+          {error && (
+            <Alert color="orange" variant="light">
+              {error}
+            </Alert>
+          )}
+          {data && (
+            <>
+              <Group gap="xs" wrap="nowrap">
+                <TextInput
+                  size="xs"
+                  flex={1}
+                  placeholder="Search values…"
+                  leftSection={<Icon icon="mdi:magnify" width={14} />}
+                  value={search}
+                  onChange={(e) => setSearch(e.currentTarget.value)}
+                />
+                <Switch
+                  size="xs"
+                  label="Unmapped only"
+                  checked={unmappedOnly}
+                  onChange={(e) => setUnmappedOnly(e.currentTarget.checked)}
+                />
+              </Group>
+              <Box
+                className={isDark ? 'ag-theme-alpine-dark' : 'ag-theme-alpine'}
+                style={{ height: collapsible ? 340 : 520, width: '100%' }}
+                data-testid="mapping-inspector-grid"
+              >
+                <AgGridReact<LinkMappingPreviewRow>
+                  rowData={rows}
+                  columnDefs={colDefs}
+                  defaultColDef={DEFAULT_COL_DEF}
+                  headerHeight={34}
+                  rowHeight={32}
+                  quickFilterText={search}
+                  tooltipShowDelay={300}
+                  pagination
+                  paginationPageSize={25}
+                  paginationPageSizeSelector={[25, 50, 100]}
+                  overlayNoRowsTemplate={
+                    '<span style="color:var(--mantine-color-dimmed);font-size:12px">No source values to inspect.</span>'
+                  }
+                />
+              </Box>
+              <Text size="xs" c="dimmed">
+                {data.source_values_total} distinct source values in{' '}
+                <Code>{data.source_column}</Code>
+                {data.truncated ? ` — showing the first ${data.rows.length}` : ''}. Mappings:{' '}
+                {data.mappings_source === 'multiqc_live'
+                  ? 'fetched live from the MultiQC reports'
+                  : data.mappings_source === 'link_config'
+                    ? 'frozen on the link'
+                    : 'none'}
+                {data.case_sensitive ? ' · case-sensitive' : ' · case-insensitive'}.
+              </Text>
+              {data.orphan_targets.length > 0 && (
+                <Text size="xs" c="dimmed">
+                  Orphan targets:{' '}
+                  {data.orphan_targets.slice(0, 12).map((t) => (
+                    <Code key={t} mr={4}>
+                      {t}
+                    </Code>
+                  ))}
+                  {data.orphan_targets.length > 12
+                    ? `… +${data.orphan_targets.length - 12} more`
+                    : ''}
+                </Text>
+              )}
+            </>
+          )}
+        </Stack>
+      </Collapse>
+    </Stack>
+  );
+};
+
+interface LinkMappingModalProps {
+  opened: boolean;
+  projectId: string;
+  /** Link to inspect. Null while the modal is closed. */
+  link: DCLink | null;
+  /** Display tags for the two endpoints, resolved by the caller. */
+  sourceTag: string;
+  targetTag: string;
+  onClose: () => void;
+}
+
+/**
+ * Standalone "inspect mapping" modal — the magnifier action on a link row.
+ * Same inspector as the edit modal's section, but opened directly so reading
+ * a link's mapping doesn't mean entering an edit form.
+ */
+export const LinkMappingModal: React.FC<LinkMappingModalProps> = ({
+  opened,
+  projectId,
+  link,
+  sourceTag,
+  targetTag,
+  onClose,
+}) => (
+  // Wide on purpose: the grid carries a source value, a status, the match
+  // rule and a full variant list per row, and at Mantine's `xl` (780px) the
+  // variant list wrapped to six lines a row.
+  <Modal opened={opened} onClose={onClose} title={null} size="90%" centered padding="lg">
+    <Stack gap="md" data-testid="link-mapping-modal">
+      <Group justify="center" gap="sm">
+        <Icon icon="mdi:magnify-scan" width={32} color="var(--mantine-color-teal-6)" />
+        <Title order={3} c="teal" m={0}>
+          Inspect mapping
+        </Title>
+      </Group>
+      {link && (
+        <Group gap="xs" justify="center">
+          <Code>
+            {sourceTag}.{link.source_column}
+          </Code>
+          <Icon icon="mdi:arrow-right" width={16} />
+          <Code>{targetTag}</Code>
+          <Badge size="sm" variant="light">
+            {link.link_config?.resolver || 'direct'}
+          </Badge>
+        </Group>
+      )}
+      {link && (
+        <LinkMappingInspector projectId={projectId} linkId={link.id} collapsible={false} />
+      )}
+    </Stack>
+  </Modal>
+);
+
+export default LinkMappingInspector;

--- a/depictio/viewer/src/projects/detail/LinkMappingInspector.tsx
+++ b/depictio/viewer/src/projects/detail/LinkMappingInspector.tsx
@@ -389,5 +389,3 @@ export const LinkMappingModal: React.FC<LinkMappingModalProps> = ({
     </Stack>
   </Modal>
 );
-
-export default LinkMappingInspector;

--- a/depictio/viewer/src/projects/detail/LinksSection.tsx
+++ b/depictio/viewer/src/projects/detail/LinksSection.tsx
@@ -29,6 +29,7 @@ import {
 import type { DCLink, ResolverInfo } from 'depictio-react-core';
 
 import LinkEditModal from './LinkEditModal';
+import { LinkMappingModal } from './LinkMappingInspector';
 
 interface DataCollectionOption {
   id: string;
@@ -95,6 +96,9 @@ const LinksSection: React.FC<LinksSectionProps> = ({
   // guarantees "Target data collection" (and every other field) starts blank
   // when the user clicks Add link a second time.
   const [modalKey, setModalKey] = useState(0);
+  // Read-only mapping inspection, opened straight from a row's magnifier so
+  // checking what a link resolves to doesn't mean entering the edit form.
+  const [inspecting, setInspecting] = useState<DCLink | null>(null);
   // Collapsed by default to keep the Overview tab compact.
   const [opened, { toggle }] = useDisclosure(false);
   const [filter, setFilter] = useState('');
@@ -219,6 +223,8 @@ const LinksSection: React.FC<LinksSectionProps> = ({
     setModalOpened(true);
   };
 
+  const closeInspect = () => setInspecting(null);
+
   const closeModal = () => {
     setModalOpened(false);
     // Clear `editing` too — without this, a saved edit would leave the
@@ -229,12 +235,16 @@ const LinksSection: React.FC<LinksSectionProps> = ({
   const disabledTip = canMutate ? undefined : 'Disabled in public/demo mode';
 
   return (
-    <Paper withBorder radius="md" p="sm">
+    <Paper withBorder radius="md" p="sm" data-testid="links-section">
       {/* Same header structure as the Data Collections Manager: clickable
           title area, then the primary action, then the chevron as an
           ActionIcon on the far right. */}
       <Group justify="space-between" wrap="nowrap">
-        <UnstyledButton onClick={toggle} style={{ flex: 1, minWidth: 0 }}>
+        <UnstyledButton
+          onClick={toggle}
+          style={{ flex: 1, minWidth: 0 }}
+          data-testid="links-section-toggle"
+        >
           <Group gap="xs" wrap="nowrap">
             <Icon icon="mdi:link-variant" width={20} />
             <Title order={4}>Cross-DC links</Title>
@@ -319,8 +329,15 @@ const LinksSection: React.FC<LinksSectionProps> = ({
                     </Text>
                   </Table.Td>
                   <Table.Td>{tgtTag(link)}</Table.Td>
-                  <Table.Td>
-                    <Badge size="sm" variant="light">
+                  <Table.Td style={{ whiteSpace: 'nowrap' }}>
+                    {/* Badge clips its label by default, which made the widest
+                        resolver name read "sample_map…" once the description
+                        column claimed the slack. */}
+                    <Badge
+                      size="sm"
+                      variant="light"
+                      styles={{ label: { overflow: 'visible' } }}
+                    >
                       {link.link_config?.resolver || 'direct'}
                     </Badge>
                   </Table.Td>
@@ -340,7 +357,18 @@ const LinksSection: React.FC<LinksSectionProps> = ({
                     </Text>
                   </Table.Td>
                   <Table.Td>
-                    <Group gap={4} justify="flex-end">
+                    <Group gap={4} justify="flex-end" wrap="nowrap">
+                      <Tooltip label="Inspect mapping" withArrow>
+                        <ActionIcon
+                          variant="subtle"
+                          color="teal"
+                          onClick={() => setInspecting(link)}
+                          aria-label="Inspect mapping"
+                          data-testid="inspect-link-btn"
+                        >
+                          <Icon icon="mdi:magnify-scan" width={16} />
+                        </ActionIcon>
+                      </Tooltip>
                       <Tooltip label={disabledTip} disabled={canMutate}>
                         <ActionIcon
                           variant="subtle"
@@ -373,6 +401,15 @@ const LinksSection: React.FC<LinksSectionProps> = ({
           )}
         </ScrollArea.Autosize>
       </Collapse>
+
+      <LinkMappingModal
+        opened={!!inspecting}
+        projectId={projectId}
+        link={inspecting}
+        sourceTag={inspecting ? srcTag(inspecting) : ''}
+        targetTag={inspecting ? tgtTag(inspecting) : ''}
+        onClose={closeInspect}
+      />
 
       <LinkEditModal
         key={modalKey}

--- a/dev/playwright_debug/docs_screenshots.py
+++ b/dev/playwright_debug/docs_screenshots.py
@@ -511,6 +511,164 @@ async def _realtime_highlight(ctx: ShotContext) -> None:
     await _page_shot_current(ctx, _rb(f"realtime_highlight_{ctx.theme}"))
 
 
+# ---- Cross-DC link inspection shots ---------------------------------------
+# Driven against a project that owns at least one MultiQC `sample_mapping`
+# link (the nf-core reference projects do). The links section is collapsed by
+# default, so every shot here expands it first.
+
+
+async def _open_links_section(ctx: ShotContext) -> None:
+    """Open the project page and expand the Cross-DC links section."""
+    await ctx.page.goto(
+        f"{ctx.viewer_url}/projects/{ctx.project_id}", wait_until="domcontentloaded"
+    )
+    await ctx.page.wait_for_timeout(1_500)
+    await dismiss_notifications(ctx.page)
+    toggle = ctx.page.get_by_test_id("links-section-toggle")
+    await toggle.wait_for(state="visible", timeout=15_000)
+    await toggle.click()
+    # Wait for a row rather than a fixed delay: the list is fetched on mount.
+    await ctx.page.locator('[data-testid="inspect-link-btn"]').first.wait_for(
+        state="visible", timeout=15_000
+    )
+    await ctx.page.wait_for_timeout(400)
+
+
+@register("link_inspect_action")
+async def _link_inspect_action(ctx: ShotContext) -> None:
+    """Cross-DC links table with the per-row inspect (magnifier) action."""
+    await _open_links_section(ctx)
+    await _shot(ctx, '[data-testid="links-section"]', _rb("link_inspect_action"))
+
+
+@register("link_mapping_modal")
+async def _link_mapping_modal(ctx: ShotContext) -> None:
+    """Standalone mapping inspector, opened from a sample_mapping link's magnifier."""
+    await _open_links_section(ctx)
+    row = ctx.page.locator("tr", has_text="sample_mapping").first
+    await row.get_by_test_id("inspect-link-btn").click()
+    # The preview resolves every distinct source value server-side; wait for
+    # the grid to hold rows so the shot isn't the loading state.
+    await ctx.page.locator('[data-testid="mapping-inspector-grid"] .ag-row').first.wait_for(
+        state="visible", timeout=60_000
+    )
+    await ctx.page.wait_for_timeout(600)
+    await _shot(ctx, '[data-testid="link-mapping-modal"]', _rb("link_mapping_modal"))
+
+
+# ---- Funnel filtering shots ------------------------------------------------
+# Driven against a dashboard with categorical (MultiSelect) filters. Funnel
+# filtering is an author-level dashboard flag; these shots flip it with the
+# panel's own toggle, which is per-page-view and writes nothing.
+
+FUNNEL_PICKS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("species", ("Adelie",)),
+    ("island", ("Torgersen", "Biscoe")),
+    ("sex", ("male",)),
+)
+
+
+async def _filter_panel(ctx: ShotContext):
+    """The filter panel Paper — located from the funnel toggle it contains."""
+    return ctx.page.get_by_test_id("funnel-toggle").locator(
+        "xpath=ancestor::*[contains(@class,'mantine-Paper-root')][1]"
+    )
+
+
+async def _open_funnel_panel(ctx: ShotContext) -> None:
+    """Open the dashboard, reveal the filter panel and switch funnelling on."""
+    await ctx.page.goto(
+        f"{ctx.viewer_url}/dashboard/{ctx.dashboard_id}", wait_until="domcontentloaded"
+    )
+    await ctx.page.wait_for_timeout(6_000)
+    await dismiss_notifications(ctx.page)
+    rail = ctx.page.locator('[aria-label="Show filters"]')
+    if await rail.count() and await rail.first.is_visible():
+        await rail.first.click()
+        await ctx.page.wait_for_timeout(800)
+    toggle = ctx.page.get_by_test_id("funnel-toggle")
+    await toggle.wait_for(state="visible", timeout=20_000)
+    # The overview button is mounted-but-disabled while funnelling is off —
+    # that is the state check, since the toggle itself only varies by variant.
+    overview = ctx.page.get_by_test_id("funnel-view-button")
+    if await overview.is_disabled():
+        await toggle.click()
+        await ctx.page.wait_for_timeout(1_500)
+
+
+async def _apply_funnel_filters(ctx: ShotContext) -> None:
+    """Select the categorical values the funnel captions describe."""
+    for column, values in FUNNEL_PICKS:
+        field = ctx.page.get_by_placeholder(f"Select {column}…")
+        await field.wait_for(state="visible", timeout=15_000)
+        await field.click()
+        for value in values:
+            await ctx.page.get_by_role("option", name=value, exact=True).first.click()
+        await ctx.page.keyboard.press("Escape")
+        # Each change debounces, refetches the availability sets and re-renders.
+        await ctx.page.wait_for_timeout(2_500)
+
+
+@register("funnel_panel_header")
+async def _funnel_panel_header(ctx: ShotContext) -> None:
+    """Panel header: title, attached funnel pair, overflow menu, Reset."""
+    await _open_funnel_panel(ctx)
+    await _apply_funnel_filters(ctx)
+    box = await (await _filter_panel(ctx)).bounding_box()
+    if not box:
+        raise RuntimeError("filter panel not found")
+    await _clip_shot(
+        ctx,
+        {"x": box["x"], "y": box["y"], "width": box["width"], "height": min(box["height"], 150)},
+        _rb("funnel_panel_header"),
+    )
+
+
+@register("funnel_panel_highlighting")
+async def _funnel_panel_highlighting(ctx: ShotContext) -> None:
+    """Whole panel with funnelling on: per-value markers and n/N badges."""
+    await _open_funnel_panel(ctx)
+    await _apply_funnel_filters(ctx)
+    panel = await _filter_panel(ctx)
+    target = ctx.output_dir / f"{_rb('funnel_panel_highlighting')}.png"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    await panel.screenshot(path=str(target))
+    typer.echo(f"  → {_rel(target)}")
+
+
+async def _open_funnel_overview(ctx: ShotContext):
+    await ctx.page.get_by_test_id("funnel-view-button").click()
+    modal = ctx.page.locator(".mantine-Modal-content").first
+    await modal.wait_for(state="visible", timeout=20_000)
+    # Plotly draws after the funnel counts land; wait for the trace itself.
+    await ctx.page.locator(".mantine-Modal-content .js-plotly-plot").first.wait_for(
+        state="visible", timeout=60_000
+    )
+    await ctx.page.wait_for_timeout(1_500)
+    return modal
+
+
+@register("funnel_overview")
+async def _funnel_overview(ctx: ShotContext) -> None:
+    """Funnel overview modal: cascading row counts + the stage list."""
+    await _open_funnel_panel(ctx)
+    await _apply_funnel_filters(ctx)
+    await _open_funnel_overview(ctx)
+    await _shot(ctx, ".mantine-Modal-content", _rb("funnel_overview"))
+
+
+@register("funnel_overview_reordered")
+async def _funnel_overview_reordered(ctx: ShotContext) -> None:
+    """Same funnel with the last stage moved up — intermediate counts change,
+    the final count does not."""
+    await _open_funnel_panel(ctx)
+    await _apply_funnel_filters(ctx)
+    await _open_funnel_overview(ctx)
+    await ctx.page.locator('[aria-label^="Move "][aria-label$=" earlier"]').last.click()
+    await ctx.page.wait_for_timeout(3_000)
+    await _shot(ctx, ".mantine-Modal-content", _rb("funnel_overview_reordered"))
+
+
 # ---- CLI ------------------------------------------------------------------
 
 

--- a/packages/depictio-components/src/lib/components/DepictioMultiSelect.tsx
+++ b/packages/depictio-components/src/lib/components/DepictioMultiSelect.tsx
@@ -61,6 +61,13 @@ export interface DepictioMultiSelectProps {
   setProps?: (props: Partial<DepictioMultiSelectProps>) => void;
   /** Non-Dash React onChange handler for the React viewer use case. */
   onChange?: (value: string[]) => void;
+  /** Custom dropdown option renderer, forwarded to Mantine's MultiSelect.
+   *  Used by funnel filtering to color-mark options that still lead to a
+   *  non-empty result set. React-viewer only — Dash never sets this. */
+  renderOption?: (item: {
+    option: MultiSelectOption;
+    checked?: boolean;
+  }) => React.ReactNode;
 }
 
 const normalizeOptions = (
@@ -91,6 +98,7 @@ const DepictioMultiSelect: React.FC<DepictioMultiSelectProps> = ({
   size = 'sm',
   setProps,
   onChange,
+  renderOption,
 }) => {
   const handleChange = useCallback(
     (next: string[]) => {
@@ -135,6 +143,7 @@ const DepictioMultiSelect: React.FC<DepictioMultiSelectProps> = ({
       size={size}
       maxDropdownHeight={220}
       comboboxProps={{ withinPortal: true }}
+      renderOption={renderOption}
     />
   );
 

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -339,7 +339,9 @@ export interface DashboardData {
   /** Ordering + icons for the left panel's filter sections. */
   filter_sections?: FilterSectionSpec[];
   grid_sections?: FilterSectionSpec[];
-  /** Funnel filtering (issue #939): author-level opt-in, off by default. */
+  /** Funnel filtering (issue #939): on by default, authors opt out per
+   *  dashboard. Absent on payloads cached before the field existed, which is
+   *  why every reader tests `!== false` rather than `Boolean(...)`. */
   funnel_filtering?: boolean;
   /** Project-level realtime config — only when ``enabled === true`` should
    *  the viewer mount the WebSocket subscription / live-updates indicator. */

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -339,6 +339,8 @@ export interface DashboardData {
   /** Ordering + icons for the left panel's filter sections. */
   filter_sections?: FilterSectionSpec[];
   grid_sections?: FilterSectionSpec[];
+  /** Funnel filtering (issue #939): author-level opt-in, off by default. */
+  funnel_filtering?: boolean;
   /** Project-level realtime config — only when ``enabled === true`` should
    *  the viewer mount the WebSocket subscription / live-updates indicator. */
   project_realtime?: { enabled: boolean; debounce_ms: number };
@@ -575,6 +577,62 @@ export async function fetchBreakdown(
     { signal },
   );
   if (!res.ok) throw new Error(`Failed to fetch breakdown: ${res.status}`);
+  return res.json();
+}
+
+// =============================================================================
+// Funnel filtering (issue #939)
+// =============================================================================
+
+/** One interactive component's funnel result: which of its values still lead
+ *  to a non-empty result set under every OTHER active filter. */
+export interface FunnelTargetResult {
+  status: 'ok' | 'unrestricted' | 'unsupported' | 'error';
+  column?: string;
+  dc_id?: string;
+  values?: string[];
+  truncated?: boolean;
+}
+
+/** One stage of the funnel overview: the filter applied at this step and the
+ *  per-DC row counts after applying every filter up to and including it. */
+export interface FunnelStage {
+  index?: string;
+  label?: string | null;
+  column_name?: string | null;
+  dc_id?: string;
+  value?: unknown;
+  rows_by_dc: Record<string, number | null>;
+}
+
+export interface FunnelValuesResponse {
+  targets: Record<string, FunnelTargetResult>;
+  stages: FunnelStage[] | null;
+  initial_rows_by_dc: Record<string, number | null> | null;
+  dc_labels: Record<string, string>;
+  filter_count: number;
+}
+
+/** Compute funnel-filtering data: per-component available values under the
+ *  current filters minus each component's own selection, and (optionally) the
+ *  cumulative per-DC row counts backing the funnel overview. */
+export async function fetchFunnelValues(
+  dashboardId: string,
+  filters: unknown[],
+  targetIndexes: string[],
+  includeStages = false,
+  signal?: AbortSignal,
+): Promise<FunnelValuesResponse> {
+  const res = await authFetch(`${API_BASE}/dashboards/funnel_values/${dashboardId}`, {
+    method: 'POST',
+    body: JSON.stringify({
+      filters,
+      target_indexes: targetIndexes,
+      include_stages: includeStages,
+    }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`Failed to fetch funnel values: ${res.status}`);
   return res.json();
 }
 
@@ -3874,6 +3932,47 @@ export async function fetchMultiQCSampleMappings(
     return body.sample_mappings as Record<string, string[]>;
   }
   return (body ?? {}) as Record<string, string[]>;
+}
+
+/** One source value's resolution outcome in the mapping-inspection view. */
+export interface LinkMappingPreviewRow {
+  source_value: string;
+  matched: boolean;
+  /** exact | variant | base | source-suffix | passthrough, or the resolver
+   *  name for non-sample_mapping resolvers. */
+  via: string;
+  resolved: string[];
+}
+
+export interface LinkMappingPreviewResponse {
+  link_id: string;
+  resolver: string;
+  source_dc_id: string;
+  source_column: string;
+  target_dc_id: string;
+  target_type: string;
+  case_sensitive: boolean;
+  mappings_source: 'link_config' | 'multiqc_live' | 'none';
+  source_values_total: number;
+  truncated: boolean;
+  matched_count: number;
+  unmapped_count: number;
+  rows: LinkMappingPreviewRow[];
+  orphan_targets: string[];
+}
+
+/** Full sample ↔ link mapping table for one link — backs the debug/inspect
+ *  view in the link editor (issue #938). */
+export async function fetchLinkMappingPreview(
+  projectId: string,
+  linkId: string,
+  limit = 500,
+): Promise<LinkMappingPreviewResponse> {
+  const res = await authFetch(
+    `${API_BASE}/links/${projectId}/${linkId}/mapping-preview?limit=${limit}`,
+  );
+  if (!res.ok) await throwHttpError(res, 'Failed to fetch mapping preview');
+  return res.json();
 }
 
 // =============================================================================

--- a/packages/depictio-react-core/src/availableValues.tsx
+++ b/packages/depictio-react-core/src/availableValues.tsx
@@ -39,13 +39,39 @@ import React, {
   useState,
 } from 'react';
 
-import { fetchMultiQCSampleMappings, fetchUniqueValues, StoredMetadata } from './api';
+import {
+  fetchFunnelValues,
+  fetchMultiQCSampleMappings,
+  fetchUniqueValues,
+  InteractiveFilter,
+  StoredMetadata,
+} from './api';
+
+/** Funnel result for one interactive component (issue #939). */
+export interface FunnelComponentState {
+  status: 'ok' | 'unrestricted' | 'unsupported' | 'error';
+  /** Values that still lead to a non-empty result set — null when the
+   *  component is unrestricted (every value available). */
+  set: Set<string> | null;
+  truncated: boolean;
+}
 
 interface AvailableValuesContextValue {
-  /** Trigger a compute for this (dc_id, column) if not already done. */
-  request: (dcId: string, columnName: string) => void;
-  /** Get the cached intersection or null if not yet computed / not applicable. */
-  getSet: (dcId: string, columnName: string) => Set<string> | null;
+  /** Trigger a compute for this (dc_id, column) if not already done. When
+   *  `ownIndex` is provided the component is also registered as a funnel
+   *  target (its availability is recomputed on every filter change while the
+   *  funnel toggle is on). */
+  request: (dcId: string, columnName: string, ownIndex?: string) => void;
+  /** Get the availability Set, or null when everything is available / not yet
+   *  computed. With the funnel active and `ownIndex` given, returns the live
+   *  funnel set (filters minus the component's own selection); otherwise the
+   *  static cross-DC intersection. */
+  getSet: (dcId: string, columnName: string, ownIndex?: string) => Set<string> | null;
+  /** Whether funnel filtering is currently on (drives the colored option
+   *  markers and per-component badges). */
+  funnelActive: boolean;
+  /** Detailed funnel state for one component, or null when inactive/unknown. */
+  getFunnelState: (ownIndex: string) => FunnelComponentState | null;
 }
 
 const AvailableValuesContext =
@@ -153,15 +179,89 @@ export interface AvailableFilterValuesProviderProps {
    *  absent, multiqc DCs are skipped and the intersection falls back to
    *  whatever delta-table DCs contribute. */
   projectId?: string;
+  /** Funnel filtering (issue #939). When `enabled`, registered components'
+   *  availability is recomputed on every (debounced) filter change: the
+   *  backend answers, per component, which of its values still lead to a
+   *  non-empty result set under every OTHER active filter — cross-DC links
+   *  included. Pass the shell's debounced filter list so the funnel refetch
+   *  cadence matches figures/cards. */
+  funnel?: {
+    enabled: boolean;
+    dashboardId: string;
+    filters: InteractiveFilter[];
+  };
   children: React.ReactNode;
+}
+
+/** Stable identity for a filter list — mirrors the shell's stableFilterKey. */
+function funnelFilterKey(filters: InteractiveFilter[]): string {
+  return JSON.stringify(
+    filters
+      .map((f) => [f.index, f.source ?? null, f.value] as const)
+      .sort((a, b) => String(a[0]).localeCompare(String(b[0]))),
+  );
 }
 
 export const AvailableFilterValuesProvider: React.FC<
   AvailableFilterValuesProviderProps
-> = ({ dashboardMetadata, projectId, children }) => {
+> = ({ dashboardMetadata, projectId, funnel, children }) => {
   const [cache, setCache] = useState<Record<string, Set<string> | null>>({});
   // Tracks which keys are currently being computed so we don't double-fetch.
   const inFlightRef = useRef<Set<string>>(new Set());
+
+  // --- Funnel layer (issue #939) ---------------------------------------
+  const funnelEnabled = Boolean(funnel?.enabled && funnel.dashboardId);
+  // Components that asked for funnel data (via useAvailableSet's ownIndex).
+  const funnelTargetsRef = useRef<Set<string>>(new Set());
+  const [funnelTargetsVersion, setFunnelTargetsVersion] = useState(0);
+  const [funnelState, setFunnelState] = useState<{
+    key: string;
+    targets: Record<string, FunnelComponentState>;
+  } | null>(null);
+
+  const funnelKey = useMemo(
+    () => (funnelEnabled && funnel ? funnelFilterKey(funnel.filters) : ''),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [funnelEnabled, funnel?.filters],
+  );
+
+  useEffect(() => {
+    if (!funnelEnabled || !funnel) {
+      setFunnelState(null);
+      return;
+    }
+    const indexes = Array.from(funnelTargetsRef.current);
+    if (indexes.length === 0) return;
+
+    const controller = new AbortController();
+    // Small extra debounce on top of the shell's deferred filters: a burst of
+    // component registrations on mount collapses into one request.
+    const timer = window.setTimeout(() => {
+      fetchFunnelValues(funnel.dashboardId, funnel.filters, indexes, false, controller.signal)
+        .then((res) => {
+          const targets: Record<string, FunnelComponentState> = {};
+          for (const [index, t] of Object.entries(res.targets || {})) {
+            targets[index] = {
+              status: t.status,
+              set: t.status === 'ok' ? new Set((t.values || []).map(String)) : null,
+              truncated: Boolean(t.truncated),
+            };
+          }
+          setFunnelState({ key: funnelKey, targets });
+        })
+        .catch((err) => {
+          if (controller.signal.aborted) return;
+          console.warn('[funnel] fetchFunnelValues failed:', err);
+        });
+    }, 150);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+    // funnelKey is the stable identity of funnel.filters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [funnelEnabled, funnel?.dashboardId, funnelKey, funnelTargetsVersion]);
 
   const dcs = useMemo(
     () => collectDataDcs(dashboardMetadata),
@@ -184,7 +284,12 @@ export const AvailableFilterValuesProvider: React.FC<
   }, [dcSignature]);
 
   const request = useCallback(
-    (dcId: string, columnName: string) => {
+    (dcId: string, columnName: string, ownIndex?: string) => {
+      if (ownIndex && !funnelTargetsRef.current.has(ownIndex)) {
+        funnelTargetsRef.current.add(ownIndex);
+        // Re-arm the funnel effect so newly mounted components get computed.
+        setFunnelTargetsVersion((v) => v + 1);
+      }
       if (!dcId || !columnName) return;
       const k = key(dcId, columnName);
       if (k in cache) return;
@@ -279,14 +384,35 @@ export const AvailableFilterValuesProvider: React.FC<
     [cache, dcs, effectiveProjectId],
   );
 
-  const getSet = useCallback(
-    (dcId: string, columnName: string): Set<string> | null => {
-      return cache[key(dcId, columnName)] ?? null;
+  const getFunnelState = useCallback(
+    (ownIndex: string): FunnelComponentState | null => {
+      if (!funnelEnabled || !funnelState) return null;
+      return funnelState.targets[ownIndex] ?? null;
     },
-    [cache],
+    [funnelEnabled, funnelState],
   );
 
-  const value = useMemo(() => ({ request, getSet }), [request, getSet]);
+  const getSet = useCallback(
+    (dcId: string, columnName: string, ownIndex?: string): Set<string> | null => {
+      if (funnelEnabled && ownIndex) {
+        const st = funnelState?.targets[ownIndex];
+        if (st) {
+          if (st.status === 'ok') return st.set;
+          if (st.status === 'unrestricted') return null;
+          // unsupported / error → fall through to the static intersection.
+        }
+        // Not computed yet → static intersection keeps the display sensible
+        // while the funnel request is in flight.
+      }
+      return cache[key(dcId, columnName)] ?? null;
+    },
+    [cache, funnelEnabled, funnelState],
+  );
+
+  const value = useMemo(
+    () => ({ request, getSet, funnelActive: funnelEnabled, getFunnelState }),
+    [request, getSet, funnelEnabled, getFunnelState],
+  );
 
   return (
     <AvailableValuesContext.Provider value={value}>
@@ -305,12 +431,24 @@ export const AvailableFilterValuesProvider: React.FC<
 export function useAvailableSet(
   dcId: string | undefined,
   columnName: string | undefined,
+  ownIndex?: string,
 ): Set<string> | null {
   const ctx = useContext(AvailableValuesContext);
   useEffect(() => {
     if (!ctx || !dcId || !columnName) return;
-    ctx.request(dcId, columnName);
-  }, [ctx, dcId, columnName]);
+    ctx.request(dcId, columnName, ownIndex);
+  }, [ctx, dcId, columnName, ownIndex]);
   if (!ctx || !dcId || !columnName) return null;
-  return ctx.getSet(dcId, columnName);
+  return ctx.getSet(dcId, columnName, ownIndex);
+}
+
+/** Whether funnel filtering is active, plus this component's funnel state
+ *  (drives the colored option markers and the per-component "n/N" badge). */
+export function useFunnelState(ownIndex: string | undefined): {
+  active: boolean;
+  state: FunnelComponentState | null;
+} {
+  const ctx = useContext(AvailableValuesContext);
+  if (!ctx || !ownIndex) return { active: false, state: null };
+  return { active: ctx.funnelActive, state: ctx.getFunnelState(ownIndex) };
 }

--- a/packages/depictio-react-core/src/components/interactive/FilterPanel.tsx
+++ b/packages/depictio-react-core/src/components/interactive/FilterPanel.tsx
@@ -9,6 +9,7 @@ import {
   Box,
   Button,
   Group,
+  Menu,
   Paper,
   Stack,
   Text,
@@ -134,10 +135,10 @@ export interface FilterPanelProps {
    *  has no business knowing that. */
   footer?: React.ReactNode;
   /** Funnel filtering (issue #939). Omitted → the controls are hidden (the
-   *  dashboard hasn't opted in, or the host — e.g. the editor — doesn't wire
-   *  it). `onOpenView` opens the funnel overview modal; it's only offered
-   *  while the toggle is on, since the overview is computed by the same
-   *  opt-in machinery. */
+   *  host, e.g. the editor, doesn't wire it). `onOpenView` opens the funnel
+   *  overview modal; the button stays mounted while the toggle is off but
+   *  disabled, since the overview is computed by the same opt-in machinery
+   *  and hiding it would make the feature undiscoverable. */
   funnel?: {
     enabled: boolean;
     onToggle: () => void;
@@ -725,91 +726,126 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
               </ActionIcon>
             </Tooltip>
           )}
-          <Title order={5}>Filters</Title>
+          <Title
+            order={5}
+            style={{
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Filters
+          </Title>
           {activeCount > 0 && (
             <Badge size="sm" variant="light" circle>
               {activeCount}
             </Badge>
           )}
         </Group>
-        <Group gap={4} wrap="nowrap">
+        {/* One icon per control does not fit: the panel column is ~280px and
+            the header already carries a title, a count badge and Reset all.
+            So the two funnel controls stay out (they are the feature this
+            header is about) as one attached pair, and the panel's own display
+            preferences move into an overflow menu. */}
+        <Group gap={6} wrap="nowrap" style={{ flexShrink: 0 }}>
           {funnel && (
-            <Tooltip
-              label={
-                funnel.enabled
-                  ? 'Funnel filtering on — values with no remaining results are greyed out'
-                  : 'Enable funnel filtering'
-              }
-              withArrow
-              openDelay={400}
-            >
-              <ActionIcon
-                variant={funnel.enabled ? 'filled' : 'subtle'}
-                color={funnel.enabled ? 'teal' : 'gray'}
-                size="sm"
-                aria-label="Toggle funnel filtering"
-                aria-pressed={funnel.enabled}
-                onClick={funnel.onToggle}
-                data-testid="funnel-toggle"
+            <ActionIcon.Group>
+              <Tooltip
+                label={
+                  funnel.enabled
+                    ? 'Funnel filtering on: values with no remaining results are greyed out'
+                    : 'Enable funnel filtering'
+                }
+                withArrow
+                openDelay={400}
               >
-                <Icon icon="mdi:filter-variant" width={16} height={16} />
-              </ActionIcon>
-            </Tooltip>
-          )}
-          {funnel?.enabled && (
-            <Tooltip label="Show the funnel overview" withArrow openDelay={400}>
-              <ActionIcon
-                variant="subtle"
-                color="teal"
-                size="sm"
-                aria-label="Show funnel overview"
-                onClick={funnel.onOpenView}
-                data-testid="funnel-view-button"
+                <ActionIcon
+                  variant={funnel.enabled ? 'filled' : 'default'}
+                  color={funnel.enabled ? 'teal' : 'gray'}
+                  size="sm"
+                  aria-label="Toggle funnel filtering"
+                  aria-pressed={funnel.enabled}
+                  onClick={funnel.onToggle}
+                  data-testid="funnel-toggle"
+                >
+                  {/* Not `mdi:filter-variant`: that is the panel's own icon on
+                      the collapsed rail, so reusing it here made the toggle
+                      read as a second "filters" button. */}
+                  <Icon icon="mdi:filter-check-outline" width={16} height={16} />
+                </ActionIcon>
+              </Tooltip>
+              {/* Kept mounted while the funnel is off, disabled rather than
+                  hidden: the overview is how you find out what the funnel does,
+                  and a control that appears only once you already enabled the
+                  feature cannot teach that. It also stops the header reflowing
+                  on every toggle. */}
+              <Tooltip
+                label={
+                  funnel.enabled
+                    ? 'Show the funnel overview'
+                    : 'Enable funnel filtering to see the overview'
+                }
+                withArrow
+                openDelay={400}
               >
-                <Icon icon="mdi:chart-sankey" width={16} height={16} />
-              </ActionIcon>
-            </Tooltip>
+                <ActionIcon
+                  variant="default"
+                  color="gray"
+                  size="sm"
+                  aria-label="Show funnel overview"
+                  disabled={!funnel.enabled}
+                  onClick={funnel.onOpenView}
+                  data-testid="funnel-view-button"
+                >
+                  <Icon icon="mdi:chart-timeline-variant" width={16} height={16} />
+                </ActionIcon>
+              </Tooltip>
+            </ActionIcon.Group>
           )}
-          {collapsibleKeys.length > 0 && (
-            <Tooltip
-              label={anyOpen ? 'Collapse all' : 'Expand all'}
-              withArrow
-              openDelay={400}
-            >
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                size="sm"
-                aria-label={anyOpen ? 'Collapse all' : 'Expand all'}
-                onClick={() => collapse.setAll(collapsibleKeys, anyOpen)}
+          <Menu shadow="md" position="bottom-end" withinPortal>
+            <Menu.Target>
+              <Tooltip label="Panel options" withArrow openDelay={400}>
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                  aria-label="Panel options"
+                  data-testid="filter-panel-options"
+                >
+                  <Icon icon="mdi:dots-vertical" width={16} height={16} />
+                </ActionIcon>
+              </Tooltip>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {collapsibleKeys.length > 0 && (
+                <Menu.Item
+                  leftSection={
+                    <Icon
+                      icon={anyOpen ? 'mdi:unfold-less-horizontal' : 'mdi:unfold-more-horizontal'}
+                      width={16}
+                      height={16}
+                    />
+                  }
+                  onClick={() => collapse.setAll(collapsibleKeys, anyOpen)}
+                >
+                  {anyOpen ? 'Collapse all' : 'Expand all'}
+                </Menu.Item>
+              )}
+              <Menu.Item
+                leftSection={
+                  <Icon
+                    icon={density === 'compact' ? 'mdi:view-sequential' : 'mdi:view-headline'}
+                    width={16}
+                    height={16}
+                  />
+                }
+                onClick={toggleDensity}
               >
-                <Icon
-                  icon={anyOpen ? 'mdi:unfold-less-horizontal' : 'mdi:unfold-more-horizontal'}
-                  width={16}
-                  height={16}
-                />
-              </ActionIcon>
-            </Tooltip>
-          )}
-          <Tooltip
-            label={density === 'compact' ? 'Comfortable density' : 'Compact density'}
-            withArrow
-            openDelay={400}
-          >
-            <ActionIcon
-              variant="subtle"
-              color="gray"
-              size="sm"
-              aria-label="Toggle filter density"
-              onClick={toggleDensity}
-            >
-              <Icon
-                icon={density === 'compact' ? 'mdi:view-sequential' : 'mdi:view-headline'}
-                width={16}
-                height={16}
-              />
-            </ActionIcon>
-          </Tooltip>
+                {density === 'compact' ? 'Comfortable density' : 'Compact density'}
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
           {onResetAllFilters && (
             <Button
               leftSection={<Icon icon="bx:reset" width={12} />}
@@ -819,11 +855,11 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
               // reads as an alert on a panel that is otherwise quiet, which is
               // most of the time.
               variant={activeCount > 0 ? 'filled' : 'light'}
-              size="xs"
+              size="compact-xs"
               onClick={onResetAllFilters}
               disabled={activeCount === 0}
             >
-              Reset all
+              Reset
             </Button>
           )}
         </Group>

--- a/packages/depictio-react-core/src/components/interactive/FilterPanel.tsx
+++ b/packages/depictio-react-core/src/components/interactive/FilterPanel.tsx
@@ -726,22 +726,9 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
               </ActionIcon>
             </Tooltip>
           )}
-          <Title
-            order={5}
-            style={{
-              minWidth: 0,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
+          <Title order={5} style={{ whiteSpace: 'nowrap' }}>
             Filters
           </Title>
-          {activeCount > 0 && (
-            <Badge size="sm" variant="light" circle>
-              {activeCount}
-            </Badge>
-          )}
         </Group>
         {/* One icon per control does not fit: the panel column is ~280px and
             the header already carries a title, a count badge and Reset all.

--- a/packages/depictio-react-core/src/components/interactive/FilterPanel.tsx
+++ b/packages/depictio-react-core/src/components/interactive/FilterPanel.tsx
@@ -133,6 +133,16 @@ export interface FilterPanelProps {
    *  opaque node: the apps put the docked map panel here, and this component
    *  has no business knowing that. */
   footer?: React.ReactNode;
+  /** Funnel filtering (issue #939). Omitted → the controls are hidden (the
+   *  dashboard hasn't opted in, or the host — e.g. the editor — doesn't wire
+   *  it). `onOpenView` opens the funnel overview modal; it's only offered
+   *  while the toggle is on, since the overview is computed by the same
+   *  opt-in machinery. */
+  funnel?: {
+    enabled: boolean;
+    onToggle: () => void;
+    onOpenView: () => void;
+  };
 }
 
 function readDensity(): FilterPanelDensity {
@@ -161,6 +171,7 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
   collapsed = false,
   onToggleCollapsed,
   footer,
+  funnel,
 }) => {
   const [density, setDensity] = useState<FilterPanelDensity>(readDensity);
   const [search, setSearch] = useState('');
@@ -722,6 +733,43 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
           )}
         </Group>
         <Group gap={4} wrap="nowrap">
+          {funnel && (
+            <Tooltip
+              label={
+                funnel.enabled
+                  ? 'Funnel filtering on — values with no remaining results are greyed out'
+                  : 'Enable funnel filtering'
+              }
+              withArrow
+              openDelay={400}
+            >
+              <ActionIcon
+                variant={funnel.enabled ? 'filled' : 'subtle'}
+                color={funnel.enabled ? 'teal' : 'gray'}
+                size="sm"
+                aria-label="Toggle funnel filtering"
+                aria-pressed={funnel.enabled}
+                onClick={funnel.onToggle}
+                data-testid="funnel-toggle"
+              >
+                <Icon icon="mdi:filter-variant" width={16} height={16} />
+              </ActionIcon>
+            </Tooltip>
+          )}
+          {funnel?.enabled && (
+            <Tooltip label="Show the funnel overview" withArrow openDelay={400}>
+              <ActionIcon
+                variant="subtle"
+                color="teal"
+                size="sm"
+                aria-label="Show funnel overview"
+                onClick={funnel.onOpenView}
+                data-testid="funnel-view-button"
+              >
+                <Icon icon="mdi:chart-sankey" width={16} height={16} />
+              </ActionIcon>
+            </Tooltip>
+          )}
           {collapsibleKeys.length > 0 && (
             <Tooltip
               label={anyOpen ? 'Collapse all' : 'Expand all'}

--- a/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
+++ b/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
@@ -1,0 +1,236 @@
+/**
+ * Funnel overview modal (issue #939).
+ *
+ * Shows the cascading restriction of the applied filters as a whole: the
+ * initial row count of every delta-backed data collection, then — for each
+ * active filter, in application order — the rows remaining per DC once that
+ * filter (and every one before it) is applied. Each stage renders one
+ * Progress bar per DC, scaled against that DC's initial row count, so the
+ * "funnel" narrows visually from top to bottom.
+ *
+ * Data comes from `POST /dashboards/funnel_values/{id}` with
+ * `include_stages: true`; it is fetched when the modal opens and refetched
+ * when the filter state changes while open. Colors are Mantine theme tokens.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Box,
+  Center,
+  Divider,
+  Group,
+  Loader,
+  Modal,
+  Progress,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import { Icon } from '@iconify/react';
+
+import {
+  fetchFunnelValues,
+  FunnelStage,
+  FunnelValuesResponse,
+  InteractiveFilter,
+} from '../../api';
+
+const formatValue = (value: unknown): string => {
+  if (Array.isArray(value)) return value.map(String).join(', ');
+  if (value === null || value === undefined) return '';
+  return String(value);
+};
+
+const DcRow: React.FC<{
+  label: string;
+  rows: number | null;
+  initial: number | null;
+}> = ({ label, rows, initial }) => {
+  const pct =
+    rows !== null && initial !== null && initial > 0 ? (rows / initial) * 100 : null;
+  return (
+    <Group gap="sm" wrap="nowrap" align="center">
+      <Text size="xs" c="dimmed" style={{ width: 140, flexShrink: 0 }} truncate>
+        {label}
+      </Text>
+      <Box style={{ flex: 1 }}>
+        {pct === null ? (
+          <Text size="xs" c="dimmed">
+            n/a
+          </Text>
+        ) : (
+          <Tooltip label={`${rows} of ${initial} rows remain`} withArrow>
+            <Progress
+              value={pct}
+              size="lg"
+              radius="sm"
+              color={rows === 0 ? 'orange' : 'teal'}
+              aria-label={`${label}: ${rows} of ${initial} rows`}
+            />
+          </Tooltip>
+        )}
+      </Box>
+      <Text
+        size="xs"
+        fw={600}
+        c={rows === 0 ? 'orange' : undefined}
+        style={{ width: 90, textAlign: 'right', flexShrink: 0 }}
+      >
+        {rows === null ? '—' : `${rows} rows`}
+      </Text>
+    </Group>
+  );
+};
+
+const StageBlock: React.FC<{
+  stage: FunnelStage;
+  position: number;
+  initialRows: Record<string, number | null>;
+  dcLabels: Record<string, string>;
+}> = ({ stage, position, initialRows, dcLabels }) => {
+  const dcIds = Object.keys(stage.rows_by_dc);
+  return (
+    <Stack gap={6}>
+      <Group gap="xs" wrap="nowrap">
+        <Badge size="sm" variant="filled" color="teal" circle>
+          {position}
+        </Badge>
+        <Text size="sm" fw={600} truncate>
+          {stage.label || stage.column_name || stage.index}
+        </Text>
+        <Text size="xs" c="dimmed" truncate style={{ flex: 1 }}>
+          {formatValue(stage.value)}
+        </Text>
+      </Group>
+      <Stack gap={4} pl="xl">
+        {dcIds.map((dc) => (
+          <DcRow
+            key={dc}
+            label={dcLabels[dc] || dc.slice(0, 8)}
+            rows={stage.rows_by_dc[dc]}
+            initial={initialRows[dc] ?? null}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  );
+};
+
+export interface FunnelViewProps {
+  opened: boolean;
+  onClose: () => void;
+  dashboardId: string;
+  /** The shell's (debounced) filter list — the same one the components use. */
+  filters: InteractiveFilter[];
+}
+
+const FunnelView: React.FC<FunnelViewProps> = ({ opened, onClose, dashboardId, filters }) => {
+  const [data, setData] = useState<FunnelValuesResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filterKey = useMemo(() => JSON.stringify(filters), [filters]);
+
+  useEffect(() => {
+    if (!opened) return;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    fetchFunnelValues(dashboardId, filters, [], true, controller.signal)
+      .then((res) => setData(res))
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+    // filterKey stands in for the filters array identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened, dashboardId, filterKey]);
+
+  const initialRows = data?.initial_rows_by_dc ?? {};
+  const stages = data?.stages ?? [];
+  const dcLabels = data?.dc_labels ?? {};
+  const initialDcIds = Object.keys(initialRows);
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      size="lg"
+      title={
+        <Group gap="xs">
+          <Icon icon="mdi:chart-sankey" width={18} height={18} />
+          <Text fw={600}>Filter funnel</Text>
+        </Group>
+      }
+    >
+      {loading && (
+        <Center py="xl">
+          <Loader size="sm" />
+        </Center>
+      )}
+      {!loading && error && (
+        <Alert color="orange" title="Funnel unavailable">
+          {error}
+        </Alert>
+      )}
+      {!loading && !error && data && (
+        <Stack gap="md">
+          {stages.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              No active filters — apply a filter to see how it narrows the data.
+            </Text>
+          ) : (
+            <>
+              <Stack gap={6}>
+                <Group gap="xs" wrap="nowrap">
+                  <Badge size="sm" variant="light" color="gray" circle>
+                    0
+                  </Badge>
+                  <Text size="sm" fw={600}>
+                    Unfiltered
+                  </Text>
+                </Group>
+                <Stack gap={4} pl="xl">
+                  {initialDcIds.map((dc) => (
+                    <DcRow
+                      key={dc}
+                      label={dcLabels[dc] || dc.slice(0, 8)}
+                      rows={initialRows[dc]}
+                      initial={initialRows[dc]}
+                    />
+                  ))}
+                </Stack>
+              </Stack>
+              <Divider
+                label="filters applied in order"
+                labelPosition="center"
+              />
+              {stages.map((stage, i) => (
+                <StageBlock
+                  key={`${stage.index ?? i}`}
+                  stage={stage}
+                  position={i + 1}
+                  initialRows={initialRows}
+                  dcLabels={dcLabels}
+                />
+              ))}
+              <Text size="xs" c="dimmed">
+                Row counts cover delta-backed data collections; cross-DC
+                filters are translated through the project's links. MultiQC
+                collections have no row table and are not charted here.
+              </Text>
+            </>
+          )}
+        </Stack>
+      )}
+    </Modal>
+  );
+};
+
+export default FunnelView;

--- a/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
+++ b/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
@@ -47,16 +47,7 @@ import {
   InteractiveFilter,
 } from '../../api';
 import { applyLayoutTheme, plotlyThemeColors } from '../advanced_viz/plotlyTheme';
-
-/** Mirrors the server's `_FUNNEL_INACTIVE_VALUES`: a filter holding one of
- *  these never becomes a stage, so the reorder list must not offer it either
- *  or its rows would stop lining up with the chart's bands. */
-const isActiveFilter = (f: InteractiveFilter): boolean => {
-  const v = f.value;
-  if (v === null || v === undefined || v === false || v === '') return false;
-  if (Array.isArray(v) && v.length === 0) return false;
-  return true;
-};
+import { isFilterActive } from '../../activeFilters';
 
 const formatValue = (value: unknown): string => {
   if (Array.isArray(value)) return value.map(String).join(', ');
@@ -103,7 +94,9 @@ const FunnelView: React.FC<FunnelViewProps> = ({ opened, onClose, dashboardId, f
   /** User-chosen stage order, as component indexes. Empty = dashboard order. */
   const [order, setOrder] = useState<string[]>([]);
 
-  const activeFilters = useMemo(() => filters.filter(isActiveFilter), [filters]);
+  // Must stay the shared rule: the server zips its `stages` array positionally
+  // against this list, so a divergence mislabels every row past it.
+  const activeFilters = useMemo(() => filters.filter(isFilterActive), [filters]);
 
   // Reconcile the stored order against the live filter list: keep the ranks the
   // user set for filters that are still active, drop the ones they cleared, and

--- a/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
+++ b/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
@@ -73,6 +73,11 @@ const stageLabel = (stage: FunnelStage, position: number): string => {
   return short ? `${position}. ${name} = ${short}` : `${position}. ${name}`;
 };
 
+/** Left gutter reserved for the stage labels, in px. Sized for the longest
+ *  label `stageLabel` can emit (a position, a column name and a 24-char value)
+ *  so the chart never has to measure its own ticks. */
+const STAGE_LABEL_GUTTER = 240;
+
 type LabelMode = 'value' | 'percent initial' | 'percent previous';
 
 export interface FunnelViewProps {
@@ -218,10 +223,16 @@ const FunnelView: React.FC<FunnelViewProps> = ({ opened, onClose, dashboardId, f
     () =>
       applyLayoutTheme(
         {
-          margin: { l: 16, r: 24, t: 8, b: 24 },
+          // Fixed left margin, NOT `yaxis.automargin`. Automargin resizes the
+          // plot to fit the tick labels, the container is width:100%, and a
+          // resize feeds back into another automargin pass: inside a modal
+          // that is still animating open, the two chase each other and the
+          // renderer spins. Stage labels are length-capped by `stageLabel`, so
+          // a fixed gutter holds them without measuring.
+          margin: { l: STAGE_LABEL_GUTTER, r: 24, t: 8, b: 24 },
           // Funnel bands read top-down; Plotly's category axis defaults to
           // bottom-up, which would put "Unfiltered" at the bottom.
-          yaxis: { autorange: 'reversed', automargin: true },
+          yaxis: { autorange: 'reversed' },
           showlegend: chartedDcs.length > 1,
           legend: { orientation: 'h', y: -0.12 },
           funnelmode: 'group',
@@ -302,12 +313,15 @@ const FunnelView: React.FC<FunnelViewProps> = ({ opened, onClose, dashboardId, f
               </Group>
 
               <Box style={{ width: '100%' }}>
+                {/* `responsive: true` alone. Pairing it with react-plotly's
+                    `useResizeHandler` gives the figure two independent resize
+                    paths onto one width:100% container, which is the other
+                    half of the relayout loop the fixed margin above avoids. */}
                 <Plot
                   data={plotData as never}
                   layout={layout as never}
                   config={{ displayModeBar: false, responsive: true }}
                   style={{ width: '100%', height: chartHeight }}
-                  useResizeHandler
                 />
               </Box>
 

--- a/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
+++ b/packages/depictio-react-core/src/components/interactive/FunnelView.tsx
@@ -1,33 +1,44 @@
 /**
  * Funnel overview modal (issue #939).
  *
- * Shows the cascading restriction of the applied filters as a whole: the
- * initial row count of every delta-backed data collection, then — for each
- * active filter, in application order — the rows remaining per DC once that
- * filter (and every one before it) is applied. Each stage renders one
- * Progress bar per DC, scaled against that DC's initial row count, so the
- * "funnel" narrows visually from top to bottom.
+ * Shows the cascading restriction of the applied filters as a real Plotly
+ * funnel: one trace per delta-backed data collection, one y-band per stage,
+ * starting from the unfiltered row count and narrowing as each active filter
+ * is applied in turn. Multiple DCs render side by side in the same funnel, so
+ * a filter that guts one collection while leaving another untouched is visible
+ * at a glance.
+ *
+ * The stage order is editable. Row counts are the whole point of the view and
+ * they depend on the order the filters are applied in, so the reorder list
+ * lets you ask "what if I had filtered by run first?" without touching the
+ * dashboard's actual filter state. The final stage is order-independent (an
+ * intersection does not care about sequence); every stage above it is not.
  *
  * Data comes from `POST /dashboards/funnel_values/{id}` with
- * `include_stages: true`; it is fetched when the modal opens and refetched
- * when the filter state changes while open. Colors are Mantine theme tokens.
+ * `include_stages: true`, which applies `filters` in the order it receives
+ * them. Reordering is therefore just a client-side permutation of the request
+ * body, refetched when it changes. Colors are Mantine theme tokens.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  ActionIcon,
   Alert,
   Badge,
   Box,
   Center,
-  Divider,
   Group,
   Loader,
   Modal,
-  Progress,
+  MultiSelect,
+  SegmentedControl,
   Stack,
   Text,
   Tooltip,
+  useMantineColorScheme,
+  useMantineTheme,
 } from '@mantine/core';
 import { Icon } from '@iconify/react';
+import Plot from 'react-plotly.js';
 
 import {
   fetchFunnelValues,
@@ -35,6 +46,17 @@ import {
   FunnelValuesResponse,
   InteractiveFilter,
 } from '../../api';
+import { applyLayoutTheme, plotlyThemeColors } from '../advanced_viz/plotlyTheme';
+
+/** Mirrors the server's `_FUNNEL_INACTIVE_VALUES`: a filter holding one of
+ *  these never becomes a stage, so the reorder list must not offer it either
+ *  or its rows would stop lining up with the chart's bands. */
+const isActiveFilter = (f: InteractiveFilter): boolean => {
+  const v = f.value;
+  if (v === null || v === undefined || v === false || v === '') return false;
+  if (Array.isArray(v) && v.length === 0) return false;
+  return true;
+};
 
 const formatValue = (value: unknown): string => {
   if (Array.isArray(value)) return value.map(String).join(', ');
@@ -42,102 +64,79 @@ const formatValue = (value: unknown): string => {
   return String(value);
 };
 
-const DcRow: React.FC<{
-  label: string;
-  rows: number | null;
-  initial: number | null;
-}> = ({ label, rows, initial }) => {
-  const pct =
-    rows !== null && initial !== null && initial > 0 ? (rows / initial) * 100 : null;
-  return (
-    <Group gap="sm" wrap="nowrap" align="center">
-      <Text size="xs" c="dimmed" style={{ width: 140, flexShrink: 0 }} truncate>
-        {label}
-      </Text>
-      <Box style={{ flex: 1 }}>
-        {pct === null ? (
-          <Text size="xs" c="dimmed">
-            n/a
-          </Text>
-        ) : (
-          <Tooltip label={`${rows} of ${initial} rows remain`} withArrow>
-            <Progress
-              value={pct}
-              size="lg"
-              radius="sm"
-              color={rows === 0 ? 'orange' : 'teal'}
-              aria-label={`${label}: ${rows} of ${initial} rows`}
-            />
-          </Tooltip>
-        )}
-      </Box>
-      <Text
-        size="xs"
-        fw={600}
-        c={rows === 0 ? 'orange' : undefined}
-        style={{ width: 90, textAlign: 'right', flexShrink: 0 }}
-      >
-        {rows === null ? '—' : `${rows} rows`}
-      </Text>
-    </Group>
-  );
+/** Label for one stage's y-band. Kept short on purpose: the y axis gets a
+ *  fixed slice of the modal, and a wrapped 60-char label eats the plot. */
+const stageLabel = (stage: FunnelStage, position: number): string => {
+  const name = stage.label || stage.column_name || `Filter ${position}`;
+  const value = formatValue(stage.value);
+  const short = value.length > 24 ? `${value.slice(0, 23)}…` : value;
+  return short ? `${position}. ${name} = ${short}` : `${position}. ${name}`;
 };
 
-const StageBlock: React.FC<{
-  stage: FunnelStage;
-  position: number;
-  initialRows: Record<string, number | null>;
-  dcLabels: Record<string, string>;
-}> = ({ stage, position, initialRows, dcLabels }) => {
-  const dcIds = Object.keys(stage.rows_by_dc);
-  return (
-    <Stack gap={6}>
-      <Group gap="xs" wrap="nowrap">
-        <Badge size="sm" variant="filled" color="teal" circle>
-          {position}
-        </Badge>
-        <Text size="sm" fw={600} truncate>
-          {stage.label || stage.column_name || stage.index}
-        </Text>
-        <Text size="xs" c="dimmed" truncate style={{ flex: 1 }}>
-          {formatValue(stage.value)}
-        </Text>
-      </Group>
-      <Stack gap={4} pl="xl">
-        {dcIds.map((dc) => (
-          <DcRow
-            key={dc}
-            label={dcLabels[dc] || dc.slice(0, 8)}
-            rows={stage.rows_by_dc[dc]}
-            initial={initialRows[dc] ?? null}
-          />
-        ))}
-      </Stack>
-    </Stack>
-  );
-};
+type LabelMode = 'value' | 'percent initial' | 'percent previous';
 
 export interface FunnelViewProps {
   opened: boolean;
   onClose: () => void;
   dashboardId: string;
-  /** The shell's (debounced) filter list — the same one the components use. */
+  /** The shell's (debounced) filter list, the same one the components use. */
   filters: InteractiveFilter[];
 }
 
 const FunnelView: React.FC<FunnelViewProps> = ({ opened, onClose, dashboardId, filters }) => {
+  const theme = useMantineTheme();
+  const { colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === 'dark';
+
   const [data, setData] = useState<FunnelValuesResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [labelMode, setLabelMode] = useState<LabelMode>('value');
+  /** DC ids to chart. `null` means "all of them", which is also what we fall
+   *  back to when the user clears the selection. */
+  const [visibleDcs, setVisibleDcs] = useState<string[] | null>(null);
+  /** User-chosen stage order, as component indexes. Empty = dashboard order. */
+  const [order, setOrder] = useState<string[]>([]);
 
-  const filterKey = useMemo(() => JSON.stringify(filters), [filters]);
+  const activeFilters = useMemo(() => filters.filter(isActiveFilter), [filters]);
+
+  // Reconcile the stored order against the live filter list: keep the ranks the
+  // user set for filters that are still active, drop the ones they cleared, and
+  // append newly applied filters at the end (they were applied last, so that is
+  // where they belong until the user says otherwise).
+  const orderedFilters = useMemo(() => {
+    const byIndex = new Map(activeFilters.map((f) => [String(f.index), f]));
+    const ranked: InteractiveFilter[] = [];
+    for (const idx of order) {
+      const f = byIndex.get(idx);
+      if (f) {
+        ranked.push(f);
+        byIndex.delete(idx);
+      }
+    }
+    // Whatever the stored order did not cover keeps its natural position.
+    for (const f of activeFilters) {
+      if (byIndex.delete(String(f.index))) ranked.push(f);
+    }
+    return ranked;
+  }, [activeFilters, order]);
+
+  const reordered = useMemo(
+    () => orderedFilters.some((f, i) => String(f.index) !== String(activeFilters[i]?.index)),
+    [orderedFilters, activeFilters],
+  );
+
+  const requestKey = useMemo(
+    () => JSON.stringify(orderedFilters.map((f) => [f.index, f.value])),
+    [orderedFilters],
+  );
 
   useEffect(() => {
     if (!opened) return;
     const controller = new AbortController();
     setLoading(true);
     setError(null);
-    fetchFunnelValues(dashboardId, filters, [], true, controller.signal)
+    fetchFunnelValues(dashboardId, orderedFilters, [], true, controller.signal)
       .then((res) => setData(res))
       .catch((err) => {
         if (!controller.signal.aborted) {
@@ -148,81 +147,244 @@ const FunnelView: React.FC<FunnelViewProps> = ({ opened, onClose, dashboardId, f
         if (!controller.signal.aborted) setLoading(false);
       });
     return () => controller.abort();
-    // filterKey stands in for the filters array identity.
+    // requestKey stands in for the orderedFilters array identity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [opened, dashboardId, filterKey]);
+  }, [opened, dashboardId, requestKey]);
 
-  const initialRows = data?.initial_rows_by_dc ?? {};
-  const stages = data?.stages ?? [];
-  const dcLabels = data?.dc_labels ?? {};
-  const initialDcIds = Object.keys(initialRows);
+  const initialRows = useMemo(() => data?.initial_rows_by_dc ?? {}, [data]);
+  const stages = useMemo(() => data?.stages ?? [], [data]);
+  const dcLabels = useMemo(() => data?.dc_labels ?? {}, [data]);
+  const allDcIds = useMemo(() => Object.keys(initialRows), [initialRows]);
+
+  // Drop a stale DC selection when the dashboard's DC set changes under us.
+  useEffect(() => {
+    setVisibleDcs((cur) => {
+      if (cur === null) return null;
+      const next = cur.filter((dc) => allDcIds.includes(dc));
+      return next.length === cur.length ? cur : next;
+    });
+  }, [allDcIds]);
+
+  const chartedDcs = useMemo(() => {
+    if (visibleDcs === null || visibleDcs.length === 0) return allDcIds;
+    return allDcIds.filter((dc) => visibleDcs.includes(dc));
+  }, [allDcIds, visibleDcs]);
+
+  const moveStage = useCallback(
+    (from: number, to: number) => {
+      if (to < 0 || to >= orderedFilters.length) return;
+      const next = orderedFilters.map((f) => String(f.index));
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      setOrder(next);
+    },
+    [orderedFilters],
+  );
+
+  // One Plotly funnel trace per DC. `y` is shared across traces so the stages
+  // line up in bands; `funnelmode: 'group'` then draws the DCs side by side
+  // inside each band instead of stacking them into one misleading bar.
+  const plotData = useMemo(() => {
+    if (chartedDcs.length === 0) return [];
+    const yLabels = ['0. Unfiltered', ...stages.map((s, i) => stageLabel(s, i + 1))];
+    const palette = [
+      theme.colors.teal[6],
+      theme.colors.blue[6],
+      theme.colors.violet[6],
+      theme.colors.orange[6],
+      theme.colors.pink[6],
+      theme.colors.cyan[6],
+      theme.colors.grape[6],
+      theme.colors.lime[7],
+    ];
+    const connectorColor = plotlyThemeColors(isDark, theme).gridColor;
+    return chartedDcs.map((dc, i) => ({
+      type: 'funnel' as const,
+      name: dcLabels[dc] || dc.slice(0, 8),
+      orientation: 'h' as const,
+      y: yLabels,
+      // A stage whose count failed to load comes back null; Plotly leaves a
+      // gap for it rather than drawing a misleading zero.
+      x: [initialRows[dc] ?? null, ...stages.map((s) => s.rows_by_dc[dc] ?? null)],
+      textinfo: labelMode === 'value' ? 'value' : `value+${labelMode}`,
+      textposition: 'inside' as const,
+      hovertemplate: '%{y}<br>%{x} rows<extra>%{fullData.name}</extra>',
+      marker: { color: palette[i % palette.length] },
+      connector: { line: { color: connectorColor, width: 1 } },
+    }));
+  }, [chartedDcs, stages, initialRows, dcLabels, labelMode, theme, isDark]);
+
+  const layout = useMemo(
+    () =>
+      applyLayoutTheme(
+        {
+          margin: { l: 16, r: 24, t: 8, b: 24 },
+          // Funnel bands read top-down; Plotly's category axis defaults to
+          // bottom-up, which would put "Unfiltered" at the bottom.
+          yaxis: { autorange: 'reversed', automargin: true },
+          showlegend: chartedDcs.length > 1,
+          legend: { orientation: 'h', y: -0.12 },
+          funnelmode: 'group',
+          plot_bgcolor: 'rgba(0,0,0,0)',
+          paper_bgcolor: 'rgba(0,0,0,0)',
+        },
+        isDark,
+        theme,
+      ),
+    [chartedDcs.length, isDark, theme],
+  );
+
+  // Each band needs a fixed slice of vertical space or the funnel collapses
+  // into unreadable slivers once a dashboard applies more than three filters.
+  const chartHeight = Math.max(260, 90 + (stages.length + 1) * 46);
 
   return (
     <Modal
       opened={opened}
       onClose={onClose}
-      size="lg"
+      size="xl"
       title={
         <Group gap="xs">
-          <Icon icon="mdi:chart-sankey" width={18} height={18} />
+          <Icon icon="mdi:filter-check-outline" width={18} height={18} />
           <Text fw={600}>Filter funnel</Text>
+          {loading && data && <Loader size="xs" />}
         </Group>
       }
     >
-      {loading && (
-        <Center py="xl">
-          <Loader size="sm" />
-        </Center>
-      )}
-      {!loading && error && (
+      {error && (
         <Alert color="orange" title="Funnel unavailable">
           {error}
         </Alert>
       )}
-      {!loading && !error && data && (
+      {!error && !data && loading && (
+        <Center py="xl">
+          <Loader size="sm" />
+        </Center>
+      )}
+      {!error && data && (
         <Stack gap="md">
           {stages.length === 0 ? (
             <Text size="sm" c="dimmed">
-              No active filters — apply a filter to see how it narrows the data.
+              No active filters. Apply a filter to see how it narrows the data.
             </Text>
           ) : (
             <>
+              <Group justify="space-between" align="flex-end" wrap="wrap" gap="sm">
+                <MultiSelect
+                  size="xs"
+                  label="Data collections"
+                  placeholder="All"
+                  style={{ flex: 1, minWidth: 220 }}
+                  data={allDcIds.map((dc) => ({
+                    value: dc,
+                    label: dcLabels[dc] || dc.slice(0, 8),
+                  }))}
+                  value={visibleDcs ?? []}
+                  onChange={(v) => setVisibleDcs(v.length === 0 ? null : v)}
+                  clearable
+                  searchable
+                />
+                <Stack gap={4}>
+                  <Text size="xs" fw={500}>
+                    Bar labels
+                  </Text>
+                  <SegmentedControl
+                    size="xs"
+                    value={labelMode}
+                    onChange={(v) => setLabelMode(v as LabelMode)}
+                    data={[
+                      { value: 'value', label: 'Rows' },
+                      { value: 'percent initial', label: '% of start' },
+                      { value: 'percent previous', label: '% of previous' },
+                    ]}
+                  />
+                </Stack>
+              </Group>
+
+              <Box style={{ width: '100%' }}>
+                <Plot
+                  data={plotData as never}
+                  layout={layout as never}
+                  config={{ displayModeBar: false, responsive: true }}
+                  style={{ width: '100%', height: chartHeight }}
+                  useResizeHandler
+                />
+              </Box>
+
               <Stack gap={6}>
                 <Group gap="xs" wrap="nowrap">
-                  <Badge size="sm" variant="light" color="gray" circle>
-                    0
-                  </Badge>
                   <Text size="sm" fw={600}>
-                    Unfiltered
+                    Filter order
                   </Text>
+                  <Text size="xs" c="dimmed" style={{ flex: 1, minWidth: 0 }}>
+                    Reorder to see how the data narrows along a different path.
+                    The last stage lands on the same rows either way.
+                  </Text>
+                  {reordered && (
+                    <Tooltip label="Back to the order the filters were applied in" withArrow>
+                      <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="sm"
+                        aria-label="Reset filter order"
+                        onClick={() => setOrder([])}
+                        data-testid="funnel-order-reset"
+                      >
+                        <Icon icon="bx:reset" width={14} height={14} />
+                      </ActionIcon>
+                    </Tooltip>
+                  )}
                 </Group>
-                <Stack gap={4} pl="xl">
-                  {initialDcIds.map((dc) => (
-                    <DcRow
-                      key={dc}
-                      label={dcLabels[dc] || dc.slice(0, 8)}
-                      rows={initialRows[dc]}
-                      initial={initialRows[dc]}
-                    />
-                  ))}
+                <Stack gap={4}>
+                  {orderedFilters.map((f, i) => {
+                    const stage = stages[i];
+                    const name =
+                      stage?.label || stage?.column_name || f.column_name || String(f.index);
+                    return (
+                      <Group
+                        key={String(f.index)}
+                        gap="xs"
+                        wrap="nowrap"
+                        data-testid="funnel-order-row"
+                      >
+                        <Badge size="sm" variant="light" color="teal" circle>
+                          {i + 1}
+                        </Badge>
+                        <Text size="sm" fw={500} truncate style={{ maxWidth: 200 }}>
+                          {name}
+                        </Text>
+                        <Text size="xs" c="dimmed" truncate style={{ flex: 1, minWidth: 0 }}>
+                          {formatValue(f.value)}
+                        </Text>
+                        <ActionIcon.Group>
+                          <ActionIcon
+                            variant="default"
+                            size="sm"
+                            aria-label={`Move ${name} earlier`}
+                            disabled={i === 0}
+                            onClick={() => moveStage(i, i - 1)}
+                          >
+                            <Icon icon="mdi:chevron-up" width={14} height={14} />
+                          </ActionIcon>
+                          <ActionIcon
+                            variant="default"
+                            size="sm"
+                            aria-label={`Move ${name} later`}
+                            disabled={i === orderedFilters.length - 1}
+                            onClick={() => moveStage(i, i + 1)}
+                          >
+                            <Icon icon="mdi:chevron-down" width={14} height={14} />
+                          </ActionIcon>
+                        </ActionIcon.Group>
+                      </Group>
+                    );
+                  })}
                 </Stack>
               </Stack>
-              <Divider
-                label="filters applied in order"
-                labelPosition="center"
-              />
-              {stages.map((stage, i) => (
-                <StageBlock
-                  key={`${stage.index ?? i}`}
-                  stage={stage}
-                  position={i + 1}
-                  initialRows={initialRows}
-                  dcLabels={dcLabels}
-                />
-              ))}
+
               <Text size="xs" c="dimmed">
-                Row counts cover delta-backed data collections; cross-DC
-                filters are translated through the project's links. MultiQC
+                Row counts cover delta-backed data collections; cross-DC filters
+                are translated through the project&apos;s links. MultiQC
                 collections have no row table and are not charted here.
               </Text>
             </>

--- a/packages/depictio-react-core/src/components/interactive/MultiSelectRenderer.tsx
+++ b/packages/depictio-react-core/src/components/interactive/MultiSelectRenderer.tsx
@@ -7,7 +7,8 @@ import {
   InteractiveFilter,
   StoredMetadata,
 } from '../../api';
-import { useAvailableSet } from '../../availableValues';
+import { useAvailableSet, useFunnelState } from '../../availableValues';
+import { FunnelAvailabilityBadge, FunnelOptionMarker } from './funnelDecorations';
 import { INTERACTIVE_FRAME, InteractiveFrame, InteractiveTitle } from './frame';
 
 // Module-level cache for unique-values fetches. Keyed by `${dcId}|${column}`.
@@ -61,10 +62,13 @@ const MultiSelectRenderer: React.FC<{
 
   // Grey out values that the filter's source DC declares but that aren't
   // present in the dashboard's joined data — see `availableValues.tsx`.
+  // With funnel filtering on, the set is live instead: values that no longer
+  // lead to a non-empty result set under every OTHER active filter.
   // Sort order: available values first (so they're immediately visible),
   // then unavailable (greyed) values; alphabetical within each bucket using
   // a locale-aware natural compare so `Sample_2` sorts before `Sample_10`.
-  const availableSet = useAvailableSet(metadata.dc_id, metadata.column_name);
+  const availableSet = useAvailableSet(metadata.dc_id, metadata.column_name, metadata.index);
+  const funnel = useFunnelState(metadata.index);
   const optionItems = useMemo(() => {
     const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
     if (!availableSet) {
@@ -93,6 +97,13 @@ const MultiSelectRenderer: React.FC<{
     );
   }
 
+  // Funnel decorations: a colored dot per option (still-filterable vs
+  // exhausted) and an "n/N available" badge on the control itself.
+  const funnelHighlight = funnel.active && availableSet !== null;
+  const availableCount = funnelHighlight
+    ? options.filter((v) => availableSet!.has(v)).length
+    : null;
+
   return (
     <InteractiveFrame compact={compact}>
       <InteractiveTitle metadata={metadata} compact={compact} />
@@ -104,6 +115,16 @@ const MultiSelectRenderer: React.FC<{
           options={optionItems}
           value={selected}
           placeholder={`Select ${metadata.column_name || 'values'}…`}
+          renderOption={
+            funnelHighlight
+              ? ({ option }) => (
+                  <FunnelOptionMarker
+                    label={option.label}
+                    available={availableSet!.has(option.value)}
+                  />
+                )
+              : undefined
+          }
           onChange={(next) =>
             onChange?.({
               index: metadata.index,
@@ -114,6 +135,13 @@ const MultiSelectRenderer: React.FC<{
             })
           }
         />
+        {funnelHighlight && (
+          <FunnelAvailabilityBadge
+            available={availableCount ?? 0}
+            total={options.length}
+            truncated={funnel.state?.truncated}
+          />
+        )}
       </CompactControlSlot>
     </InteractiveFrame>
   );

--- a/packages/depictio-react-core/src/components/interactive/SegmentedControlRenderer.tsx
+++ b/packages/depictio-react-core/src/components/interactive/SegmentedControlRenderer.tsx
@@ -3,8 +3,9 @@ import { Text, SegmentedControl } from '@mantine/core';
 import { CompactControlSlot } from 'depictio-components';
 
 import { fetchUniqueValues, InteractiveFilter, StoredMetadata } from '../../api';
-import { useAvailableSet } from '../../availableValues';
+import { useAvailableSet, useFunnelState } from '../../availableValues';
 import ComponentSkeleton from '../ComponentSkeleton';
+import { FunnelAvailabilityBadge, FunnelOptionMarker } from './funnelDecorations';
 import { INTERACTIVE_FRAME, InteractiveFrame, InteractiveTitle } from './frame';
 
 /**
@@ -86,7 +87,11 @@ const SegmentedControlRenderer: React.FC<{
   // segments whose value isn't present in any other joined DC as disabled.
   // Available segments come first, then unavailable; locale-aware natural
   // sort within each bucket so `Sample_2` precedes `Sample_10`.
-  const availableSet = useAvailableSet(metadata.dc_id, metadata.column_name);
+  const availableSet = useAvailableSet(metadata.dc_id, metadata.column_name, metadata.index);
+  const funnel = useFunnelState(metadata.index);
+  // With the funnel active, segments carry a colored dot: teal = still leads
+  // to a non-empty result set, dimmed grey = exhausted by the other filters.
+  const funnelHighlight = funnel.active && availableSet !== null;
   const data = useMemo(() => {
     const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
     const sorted = [...options].sort((a, b) => {
@@ -99,10 +104,17 @@ const SegmentedControlRenderer: React.FC<{
     });
     return sorted.map((v) => ({
       value: v,
-      label: v,
+      label: funnelHighlight ? (
+        <FunnelOptionMarker label={v} available={availableSet!.has(v)} />
+      ) : (
+        v
+      ),
       disabled: availableSet ? !availableSet.has(v) : false,
     }));
-  }, [options, availableSet]);
+  }, [options, availableSet, funnelHighlight]);
+  const availableCount = funnelHighlight
+    ? options.filter((v) => availableSet!.has(v)).length
+    : null;
 
   const handleChange = useCallback(
     (next: string) => {
@@ -161,6 +173,7 @@ const SegmentedControlRenderer: React.FC<{
   }
 
   return frame(
+      <>
       <SegmentedControl
         data={data}
         value={selectedValue ?? data[0]?.value}
@@ -194,6 +207,14 @@ const SegmentedControlRenderer: React.FC<{
           },
         }}
       />
+      {funnelHighlight && (
+        <FunnelAvailabilityBadge
+          available={availableCount ?? 0}
+          total={options.length}
+          truncated={funnel.state?.truncated}
+        />
+      )}
+      </>
     );
 };
 

--- a/packages/depictio-react-core/src/components/interactive/funnelDecorations.tsx
+++ b/packages/depictio-react-core/src/components/interactive/funnelDecorations.tsx
@@ -1,0 +1,66 @@
+/**
+ * Shared funnel-filtering decorations (issue #939).
+ *
+ * Two small pieces of differential color highlighting, used by the
+ * categorical filter renderers when the dashboard's funnel toggle is on:
+ *
+ * - `FunnelOptionMarker`: an option row with a colored dot — teal for values
+ *   that still lead to a non-empty result set, dimmed grey for values the
+ *   current filter state has exhausted.
+ * - `FunnelAvailabilityBadge`: a per-component "n/N available" badge — teal
+ *   while the component can still narrow the result set, orange once nothing
+ *   (or only one value) remains selectable.
+ *
+ * Colors come from Mantine theme tokens only.
+ */
+import React from 'react';
+import { Badge, Group, Text, Tooltip } from '@mantine/core';
+
+export const FunnelOptionMarker: React.FC<{
+  label: string;
+  available: boolean;
+}> = ({ label, available }) => (
+  <Group gap={6} wrap="nowrap">
+    <span
+      aria-hidden
+      style={{
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        flexShrink: 0,
+        backgroundColor: available
+          ? 'var(--mantine-color-teal-6)'
+          : 'var(--mantine-color-gray-5)',
+        opacity: available ? 1 : 0.6,
+      }}
+    />
+    <Text size="sm" c={available ? undefined : 'dimmed'} truncate>
+      {label}
+    </Text>
+  </Group>
+);
+
+export const FunnelAvailabilityBadge: React.FC<{
+  available: number;
+  total: number;
+  truncated?: boolean;
+}> = ({ available, total, truncated }) => {
+  const exhausted = available === 0;
+  const tooltip = exhausted
+    ? 'No value of this filter matches the current result set'
+    : `${available} of ${total} values still lead to a non-empty result set` +
+      (truncated ? ' (list truncated)' : '');
+  return (
+    <Tooltip label={tooltip} withArrow>
+      <Badge
+        size="xs"
+        variant="light"
+        color={exhausted ? 'orange' : 'teal'}
+        mt={4}
+        style={{ alignSelf: 'flex-start', textTransform: 'none' }}
+      >
+        {available}/{total} available
+      </Badge>
+    </Tooltip>
+  );
+};

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -258,6 +258,9 @@ export {
   deleteProjectLink,
   listLinkResolvers,
   fetchMultiQCSampleMappings,
+  fetchLinkMappingPreview,
+  // Funnel filtering (issue #939)
+  fetchFunnelValues,
   // MultiQC management (multipart uploads)
   createMultiQCDataCollection,
   checkMultiQCUniformity,
@@ -353,11 +356,16 @@ export {
 export type { EditorFilterPayload } from './editorFilters';
 
 // Cross-DC available-values intersection (powers greying-out unavailable
-// options in interactive filter dropdowns).
+// options in interactive filter dropdowns) + the funnel-filtering layer on
+// top of it (issue #939).
 export {
   AvailableFilterValuesProvider,
   useAvailableSet,
+  useFunnelState,
 } from './availableValues';
+export type { FunnelComponentState } from './availableValues';
+export { default as FunnelView } from './components/interactive/FunnelView';
+export type { FunnelViewProps } from './components/interactive/FunnelView';
 
 // Real-time event subscription (WebSocket /events/ws)
 export { useDataCollectionUpdates, useMonitoringEvents, ADMIN_MONITORING_CHANNEL } from './realtime';
@@ -462,6 +470,12 @@ export type {
   CreateLinkInput,
   UpdateLinkInput,
   ResolverInfo,
+  LinkMappingPreviewRow,
+  LinkMappingPreviewResponse,
+  // Funnel filtering types (issue #939)
+  FunnelTargetResult,
+  FunnelStage,
+  FunnelValuesResponse,
   // MultiQC management types
   CreateMultiQCDCInput,
   MultiQCMutationResult,


### PR DESCRIPTION
## Summary

Two related deliveries in one PR: the MultiQC sample-mapping bug fix with a mapping-inspection UX (#938), and opt-in **funnel filtering** — highlighting, in every other filter, the values that still lead to a non-empty result set, plus an overview of the cascading restriction (#939).

### #938 — MultiQC sample mapping

The mapping logic existed in two diverging copies (`SampleMappingResolver` for generic cross-DC link resolution, `expand_canonical_samples_to_variants` for MultiQC figure patching) with several concrete defects, now fixed through one shared implementation (`depictio/api/v1/services/multiqc/sample_matching.py`):

- **Union instead of intersection** — in `_resolve_multiqc_sample_filter`, a direct sample filter and a metadata-DC filter were concatenated, so adding a second filter *widened* the visible samples. Every active filter is now an AND constraint and the result is the intersection of the per-filter sets.
- **Only the first metadata DC was honored** — filters from any other linked DC were silently dropped, making the outcome depend on filter ordering. Every linked metadata DC now contributes its own constraint.
- **Hardcoded `"sample"` column** for direct MultiQC filters, while the frontend accepts 7 spellings (`sample_id`, `sample_name`, …). The backend now accepts the same allowlist.
- **`{sample: []}` mappings read as unmapped** — canonical-only mappings (synthesized from `canonical_samples`) failed the truthiness check and every known sample was reported unmapped.
- **One-directional matching** — suffix stripping applied to mapping keys only. A source value that *is* a variant (`SRR001_1`) or a suffixed form of a key (`HG001_R1` vs key `HG001`) never matched. The shared matcher tries exact key → variant identity → suffix-stripped key base → suffix-stripped source value.
- **No whitespace normalization, no dedup, inconsistent case handling** between the exact and fallback lookups.
- **"Matched nothing" was indistinguishable from "no filter"** — a selection that matched no sample rendered the *full* figure. The resolver now returns `None` (no filter) vs `[]` (empty result), and render/general-stats/patching render an empty figure for the latter, with distinct cache signatures.

Two UI-side config fixes in `LinkEditModal`: MultiQC `sample_mapping` links no longer freeze the auto-loaded mappings snapshot into `link_config.mappings` (the server resolves against live report mappings, as the modal already claimed — a frozen snapshot went stale on every re-ingest), and they are stored `case_sensitive: false` (the model default `true` was never surfaced by the UI and silently made real-world links strict).

**Mapping inspector** — new `GET /links/{project}/{link}/mapping-preview` resolves every distinct source value through the link's actual resolver and reports, per value, whether and *how* it matched, plus target-side orphans. Every row in the Cross-DC links table opens it from a magnifier, so reading what a link resolves to no longer means entering the edit form. The action is read-only, so unlike Edit and Delete it stays enabled in public/demo mode:

![Cross-DC links table for nf-core/ampliseq: sixteen links with source DC, source column, target DC, resolver badge and enabled switch, each row ending in inspect, edit and delete actions](https://raw.githubusercontent.com/depictio/depictio/assets/pr-975/links-inspect-action.png)

The inspector itself is an AG Grid (quick filter, unmapped-only switch, resizable and sortable columns, pagination), with the resolved variant list wrapped rather than clipped:

![Mapping inspector modal for the metadata.sample to multiqc_data link: twelve matched source values, each resolving through Canonical ID to the sample name plus its MultiQC variants](https://raw.githubusercontent.com/depictio/depictio/assets/pr-975/mapping-inspector-live.png)

The `Matched via` column names the *lookup rule*, not the shape of the result, and each label carries a hover explanation. `Canonical ID` (the endpoint's `exact`) means the source value is a mapping key, and a key expands to the canonical ID **plus** every MultiQC variant recorded for it — which is why `SRR10070130` resolves to `SRR10070130 - First read: Adapter 1` and friends. It was labelled "Exact key" before, which read as a claim about the resolved names. Non-`sample_mapping` links report the resolver's own name (`direct`, `pattern`, `regex`, `wildcard`), which the grid now labels and explains too.

### #939 — Funnel filtering

New `POST /dashboards/funnel_values/{dashboard}` answers, per interactive component: given every OTHER active filter (the component's own selection excluded), which of its values still yield a non-empty result set. It reuses the exact cross-DC pipeline the figure/table renders use (`_resolve_link_filters_cached` → `_build_filter_metadata` → `load_deltatable_lite`), so the funnel works across linked data collections, multi-hop links included. MultiQC-backed sample filters go through the (fixed) `_resolve_multiqc_sample_filter` intersection and project back onto canonical sample IDs.

In the viewer, with the toggle on, values that can still narrow the data carry a teal marker; exhausted values are dimmed, disabled and sorted last, and each control shows an `n/N available` badge (orange when nothing remains):

![Filter panel with funnel filtering on: Species, Island and Sex each carrying an n/N available badge under the control, above the live Palmer Penguins filter set](https://raw.githubusercontent.com/depictio/depictio/assets/pr-975/funnel-panel-highlighting-v2.png)

The panel header was reworked at the same time. The funnel toggle previously reused `mdi:filter-variant`, the same icon the collapsed rail uses for the panel itself, so two unrelated controls carried one symbol; and four icon buttons plus Reset did not fit a ~280px column. The two funnel controls are now one attached pair with distinct icons, expand-all and density moved into an overflow menu, and the active-filter count badge was dropped from the header: `ActiveFilterSummary` states it one line below ("3 filters active"), and being conditional the badge appeared and vanished mid-session, shoving the title until "Filters" itself was ellipsed away. The overview button stays mounted but disabled while the funnel is off, so toggling no longer reflows the header:

![Filter panel header: the Filters title in full, the attached funnel toggle and overview pair, an overflow menu and Reset, with the active count shown by the summary row underneath](https://raw.githubusercontent.com/depictio/depictio/assets/pr-975/funnel-panel-header-v2.png)

The funnel itself, the cascading restriction across the applied filters as a whole, opens from the panel (`include_stages: true`). It is a real Plotly `funnel`: one trace per delta-backed data collection, one y-band per stage, starting at the unfiltered row count and narrowing as each filter is applied. Multiple collections render side by side (`funnelmode: 'group'`) in each band, so a filter that guts one collection while leaving another intact is visible at a glance. Bars are labelled with rows, % of start, or % of previous:

![Funnel overview: a Plotly funnel narrowing 342 unfiltered rows to 151 after Species = Adelie, 95 after Island = Torgersen, Biscoe, and 45 after Sex = male, with the reorderable stage list below](https://raw.githubusercontent.com/depictio/depictio/assets/pr-975/funnel-overview-modal-v2.png)

The stage order is editable, because the row counts depend on the order the filters are applied in. Moving Sex ahead of Island re-runs the same three filters along a different path: the intermediate stage becomes 73 instead of 95, while the last stage still lands on the same 45 rows, since an intersection does not care about sequence. That invariant is what makes the intermediate stages the interesting part, and the caption in the modal says so:

![The same funnel with Sex moved ahead of Island: the middle stage now reads 73 instead of 95, and the final stage is still 45](https://raw.githubusercontent.com/depictio/depictio/assets/pr-975/funnel-overview-reordered-v2.png)

Reordering is a client-side permutation of the request body (the endpoint already applied `filters` in the order it received them), so it costs one refetch and no new server semantics. Up/down controls rather than drag-and-drop: the list runs 2 to 12 rows, it stays keyboard-operable, and it adds no dependency.

### Design decisions (as asked)

- **"Still filterable" computation**: current combined filter state minus the target component's own selection, evaluated server-side against the same runtime-filter pipeline the renders use — no new query semantics, one batched request per (debounced) filter change for all registered components.
- **Toggle**: one **global** toggle gating both affordances (per-option/per-component highlighting *and* the overview button). `funnel_filtering: bool` on the dashboard model (default **on**: knowing which values still lead somewhere is the point of a filter panel, so authors opt out rather than in, at the cost of one availability query per filter change) is the author-level default, set via a Switch in the editor's settings drawer and round-tripping through YAML export/import; the filter-panel button flips it per page view without writing (viewers may lack edit rights).
- **Scope v1**: categorical controls (MultiSelect/Select/SegmentedControl) get the live sets; sliders/date pickers are untouched. The funnel overview counts delta-backed DCs (MultiQC DCs have no row table). Caps: 32 targets, 12 stages, 1000 values per component.
- **PR #969 compatibility**: #969 is still open, so nothing here depends on its code. The funnel layer reads only the provider's `dashboardMetadata`/`filters` props and never touches `floatingFilters.ts`; when #969 lands and `App.tsx` switches those props to the family-wide `summaryMetadata` + hydrated cross-tab filters, the funnel covers persistent controls with no further work. Only trivial merge surfaces (the provider call site in `App.tsx`, adjacent-but-distinct dashboard model fields).

### Out of scope (documented follow-ups)

Unifying the MultiQC render path onto the resolver registry entirely (it still bypasses `link_config.resolver`), `_find_link_for_resolution` first-match-wins when two links share a DC pair, and the process-salted `hash()` in the link-resolution cache key.

Every screenshot above is a live-stack capture: the funnel ones against the seeded Palmer Penguins dashboard (Species = Adelie, Island = Torgersen + Biscoe, Sex = male), the mapping-inspector ones against the seeded nf-core/ampliseq project. All six are registered shots in `dev/playwright_debug/docs_screenshots.py`, so they can be re-taken with one command rather than driven by hand. The flows are covered by the unit/API tests below.

## Type of change
- [x] Bugfix
- [x] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
Closes #938
Closes #939

## How was this tested?
- New `tests/api/v1/test_sample_matching.py` (9 tests) pinning the shared matcher: canonical-only mappings, variant identity, source-suffix stripping, whitespace, dedup, over-strip guards, per-value match detail.
- 5 regression tests added to `test_sample_mapping_resolver.py` (26 total, all previous expectations preserved).
- New `tests/api/v1/endpoints/dashboards_endpoints/test_multiqc_sample_filter.py` (8 tests): intersection semantics, every-metadata-DC contribution, order independence, sample-column spellings, `None` vs `[]`.
- New `tests/api/v1/endpoints/links_endpoints/test_mapping_preview.py` (3 tests) and `tests/api/v1/endpoints/dashboards_endpoints/test_funnel_values.py` (6 tests: own-selection exclusion, unrestricted, cumulative stages, inactive filters).
- Full `tests/{api,models,cli,unit}`: **2240 passed, 15 skipped**; the 3 `test_s3_backup_integration` setup errors need a live MinIO and fail identically on `main`.
- `tsc --noEmit` clean on `depictio/viewer`, `packages/depictio-react-core`, `packages/depictio-components`; `ruff` + `ty check depictio/models/` clean.
- `pre-commit run --all-files`: all hooks touching this diff pass; the `helm-lint` (no `helm` binary in this environment) and `shellcheck` (pre-existing warnings in untouched scripts) failures are unrelated.
- No dashboard YAML touched. No seed under `depictio/projects/` carries `funnel_filtering`, so they all inherit the new `true` default and need no regeneration; a dashboard saved with an explicit `false` keeps it and stays opted out.
- No new Playwright spec: the filter-interaction flows above are covered at the unit/API level. Six capture shots were added to `dev/playwright_debug/docs_screenshots.py` instead (`link_inspect_action`, `link_mapping_modal`, `funnel_panel_header`, `funnel_panel_highlighting`, `funnel_overview`, `funnel_overview_reordered`); each was run against a live dev stack and waits on rendered artefacts rather than fixed delays.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed

