### PR TITLE
feat(admin): backup & restore UI + backup/restore flow simplification

### DIFF
--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -795,7 +795,25 @@ class BackupConfig(BaseSettings):
     backup_s3_secret_key: Optional[str] = Field(default=None, description="Backup S3 secret key")
     backup_s3_region: str = Field(default="us-east-1", description="Backup S3 region")
     compress_local_backups: bool = Field(default=True, description="Compress local S3 data backups")
-    backup_file_retention_days: int = Field(default=30, description="Days to retain backup files")
+    backup_file_retention_days: int = Field(
+        default=30,
+        description=(
+            "Days to retain backup files. Applied to the MongoDB backup directory after "
+            "every backup (scheduled or manual). Set to 0 to keep backups forever."
+        ),
+    )
+    auto_backup_enabled: bool = Field(
+        default=False,
+        description=(
+            "Run scheduled MongoDB backups in the background. Opt-in: a deployment that "
+            "has not sized its backup volume should not start filling it on upgrade."
+        ),
+    )
+    auto_backup_interval_hours: int = Field(
+        default=24,
+        ge=1,
+        description="Hours between scheduled backups when auto_backup_enabled is true.",
+    )
     migration_allowed_s3_endpoints: list[str] | str = Field(
         default_factory=list,
         description=(

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -832,6 +832,15 @@ class BackupConfig(BaseSettings):
         ge=1,
         description="Hours between scheduled backups when auto_backup_enabled is true.",
     )
+    auto_backup_time_of_day: Optional[str] = Field(
+        default=None,
+        description=(
+            "Time of day to anchor scheduled backups to, as 'HH:MM' on a 24-hour clock "
+            "in UTC (e.g. '03:00'). Slots then sit on a fixed grid from that time, so a "
+            "daily backup lands at it every day. Unset leaves the schedule rolling: due "
+            "whenever an interval has passed since the last run."
+        ),
+    )
     migration_allowed_s3_endpoints: list[str] | str = Field(
         default_factory=list,
         description=(

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -798,8 +798,26 @@ class BackupConfig(BaseSettings):
     backup_file_retention_days: int = Field(
         default=30,
         description=(
-            "Days to retain backup files. Applied to the MongoDB backup directory after "
-            "every backup (scheduled or manual). Set to 0 to keep backups forever."
+            "Days to keep every backup file. First tier of the retention policy, applied "
+            "to the MongoDB backup directory after every backup (scheduled or manual). "
+            "Set to 0 to keep backups forever."
+        ),
+    )
+    backup_retention_weekly_weeks: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Second retention tier: after backup_file_retention_days, keep one backup per "
+            "ISO week for this many weeks. 0 disables the tier, which makes retention a "
+            "plain age cutoff."
+        ),
+    )
+    backup_retention_monthly_months: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Third retention tier: after the weekly tier, keep one backup per calendar "
+            "month for this many months. 0 disables the tier."
         ),
     )
     auto_backup_enabled: bool = Field(

--- a/depictio/api/v1/endpoints/backup_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/backup_endpoints/routes.py
@@ -1,3 +1,4 @@
+import calendar
 import hashlib
 import json
 import os
@@ -172,19 +173,105 @@ def _write_backup_file(backup_payload: dict, backup_id: str) -> str:
     return backup_filename
 
 
+def _parse_backup_created(filename: str) -> datetime | None:
+    """Creation time of a backup from its filename, or None if it is not one.
+
+    The age comes from the ``backup_id`` in the filename rather than the file's
+    mtime: mtimes do not survive a volume restore or an rsync, and the id is the
+    creation timestamp by construction.
+    """
+    if not (filename.startswith("depictio_backup_") and filename.endswith(".json")):
+        return None
+    backup_id = filename[len("depictio_backup_") : -len(".json")]
+    if not _BACKUP_ID_PATTERN.fullmatch(backup_id):
+        return None
+    try:
+        return datetime.strptime(backup_id, "%Y%m%d_%H%M%S")
+    except ValueError:
+        return None
+
+
+def _subtract_months(moment: datetime, months: int) -> datetime:
+    """Step back whole calendar months, clamping the day to the target month.
+
+    The monthly tier is expressed in calendar months, so its boundary cannot be
+    a fixed number of days without drifting against the buckets it is meant to
+    bound (31 March minus one month is 28 February, not 3 March).
+    """
+    month_index = (moment.year * 12 + moment.month - 1) - months
+    year, month = divmod(month_index, 12)
+    day = min(moment.day, calendar.monthrange(year, month + 1)[1])
+    return moment.replace(year=year, month=month + 1, day=day)
+
+
+def select_expired_backups(
+    backups: list[tuple[datetime, str]],
+    now: datetime,
+    retention_days: int,
+    weekly_weeks: int,
+    monthly_months: int,
+) -> list[str]:
+    """Apply the grandfather-father-son policy; return the filenames to delete.
+
+    Three tiers, each covering the age range where the one before it stops:
+
+    - every backup younger than ``retention_days`` is kept;
+    - for the next ``weekly_weeks`` weeks, the newest backup of each ISO week;
+    - for the next ``monthly_months`` calendar months, the newest of each month.
+
+    Anything older than the last tier, or landing in a bucket a newer backup
+    already fills, is expired. With both tier sizes at 0 this reduces exactly to
+    a plain ``retention_days`` age cutoff, which is what a deployment that never
+    touches the tiers keeps getting. ``retention_days <= 0`` means keep forever.
+
+    A backup kept by an earlier tier also fills its week and month buckets, so a
+    week that still has a daily-tier survivor does not additionally retain a
+    weekly copy of itself.
+
+    Pure and total: takes the clock as an argument and touches no filesystem, so
+    the policy can be tested directly over a set of dates.
+    """
+    if retention_days <= 0:
+        return []
+
+    daily_cutoff = now - timedelta(days=retention_days)
+    weekly_cutoff = daily_cutoff - timedelta(weeks=weekly_weeks)
+    monthly_cutoff = _subtract_months(weekly_cutoff, monthly_months)
+
+    expired: list[str] = []
+    kept_weeks: set[tuple[int, int]] = set()
+    kept_months: set[tuple[int, int]] = set()
+
+    # Newest first: the first backup to reach a bucket is the one that fills it.
+    for created, filename in sorted(backups, reverse=True):
+        week = created.isocalendar()[:2]
+        month = (created.year, created.month)
+
+        if created >= daily_cutoff:
+            kept_weeks.add(week)
+            kept_months.add(month)
+        elif created >= weekly_cutoff and week not in kept_weeks:
+            kept_weeks.add(week)
+            kept_months.add(month)
+        elif monthly_cutoff <= created < weekly_cutoff and month not in kept_months:
+            kept_months.add(month)
+        else:
+            expired.append(filename)
+
+    return expired
+
+
 def prune_expired_backups() -> int:
-    """Delete backups older than ``backup_file_retention_days``; return the count.
+    """Delete the backups the retention policy no longer covers; return the count.
 
     Runs after every backup, scheduled or manual — nothing else prunes this
     directory, and each snapshot is the size of the whole database, so without
     this the backup volume grows without bound.
 
-    The age comes from the ``backup_id`` in the filename rather than the file's
-    mtime: mtimes do not survive a volume restore or an rsync, and the id is the
-    creation timestamp by construction. Files that do not parse are left alone.
-    Retention <= 0 means "keep forever". Never raises.
+    Files that do not parse as a backup are left alone. Never raises.
     """
-    retention_days = get_backup_schedule_config()["retention_days"]
+    config = get_backup_schedule_config()
+    retention_days = config["retention_days"]
     if retention_days <= 0:
         return 0
 
@@ -192,26 +279,28 @@ def prune_expired_backups() -> int:
     if not os.path.isdir(backup_dir):
         return 0
 
-    cutoff = datetime.now() - timedelta(days=retention_days)
-    removed = 0
     try:
         filenames = os.listdir(backup_dir)
     except OSError as exc:
         logger.warning(f"Backup retention: cannot list {backup_dir}: {exc}")
         return 0
 
+    backups = []
     for filename in filenames:
-        if not (filename.startswith("depictio_backup_") and filename.endswith(".json")):
-            continue
-        backup_id = filename[len("depictio_backup_") : -len(".json")]
-        if not _BACKUP_ID_PATTERN.fullmatch(backup_id):
-            continue
-        try:
-            created = datetime.strptime(backup_id, "%Y%m%d_%H%M%S")
-        except ValueError:
-            continue
-        if created >= cutoff:
-            continue
+        created = _parse_backup_created(filename)
+        if created is not None:
+            backups.append((created, filename))
+
+    expired = select_expired_backups(
+        backups,
+        datetime.now(),
+        retention_days,
+        config["weekly_weeks"],
+        config["monthly_months"],
+    )
+
+    removed = 0
+    for filename in expired:
         backup_path = os.path.join(backup_dir, filename)
         try:
             os.remove(backup_path)
@@ -224,7 +313,9 @@ def prune_expired_backups() -> int:
 
     if removed:
         logger.info(
-            f"Backup retention: removed {removed} backup(s) older than {retention_days} days"
+            f"Backup retention: removed {removed} backup(s) outside the policy "
+            f"(keep {retention_days}d, then {config['weekly_weeks']}w, "
+            f"then {config['monthly_months']}m)"
         )
     return removed
 
@@ -285,6 +376,44 @@ def claim_auto_backup_slot(interval_seconds: int) -> datetime | None:
     return now if claimed else None
 
 
+#: ``_id`` of the document naming the backup this deployment's data was last
+#: restored from. Lives beside the scheduler state, in a collection that restore
+#: never touches — a document inside a restored collection would be overwritten
+#: by the very restore it is meant to record.
+LAST_RESTORE_STATE_ID = "last_restore_state"
+
+
+def record_last_restore(backup_id: str, restored_by: str) -> None:
+    """Remember which backup was just restored. Never raises.
+
+    A bookkeeping failure must not turn a completed restore into an error the
+    caller sees, so this only logs.
+    """
+    try:
+        initialization_collection.update_one(
+            {"_id": LAST_RESTORE_STATE_ID},
+            {
+                "$set": {
+                    "backup_id": backup_id,
+                    "restored_at": datetime.now(timezone.utc),
+                    "restored_by": restored_by,
+                }
+            },
+            upsert=True,
+        )
+    except Exception as exc:
+        logger.warning(f"Could not record the last restore: {exc}")
+
+
+def get_last_restore_state() -> dict:
+    """Read the last-restore marker. Never raises."""
+    try:
+        return initialization_collection.find_one({"_id": LAST_RESTORE_STATE_ID}) or {}
+    except Exception as exc:
+        logger.warning(f"Could not read the last restore state: {exc}")
+        return {}
+
+
 def get_auto_backup_state() -> dict:
     """Read the scheduled-backup state document. Never raises."""
     try:
@@ -296,7 +425,13 @@ def get_auto_backup_state() -> dict:
 
 #: Schedule fields an admin can change from the Backups tab. Everything else
 #: about backups (paths, S3 targets, credentials) stays deployment configuration.
-SCHEDULE_FIELDS = ("enabled", "interval_hours", "retention_days")
+SCHEDULE_FIELDS = (
+    "enabled",
+    "interval_hours",
+    "retention_days",
+    "weekly_weeks",
+    "monthly_months",
+)
 
 
 def get_backup_schedule_config() -> dict:
@@ -315,6 +450,8 @@ def get_backup_schedule_config() -> dict:
         "enabled": settings.backup.auto_backup_enabled,
         "interval_hours": settings.backup.auto_backup_interval_hours,
         "retention_days": settings.backup.backup_file_retention_days,
+        "weekly_weeks": settings.backup.backup_retention_weekly_weeks,
+        "monthly_months": settings.backup.backup_retention_monthly_months,
     }
     state = get_auto_backup_state()
     overrides = {field: state[field] for field in SCHEDULE_FIELDS if field in state}
@@ -560,6 +697,10 @@ class BackupListItem(BaseModel):
     total_documents: int = 0
     collections: list[str] = []
     depictio_version: str | None = None
+    # Set only on the backup this deployment's data was last restored from, so
+    # the admin can tell which snapshot the live data actually came from.
+    restored_at: str | None = None
+    restored_by: str | None = None
     # False for legacy backups without a .sha256 sidecar — those can only be
     # restored with allow_unverified=true.
     has_checksum: bool = False
@@ -626,6 +767,9 @@ class BackupScheduleResponse(BaseModel):
     enabled: bool
     interval_hours: int
     retention_days: int
+    # Grandfather-father-son tiers past retention_days; 0 means the tier is off.
+    weekly_weeks: int = 0
+    monthly_months: int = 0
     last_run: str | None = None
     next_run: str | None = None
     # True once any field has been set from the Backups tab, so the UI can say
@@ -642,6 +786,10 @@ class BackupScheduleUpdate(BaseModel):
     interval_hours: int | None = Field(default=None, ge=1, le=8760)
     # 0 means "keep forever"; ten years is the ceiling.
     retention_days: int | None = Field(default=None, ge=0, le=3650)
+    # Retention tiers past retention_days. 0 turns a tier off; the ceilings are
+    # generous enough for any real policy while still rejecting typos.
+    weekly_weeks: int | None = Field(default=None, ge=0, le=520)
+    monthly_months: int | None = Field(default=None, ge=0, le=120)
 
 
 def _schedule_response() -> BackupScheduleResponse:
@@ -663,6 +811,8 @@ def _schedule_response() -> BackupScheduleResponse:
         enabled=config["enabled"],
         interval_hours=config["interval_hours"],
         retention_days=config["retention_days"],
+        weekly_weeks=config["weekly_weeks"],
+        monthly_months=config["monthly_months"],
         last_run=last_run.isoformat() if last_run else None,
         next_run=next_run.isoformat() if next_run else None,
         is_customized=config["is_customized"],
@@ -740,6 +890,11 @@ async def list_backups(
         if not os.path.exists(backup_dir):
             return BackupListResponse(success=True, backups=[], count=0)
 
+        # Read once for the whole listing rather than per row.
+        last_restore = get_last_restore_state()
+        restored_backup_id = last_restore.get("backup_id")
+        restored_at = _as_utc(last_restore.get("restored_at"))
+
         backup_files = []
         for filename in os.listdir(backup_dir):
             if filename.startswith("depictio_backup_") and filename.endswith(".json"):
@@ -767,6 +922,16 @@ async def list_backups(
                         depictio_version=metadata.get("depictio_version"),
                         has_checksum=has_checksum,
                         is_automatic=bool(metadata.get("automatic", False)),
+                        restored_at=(
+                            restored_at.isoformat()
+                            if restored_at and backup_id == restored_backup_id
+                            else None
+                        ),
+                        restored_by=(
+                            last_restore.get("restored_by")
+                            if backup_id == restored_backup_id
+                            else None
+                        ),
                     )
                 except Exception:
                     # If can't read metadata, just use file info
@@ -776,6 +941,16 @@ async def list_backups(
                         size_mb=round(file_stat.st_size / (1024 * 1024), 2),
                         created=datetime.fromtimestamp(file_stat.st_ctime).isoformat(),
                         has_checksum=has_checksum,
+                        restored_at=(
+                            restored_at.isoformat()
+                            if restored_at and backup_id == restored_backup_id
+                            else None
+                        ),
+                        restored_by=(
+                            last_restore.get("restored_by")
+                            if backup_id == restored_backup_id
+                            else None
+                        ),
                     )
 
                 backup_files.append(backup_info)
@@ -1219,6 +1394,12 @@ async def restore_backup(
                     "status": "failed",
                     "error": "restore failed",
                 }
+
+        # Mark the source only once the restore actually stuck: a partial
+        # restore leaves the deployment in a state no single backup describes,
+        # so labelling a row "restored" there would be a lie.
+        if not errors:
+            record_last_restore(request.backup_id, current_user.email)
 
         return BackupRestoreResponse(
             success=len(errors) == 0,

--- a/depictio/api/v1/endpoints/backup_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/backup_endpoints/routes.py
@@ -343,7 +343,41 @@ def _as_utc(value: datetime | None) -> datetime | None:
     return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
 
 
-def claim_auto_backup_slot(interval_seconds: int) -> datetime | None:
+#: An "HH:MM" time-of-day anchor, 24-hour clock. Empty string clears the anchor.
+_TIME_OF_DAY_PATTERN = re.compile(r"^([01]\d|2[0-3]):([0-5]\d)$")
+
+
+def parse_time_of_day(value: str | None) -> int | None:
+    """Minutes from midnight UTC for an "HH:MM" anchor, or None if unset/invalid.
+
+    Invalid input degrades to "no anchor" rather than raising: a malformed value
+    in the environment should leave the schedule rolling, not stop it backing up.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    match = _TIME_OF_DAY_PATTERN.fullmatch(value.strip())
+    if not match:
+        return None
+    return int(match.group(1)) * 60 + int(match.group(2))
+
+
+def scheduled_slot(now: datetime, interval_seconds: int, anchor_minutes: int) -> datetime:
+    """The most recent scheduled slot at or before ``now``.
+
+    Slots sit on a fixed grid anchored at the chosen time of day, so a daily
+    backup lands at that time every day, and a six-hourly one lands at that time
+    and every six hours after it. Anchoring to a fixed epoch rather than to the
+    last run is what stops the schedule drifting later and later: a run that
+    fires a few minutes late does not push tomorrow's slot back with it.
+    """
+    base = datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=anchor_minutes)
+    elapsed = (now - base).total_seconds()
+    return base + timedelta(seconds=(elapsed // interval_seconds) * interval_seconds)
+
+
+def claim_auto_backup_slot(
+    interval_seconds: int, anchor_minutes: int | None = None
+) -> datetime | None:
     """Claim the right to take the next scheduled backup, across all workers.
 
     Every API worker runs the scheduler loop — gating on the initialization
@@ -356,6 +390,12 @@ def claim_auto_backup_slot(interval_seconds: int) -> datetime | None:
     Returns the claim time, or None when the slot is not due or is already taken.
     """
     now = datetime.now(timezone.utc)
+    # Without an anchor the schedule stays rolling: due once an interval has
+    # passed since the last run, wherever in the day that lands.
+    if anchor_minutes is None:
+        due_filter = {"$lte": now - timedelta(seconds=interval_seconds)}
+    else:
+        due_filter = {"$lt": scheduled_slot(now, interval_seconds, anchor_minutes)}
     try:
         initialization_collection.update_one(
             {"_id": AUTO_BACKUP_STATE_ID},
@@ -363,10 +403,7 @@ def claim_auto_backup_slot(interval_seconds: int) -> datetime | None:
             upsert=True,
         )
         claimed = initialization_collection.find_one_and_update(
-            {
-                "_id": AUTO_BACKUP_STATE_ID,
-                "last_run_at": {"$lte": now - timedelta(seconds=interval_seconds)},
-            },
+            {"_id": AUTO_BACKUP_STATE_ID, "last_run_at": due_filter},
             {"$set": {"last_run_at": now}},
         )
     except Exception as exc:
@@ -431,6 +468,7 @@ SCHEDULE_FIELDS = (
     "retention_days",
     "weekly_weeks",
     "monthly_months",
+    "time_of_day",
 )
 
 
@@ -452,6 +490,7 @@ def get_backup_schedule_config() -> dict:
         "retention_days": settings.backup.backup_file_retention_days,
         "weekly_weeks": settings.backup.backup_retention_weekly_weeks,
         "monthly_months": settings.backup.backup_retention_monthly_months,
+        "time_of_day": settings.backup.auto_backup_time_of_day,
     }
     state = get_auto_backup_state()
     overrides = {field: state[field] for field in SCHEDULE_FIELDS if field in state}
@@ -770,6 +809,8 @@ class BackupScheduleResponse(BaseModel):
     # Grandfather-father-son tiers past retention_days; 0 means the tier is off.
     weekly_weeks: int = 0
     monthly_months: int = 0
+    # "HH:MM" UTC anchor for the schedule grid; null means a rolling schedule.
+    time_of_day: str | None = None
     last_run: str | None = None
     next_run: str | None = None
     # True once any field has been set from the Backups tab, so the UI can say
@@ -790,6 +831,9 @@ class BackupScheduleUpdate(BaseModel):
     # generous enough for any real policy while still rejecting typos.
     weekly_weeks: int | None = Field(default=None, ge=0, le=520)
     monthly_months: int | None = Field(default=None, ge=0, le=120)
+    # "HH:MM" on a 24-hour clock, UTC. The empty string clears the anchor and
+    # returns the schedule to rolling; null means "leave it as it is".
+    time_of_day: str | None = Field(default=None, pattern=r"^$|^([01]\d|2[0-3]):([0-5]\d)$")
 
 
 def _schedule_response() -> BackupScheduleResponse:
@@ -801,11 +845,24 @@ def _schedule_response() -> BackupScheduleResponse:
     if last_run is not None and last_run <= _NEVER_RAN:
         last_run = None
 
+    anchor_minutes = parse_time_of_day(config["time_of_day"])
+    interval_seconds = config["interval_hours"] * 3600
+
     next_run = None
     if config["enabled"]:
-        # With no run on record the first tick fires as soon as the loop wakes.
-        base = last_run or datetime.now(timezone.utc)
-        next_run = base + timedelta(hours=config["interval_hours"])
+        if anchor_minutes is None:
+            # With no run on record the first tick fires as soon as the loop wakes.
+            base = last_run or datetime.now(timezone.utc)
+            next_run = base + timedelta(seconds=interval_seconds)
+        else:
+            slot = scheduled_slot(datetime.now(timezone.utc), interval_seconds, anchor_minutes)
+            # An unclaimed current slot is itself the next run: it fires on the
+            # next poll rather than waiting a further interval.
+            next_run = (
+                slot
+                if last_run is None or last_run < slot
+                else slot + timedelta(seconds=interval_seconds)
+            )
 
     return BackupScheduleResponse(
         enabled=config["enabled"],
@@ -813,6 +870,7 @@ def _schedule_response() -> BackupScheduleResponse:
         retention_days=config["retention_days"],
         weekly_weeks=config["weekly_weeks"],
         monthly_months=config["monthly_months"],
+        time_of_day=config["time_of_day"] or None,
         last_run=last_run.isoformat() if last_run else None,
         next_run=next_run.isoformat() if next_run else None,
         is_customized=config["is_customized"],

--- a/depictio/api/v1/endpoints/backup_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/backup_endpoints/routes.py
@@ -2,13 +2,14 @@ import hashlib
 import json
 import os
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast
 
+from bson import DBRef, ObjectId
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pymongo.collection import Collection
 
 from depictio.api.v1.configs.config import settings
@@ -20,6 +21,7 @@ from depictio.api.v1.db import (
     deltatables_collection,
     files_collection,
     groups_collection,
+    initialization_collection,
     instance_settings_collection,
     projects_collection,
     runs_collection,
@@ -144,6 +146,183 @@ def _verify_backup_integrity(backup_path: str, allow_unverified: bool) -> None:
         )
 
 
+def _write_backup_file(backup_payload: dict, backup_id: str) -> str:
+    """Write a backup payload and its SHA-256 sidecar; return the filename.
+
+    Shared by the ``/create`` endpoint and the scheduled backup task so both
+    produce byte-identical artefacts — including the sidecar, without which a
+    later restore refuses to run unless the admin passes allow_unverified.
+    """
+    backup_dir = settings.backup.backup_path
+    os.makedirs(backup_dir, exist_ok=True)
+
+    backup_filename = f"depictio_backup_{backup_id}.json"
+    backup_path = os.path.join(backup_dir, backup_filename)
+
+    with open(backup_path, "w") as backup_file:
+        json.dump(backup_payload, backup_file, indent=2, default=str)
+
+    # Integrity: store a SHA-256 sidecar so restores can verify the backup
+    # file has not been tampered with or truncated. The sidecar is written
+    # after the backup file so the digest reflects the final contents.
+    backup_checksum = _compute_file_sha256(backup_path)
+    with open(f"{backup_path}.sha256", "w") as checksum_file:
+        checksum_file.write(f"{backup_checksum}  {backup_filename}\n")
+
+    return backup_filename
+
+
+def prune_expired_backups() -> int:
+    """Delete backups older than ``backup_file_retention_days``; return the count.
+
+    Runs after every backup, scheduled or manual — nothing else prunes this
+    directory, and each snapshot is the size of the whole database, so without
+    this the backup volume grows without bound.
+
+    The age comes from the ``backup_id`` in the filename rather than the file's
+    mtime: mtimes do not survive a volume restore or an rsync, and the id is the
+    creation timestamp by construction. Files that do not parse are left alone.
+    Retention <= 0 means "keep forever". Never raises.
+    """
+    retention_days = get_backup_schedule_config()["retention_days"]
+    if retention_days <= 0:
+        return 0
+
+    backup_dir = settings.backup.backup_path
+    if not os.path.isdir(backup_dir):
+        return 0
+
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    removed = 0
+    try:
+        filenames = os.listdir(backup_dir)
+    except OSError as exc:
+        logger.warning(f"Backup retention: cannot list {backup_dir}: {exc}")
+        return 0
+
+    for filename in filenames:
+        if not (filename.startswith("depictio_backup_") and filename.endswith(".json")):
+            continue
+        backup_id = filename[len("depictio_backup_") : -len(".json")]
+        if not _BACKUP_ID_PATTERN.fullmatch(backup_id):
+            continue
+        try:
+            created = datetime.strptime(backup_id, "%Y%m%d_%H%M%S")
+        except ValueError:
+            continue
+        if created >= cutoff:
+            continue
+        backup_path = os.path.join(backup_dir, filename)
+        try:
+            os.remove(backup_path)
+            # The sidecar is worthless on its own; drop it with the backup.
+            if os.path.exists(f"{backup_path}.sha256"):
+                os.remove(f"{backup_path}.sha256")
+            removed += 1
+        except OSError as exc:
+            logger.warning(f"Backup retention: failed to delete {filename}: {exc}")
+
+    if removed:
+        logger.info(
+            f"Backup retention: removed {removed} backup(s) older than {retention_days} days"
+        )
+    return removed
+
+
+#: ``_id`` of the document holding the scheduled-backup state. Lives in the
+#: initialization collection alongside the other cross-worker coordination
+#: documents (the init lock, the YAML watcher lock).
+AUTO_BACKUP_STATE_ID = "auto_backup_state"
+
+#: Sentinel for "never ran". A fresh deployment is therefore due immediately,
+#: while a restart of an existing one resumes its schedule instead of firing a
+#: backup on every boot.
+_NEVER_RAN = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Attach UTC to a naive datetime read back from MongoDB.
+
+    The pymongo client is not tz-aware, so stored UTC datetimes come back naive.
+    Serializing those without an offset makes the browser read them as local
+    time, which is how a "next run" lands hours away from where it should be.
+    """
+    if value is None:
+        return None
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def claim_auto_backup_slot(interval_seconds: int) -> datetime | None:
+    """Claim the right to take the next scheduled backup, across all workers.
+
+    Every API worker runs the scheduler loop — gating on the initialization
+    election would not work, because that election has no winner once a
+    deployment has booted before. Instead the due time lives in MongoDB and the
+    claim is a single conditional update: the first worker whose update matches
+    moves ``last_run_at`` forward, and every other worker's update matches
+    nothing and returns None.
+
+    Returns the claim time, or None when the slot is not due or is already taken.
+    """
+    now = datetime.now(timezone.utc)
+    try:
+        initialization_collection.update_one(
+            {"_id": AUTO_BACKUP_STATE_ID},
+            {"$setOnInsert": {"last_run_at": _NEVER_RAN}},
+            upsert=True,
+        )
+        claimed = initialization_collection.find_one_and_update(
+            {
+                "_id": AUTO_BACKUP_STATE_ID,
+                "last_run_at": {"$lte": now - timedelta(seconds=interval_seconds)},
+            },
+            {"$set": {"last_run_at": now}},
+        )
+    except Exception as exc:
+        # Declining to back up is the safe failure: the next tick retries.
+        logger.warning(f"Scheduled backup: could not claim slot: {exc}")
+        return None
+    return now if claimed else None
+
+
+def get_auto_backup_state() -> dict:
+    """Read the scheduled-backup state document. Never raises."""
+    try:
+        return initialization_collection.find_one({"_id": AUTO_BACKUP_STATE_ID}) or {}
+    except Exception as exc:
+        logger.warning(f"Scheduled backup: could not read state: {exc}")
+        return {}
+
+
+#: Schedule fields an admin can change from the Backups tab. Everything else
+#: about backups (paths, S3 targets, credentials) stays deployment configuration.
+SCHEDULE_FIELDS = ("enabled", "interval_hours", "retention_days")
+
+
+def get_backup_schedule_config() -> dict:
+    """Resolve the schedule an admin actually gets: stored values over settings.
+
+    The environment supplies the *default*; a value stored from the Backups tab
+    overrides it. Read this way round, an admin's click is never silently
+    reverted on the next restart by an env var they cannot see from the page,
+    while a deployment that never touches the UI keeps behaving exactly as its
+    Helm values say.
+
+    Read fresh on every use rather than cached at startup, so enabling the
+    schedule from the UI takes effect without restarting the API.
+    """
+    config = {
+        "enabled": settings.backup.auto_backup_enabled,
+        "interval_hours": settings.backup.auto_backup_interval_hours,
+        "retention_days": settings.backup.backup_file_retention_days,
+    }
+    state = get_auto_backup_state()
+    overrides = {field: state[field] for field in SCHEDULE_FIELDS if field in state}
+    config.update(overrides)
+    config["is_customized"] = bool(overrides)
+    return config
+
+
 class BackupRequest(BaseModel):
     """Request model for backup creation with optional S3 data."""
 
@@ -166,9 +345,13 @@ class BackupResponse(BaseModel):
     s3_backup_metadata: dict | None = None
 
 
-async def _create_mongodb_backup(current_user: User) -> dict:
+async def _create_mongodb_backup(created_by: str, *, automatic: bool = False) -> dict:
     """
     Create a MongoDB backup with standard exclusions.
+
+    ``created_by`` is the admin's email for a manual backup and ``"scheduler"``
+    for one the background task took; ``automatic`` records the same distinction
+    as a flag so the UI can label rows without parsing the email.
 
     Returns a dictionary containing backup data and metadata.
     """
@@ -259,7 +442,8 @@ async def _create_mongodb_backup(current_user: User) -> dict:
     mongodb_backup = {
         "backup_metadata": {
             "timestamp": timestamp.isoformat(),
-            "created_by": current_user.email,
+            "created_by": created_by,
+            "automatic": automatic,
             "depictio_version": get_version(),
             "total_documents": total_documents,
             "excluded_documents": excluded_documents,
@@ -300,7 +484,7 @@ async def create_backup(
 
     try:
         # Create MongoDB backup
-        mongodb_backup = await _create_mongodb_backup(current_user)
+        mongodb_backup = await _create_mongodb_backup(current_user.email)
 
         # Add S3 backup if requested
         if request.include_s3_data:
@@ -337,23 +521,10 @@ async def create_backup(
         else:
             enhanced_backup = mongodb_backup
 
-        backup_dir = settings.backup.backup_path
-        os.makedirs(backup_dir, exist_ok=True)
-
-        backup_id_str = mongodb_backup["backup_metadata"]["backup_id"]
-        backup_filename = f"depictio_backup_{backup_id_str}.json"
-        backup_path = os.path.join(backup_dir, backup_filename)
-
-        with open(backup_path, "w") as backup_file:
-            json.dump(enhanced_backup, backup_file, indent=2, default=str)
-
-        # Integrity: store a SHA-256 sidecar so restores can verify the backup
-        # file has not been tampered with or truncated. The sidecar is written
-        # after the backup file so the digest reflects the final contents.
-        backup_checksum = _compute_file_sha256(backup_path)
-        checksum_path = f"{backup_path}.sha256"
-        with open(checksum_path, "w") as checksum_file:
-            checksum_file.write(f"{backup_checksum}  {backup_filename}\n")
+        backup_filename = _write_backup_file(
+            enhanced_backup, mongodb_backup["backup_metadata"]["backup_id"]
+        )
+        prune_expired_backups()
 
         logger.info(f"Backup created successfully: {backup_filename}")
 
@@ -392,6 +563,9 @@ class BackupListItem(BaseModel):
     # False for legacy backups without a .sha256 sidecar — those can only be
     # restored with allow_unverified=true.
     has_checksum: bool = False
+    # True for snapshots the scheduler took. Absent in backups written before
+    # scheduled backups existed, which read back as manual.
+    is_automatic: bool = False
 
 
 class BackupListResponse(BaseModel):
@@ -446,6 +620,109 @@ class BackupRestoreResponse(BaseModel):
     errors: list = []
 
 
+class BackupScheduleResponse(BaseModel):
+    """The schedule in force, plus when it last ran and when it runs next."""
+
+    enabled: bool
+    interval_hours: int
+    retention_days: int
+    last_run: str | None = None
+    next_run: str | None = None
+    # True once any field has been set from the Backups tab, so the UI can say
+    # why this deployment's env vars are no longer what is in force.
+    is_customized: bool = False
+
+
+class BackupScheduleUpdate(BaseModel):
+    """Partial update of the schedule. Omitted fields are left as they are."""
+
+    enabled: bool | None = None
+    # One hour is the floor because a snapshot is the size of the whole
+    # database; a year is a generous ceiling that still rejects typos.
+    interval_hours: int | None = Field(default=None, ge=1, le=8760)
+    # 0 means "keep forever"; ten years is the ceiling.
+    retention_days: int | None = Field(default=None, ge=0, le=3650)
+
+
+def _schedule_response() -> BackupScheduleResponse:
+    """Build the schedule payload from the config in force."""
+    config = get_backup_schedule_config()
+
+    last_run = _as_utc(get_auto_backup_state().get("last_run_at"))
+    # _NEVER_RAN is a sentinel, not a real run: report it as "never".
+    if last_run is not None and last_run <= _NEVER_RAN:
+        last_run = None
+
+    next_run = None
+    if config["enabled"]:
+        # With no run on record the first tick fires as soon as the loop wakes.
+        base = last_run or datetime.now(timezone.utc)
+        next_run = base + timedelta(hours=config["interval_hours"])
+
+    return BackupScheduleResponse(
+        enabled=config["enabled"],
+        interval_hours=config["interval_hours"],
+        retention_days=config["retention_days"],
+        last_run=last_run.isoformat() if last_run else None,
+        next_run=next_run.isoformat() if next_run else None,
+        is_customized=config["is_customized"],
+    )
+
+
+@backup_endpoint_router.get("/schedule", response_model=BackupScheduleResponse)
+async def get_backup_schedule(
+    current_user: User = Depends(get_current_user),
+):
+    """Report whether scheduled backups run, how often, and when they last did."""
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: Only administrators can view the backup schedule",
+        )
+    return _schedule_response()
+
+
+@backup_endpoint_router.put("/schedule", response_model=BackupScheduleResponse)
+async def update_backup_schedule(
+    request: BackupScheduleUpdate,
+    current_user: User = Depends(get_current_user),
+):
+    """Turn scheduled backups on or off, and set the interval and retention.
+
+    Stored in MongoDB rather than pushed back into the environment: the running
+    scheduler re-reads this on every tick, so a change takes effect without a
+    restart, and every worker picks it up at once.
+    """
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: Only administrators can change the backup schedule",
+        )
+
+    updates = {
+        field: value
+        for field, value in request.model_dump().items()
+        if field in SCHEDULE_FIELDS and value is not None
+    }
+    if not updates:
+        raise HTTPException(status_code=422, detail="No schedule fields to update.")
+
+    try:
+        initialization_collection.update_one(
+            {"_id": AUTO_BACKUP_STATE_ID},
+            # last_run_at must exist for the claim query to ever match, and this
+            # update can be what creates the document.
+            {"$set": updates, "$setOnInsert": {"last_run_at": _NEVER_RAN}},
+            upsert=True,
+        )
+    except Exception as exc:
+        logger.error(f"Failed to update the backup schedule: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to update the backup schedule.")
+
+    logger.info(f"Admin user {current_user.email} updated the backup schedule: {updates}")
+    return _schedule_response()
+
+
 @backup_endpoint_router.get("/list", response_model=BackupListResponse)
 async def list_backups(
     current_user: User = Depends(get_current_user),
@@ -489,6 +766,7 @@ async def list_backups(
                         collections=metadata.get("collections", []),
                         depictio_version=metadata.get("depictio_version"),
                         has_checksum=has_checksum,
+                        is_automatic=bool(metadata.get("automatic", False)),
                     )
                 except Exception:
                     # If can't read metadata, just use file info
@@ -715,8 +993,6 @@ async def upload_backup(
 
 def _convert_complex_objects_to_strings(obj):
     """Convert DBRef and ObjectId to strings for JSON serialization."""
-    from bson import DBRef, ObjectId
-
     if isinstance(obj, DBRef):
         return str(obj.id)
     if isinstance(obj, ObjectId):
@@ -725,6 +1001,32 @@ def _convert_complex_objects_to_strings(obj):
         return {key: _convert_complex_objects_to_strings(value) for key, value in obj.items()}
     if isinstance(obj, list):
         return [_convert_complex_objects_to_strings(item) for item in obj]
+    return obj
+
+
+def _restore_complex_objects(obj):
+    """Re-hydrate the ObjectIds that backup serialization flattened to strings.
+
+    Backups are plain JSON, so ``_convert_complex_objects_to_strings`` turns
+    *every* ObjectId in a document into a string, not just the top-level
+    ``_id``: ``dashboards.project_id``, ``permissions.owners[]._id``,
+    ``projects.workflows[].data_collections[]._id``,
+    ``stored_metadata[].dc_id`` and so on. Inserting those back as strings
+    produces documents Mongo can no longer join — the dashboard listing filters
+    on ``{"project_id": {"$in": [<ObjectId>]}}``, which matches nothing, so
+    every dashboard silently disappears after a restore.
+
+    The rule mirrors ``MongoModel.mongo()``, the writer the application itself
+    uses: any string that is a valid ObjectId is one. DBRefs cannot be rebuilt
+    (the backup only kept ``str(ref.id)``, dropping the collection name) and
+    come back as plain ObjectIds, which is the shape ``db_init`` writes.
+    """
+    if isinstance(obj, dict):
+        return {key: _restore_complex_objects(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_restore_complex_objects(item) for item in obj]
+    if isinstance(obj, str) and ObjectId.is_valid(obj):
+        return ObjectId(obj)
     return obj
 
 
@@ -868,24 +1170,39 @@ async def restore_backup(
 
             try:
                 collection = collection_map[collection_name]
-                documents = data_section[collection_name]
-                from bson import ObjectId
+                documents = [_restore_complex_objects(doc) for doc in data_section[collection_name]]
 
                 for doc in documents:
+                    # Backups written from Mongo carry ``_id``; documents dumped
+                    # through a Pydantic model carry ``id``. Accept both.
                     if "id" in doc:
-                        doc["_id"] = ObjectId(doc.pop("id"))
-                    if "_id" in doc and isinstance(doc["_id"], str):
-                        doc["_id"] = ObjectId(doc["_id"])
+                        doc["_id"] = doc.pop("id")
 
+                # Restore is wipe-and-replace, so a failed insert would leave
+                # the collection empty. Keep the previous contents in memory and
+                # put them back if the insert fails, rather than losing both the
+                # old and the new data.
+                previous_documents = list(collection.find({}))
+                collection.delete_many({})
                 if documents:
                     try:
-                        collection.delete_many({})
                         collection.insert_many(documents)
                     except Exception as e:
                         logger.error(f"Failed to restore {collection_name}: {e}")
+                        try:
+                            collection.delete_many({})
+                            if previous_documents:
+                                collection.insert_many(previous_documents)
+                            logger.warning(
+                                f"Rolled {collection_name} back to its pre-restore contents "
+                                f"({len(previous_documents)} documents)"
+                            )
+                        except Exception as rollback_error:
+                            logger.error(
+                                f"Rollback of {collection_name} failed after a failed restore; "
+                                f"the collection may be empty: {rollback_error}"
+                            )
                         raise
-                else:
-                    collection.delete_many({})
 
                 restored_collections[collection_name] = {
                     "count": len(documents),

--- a/depictio/api/v1/endpoints/backup_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/backup_endpoints/routes.py
@@ -2,11 +2,12 @@ import hashlib
 import json
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from pymongo.collection import Collection
 
@@ -30,6 +31,10 @@ from depictio.models.models.users import User
 from depictio.version import get_version
 
 backup_endpoint_router = APIRouter()
+
+# Uploaded backup files are read fully into memory before being written to the
+# backup directory, so cap their size. Module-level so tests can patch it.
+MAX_BACKUP_UPLOAD_BYTES = 200 * 1024 * 1024  # 200 MB
 
 # Backup IDs are generated as ``datetime.strftime("%Y%m%d_%H%M%S")`` in
 # ``_create_mongodb_backup`` (e.g. ``20250627_123456``). Enforcing this strict
@@ -156,6 +161,9 @@ class BackupResponse(BaseModel):
     collections_backed_up: list = []
     timestamp: str | None = None
     filename: str | None = None
+    # Populated only when include_s3_data was requested. Must be a declared
+    # field — response_model filtering silently drops undeclared keys.
+    s3_backup_metadata: dict | None = None
 
 
 async def _create_mongodb_backup(current_user: User) -> dict:
@@ -372,9 +380,23 @@ async def create_backup(
         raise HTTPException(status_code=500, detail="Backup creation failed.")
 
 
+class BackupListItem(BaseModel):
+    backup_id: str
+    filename: str
+    size_mb: float
+    created: str
+    created_by: str = "unknown"
+    total_documents: int = 0
+    collections: list[str] = []
+    depictio_version: str | None = None
+    # False for legacy backups without a .sha256 sidecar — those can only be
+    # restored with allow_unverified=true.
+    has_checksum: bool = False
+
+
 class BackupListResponse(BaseModel):
     success: bool
-    backups: list
+    backups: list[BackupListItem]
     count: int
 
 
@@ -391,6 +413,17 @@ class BackupValidateResponse(BaseModel):
     invalid_documents: int = 0
     collections_validated: dict = {}
     errors: list = []
+    warnings: list = []
+
+
+class BackupUploadResponse(BaseModel):
+    success: bool
+    message: str
+    backup_id: str | None = None
+    filename: str | None = None
+    # Validation runs automatically on upload; the file is stored either way —
+    # the restore endpoint's validation gate is what protects the database.
+    validation: BackupValidateResponse | None = None
 
 
 class BackupRestoreRequest(BaseModel):
@@ -400,6 +433,9 @@ class BackupRestoreRequest(BaseModel):
     # Escape hatch for legacy backups created before checksum sidecars existed.
     # Only bypasses a *missing* checksum; a checksum *mismatch* is never bypassable.
     allow_unverified: bool = False
+    # Escape hatch for the pre-restore Pydantic validation gate. Restoring
+    # documents that fail model validation can leave the app broken.
+    skip_validation: bool = False
 
 
 class BackupRestoreResponse(BaseModel):
@@ -435,6 +471,7 @@ async def list_backups(
 
                 # Extract backup ID from filename
                 backup_id = filename.replace("depictio_backup_", "").replace(".json", "")
+                has_checksum = os.path.exists(f"{file_path}.sha256")
 
                 # Try to read metadata
                 try:
@@ -442,37 +479,56 @@ async def list_backups(
                         data = json.load(f)
                         metadata = data.get("backup_metadata", {})
 
-                    backup_info = {
-                        "backup_id": backup_id,
-                        "filename": filename,
-                        "size_mb": round(file_stat.st_size / (1024 * 1024), 2),
-                        "created": datetime.fromtimestamp(file_stat.st_ctime).isoformat(),
-                        "created_by": metadata.get("created_by", "unknown"),
-                        "total_documents": metadata.get("total_documents", 0),
-                        "collections": metadata.get("collections", []),
-                    }
+                    backup_info = BackupListItem(
+                        backup_id=backup_id,
+                        filename=filename,
+                        size_mb=round(file_stat.st_size / (1024 * 1024), 2),
+                        created=datetime.fromtimestamp(file_stat.st_ctime).isoformat(),
+                        created_by=metadata.get("created_by", "unknown"),
+                        total_documents=metadata.get("total_documents", 0),
+                        collections=metadata.get("collections", []),
+                        depictio_version=metadata.get("depictio_version"),
+                        has_checksum=has_checksum,
+                    )
                 except Exception:
                     # If can't read metadata, just use file info
-                    backup_info = {
-                        "backup_id": backup_id,
-                        "filename": filename,
-                        "size_mb": round(file_stat.st_size / (1024 * 1024), 2),
-                        "created": datetime.fromtimestamp(file_stat.st_ctime).isoformat(),
-                        "created_by": "unknown",
-                        "total_documents": 0,
-                        "collections": [],
-                    }
+                    backup_info = BackupListItem(
+                        backup_id=backup_id,
+                        filename=filename,
+                        size_mb=round(file_stat.st_size / (1024 * 1024), 2),
+                        created=datetime.fromtimestamp(file_stat.st_ctime).isoformat(),
+                        has_checksum=has_checksum,
+                    )
 
                 backup_files.append(backup_info)
 
         # Sort by creation time (newest first)
-        backup_files.sort(key=lambda x: x["created"], reverse=True)
+        backup_files.sort(key=lambda x: x.created, reverse=True)
 
         return BackupListResponse(success=True, backups=backup_files, count=len(backup_files))
 
     except Exception as e:
         logger.error(f"Failed to list backups: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to list backups.")
+
+
+def _build_validate_response(result: dict) -> BackupValidateResponse:
+    """Map a ``validate_backup_file`` result dict onto the API response model.
+
+    Shared by ``/validate`` and ``/upload`` so both surfaces report validation
+    identically.
+    """
+    return BackupValidateResponse(
+        success=True,
+        message="Validation completed",
+        valid=result.get("valid", False),
+        total_documents=result.get("total_documents", 0),
+        valid_documents=result.get("valid_documents", 0),
+        invalid_documents=result.get("invalid_documents", 0),
+        collections_validated=result.get("collections_validated", {}),
+        errors=result.get("errors", []),
+        warnings=result.get("warnings", []),
+    )
 
 
 @backup_endpoint_router.post("/validate", response_model=BackupValidateResponse)
@@ -506,22 +562,155 @@ async def validate_backup(
         # Validate the backup
         result = validate_backup_file(backup_path)
 
-        return BackupValidateResponse(
-            success=True,
-            message="Validation completed",
-            valid=result.get("valid", False),
-            total_documents=result.get("total_documents", 0),
-            valid_documents=result.get("valid_documents", 0),
-            invalid_documents=result.get("invalid_documents", 0),
-            collections_validated=result.get("collections_validated", {}),
-            errors=result.get("errors", []),
-        )
+        return _build_validate_response(result)
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Backup validation failed: {str(e)}")
         raise HTTPException(status_code=500, detail="Backup validation failed.")
+
+
+@backup_endpoint_router.get("/download/{backup_id}")
+async def download_backup(
+    backup_id: str,
+    current_user: User = Depends(get_current_user),
+) -> FileResponse:
+    """Download a backup file from the server.
+
+    Streams the backup JSON as an attachment so admins can keep off-server
+    copies (and re-upload them later via ``/upload``).
+    """
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=403, detail="Access denied: Only administrators can download backups"
+        )
+
+    # Reject malformed backup_id before it touches the filesystem.
+    _validate_backup_id(backup_id)
+
+    backup_dir = settings.backup.backup_path
+    backup_path = _resolve_backup_path(backup_dir, backup_id)
+
+    if not os.path.exists(backup_path):
+        raise HTTPException(status_code=404, detail=f"Backup not found: {backup_id}")
+
+    # The filename is derived from the strictly validated backup_id, so it is
+    # plain ASCII — no RFC 5987 encoding needed (unlike migrate's export_project
+    # which embeds user-controlled project names).
+    return FileResponse(
+        backup_path,
+        media_type="application/json",
+        filename=f"depictio_backup_{backup_id}.json",
+    )
+
+
+def _mint_upload_backup_id(backup_dir: str) -> str:
+    """Mint a fresh server-side backup_id for an uploaded file.
+
+    Uses the same ``YYYYMMDD_HHMMSS`` convention as ``/create``; bumps by one
+    second while the target path already exists so rapid uploads cannot
+    overwrite each other.
+    """
+    timestamp = datetime.now()
+    while True:
+        backup_id = timestamp.strftime("%Y%m%d_%H%M%S")
+        if not os.path.exists(os.path.join(backup_dir, f"depictio_backup_{backup_id}.json")):
+            return backup_id
+        timestamp += timedelta(seconds=1)
+
+
+@backup_endpoint_router.post("/upload", response_model=BackupUploadResponse)
+async def upload_backup(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+):
+    """Upload a backup file to the server and validate it.
+
+    The uploaded file is stored in the backup directory under a freshly minted
+    server-side backup_id (with a SHA-256 sidecar), making it a first-class
+    backup: it appears in ``/list`` and can be validated, downloaded, and
+    restored like any server-created backup. Validation runs automatically and
+    its result is returned; a failing validation does not reject the upload —
+    the restore endpoint refuses invalid backups by default.
+    """
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=403, detail="Access denied: Only administrators can upload backups"
+        )
+
+    try:
+        # Read fully into memory (matches the repo's upload pattern); the size
+        # cap bounds memory usage.
+        body = await file.read()
+        if len(body) > MAX_BACKUP_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"Uploaded backup exceeds the maximum allowed size of "
+                    f"{MAX_BACKUP_UPLOAD_BYTES // (1024 * 1024)} MB."
+                ),
+            )
+
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Uploaded file is not valid JSON.")
+
+        if (
+            not isinstance(payload, dict)
+            or "data" not in payload
+            or not isinstance(payload["data"], dict)
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Not a depictio backup file (missing 'data' section).",
+            )
+
+        backup_dir = settings.backup.backup_path
+        os.makedirs(backup_dir, exist_ok=True)
+
+        # Assign a server-side id so the filename-derived id and the metadata
+        # agree; everything else in the file is preserved.
+        backup_id = _mint_upload_backup_id(backup_dir)
+        metadata = payload.setdefault("backup_metadata", {})
+        if isinstance(metadata, dict):
+            metadata["backup_id"] = backup_id
+
+        backup_filename = f"depictio_backup_{backup_id}.json"
+        backup_path = _resolve_backup_path(backup_dir, backup_id)
+
+        with open(backup_path, "w") as backup_file:
+            json.dump(payload, backup_file, indent=2, default=str)
+
+        # Same sidecar convention as /create; computed over the re-serialized
+        # file so the checksum always matches what is on disk.
+        backup_checksum = _compute_file_sha256(backup_path)
+        with open(f"{backup_path}.sha256", "w") as checksum_file:
+            checksum_file.write(f"{backup_checksum}  {backup_filename}\n")
+
+        logger.info(
+            f"Admin user {current_user.email} uploaded backup {backup_filename} ({len(body)} bytes)"
+        )
+
+        from depictio.cli.cli.utils.backup_validation import validate_backup_file
+
+        validation = _build_validate_response(validate_backup_file(backup_path))
+
+        return BackupUploadResponse(
+            success=True,
+            message="Backup uploaded"
+            + (" and validated" if validation.valid else "; validation found errors"),
+            backup_id=backup_id,
+            filename=backup_filename,
+            validation=validation,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Backup upload failed: {str(e)}")
+        raise HTTPException(status_code=500, detail="Backup upload failed.")
 
 
 def _convert_complex_objects_to_strings(obj):
@@ -549,6 +738,10 @@ async def restore_backup(
 
     WARNING: This is a destructive operation that will replace existing data.
     Use dry_run=True to preview what would be restored.
+
+    Before any data is touched, the backup is validated against the current
+    Pydantic models (same validator as /validate); restores of invalid backups
+    are refused unless skip_validation=true.
     """
 
     # Check if user is admin
@@ -632,6 +825,37 @@ async def restore_backup(
                 total_restored=total_restored,
                 errors=errors,
             )
+
+        # Validation gate: refuse to wipe collections for documents that fail
+        # Pydantic model validation. Same validator as /validate and the CLI,
+        # so UI and CLI share one "validate then restore" path. Scoped to the
+        # collections actually being restored, so a partial restore is not
+        # blocked by unrelated broken documents.
+        if not request.skip_validation:
+            from depictio.cli.cli.utils.backup_validation import validate_backup_file
+
+            validation_result = validate_backup_file(backup_path)
+            per_collection = validation_result.get("collections_validated", {})
+            invalid_selected = sum(
+                per_collection.get(name, {}).get("invalid", 0) for name in collections_to_restore
+            )
+            if invalid_selected > 0:
+                # validate_backup_file formats errors as "Document {i} in {collection}: ..."
+                selected_errors = [
+                    err
+                    for err in validation_result.get("errors", [])
+                    if any(f" in {name}:" in err for name in collections_to_restore)
+                ]
+                return BackupRestoreResponse(
+                    success=False,
+                    message=(
+                        f"Backup failed model validation: {invalid_selected} invalid "
+                        "document(s) in the selected collections. Refusing to restore. "
+                        "Run validation for details, or set skip_validation=true to "
+                        "override at your own risk."
+                    ),
+                    errors=selected_errors[:25],
+                )
 
         for collection_name in collections_to_restore:
             if collection_name not in data_section:

--- a/depictio/api/v1/services/lifespan.py
+++ b/depictio/api/v1/services/lifespan.py
@@ -33,6 +33,7 @@ from depictio.api.v1.services.yaml_sync import (
     start_yaml_sync_services,
     stop_yaml_sync_services,
 )
+from depictio.api.v1.tasks.backup_tasks import start_backup_tasks
 from depictio.api.v1.tasks.cleanup_tasks import start_cleanup_tasks
 from depictio.api.v1.utils import clean_screenshots
 from depictio.models.models.analytics import UserActivity, UserSession
@@ -132,6 +133,11 @@ def start_background_services(should_initialize: bool):
     # Start cleanup tasks on every worker
     logger.info(f"Worker {WORKER_ID}: Starting cleanup tasks")
     start_cleanup_tasks()
+
+    # Scheduled backups. Started on every worker even when the schedule is off,
+    # so enabling it from the admin UI takes effect without a restart; the due
+    # time is claimed in MongoDB, so only one worker takes each backup.
+    start_backup_tasks()
 
     return background_task
 

--- a/depictio/api/v1/tasks/backup_tasks.py
+++ b/depictio/api/v1/tasks/backup_tasks.py
@@ -1,0 +1,82 @@
+"""Scheduled MongoDB backups.
+
+Off by default, because a snapshot is the size of the whole database and a
+deployment that has not sized its backup volume should not start filling it on
+upgrade. Admins turn it on from Admin > Backups; the environment only supplies
+the default (see ``get_backup_schedule_config``).
+
+Every API worker runs the loop; correctness lives in the MongoDB claim, not in
+worker election. See ``claim_auto_backup_slot`` for why gating on the
+initialization election would silently never fire.
+"""
+
+import asyncio
+
+from depictio.api.v1.configs.logging_init import logger
+from depictio.api.v1.endpoints.backup_endpoints.routes import (
+    _create_mongodb_backup,
+    _write_backup_file,
+    claim_auto_backup_slot,
+    get_backup_schedule_config,
+    prune_expired_backups,
+)
+
+#: Upper bound on how long a due backup waits for a worker to notice it. Polling
+#: faster than the interval keeps a scheduled backup close to its due time even
+#: though each worker's loop starts at an arbitrary phase, and bounds how long a
+#: schedule change made in the UI takes to be picked up.
+_MAX_POLL_SECONDS = 15 * 60
+_MIN_POLL_SECONDS = 60
+
+
+def _poll_seconds(interval_hours: int) -> int:
+    return max(_MIN_POLL_SECONDS, min(interval_hours * 3600, _MAX_POLL_SECONDS))
+
+
+async def run_scheduled_backup() -> str | None:
+    """Take one scheduled backup if it is due. Returns the backup ID, or None."""
+    config = get_backup_schedule_config()
+    if not config["enabled"]:
+        return None
+    if claim_auto_backup_slot(config["interval_hours"] * 3600) is None:
+        return None
+
+    backup = await _create_mongodb_backup("scheduler", automatic=True)
+    backup_id = backup["backup_metadata"]["backup_id"]
+    filename = _write_backup_file(backup, backup_id)
+    prune_expired_backups()
+
+    logger.info(
+        f"Scheduled backup created: {filename} "
+        f"({backup['backup_metadata']['total_documents']} documents)"
+    )
+    return backup_id
+
+
+async def periodic_backup() -> None:
+    """Poll for a due scheduled backup forever.
+
+    The loop runs even when the schedule is off, and re-reads the configuration
+    on every tick: that is what lets an admin enable scheduled backups from the
+    UI without restarting the API. An idle tick is one indexed MongoDB read.
+
+    A failure never breaks the loop: the claim has already moved the due time
+    forward, so a failed attempt costs one interval and the next tick retries.
+    """
+    logger.info("Scheduled backup loop started")
+
+    while True:
+        interval_hours = None
+        try:
+            config = get_backup_schedule_config()
+            interval_hours = config["interval_hours"]
+            if config["enabled"]:
+                await run_scheduled_backup()
+        except Exception as exc:
+            logger.error(f"Scheduled backup failed: {exc}")
+        await asyncio.sleep(_poll_seconds(interval_hours or 24))
+
+
+def start_backup_tasks() -> None:
+    """Start the scheduled-backup loop."""
+    asyncio.create_task(periodic_backup())

--- a/depictio/api/v1/tasks/backup_tasks.py
+++ b/depictio/api/v1/tasks/backup_tasks.py
@@ -18,6 +18,7 @@ from depictio.api.v1.endpoints.backup_endpoints.routes import (
     _write_backup_file,
     claim_auto_backup_slot,
     get_backup_schedule_config,
+    parse_time_of_day,
     prune_expired_backups,
 )
 
@@ -38,7 +39,8 @@ async def run_scheduled_backup() -> str | None:
     config = get_backup_schedule_config()
     if not config["enabled"]:
         return None
-    if claim_auto_backup_slot(config["interval_hours"] * 3600) is None:
+    anchor_minutes = parse_time_of_day(config["time_of_day"])
+    if claim_auto_backup_slot(config["interval_hours"] * 3600, anchor_minutes) is None:
         return None
 
     backup = await _create_mongodb_backup("scheduler", automatic=True)

--- a/depictio/cli/cli/commands/backup.py
+++ b/depictio/cli/cli/commands/backup.py
@@ -123,6 +123,8 @@ def create(
                 )
                 raise typer.Exit(1)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         rich_print_checked_statement(f"Backup operation failed: {e}", "error")
         raise typer.Exit(1)
@@ -171,6 +173,8 @@ def list(
             )
             raise typer.Exit(1)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         rich_print_checked_statement(f"Failed to list backups: {e}", "error")
         raise typer.Exit(1)
@@ -225,6 +229,11 @@ def validate(
                     "collections_validated": validation_result.get("collections_validated", {}),
                 }
                 rich_print_json("Validation details:", validation_details)
+                warnings = validation_result.get("warnings", [])
+                if warnings:
+                    rich_print_checked_statement("Validation warnings:", "warning")
+                    for warning in warnings:
+                        rich_print_checked_statement(f"  • {warning}", "warning")
             else:
                 rich_print_checked_statement("Backup file validation failed", "error")
                 errors = validation_result.get("errors", [])
@@ -239,6 +248,8 @@ def validate(
             )
             raise typer.Exit(1)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         rich_print_checked_statement(f"Backup validation failed: {e}", "error")
         raise typer.Exit(1)
@@ -319,6 +330,8 @@ def check_coverage(
         if not coverage_report["valid"]:
             raise typer.Exit(1)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         rich_print_checked_statement(f"Coverage check failed: {e}", "error")
         raise typer.Exit(1)
@@ -342,6 +355,23 @@ def restore(
     force: Annotated[
         bool, typer.Option("--force", help="Skip confirmation prompt (use with caution!)")
     ] = False,
+    allow_unverified: Annotated[
+        bool,
+        typer.Option(
+            "--allow-unverified",
+            help=(
+                "Allow restoring a legacy backup without a checksum sidecar. "
+                "Checksum mismatches are never bypassable."
+            ),
+        ),
+    ] = False,
+    skip_validation: Annotated[
+        bool,
+        typer.Option(
+            "--skip-validation",
+            help="Skip the server-side Pydantic validation gate before restore (dangerous!)",
+        ),
+    ] = False,
 ):
     """
     Restore data from a backup file.
@@ -349,12 +379,18 @@ def restore(
     WARNING: This is a destructive operation that will replace existing data!
     Use --dry-run to preview what would be restored without making changes.
 
+    Before restoring, the server validates the backup against the current
+    Pydantic models and refuses to restore invalid backups unless
+    --skip-validation is passed.
+
     Args:
         backup_id: ID of the backup to restore from
         CLI_config_path: Path to the CLI configuration file
         dry_run: If True, only simulate the restore
         collections: Comma-separated list of collections to restore (if not specified, restore all)
         force: Skip confirmation prompt
+        allow_unverified: Allow restoring a backup that has no checksum sidecar
+        skip_validation: Skip the server-side validation gate before restore
     """
     rich_print_command_usage("backup restore")
 
@@ -405,7 +441,14 @@ def restore(
         else:
             rich_print_checked_statement(f"Restoring from backup {backup_id}...", "warning")
 
-        restore_result = api_restore_backup(CLI_config, backup_id, dry_run, collections_list)
+        restore_result = api_restore_backup(
+            CLI_config,
+            backup_id,
+            dry_run,
+            collections_list,
+            allow_unverified=allow_unverified,
+            skip_validation=skip_validation,
+        )
 
         if restore_result.get("success", False):
             if dry_run:
@@ -431,8 +474,16 @@ def restore(
             rich_print_checked_statement(
                 f"Restore failed: {restore_result.get('message', 'Unknown error')}", "error"
             )
+            errors = restore_result.get("errors", [])
+            if errors:
+                for error in errors:
+                    rich_print_checked_statement(f"  • {error}", "error")
             raise typer.Exit(1)
 
+    except typer.Exit:
+        # Deliberate exits (declined confirmation, handled failures) must keep
+        # their exit code instead of being reported as unexpected errors.
+        raise
     except Exception as e:
         rich_print_checked_statement(f"Restore operation failed: {e}", "error")
         raise typer.Exit(1)

--- a/depictio/cli/cli/utils/api_calls.py
+++ b/depictio/cli/cli/utils/api_calls.py
@@ -784,7 +784,12 @@ def api_validate_backup(CLI_config: CLIConfig, backup_id: str) -> dict:
 
 @validate_call
 def api_restore_backup(
-    CLI_config: CLIConfig, backup_id: str, dry_run: bool = True, collections: list | None = None
+    CLI_config: CLIConfig,
+    backup_id: str,
+    dry_run: bool = True,
+    collections: list | None = None,
+    allow_unverified: bool = False,
+    skip_validation: bool = False,
 ) -> dict:
     """
     Restore from a backup on the server.
@@ -794,6 +799,8 @@ def api_restore_backup(
         backup_id (str): ID of the backup to restore from.
         dry_run (bool): If True, only simulate the restore without actually changing data.
         collections (list): List of collection names to restore. If None, restore all collections.
+        allow_unverified (bool): Allow restoring a legacy backup without a checksum sidecar.
+        skip_validation (bool): Skip the server-side Pydantic validation gate before restore.
 
     Returns:
         dict: Response containing restore operation results.
@@ -804,6 +811,12 @@ def api_restore_backup(
     payload = {"backup_id": backup_id, "dry_run": dry_run}
     if collections:
         payload["collections"] = collections
+    # Only sent when set, so the CLI stays compatible with older servers that
+    # reject unknown fields.
+    if allow_unverified:
+        payload["allow_unverified"] = True
+    if skip_validation:
+        payload["skip_validation"] = True
 
     try:
         response = get_http_client().post(

--- a/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
+++ b/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
@@ -1,6 +1,6 @@
 import json
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +11,10 @@ from depictio.api.v1.endpoints.backup_endpoints.routes import (
     _compute_file_sha256,
     _subtract_months,
     backup_endpoint_router,
+    claim_auto_backup_slot,
+    parse_time_of_day,
     record_last_restore,
+    scheduled_slot,
     select_expired_backups,
 )
 from depictio.models.models.base import PyObjectId
@@ -58,6 +61,7 @@ def backup_settings(tmp_path):
     mock_settings.backup.backup_retention_monthly_months = 0
     mock_settings.backup.auto_backup_enabled = False
     mock_settings.backup.auto_backup_interval_hours = 24
+    mock_settings.backup.auto_backup_time_of_day = None
     with patch("depictio.api.v1.endpoints.backup_endpoints.routes.settings", mock_settings):
         yield mock_settings
 
@@ -767,6 +771,95 @@ class TestBackupRetention:
 
         assert prune_expired_backups() == 0
         assert stray.exists()
+
+
+class TestScheduleTimeOfDay:
+    """An anchored schedule fires at a chosen time of day instead of drifting
+    forward from whenever the last run happened to land."""
+
+    def test_parses_a_valid_anchor(self):
+        assert parse_time_of_day("03:00") == 180
+        assert parse_time_of_day("23:59") == 23 * 60 + 59
+        assert parse_time_of_day("00:00") == 0
+
+    @pytest.mark.parametrize("value", [None, "", "  ", "24:00", "3:00", "03:60", "nope", 42])
+    def test_unusable_anchors_degrade_to_rolling(self, value):
+        """A malformed value must leave the schedule rolling, not stop backups."""
+        assert parse_time_of_day(value) is None
+
+    def test_daily_slots_land_on_the_anchor(self):
+        now = datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc)
+        slot = scheduled_slot(now, 24 * 3600, parse_time_of_day("03:00"))
+
+        assert slot == datetime(2026, 8, 28, 3, 0, tzinfo=timezone.utc)
+
+    def test_before_the_anchor_the_slot_is_yesterdays(self):
+        now = datetime(2026, 8, 28, 1, 0, tzinfo=timezone.utc)
+        slot = scheduled_slot(now, 24 * 3600, parse_time_of_day("03:00"))
+
+        assert slot == datetime(2026, 8, 27, 3, 0, tzinfo=timezone.utc)
+
+    def test_sub_daily_intervals_step_from_the_anchor(self):
+        """A six-hourly schedule anchored at 03:00 runs at 03, 09, 15 and 21."""
+        anchor = parse_time_of_day("03:00")
+        slots = {
+            scheduled_slot(datetime(2026, 8, 28, hour, 30, tzinfo=timezone.utc), 6 * 3600, anchor)
+            for hour in range(0, 24)
+        }
+
+        assert {s.hour for s in slots} == {3, 9, 15, 21}
+
+    def test_a_late_run_does_not_push_the_next_slot_back(self):
+        """The grid is anchored to a fixed epoch, not to the previous run, which
+        is what stops a daily backup creeping later every day."""
+        anchor = parse_time_of_day("03:00")
+        # A run that fired 40 minutes late still leaves tomorrow's slot at 03:00.
+        tomorrow = datetime(2026, 8, 29, 3, 5, tzinfo=timezone.utc)
+
+        assert scheduled_slot(tomorrow, 24 * 3600, anchor) == datetime(
+            2026, 8, 29, 3, 0, tzinfo=timezone.utc
+        )
+
+    def test_an_anchored_claim_compares_against_the_slot(self, backup_state, backup_settings):
+        backup_state.find_one_and_update.return_value = {"_id": "auto_backup_state"}
+
+        assert claim_auto_backup_slot(24 * 3600, parse_time_of_day("03:00")) is not None
+
+        query = backup_state.find_one_and_update.call_args.args[0]
+        # Strictly-before the slot, rather than the rolling "one interval old".
+        assert "$lt" in query["last_run_at"]
+        assert query["last_run_at"]["$lt"].hour == 3
+
+    def test_no_anchor_keeps_the_rolling_claim(self, backup_state, backup_settings):
+        backup_state.find_one_and_update.return_value = {"_id": "auto_backup_state"}
+
+        assert claim_auto_backup_slot(3600) is not None
+
+        query = backup_state.find_one_and_update.call_args.args[0]
+        assert "$lte" in query["last_run_at"]
+
+    def test_the_endpoint_reports_the_anchored_next_run(
+        self, backup_state, as_admin, backup_settings
+    ):
+        backup_settings.backup.auto_backup_enabled = True
+        backup_settings.backup.auto_backup_interval_hours = 24
+        backup_settings.backup.auto_backup_time_of_day = "03:00"
+
+        body = as_admin.get("/backup/schedule").json()
+
+        assert body["time_of_day"] == "03:00"
+        assert datetime.fromisoformat(body["next_run"]).hour == 3
+
+    def test_an_empty_string_clears_the_anchor(self, backup_state, as_admin, backup_settings):
+        """Null means "leave it alone", so clearing needs its own value."""
+        response = as_admin.put("/backup/schedule", json={"time_of_day": ""})
+
+        assert response.status_code == 200
+        stored = backup_state.update_one.call_args.args[1]["$set"]
+        assert stored["time_of_day"] == ""
+
+    def test_a_malformed_anchor_is_rejected(self, backup_state, as_admin, backup_settings):
+        assert as_admin.put("/backup/schedule", json={"time_of_day": "25:00"}).status_code == 422
 
 
 class TestGFSRetentionPolicy:

--- a/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
+++ b/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
@@ -9,7 +9,10 @@ from fastapi.testclient import TestClient
 
 from depictio.api.v1.endpoints.backup_endpoints.routes import (
     _compute_file_sha256,
+    _subtract_months,
     backup_endpoint_router,
+    record_last_restore,
+    select_expired_backups,
 )
 from depictio.models.models.base import PyObjectId
 from depictio.models.models.users import User
@@ -51,6 +54,8 @@ def backup_settings(tmp_path):
     mock_settings = MagicMock()
     mock_settings.backup.backup_path = str(tmp_path / "backups")
     mock_settings.backup.backup_file_retention_days = 30
+    mock_settings.backup.backup_retention_weekly_weeks = 0
+    mock_settings.backup.backup_retention_monthly_months = 0
     mock_settings.backup.auto_backup_enabled = False
     mock_settings.backup.auto_backup_interval_hours = 24
     with patch("depictio.api.v1.endpoints.backup_endpoints.routes.settings", mock_settings):
@@ -762,6 +767,144 @@ class TestBackupRetention:
 
         assert prune_expired_backups() == 0
         assert stray.exists()
+
+
+class TestGFSRetentionPolicy:
+    """Tiered retention, exercised directly over dates: `select_expired_backups`
+    takes the clock as an argument and touches no filesystem, so the policy can
+    be checked without writing hundreds of files."""
+
+    NOW = datetime(2026, 8, 28, 12, 0, 0)
+
+    def _daily_backups(self, days):
+        """One backup a day for the last `days` days, newest first."""
+        return [
+            (
+                self.NOW - timedelta(days=d),
+                f"depictio_backup_{(self.NOW - timedelta(days=d)).strftime('%Y%m%d_%H%M%S')}.json",
+            )
+            for d in range(days)
+        ]
+
+    def _kept(self, backups, **policy):
+        expired = set(select_expired_backups(backups, self.NOW, **policy))
+        return sorted((created for created, name in backups if name not in expired), reverse=True)
+
+    def test_tiers_off_is_a_plain_age_cutoff(self):
+        """The default for every existing deployment: unchanged behaviour."""
+        backups = self._daily_backups(40)
+        kept = self._kept(backups, retention_days=30, weekly_weeks=0, monthly_months=0)
+
+        # Day 0 through day 30 inclusive: a backup exactly at the cutoff is not
+        # yet older than the retention window.
+        assert len(kept) == 31
+        assert min(kept) >= self.NOW - timedelta(days=30)
+
+    def test_weekly_tier_keeps_one_backup_per_week(self):
+        backups = self._daily_backups(60)
+        kept = self._kept(backups, retention_days=7, weekly_weeks=4, monthly_months=0)
+
+        recent = [d for d in kept if d >= self.NOW - timedelta(days=7)]
+        weekly = [d for d in kept if d < self.NOW - timedelta(days=7)]
+
+        assert len(recent) == 8  # day 0 through day 7 inclusive
+        # One per ISO week, and no week represented twice.
+        weeks = [d.isocalendar()[:2] for d in weekly]
+        assert len(weeks) == len(set(weeks))
+        assert weekly, "the weekly tier kept nothing"
+        assert min(weekly) >= self.NOW - timedelta(days=7) - timedelta(weeks=4)
+
+    def test_monthly_tier_keeps_one_backup_per_month(self):
+        backups = self._daily_backups(400)
+        kept = self._kept(backups, retention_days=7, weekly_weeks=4, monthly_months=6)
+
+        monthly_start = self.NOW - timedelta(days=7) - timedelta(weeks=4)
+        monthly = [d for d in kept if d < monthly_start]
+        months = [(d.year, d.month) for d in monthly]
+
+        assert months, "the monthly tier kept nothing"
+        assert len(months) == len(set(months))
+        # Six months back from the weekly boundary, and nothing older survives.
+        assert min(monthly) >= _subtract_months(monthly_start, 6)
+
+    def test_a_year_of_dailies_collapses_to_a_bounded_set(self):
+        """The point of the policy: unbounded input, bounded output."""
+        backups = self._daily_backups(365)
+        kept = self._kept(backups, retention_days=7, weekly_weeks=4, monthly_months=12)
+
+        # 7 daily + at most 5 weekly buckets + at most 12 monthly buckets.
+        assert 7 <= len(kept) <= 24
+        # The newest backup is never a candidate for deletion.
+        assert max(kept) == self.NOW
+
+    def test_a_backup_kept_by_an_earlier_tier_fills_its_bucket(self):
+        """A week with a surviving daily backup does not also keep a weekly copy."""
+        # Two backups in the same ISO week, one either side of the daily cutoff.
+        inside = self.NOW - timedelta(days=6)
+        outside = self.NOW - timedelta(days=8)
+        assert inside.isocalendar()[:2] == outside.isocalendar()[:2]
+        backups = [
+            (inside, "depictio_backup_" + inside.strftime("%Y%m%d_%H%M%S") + ".json"),
+            (outside, "depictio_backup_" + outside.strftime("%Y%m%d_%H%M%S") + ".json"),
+        ]
+
+        expired = select_expired_backups(
+            backups, self.NOW, retention_days=7, weekly_weeks=4, monthly_months=0
+        )
+
+        assert expired == ["depictio_backup_" + outside.strftime("%Y%m%d_%H%M%S") + ".json"]
+
+    def test_keep_forever_ignores_the_tiers(self):
+        backups = self._daily_backups(500)
+        assert (
+            select_expired_backups(
+                backups, self.NOW, retention_days=0, weekly_weeks=1, monthly_months=1
+            )
+            == []
+        )
+
+    def test_subtract_months_clamps_to_the_shorter_month(self):
+        assert _subtract_months(datetime(2026, 3, 31), 1) == datetime(2026, 2, 28)
+        assert _subtract_months(datetime(2026, 1, 15), 13) == datetime(2024, 12, 15)
+
+
+class TestLastRestoreMarker:
+    """After a restore, the list marks which backup the live data came from."""
+
+    def test_a_successful_restore_records_its_source(self, backup_state):
+        record_last_restore("20260828_120000", "admin@example.com")
+
+        update = backup_state.update_one.call_args
+        assert update.args[0] == {"_id": "last_restore_state"}
+        stored = update.args[1]["$set"]
+        assert stored["backup_id"] == "20260828_120000"
+        assert stored["restored_by"] == "admin@example.com"
+
+    def test_bookkeeping_failure_does_not_raise(self, backup_state):
+        """A completed restore must not surface as an error because the marker
+        could not be written."""
+        backup_state.update_one.side_effect = RuntimeError("mongo is down")
+
+        record_last_restore("20260828_120000", "admin@example.com")
+
+    def test_list_marks_only_the_restored_backup(self, as_admin, backup_dir, backup_state):
+        _write_backup(backup_dir, "20260101_000000", {"projects": []})
+        _write_backup(backup_dir, "20260202_000000", {"projects": []})
+        backup_state.find_one.return_value = {
+            "_id": "last_restore_state",
+            "backup_id": "20260101_000000",
+            "restored_at": datetime(2026, 3, 1, 9, 0, 0),
+            "restored_by": "admin@example.com",
+        }
+
+        rows = as_admin.get("/backup/list").json()["backups"]
+        by_id = {row["backup_id"]: row for row in rows}
+
+        assert by_id["20260101_000000"]["restored_by"] == "admin@example.com"
+        # Naive UTC out of Mongo must be serialized with an offset, or the
+        # browser reads it as local time.
+        assert by_id["20260101_000000"]["restored_at"].endswith("+00:00")
+        assert by_id["20260202_000000"]["restored_at"] is None
 
 
 class TestBackupScheduleClaim:

--- a/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
+++ b/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
@@ -1,11 +1,70 @@
-from unittest.mock import patch
+import json
+import re
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from depictio.api.v1.endpoints.backup_endpoints.routes import backup_endpoint_router
+from depictio.api.v1.endpoints.backup_endpoints.routes import (
+    _compute_file_sha256,
+    backup_endpoint_router,
+)
 from depictio.models.models.base import PyObjectId
 from depictio.models.models.users import User
+
+
+def _write_backup(backup_dir, backup_id, data, with_sidecar=True, metadata=None):
+    """Write a backup file (and optional .sha256 sidecar) the way /create does."""
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"depictio_backup_{backup_id}.json"
+    backup_path = backup_dir / filename
+    payload = {
+        "backup_metadata": metadata
+        or {
+            "timestamp": "2025-01-01T00:00:00",
+            "created_by": "admin@example.com",
+            "depictio_version": "1.5.1",
+            "total_documents": sum(len(docs) for docs in data.values()),
+            "excluded_documents": 0,
+            "collections": list(data.keys()),
+            "backup_id": backup_id,
+        },
+        "data": data,
+    }
+    backup_path.write_text(json.dumps(payload, indent=2, default=str))
+    if with_sidecar:
+        digest = _compute_file_sha256(str(backup_path))
+        (backup_dir / f"{filename}.sha256").write_text(f"{digest}  {filename}\n")
+    return backup_path
+
+
+@pytest.fixture
+def backup_dir(tmp_path):
+    """Point the routes module's settings at a temporary backup directory."""
+    mock_settings = MagicMock()
+    mock_settings.backup.backup_path = str(tmp_path / "backups")
+    with patch("depictio.api.v1.endpoints.backup_endpoints.routes.settings", mock_settings):
+        yield tmp_path / "backups"
+
+
+@pytest.fixture
+def as_admin(client, admin_user):
+    """Authenticate the test client as an admin for the duration of a test."""
+    from depictio.api.v1.endpoints.backup_endpoints.routes import get_current_user
+
+    client.app.dependency_overrides[get_current_user] = lambda: admin_user
+    yield client
+    client.app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def as_regular_user(client, regular_user):
+    """Authenticate the test client as a non-admin for the duration of a test."""
+    from depictio.api.v1.endpoints.backup_endpoints.routes import get_current_user
+
+    client.app.dependency_overrides[get_current_user] = lambda: regular_user
+    yield client
+    client.app.dependency_overrides.clear()
 
 
 @pytest.fixture
@@ -300,3 +359,242 @@ class TestBackupEndpoints:
         assert response.excluded_documents == 5
         assert len(response.collections_backed_up) == 2
         assert response.filename == "backup_123456.json"
+
+
+EMPTY_DATA = {
+    "users": [],
+    "projects": [],
+    "dashboards": [],
+    "data_collections": [],
+    "workflows": [],
+    "files": [],
+    "deltatables": [],
+    "runs": [],
+    "groups": [],
+}
+
+
+class TestBackupDownload:
+    """Tests for GET /backup/download/{backup_id}."""
+
+    def test_download_success(self, as_admin, backup_dir):
+        _write_backup(backup_dir, "20250101_010101", EMPTY_DATA)
+
+        response = as_admin.get("/backup/download/20250101_010101")
+
+        assert response.status_code == 200
+        assert "depictio_backup_20250101_010101.json" in response.headers["content-disposition"]
+        payload = response.json()
+        assert payload["backup_metadata"]["backup_id"] == "20250101_010101"
+        assert set(payload["data"].keys()) == set(EMPTY_DATA.keys())
+
+    def test_download_denied_for_non_admin(self, as_regular_user, backup_dir):
+        _write_backup(backup_dir, "20250101_010101", EMPTY_DATA)
+
+        response = as_regular_user.get("/backup/download/20250101_010101")
+
+        assert response.status_code == 403
+
+    def test_download_rejects_malformed_id(self, as_admin, backup_dir):
+        response = as_admin.get("/backup/download/not-a-backup-id")
+
+        assert response.status_code == 422
+
+    def test_download_missing_backup(self, as_admin, backup_dir):
+        response = as_admin.get("/backup/download/20250101_010101")
+
+        assert response.status_code == 404
+
+
+class TestBackupUpload:
+    """Tests for POST /backup/upload."""
+
+    def _upload(self, client, body: bytes):
+        return client.post(
+            "/backup/upload", files={"file": ("backup.json", body, "application/json")}
+        )
+
+    def test_upload_success_makes_first_class_backup(self, as_admin, backup_dir):
+        body = json.dumps(
+            {
+                "backup_metadata": {
+                    "backup_id": "20200101_000000",
+                    "created_by": "admin@example.com",
+                    "depictio_version": "1.5.0",
+                    "total_documents": 0,
+                    "collections": list(EMPTY_DATA.keys()),
+                },
+                "data": EMPTY_DATA,
+            }
+        ).encode()
+
+        response = self._upload(as_admin, body)
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["success"] is True
+        assert re.fullmatch(r"\d{8}_\d{6}", result["backup_id"])
+        assert result["validation"]["valid"] is True
+
+        # The file and its checksum sidecar exist on disk under the new id.
+        stored = backup_dir / f"depictio_backup_{result['backup_id']}.json"
+        assert stored.exists()
+        assert (backup_dir / f"{stored.name}.sha256").exists()
+        # The embedded metadata id was rewritten to the server-side id.
+        assert json.loads(stored.read_text())["backup_metadata"]["backup_id"] == result["backup_id"]
+
+        # The uploaded backup is listed like any server-created one.
+        listing = as_admin.get("/backup/list").json()
+        entry = next(b for b in listing["backups"] if b["backup_id"] == result["backup_id"])
+        assert entry["has_checksum"] is True
+        assert entry["depictio_version"] == "1.5.0"
+
+    def test_upload_rejects_invalid_json(self, as_admin, backup_dir):
+        response = self._upload(as_admin, b"this is not json")
+
+        assert response.status_code == 400
+        assert "not valid JSON" in response.json()["detail"]
+
+    def test_upload_rejects_missing_data_section(self, as_admin, backup_dir):
+        response = self._upload(as_admin, json.dumps({"backup_metadata": {}}).encode())
+
+        assert response.status_code == 400
+        assert "missing 'data' section" in response.json()["detail"]
+
+    def test_upload_rejects_oversized_file(self, as_admin, backup_dir):
+        with patch("depictio.api.v1.endpoints.backup_endpoints.routes.MAX_BACKUP_UPLOAD_BYTES", 10):
+            response = self._upload(as_admin, json.dumps({"data": EMPTY_DATA}).encode())
+
+        assert response.status_code == 413
+
+    def test_upload_denied_for_non_admin(self, as_regular_user, backup_dir):
+        response = self._upload(as_regular_user, json.dumps({"data": {}}).encode())
+
+        assert response.status_code == 403
+
+    def test_upload_reports_validation_errors_but_stores_file(self, as_admin, backup_dir):
+        data = dict(EMPTY_DATA)
+        data["users"] = [{"email": "not-an-email"}]
+        response = self._upload(as_admin, json.dumps({"data": data}).encode())
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["success"] is True  # stored anyway; restore gate protects the DB
+        assert result["validation"]["valid"] is False
+        assert result["validation"]["invalid_documents"] == 1
+        assert (backup_dir / f"depictio_backup_{result['backup_id']}.json").exists()
+
+
+class TestBackupListMetadata:
+    """Tests for the enriched /backup/list entries."""
+
+    def test_list_surfaces_version_and_checksum(self, as_admin, backup_dir):
+        _write_backup(backup_dir, "20250101_010101", EMPTY_DATA)
+        _write_backup(backup_dir, "20250102_010101", EMPTY_DATA, with_sidecar=False)
+
+        listing = as_admin.get("/backup/list").json()
+
+        assert listing["success"] is True
+        by_id = {b["backup_id"]: b for b in listing["backups"]}
+        assert by_id["20250101_010101"]["has_checksum"] is True
+        assert by_id["20250101_010101"]["depictio_version"] == "1.5.1"
+        assert by_id["20250102_010101"]["has_checksum"] is False
+
+
+@patch("depictio.api.v1.endpoints.backup_endpoints.routes.users_collection")
+@patch("depictio.api.v1.endpoints.backup_endpoints.routes.projects_collection")
+class TestRestoreValidationGate:
+    """Tests for the pre-restore Pydantic validation gate."""
+
+    INVALID_USERS_DATA = {
+        "users": [{"email": "not-an-email"}],
+        "projects": [],
+    }
+
+    def test_restore_refuses_invalid_backup(self, mock_projects, mock_users, as_admin, backup_dir):
+        _write_backup(backup_dir, "20250101_010101", self.INVALID_USERS_DATA)
+
+        response = as_admin.post(
+            "/backup/restore", json={"backup_id": "20250101_010101", "dry_run": False}
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["success"] is False
+        assert "failed model validation" in result["message"]
+        assert result["errors"]  # per-document errors surfaced
+        mock_users.delete_many.assert_not_called()
+        mock_projects.delete_many.assert_not_called()
+
+    def test_skip_validation_overrides_gate(self, mock_projects, mock_users, as_admin, backup_dir):
+        data = {
+            "users": [{"_id": "507f1f77bcf86cd799439011", "email": "not-an-email"}],
+        }
+        _write_backup(backup_dir, "20250101_010101", data)
+
+        response = as_admin.post(
+            "/backup/restore",
+            json={"backup_id": "20250101_010101", "dry_run": False, "skip_validation": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_users.delete_many.assert_called_once()
+        mock_users.insert_many.assert_called_once()
+
+    def test_gate_scoped_to_selected_collections(
+        self, mock_projects, mock_users, as_admin, backup_dir
+    ):
+        _write_backup(backup_dir, "20250101_010101", self.INVALID_USERS_DATA)
+
+        response = as_admin.post(
+            "/backup/restore",
+            json={
+                "backup_id": "20250101_010101",
+                "dry_run": False,
+                "collections": ["projects"],
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_projects.delete_many.assert_called_once()
+        mock_users.delete_many.assert_not_called()
+
+    def test_dry_run_skips_validation(self, mock_projects, mock_users, as_admin, backup_dir):
+        _write_backup(backup_dir, "20250101_010101", self.INVALID_USERS_DATA)
+
+        with patch(
+            "depictio.cli.cli.utils.backup_validation.validate_backup_file"
+        ) as mock_validate:
+            response = as_admin.post(
+                "/backup/restore", json={"backup_id": "20250101_010101", "dry_run": True}
+            )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["success"] is True
+        assert "DRY RUN" in result["message"]
+        mock_validate.assert_not_called()
+        mock_users.delete_many.assert_not_called()
+
+    def test_restore_without_sidecar_requires_allow_unverified(
+        self, mock_projects, mock_users, as_admin, backup_dir
+    ):
+        _write_backup(backup_dir, "20250101_010101", {"projects": []}, with_sidecar=False)
+
+        refused = as_admin.post(
+            "/backup/restore", json={"backup_id": "20250101_010101", "dry_run": False}
+        )
+        assert refused.status_code == 409
+
+        allowed = as_admin.post(
+            "/backup/restore",
+            json={
+                "backup_id": "20250101_010101",
+                "dry_run": False,
+                "allow_unverified": True,
+            },
+        )
+        assert allowed.status_code == 200
+        assert allowed.json()["success"] is True

--- a/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
+++ b/depictio/tests/api/v1/endpoints/backup_endpoints/test_backup_routes.py
@@ -1,8 +1,10 @@
 import json
 import re
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from bson import ObjectId
 from fastapi.testclient import TestClient
 
 from depictio.api.v1.endpoints.backup_endpoints.routes import (
@@ -39,12 +41,43 @@ def _write_backup(backup_dir, backup_id, data, with_sidecar=True, metadata=None)
 
 
 @pytest.fixture
-def backup_dir(tmp_path):
-    """Point the routes module's settings at a temporary backup directory."""
+def backup_settings(tmp_path):
+    """Point the routes module's settings at a temporary backup directory.
+
+    Backup-related fields are set to real values rather than left as MagicMock
+    attributes: retention and the schedule are compared numerically, and a
+    MagicMock silently compares truthy in either direction.
+    """
     mock_settings = MagicMock()
     mock_settings.backup.backup_path = str(tmp_path / "backups")
+    mock_settings.backup.backup_file_retention_days = 30
+    mock_settings.backup.auto_backup_enabled = False
+    mock_settings.backup.auto_backup_interval_hours = 24
     with patch("depictio.api.v1.endpoints.backup_endpoints.routes.settings", mock_settings):
-        yield tmp_path / "backups"
+        yield mock_settings
+
+
+@pytest.fixture
+def backup_state():
+    """Isolate the schedule state document from a real MongoDB.
+
+    The effective schedule is read from Mongo on every retention pass and every
+    /schedule call; without this a test that never mentions the scheduler still
+    blocks for the full 30s connection timeout.
+    """
+    mock_collection = MagicMock()
+    mock_collection.find_one.return_value = None
+    with patch(
+        "depictio.api.v1.endpoints.backup_endpoints.routes.initialization_collection",
+        mock_collection,
+    ):
+        yield mock_collection
+
+
+@pytest.fixture
+def backup_dir(backup_settings, backup_state, tmp_path):
+    """The temporary backup directory ``backup_settings`` points the routes at."""
+    return tmp_path / "backups"
 
 
 @pytest.fixture
@@ -151,6 +184,7 @@ class TestBackupEndpoints:
         mock_users,
         client,
         admin_user,
+        backup_dir,
     ):
         """Test successful backup creation by admin user."""
         from depictio.api.v1.endpoints.backup_endpoints.routes import get_current_user
@@ -215,6 +249,7 @@ class TestBackupEndpoints:
         mock_users,
         client,
         admin_user,
+        backup_dir,
     ):
         """Test that temporary users and their resources are excluded from backup."""
         from depictio.api.v1.endpoints.backup_endpoints.routes import get_current_user
@@ -598,3 +633,266 @@ class TestRestoreValidationGate:
         )
         assert allowed.status_code == 200
         assert allowed.json()["success"] is True
+
+
+@patch("depictio.api.v1.endpoints.backup_endpoints.routes.dashboards_collection")
+@patch("depictio.api.v1.endpoints.backup_endpoints.routes.projects_collection")
+class TestRestoreObjectIdRehydration:
+    """Backups serialize every ObjectId to a string; restore has to undo that.
+
+    Writing the ids back as strings leaves documents Mongo can no longer join:
+    the dashboard listing filters on an ObjectId ``project_id``, so a restored
+    instance shows no dashboards at all.
+    """
+
+    DASHBOARD_OID = "6824cb3b89d2b72169309737"
+    PROJECT_OID = "646b0f3c1e4a2d7f8e5b8c9a"
+    OWNER_OID = "67658ba033c8b59ad489d7c7"
+    DC_OID = "646b0f3c1e4a2d7f8e5b8c9c"
+
+    def _dashboard(self):
+        return {
+            "_id": self.DASHBOARD_OID,
+            "dashboard_id": self.DASHBOARD_OID,
+            "project_id": self.PROJECT_OID,
+            "title": "Iris",
+            "permissions": {
+                "owners": [{"_id": self.OWNER_OID, "email": "admin@example.com"}],
+                "viewers": ["*"],
+            },
+            "stored_metadata": [{"index": "0", "dc_id": self.DC_OID}],
+        }
+
+    def _restore(self, as_admin, backup_dir, data):
+        _write_backup(backup_dir, "20250101_010101", data)
+        return as_admin.post(
+            "/backup/restore",
+            json={
+                "backup_id": "20250101_010101",
+                "dry_run": False,
+                "skip_validation": True,
+                "collections": ["dashboards"],
+            },
+        )
+
+    def test_nested_ids_come_back_as_objectids(
+        self, mock_projects, mock_dashboards, as_admin, backup_dir
+    ):
+        response = self._restore(as_admin, backup_dir, {"dashboards": [self._dashboard()]})
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        (inserted,), _ = mock_dashboards.insert_many.call_args
+        doc = inserted[0]
+        assert doc["_id"] == ObjectId(self.DASHBOARD_OID)
+        assert doc["project_id"] == ObjectId(self.PROJECT_OID)
+        assert doc["permissions"]["owners"][0]["_id"] == ObjectId(self.OWNER_OID)
+        assert doc["stored_metadata"][0]["dc_id"] == ObjectId(self.DC_OID)
+
+    def test_non_id_strings_are_left_alone(
+        self, mock_projects, mock_dashboards, as_admin, backup_dir
+    ):
+        self._restore(as_admin, backup_dir, {"dashboards": [self._dashboard()]})
+
+        (inserted,), _ = mock_dashboards.insert_many.call_args
+        doc = inserted[0]
+        assert doc["title"] == "Iris"
+        assert doc["permissions"]["viewers"] == ["*"]
+        assert doc["stored_metadata"][0]["index"] == "0"
+
+    def test_failed_insert_rolls_the_collection_back(
+        self, mock_projects, mock_dashboards, as_admin, backup_dir
+    ):
+        """A wipe-and-replace that fails half way must not leave an empty collection."""
+        existing = [{"_id": ObjectId(self.DASHBOARD_OID), "title": "before restore"}]
+        mock_dashboards.find.return_value = existing
+        mock_dashboards.insert_many.side_effect = [Exception("insert failed"), None]
+
+        response = self._restore(as_admin, backup_dir, {"dashboards": [self._dashboard()]})
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["success"] is False
+        assert result["restored_collections"]["dashboards"]["status"] == "failed"
+        # Second call is the rollback, re-inserting exactly what was there before.
+        assert mock_dashboards.insert_many.call_args_list[-1].args[0] == existing
+
+
+class TestBackupRetention:
+    """`backup_file_retention_days` was declared but never applied — nothing
+    pruned the backup directory, so it grew by one full database snapshot per
+    backup, forever."""
+
+    def _write(self, backup_dir, backup_id, with_sidecar=True):
+        return _write_backup(backup_dir, backup_id, {"projects": []}, with_sidecar=with_sidecar)
+
+    def test_prunes_backups_past_retention(self, backup_settings, backup_dir):
+        from depictio.api.v1.endpoints.backup_endpoints.routes import prune_expired_backups
+
+        backup_settings.backup.backup_file_retention_days = 30
+        old_id = (datetime.now() - timedelta(days=45)).strftime("%Y%m%d_%H%M%S")
+        recent_id = (datetime.now() - timedelta(days=2)).strftime("%Y%m%d_%H%M%S")
+        old_path = self._write(backup_dir, old_id)
+        recent_path = self._write(backup_dir, recent_id)
+
+        assert prune_expired_backups() == 1
+        assert not old_path.exists()
+        # The sidecar is worthless without its backup and goes with it.
+        assert not (backup_dir / f"{old_path.name}.sha256").exists()
+        assert recent_path.exists()
+
+    def test_zero_retention_keeps_everything(self, backup_settings, backup_dir):
+        from depictio.api.v1.endpoints.backup_endpoints.routes import prune_expired_backups
+
+        backup_settings.backup.backup_file_retention_days = 0
+        old_path = self._write(backup_dir, "20200101_000000")
+
+        assert prune_expired_backups() == 0
+        assert old_path.exists()
+
+    def test_unparseable_filenames_are_left_alone(self, backup_settings, backup_dir):
+        """Only files whose id parses as a timestamp have a knowable age."""
+        from depictio.api.v1.endpoints.backup_endpoints.routes import prune_expired_backups
+
+        backup_settings.backup.backup_file_retention_days = 1
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        stray = backup_dir / "depictio_backup_manual-copy.json"
+        stray.write_text("{}")
+
+        assert prune_expired_backups() == 0
+        assert stray.exists()
+
+
+class TestBackupScheduleClaim:
+    """Every API worker runs the scheduler loop, so the due time is claimed in
+    MongoDB — the initialization election has no winner after the first boot."""
+
+    def test_claim_matches_only_a_due_slot(self, backup_state, backup_settings):
+        from depictio.api.v1.endpoints.backup_endpoints.routes import claim_auto_backup_slot
+
+        backup_state.find_one_and_update.return_value = {"_id": "auto_backup_state"}
+        claimed = claim_auto_backup_slot(3600)
+
+        assert claimed is not None
+        query = backup_state.find_one_and_update.call_args.args[0]
+        assert query["_id"] == "auto_backup_state"
+        # The filter is what makes the claim exclusive: a worker only wins when
+        # the recorded run is at least one interval old.
+        assert "$lte" in query["last_run_at"]
+
+    def test_losing_worker_gets_nothing(self, backup_state, backup_settings):
+        from depictio.api.v1.endpoints.backup_endpoints.routes import claim_auto_backup_slot
+
+        backup_state.find_one_and_update.return_value = None
+        assert claim_auto_backup_slot(3600) is None
+
+    def test_unreachable_mongo_declines_rather_than_raising(self, backup_state, backup_settings):
+        from depictio.api.v1.endpoints.backup_endpoints.routes import claim_auto_backup_slot
+
+        backup_state.update_one.side_effect = Exception("mongo down")
+        assert claim_auto_backup_slot(3600) is None
+
+
+class TestBackupScheduleEndpoint:
+    def test_requires_admin(self, backup_state, as_regular_user, backup_settings):
+        assert as_regular_user.get("/backup/schedule").status_code == 403
+        assert as_regular_user.put("/backup/schedule", json={"enabled": True}).status_code == 403
+
+    def test_reports_the_environment_defaults(self, backup_state, as_admin, backup_settings):
+        result = as_admin.get("/backup/schedule").json()
+
+        assert result["enabled"] is False
+        assert result["retention_days"] == 30
+        assert result["last_run"] is None
+        # Nothing is scheduled, so there is no next run to promise.
+        assert result["next_run"] is None
+        # Nothing has been saved from the UI, so the env values are in force.
+        assert result["is_customized"] is False
+
+    def test_next_run_follows_the_last_run(self, backup_state, as_admin, backup_settings):
+        backup_settings.backup.auto_backup_enabled = True
+        backup_settings.backup.auto_backup_interval_hours = 6
+        # pymongo hands back naive UTC datetimes; the response must still carry
+        # an offset or the browser reads it as local time.
+        backup_state.find_one.return_value = {"last_run_at": datetime(2026, 1, 1, 12, 0, 0)}
+
+        result = as_admin.get("/backup/schedule").json()
+
+        assert result["enabled"] is True
+        assert result["last_run"] == "2026-01-01T12:00:00+00:00"
+        assert result["next_run"] == "2026-01-01T18:00:00+00:00"
+
+
+class TestBackupScheduleUpdate:
+    """The schedule is editable from the admin UI; the environment only supplies
+    the default, so a saved value has to survive and win."""
+
+    def test_saving_overrides_the_environment_default(
+        self, backup_state, as_admin, backup_settings
+    ):
+        backup_settings.backup.auto_backup_enabled = False
+        backup_settings.backup.auto_backup_interval_hours = 24
+        # What the endpoint just wrote is what the next read returns.
+        backup_state.find_one.return_value = {"enabled": True, "interval_hours": 6}
+
+        result = as_admin.put(
+            "/backup/schedule", json={"enabled": True, "interval_hours": 6}
+        ).json()
+
+        assert result["enabled"] is True
+        assert result["interval_hours"] == 6
+        # Retention was not part of the update, so it still comes from settings.
+        assert result["retention_days"] == 30
+        assert result["is_customized"] is True
+
+    def test_creates_the_state_document_with_a_claimable_due_time(
+        self, backup_state, as_admin, backup_settings
+    ):
+        """Upserting only the schedule fields would leave last_run_at missing,
+        and the claim filter never matches a missing field — the scheduler would
+        be enabled and silently never fire."""
+        as_admin.put("/backup/schedule", json={"enabled": True})
+
+        update = backup_state.update_one.call_args.args[1]
+        assert update["$set"] == {"enabled": True}
+        assert "last_run_at" in update["$setOnInsert"]
+        assert backup_state.update_one.call_args.kwargs["upsert"] is True
+
+    def test_omitted_fields_are_left_alone(self, backup_state, as_admin, backup_settings):
+        as_admin.put("/backup/schedule", json={"retention_days": 7})
+
+        assert backup_state.update_one.call_args.args[1]["$set"] == {"retention_days": 7}
+
+    def test_empty_update_is_rejected(self, backup_state, as_admin, backup_settings):
+        assert as_admin.put("/backup/schedule", json={}).status_code == 422
+        backup_state.update_one.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"interval_hours": 0},  # a snapshot is the whole database
+            {"interval_hours": 100000},
+            {"retention_days": -1},
+        ],
+    )
+    def test_out_of_range_values_are_rejected(
+        self, backup_state, as_admin, backup_settings, payload
+    ):
+        assert as_admin.put("/backup/schedule", json=payload).status_code == 422
+        backup_state.update_one.assert_not_called()
+
+    def test_retention_pruning_follows_the_saved_value(
+        self, backup_state, backup_settings, backup_dir
+    ):
+        """Retention is read through the same override, so changing it in the UI
+        changes what the next prune deletes."""
+        from depictio.api.v1.endpoints.backup_endpoints.routes import prune_expired_backups
+
+        backup_settings.backup.backup_file_retention_days = 3650
+        backup_state.find_one.return_value = {"retention_days": 1}
+        old_id = (datetime.now() - timedelta(days=5)).strftime("%Y%m%d_%H%M%S")
+        old_path = _write_backup(backup_dir, old_id, {"projects": []})
+
+        assert prune_expired_backups() == 1
+        assert not old_path.exists()

--- a/depictio/tests/api/v1/tasks/test_backup_tasks.py
+++ b/depictio/tests/api/v1/tasks/test_backup_tasks.py
@@ -18,6 +18,8 @@ def backup_settings(tmp_path):
     mock_settings = MagicMock()
     mock_settings.backup.backup_path = str(tmp_path / "backups")
     mock_settings.backup.backup_file_retention_days = 30
+    mock_settings.backup.backup_retention_weekly_weeks = 0
+    mock_settings.backup.backup_retention_monthly_months = 0
     mock_settings.backup.auto_backup_enabled = True
     mock_settings.backup.auto_backup_interval_hours = 24
     mock_state = MagicMock()

--- a/depictio/tests/api/v1/tasks/test_backup_tasks.py
+++ b/depictio/tests/api/v1/tasks/test_backup_tasks.py
@@ -22,6 +22,7 @@ def backup_settings(tmp_path):
     mock_settings.backup.backup_retention_monthly_months = 0
     mock_settings.backup.auto_backup_enabled = True
     mock_settings.backup.auto_backup_interval_hours = 24
+    mock_settings.backup.auto_backup_time_of_day = None
     mock_state = MagicMock()
     mock_state.find_one.return_value = None
     with (

--- a/depictio/tests/api/v1/tasks/test_backup_tasks.py
+++ b/depictio/tests/api/v1/tasks/test_backup_tasks.py
@@ -1,0 +1,116 @@
+"""Tests for the scheduled MongoDB backup task."""
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from depictio.api.v1.tasks.backup_tasks import run_scheduled_backup, start_backup_tasks
+
+ROUTES = "depictio.api.v1.endpoints.backup_endpoints.routes"
+TASKS = "depictio.api.v1.tasks.backup_tasks"
+
+
+@pytest.fixture
+def backup_settings(tmp_path):
+    """Real values for every field the task compares or formats."""
+    mock_settings = MagicMock()
+    mock_settings.backup.backup_path = str(tmp_path / "backups")
+    mock_settings.backup.backup_file_retention_days = 30
+    mock_settings.backup.auto_backup_enabled = True
+    mock_settings.backup.auto_backup_interval_hours = 24
+    mock_state = MagicMock()
+    mock_state.find_one.return_value = None
+    with (
+        patch(f"{ROUTES}.settings", mock_settings),
+        patch(f"{ROUTES}.initialization_collection", mock_state),
+    ):
+        yield mock_settings
+
+
+@pytest.mark.asyncio
+async def test_skips_when_the_slot_is_not_due(backup_settings, tmp_path):
+    with (
+        patch(f"{TASKS}.claim_auto_backup_slot", return_value=None),
+        patch(f"{TASKS}._create_mongodb_backup", new=AsyncMock()) as mock_create,
+    ):
+        assert await run_scheduled_backup() is None
+
+    mock_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_while_the_schedule_is_off(backup_settings, tmp_path):
+    """The loop runs even when disabled so the UI toggle needs no restart, so
+    the enabled check has to happen per tick rather than at startup."""
+    backup_settings.backup.auto_backup_enabled = False
+    with (
+        patch(f"{TASKS}.claim_auto_backup_slot") as mock_claim,
+        patch(f"{TASKS}._create_mongodb_backup", new=AsyncMock()) as mock_create,
+    ):
+        assert await run_scheduled_backup() is None
+
+    # Not even the claim is attempted: a disabled tick must not move the due time.
+    mock_claim.assert_not_called()
+    mock_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_writes_a_backup_and_its_sidecar_when_due(backup_settings, tmp_path):
+    """A scheduled backup has to be a first-class one: same filename, same
+    sidecar. Without the sidecar a later restore refuses to run unverified."""
+    # A real backup id is minted from "now"; using a fixed past one would be
+    # pruned by the retention pass that runs right after the write.
+    now_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+    payload = {
+        "backup_metadata": {"backup_id": now_id, "total_documents": 3, "automatic": True},
+        "data": {"projects": []},
+    }
+    with (
+        patch(f"{TASKS}.claim_auto_backup_slot", return_value=object()),
+        patch(
+            f"{TASKS}._create_mongodb_backup", new=AsyncMock(return_value=payload)
+        ) as mock_create,
+    ):
+        backup_id = await run_scheduled_backup()
+
+    assert backup_id == now_id
+    # The scheduler identifies itself, and stamps the snapshot as automatic so
+    # the admin UI can tell it apart from a hand-made one.
+    assert mock_create.await_args.args == ("scheduler",)
+    assert mock_create.await_args.kwargs == {"automatic": True}
+
+    backup_dir = tmp_path / "backups"
+    written = backup_dir / f"depictio_backup_{now_id}.json"
+    assert written.exists()
+    assert (backup_dir / f"depictio_backup_{now_id}.json.sha256").exists()
+    assert json.loads(written.read_text())["backup_metadata"]["automatic"] is True
+
+
+@pytest.mark.asyncio
+async def test_prunes_after_a_scheduled_backup(backup_settings, tmp_path):
+    payload = {
+        "backup_metadata": {
+            "backup_id": datetime.now().strftime("%Y%m%d_%H%M%S"),
+            "total_documents": 0,
+        },
+        "data": {},
+    }
+    with (
+        patch(f"{TASKS}.claim_auto_backup_slot", return_value=object()),
+        patch(f"{TASKS}._create_mongodb_backup", new=AsyncMock(return_value=payload)),
+        patch(f"{TASKS}.prune_expired_backups") as mock_prune,
+    ):
+        await run_scheduled_backup()
+
+    mock_prune.assert_called_once()
+
+
+def test_the_loop_starts_even_when_the_schedule_is_off(backup_settings):
+    """Starting only when enabled would mean the admin's toggle did nothing
+    until someone restarted the API."""
+    backup_settings.backup.auto_backup_enabled = False
+    with patch(f"{TASKS}.asyncio.create_task") as mock_create_task:
+        start_backup_tasks()
+    mock_create_task.assert_called_once()

--- a/depictio/tests/cli/commands/test_backup.py
+++ b/depictio/tests/cli/commands/test_backup.py
@@ -349,3 +349,79 @@ class TestBackupCLI:
 
         assert result.exit_code == 1
         assert "Coverage check failed" in result.stdout
+
+
+class TestRestoreCLI:
+    """Test the backup restore CLI command."""
+
+    @patch("depictio.cli.cli.commands.backup.load_depictio_config")
+    @patch("depictio.cli.cli.commands.backup.api_login")
+    def test_restore_declined_confirmation_exits_cleanly(
+        self, mock_api_login, mock_load_config, runner
+    ):
+        """Declining the confirmation prompt must exit 0, not report a failure."""
+        mock_load_config.return_value = Mock()
+        mock_api_login.return_value = {"success": True, "is_admin": True}
+
+        result = runner.invoke(app, ["restore", "20250101_010101"], input="n\n")
+
+        assert result.exit_code == 0
+        assert "Restore cancelled" in result.stdout
+        assert "Restore operation failed" not in result.stdout
+
+    @patch("depictio.cli.cli.utils.api_calls.api_restore_backup")
+    @patch("depictio.cli.cli.commands.backup.load_depictio_config")
+    @patch("depictio.cli.cli.commands.backup.api_login")
+    def test_restore_forwards_safety_flags(
+        self, mock_api_login, mock_load_config, mock_api_restore, runner
+    ):
+        """--allow-unverified and --skip-validation are forwarded to the API call."""
+        mock_load_config.return_value = Mock()
+        mock_api_login.return_value = {"success": True, "is_admin": True}
+        mock_api_restore.return_value = {
+            "success": True,
+            "message": "Restored 0 documents from backup",
+            "restored_collections": {},
+            "total_restored": 0,
+            "errors": [],
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "restore",
+                "20250101_010101",
+                "--force",
+                "--allow-unverified",
+                "--skip-validation",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Restore completed successfully" in result.stdout
+        _args, kwargs = mock_api_restore.call_args
+        assert kwargs["allow_unverified"] is True
+        assert kwargs["skip_validation"] is True
+
+    @patch("depictio.cli.cli.utils.api_calls.api_restore_backup")
+    @patch("depictio.cli.cli.commands.backup.load_depictio_config")
+    @patch("depictio.cli.cli.commands.backup.api_login")
+    def test_restore_refused_by_validation_gate(
+        self, mock_api_login, mock_load_config, mock_api_restore, runner
+    ):
+        """A server-side validation refusal surfaces the message and errors."""
+        mock_load_config.return_value = Mock()
+        mock_api_login.return_value = {"success": True, "is_admin": True}
+        mock_api_restore.return_value = {
+            "success": False,
+            "message": "Backup failed model validation: 2 invalid document(s) ...",
+            "restored_collections": {},
+            "total_restored": 0,
+            "errors": ["Document 0 in users: invalid email"],
+        }
+
+        result = runner.invoke(app, ["restore", "20250101_010101", "--force"])
+
+        assert result.exit_code == 1
+        assert "failed model validation" in result.stdout
+        assert "Document 0 in users" in result.stdout

--- a/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
@@ -77,6 +77,8 @@ test.describe("admin backup & restore", () => {
     expect(filePath).toBeTruthy();
 
     // -- upload the downloaded file --------------------------------------
+    // The drop zone lives in a modal now, so open it before reaching the input.
+    await page.getByTestId("backup-upload-button").click();
     await page
       .locator("[data-testid='backup-upload-zone'] input[type='file']")
       .setInputFiles(filePath!);

--- a/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
@@ -82,9 +82,11 @@ test.describe("admin backup & restore", () => {
       .setInputFiles(filePath!);
 
     // Upload runs validation server-side and opens the restore modal on the
-    // results step directly.
-    await expect(page.getByTestId("backup-restore-modal")).toBeVisible({ timeout: 60_000 });
-    await expect(page.getByTestId("backup-validation-valid")).toBeVisible();
+    // results step directly. Assert on the modal's *content* testids: the
+    // Mantine Modal root carries the data-testid but is an unstyled wrapper
+    // whose overlay/content children are position-fixed, so the root itself
+    // has a zero-size bounding box and Playwright's toBeVisible() rejects it.
+    await expect(page.getByTestId("backup-validation-valid")).toBeVisible({ timeout: 60_000 });
     await expect(page.getByTestId("backup-validation-table")).toBeVisible();
 
     // -- typed confirmation + destructive restore ------------------------

--- a/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
@@ -97,6 +97,12 @@ test.describe("admin backup & restore", () => {
     await expect(page.getByTestId("backup-restore-success")).toBeVisible({ timeout: 120_000 });
     await page.getByRole("button", { name: "Close" }).click();
 
+    // The list now marks which snapshot the live data came from, so an admin
+    // looking at several backups can tell which one is currently in effect.
+    await expect(page.getByTestId(`backup-restored-${backupId}`)).toBeVisible({
+      timeout: 30_000,
+    });
+
     // The app is still functional after the restore (the admin session
     // survives because tokens are never part of backups) — and the restored
     // data is still queryable. Backups serialize every ObjectId to a string;

--- a/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, getAuthMode } from "@fixtures/auth";
+
+/**
+ * Admin > Backups: full backup & restore loop.
+ *
+ * create → newest row appears → download the file → re-upload it (server
+ * validates on upload) → typed RESTORE confirmation → destructive restore
+ * succeeds. Restoring a seconds-old snapshot of the live database is
+ * near-idempotent, which is what makes the destructive step safe to run
+ * against the shared CI stack; everything happens inside one test to keep
+ * the snapshot→restore window minimal.
+ *
+ * The Backups tab is gated like the Log & Task tab: hidden on pure
+ * public/demo instances (and restore would destroy the demo DB), so the
+ * spec skips there.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("admin backup & restore", () => {
+  test.beforeEach(async () => {
+    const mode = await getAuthMode();
+    test.skip(
+      (mode.is_public_mode || mode.is_demo_mode) && !mode.is_single_user_mode,
+      "Backups tab is hidden in public/demo mode",
+    );
+  });
+
+  test("create, download, upload, validate and restore a backup", async ({
+    page,
+    loginAsAdmin,
+  }) => {
+    await loginAsAdmin();
+    await page.goto("/admin");
+
+    await page.getByTestId("admin-tab-backups").click();
+    await expect(page.getByTestId("backup-create-button")).toBeVisible({ timeout: 20_000 });
+
+    // -- create ----------------------------------------------------------
+    const rows = page.locator("[data-testid^='backup-row-']");
+    // Wait for the initial list fetch to settle before counting.
+    await expect(
+      page.getByTestId("backup-list-table").or(page.getByText("No backups on the server yet.")),
+    ).toBeVisible({ timeout: 20_000 });
+    const rowsBefore = await rows.count();
+
+    await page.getByTestId("backup-create-button").click();
+    await expect(rows).toHaveCount(rowsBefore + 1, { timeout: 60_000 });
+
+    // Rows are sorted newest-first, so the created backup is the first row.
+    const rowTestId = await rows.first().getAttribute("data-testid");
+    const backupId = rowTestId!.replace("backup-row-", "");
+    expect(backupId).toMatch(/^\d{8}_\d{6}$/);
+
+    // -- download --------------------------------------------------------
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByTestId(`backup-download-${backupId}`).click(),
+    ]);
+    expect(download.suggestedFilename()).toBe(`depictio_backup_${backupId}.json`);
+    const filePath = await download.path();
+    expect(filePath).toBeTruthy();
+
+    // -- upload the downloaded file --------------------------------------
+    await page
+      .locator("[data-testid='backup-upload-zone'] input[type='file']")
+      .setInputFiles(filePath!);
+
+    // Upload runs validation server-side and opens the restore modal on the
+    // results step directly.
+    await expect(page.getByTestId("backup-restore-modal")).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByTestId("backup-validation-valid")).toBeVisible();
+    await expect(page.getByTestId("backup-validation-table")).toBeVisible();
+
+    // -- typed confirmation + destructive restore ------------------------
+    const confirmButton = page.getByTestId("backup-restore-confirm-button");
+    await expect(confirmButton).toBeDisabled();
+    await page.getByTestId("backup-restore-confirm-input").fill("RESTORE");
+    await expect(confirmButton).toBeEnabled();
+    await confirmButton.click();
+
+    await expect(page.getByTestId("backup-restore-success")).toBeVisible({ timeout: 120_000 });
+    await page.getByRole("button", { name: "Close" }).click();
+
+    // The app is still functional after the restore (the admin session
+    // survives because tokens are never part of backups).
+    await page.goto("/dashboards");
+    await expect(page).toHaveURL(/\/dashboards/);
+  });
+});

--- a/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
@@ -101,9 +101,15 @@ test.describe("admin backup & restore", () => {
 
     // The list now marks which snapshot the live data came from, so an admin
     // looking at several backups can tell which one is currently in effect.
-    await expect(page.getByTestId(`backup-restored-${backupId}`)).toBeVisible({
+    // The badge lands on the *uploaded* copy, not on `backupId`: an upload is
+    // stored as a first-class backup under a freshly minted id, and that copy
+    // is what the restore ran from. Assert the count instead of guessing the
+    // id — the marker is a single document, so exactly one row can carry it.
+    await expect(page.locator("[data-testid^='backup-restored-']")).toHaveCount(1, {
       timeout: 30_000,
     });
+    // ...and it is not the backup we created, which was never restored from.
+    await expect(page.getByTestId(`backup-restored-${backupId}`)).toHaveCount(0);
 
     // The app is still functional after the restore (the admin session
     // survives because tokens are never part of backups) — and the restored

--- a/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/admin/backup-restore.spec.ts
@@ -36,6 +36,21 @@ test.describe("admin backup & restore", () => {
     await page.getByTestId("admin-tab-backups").click();
     await expect(page.getByTestId("backup-create-button")).toBeVisible({ timeout: 20_000 });
 
+    // Dashboards visible before the restore — the same listing has to still
+    // hold them afterwards (see the post-restore assertion below).
+    const dashboardCards = page.locator("[data-testid='dashboard-card']");
+    await page.goto("/dashboards");
+    await expect(page.locator(".mantine-AppShell-root")).toBeVisible({ timeout: 15_000 });
+    // Give the listing fetch a chance to paint before counting; a stack with
+    // no seeded dashboards legitimately stays at zero and skips the check.
+    await dashboardCards
+      .first()
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .catch(() => {});
+    const dashboardsBefore = await dashboardCards.count();
+    await page.goto("/admin");
+    await page.getByTestId("admin-tab-backups").click();
+
     // -- create ----------------------------------------------------------
     const rows = page.locator("[data-testid^='backup-row-']");
     // Wait for the initial list fetch to settle before counting.
@@ -83,8 +98,16 @@ test.describe("admin backup & restore", () => {
     await page.getByRole("button", { name: "Close" }).click();
 
     // The app is still functional after the restore (the admin session
-    // survives because tokens are never part of backups).
+    // survives because tokens are never part of backups) — and the restored
+    // data is still queryable. Backups serialize every ObjectId to a string;
+    // a restore that fails to re-hydrate them writes documents whose
+    // project_id no longer matches the listing's ObjectId filter, so the page
+    // loads with zero dashboards instead of an error.
     await page.goto("/dashboards");
     await expect(page).toHaveURL(/\/dashboards/);
+    if (dashboardsBefore > 0) {
+      await expect(dashboardCards.first()).toBeVisible({ timeout: 30_000 });
+      await expect(dashboardCards).toHaveCount(dashboardsBefore, { timeout: 30_000 });
+    }
   });
 });

--- a/depictio/viewer/src/admin/AdminApp.tsx
+++ b/depictio/viewer/src/admin/AdminApp.tsx
@@ -21,11 +21,19 @@ import AdminUsersPanel from './AdminUsersPanel';
 import AdminProjectsPanel from './AdminProjectsPanel';
 import AdminDashboardsPanel from './AdminDashboardsPanel';
 import AdminBrandingPanel from './AdminBrandingPanel';
+import AdminBackupsPanel from './AdminBackupsPanel';
 import AdminMaintenancePanel from './AdminMaintenancePanel';
 import AdminMonitoringPanel from './AdminMonitoringPanel';
 import { usePageTitle } from '../branding';
 
-type AdminTab = 'users' | 'projects' | 'dashboards' | 'branding' | 'monitoring' | 'maintenance';
+type AdminTab =
+  | 'users'
+  | 'projects'
+  | 'dashboards'
+  | 'branding'
+  | 'monitoring'
+  | 'backups'
+  | 'maintenance';
 
 /** Persist the active tab so a refresh keeps the admin where they left off. */
 const TAB_KEY = 'admin-active-tab';
@@ -39,6 +47,7 @@ function readInitialTab(): AdminTab {
       raw === 'dashboards' ||
       raw === 'branding' ||
       raw === 'monitoring' ||
+      raw === 'backups' ||
       raw === 'maintenance'
     ) {
       return raw;
@@ -55,6 +64,8 @@ const AdminApp: React.FC = () => {
   // always wins — it's a personal admin instance even if public_mode is also
   // set; only pure public/demo instances hide it.
   const showMonitoring = isSingleUserMode || (!isPublicMode && !isDemoMode);
+  // Full-DB backup/restore is likewise a trusted-deployment tool.
+  const showBackups = showMonitoring;
   const [mobileOpened, { toggle: toggleMobile }] = useDisclosure(false);
   const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
   const [activeTab, setActiveTab] = useState<AdminTab>(readInitialTab);
@@ -132,6 +143,15 @@ const AdminApp: React.FC = () => {
               Log &amp; Task
             </Tabs.Tab>
           )}
+          {showBackups && (
+            <Tabs.Tab
+              value="backups"
+              leftSection={<Icon icon="mdi:backup-restore" width={16} />}
+              data-testid="admin-tab-backups"
+            >
+              Backups
+            </Tabs.Tab>
+          )}
           <Tabs.Tab value="maintenance" leftSection={<Icon icon="mdi:broom" width={16} />}>
             Maintenance
           </Tabs.Tab>
@@ -152,6 +172,11 @@ const AdminApp: React.FC = () => {
         {showMonitoring && (
           <Tabs.Panel value="monitoring" pt="md">
             <AdminMonitoringPanel />
+          </Tabs.Panel>
+        )}
+        {showBackups && (
+          <Tabs.Panel value="backups" pt="md">
+            <AdminBackupsPanel />
           </Tabs.Panel>
         )}
         <Tabs.Panel value="maintenance" pt="md">

--- a/depictio/viewer/src/admin/AdminBackupsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBackupsPanel.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActionIcon,
   Alert,
+  Anchor,
   Badge,
   Button,
   Card,
@@ -63,11 +64,20 @@ const ScheduleFact: React.FC<{ label: string; value: React.ReactNode }> = ({ lab
   </Group>
 );
 
-/** The tiers "Smart retention" turns on. Fixed rather than exposed as two more
- *  number inputs: the value of the mode is that an admin picks thinning without
- *  having to design a policy, and a wrong pair of tiers is worse than none. */
-const SMART_WEEKLY_WEEKS = 4;
-const SMART_MONTHLY_MONTHS = 12;
+/** The one policy "Smart retention" stands for. Fully fixed rather than exposed
+ *  as three number inputs: the value of the mode is that an admin picks thinning
+ *  without having to design a policy, and a badly chosen set of tiers is worse
+ *  than none.
+ *
+ *  30 days of full fidelity, not the textbook 7, so that switching from the
+ *  default fixed policy (also 30 days) can only ever keep *more* history than
+ *  before. A mode that silently shortened the window an admin already had would
+ *  be the wrong kind of surprise in a backup feature. */
+const SMART_RETENTION = {
+  retention_days: 30,
+  weekly_weeks: 4,
+  monthly_months: 12,
+} as const;
 
 type RetentionMode = 'simple' | 'smart';
 
@@ -104,6 +114,8 @@ const AdminBackupsPanel: React.FC = () => {
   const [draft, setDraft] = useState<ScheduleDraft | null>(null);
   const [savingSchedule, setSavingSchedule] = useState(false);
   const [togglingSchedule, setTogglingSchedule] = useState(false);
+  /** The admin's own "keep for" value, parked while smart mode overrides it. */
+  const fixedTimeDays = useRef<number>(SMART_RETENTION.retention_days);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -183,20 +195,21 @@ const AdminBackupsPanel: React.FC = () => {
     }
   };
 
-  /** Switching mode only turns the weekly/monthly tiers on or off. The days
-   *  field is deliberately left alone: it means something in both modes (in
-   *  smart mode it is the window before thinning starts), so flipping the mode
-   *  never silently rewrites a number the admin chose. */
+  /** Smart mode forces the whole preset, including the days. Switching back
+   *  hands the admin their own number again rather than the preset's, so the
+   *  mode switch is not a one-way door for a value they chose. */
   const setRetentionMode = (draft: ScheduleDraft, mode: RetentionMode) => {
-    setDraft(
-      mode === 'smart'
-        ? {
-            ...draft,
-            weekly_weeks: SMART_WEEKLY_WEEKS,
-            monthly_months: SMART_MONTHLY_MONTHS,
-          }
-        : { ...draft, weekly_weeks: 0, monthly_months: 0 },
-    );
+    if (mode === 'smart') {
+      fixedTimeDays.current = draft.retention_days;
+      setDraft({ ...draft, ...SMART_RETENTION });
+      return;
+    }
+    setDraft({
+      ...draft,
+      retention_days: fixedTimeDays.current,
+      weekly_weeks: 0,
+      monthly_months: 0,
+    });
   };
 
   /** The header switch commits on the spot rather than waiting for Save: it is
@@ -342,27 +355,41 @@ const AdminBackupsPanel: React.FC = () => {
           ]}
         />
 
-        <NumberInput
-          label={retentionModeOf(d) === 'smart' ? 'Keep every backup for' : 'Keep backups for'}
-          description="0 keeps every backup forever"
-          suffix=" days"
-          min={0}
-          max={3650}
-          clampBehavior="strict"
-          allowDecimal={false}
-          value={d.retention_days}
-          onChange={(v) =>
-            setDraft({ ...d, retention_days: typeof v === 'number' ? v : d.retention_days })
-          }
-          disabled={savingSchedule}
-          data-testid="backup-schedule-retention"
-        />
+        {retentionModeOf(d) === 'smart' ? (
+          // Smart mode has nothing to configure, so it shows what it does
+          // instead of a disabled input the admin would try to edit.
+          <Stack gap={4} data-testid="backup-retention-smart">
+            <Text size="sm" fw={500}>
+              Keeps, from newest to oldest:
+            </Text>
+            <Text size="sm" c="dimmed">
+              every backup for {plural(SMART_RETENTION.retention_days, 'day')}, then one a week
+              for {plural(SMART_RETENTION.weekly_weeks, 'week')}, then one a month for{' '}
+              {plural(SMART_RETENTION.monthly_months, 'month')}.
+            </Text>
+          </Stack>
+        ) : (
+          <NumberInput
+            label="Keep backups for"
+            description="0 keeps every backup forever"
+            suffix=" days"
+            min={0}
+            max={3650}
+            clampBehavior="strict"
+            allowDecimal={false}
+            value={d.retention_days}
+            onChange={(v) =>
+              setDraft({ ...d, retention_days: typeof v === 'number' ? v : d.retention_days })
+            }
+            disabled={savingSchedule}
+            data-testid="backup-schedule-retention"
+          />
+        )}
 
         <Text size="xs" c="dimmed" data-testid="backup-retention-summary">
-          {describeRetention(d)}
-          {retentionModeOf(d) === 'smart' && d.retention_days > 0
-            ? ' Older snapshots stay reachable without the volume growing forever.'
-            : ''}
+          {retentionModeOf(d) === 'smart'
+            ? 'A year of history stays reachable without the backup volume growing forever.'
+            : describeRetention(d)}
         </Text>
 
         <Group justify="flex-end">
@@ -649,8 +676,16 @@ const AdminBackupsPanel: React.FC = () => {
               metadata pointing at your data. The data itself (Delta tables in S3 or MinIO) is
               not included and is not restored from here. Back it up separately, with your
               object store&apos;s own replication or with{' '}
-              <Code>depictio-cli backup create --include-s3-data</Code>. See{' '}
-              <Code>docs/backup-restore.md</Code>.
+              <Code>depictio-cli backup create --include-s3-data</Code>.{' '}
+              <Anchor
+                href="https://depictio.github.io/depictio-docs/latest/usage/administration/backup/"
+                target="_blank"
+                rel="noopener noreferrer"
+                size="sm"
+              >
+                Backup &amp; restore documentation
+              </Anchor>
+              .
             </Text>
           </Alert>
         </Stack>

--- a/depictio/viewer/src/admin/AdminBackupsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBackupsPanel.tsx
@@ -1,0 +1,310 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Center,
+  FileButton,
+  Group,
+  Loader,
+  Stack,
+  Table,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { Icon } from '@iconify/react';
+
+import { createBackup, downloadBackup, listBackups, uploadBackup } from 'depictio-react-core';
+import type { AdminBackupEntry } from 'depictio-react-core';
+
+import UnstyledDropZone from '../components/UnstyledDropZone';
+import { formatDateTime } from '../lib/datetime';
+import RestoreBackupModal from './RestoreBackupModal';
+import type { RestoreTarget } from './RestoreBackupModal';
+
+/**
+ * Admin > Backups tab. One-click server-side backup (create + download),
+ * a list of the backups on the server, and a restore flow: pick a listed
+ * backup or upload a file → validation → typed-phrase confirmation →
+ * destructive restore (see RestoreBackupModal for the safety rails).
+ */
+const AdminBackupsPanel: React.FC = () => {
+  const [backups, setBackups] = useState<AdminBackupEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoadError(null);
+    try {
+      const rows = await listBackups();
+      setBackups(rows);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to list backups');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    try {
+      const result = await createBackup();
+      notifications.show({
+        color: 'teal',
+        title: 'Backup created',
+        message: `${result.backup_id} — ${result.total_documents} documents.`,
+        autoClose: 2500,
+      });
+      await refresh();
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Backup failed',
+        message: err instanceof Error ? err.message : 'Failed to create backup',
+      });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDownload = async (backupId: string) => {
+    try {
+      await downloadBackup(backupId);
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Download failed',
+        message: err instanceof Error ? err.message : 'Failed to download backup',
+      });
+    }
+  };
+
+  const handleUpload = async (file: File | null) => {
+    if (!file) return;
+    setUploading(true);
+    try {
+      const result = await uploadBackup(file);
+      await refresh();
+      if (result.backup_id) {
+        // Open the restore modal directly on the validation results — the
+        // upload endpoint already ran validation server-side.
+        setRestoreTarget({
+          backupId: result.backup_id,
+          filename: result.filename ?? file.name,
+          hasChecksum: true, // upload always writes a fresh sidecar
+          initialValidation: result.validation ?? undefined,
+        });
+      }
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Upload failed',
+        message: err instanceof Error ? err.message : 'Failed to upload backup',
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const renderList = () => {
+    if (loading) {
+      return (
+        <Center mih={120}>
+          <Loader />
+        </Center>
+      );
+    }
+    if (loadError) {
+      return (
+        <Alert color="red" variant="light" icon={<Icon icon="mdi:alert-circle" />}>
+          {loadError}
+        </Alert>
+      );
+    }
+    if (backups.length === 0) {
+      return (
+        <Center mih={120}>
+          <Stack align="center" gap="xs">
+            <Icon icon="ph:empty-bold" width={40} color="var(--mantine-color-dimmed)" />
+            <Text c="dimmed" size="sm">
+              No backups on the server yet.
+            </Text>
+          </Stack>
+        </Center>
+      );
+    }
+    return (
+      <Table.ScrollContainer minWidth={720}>
+        <Table withTableBorder fz="sm" data-testid="backup-list-table">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Created</Table.Th>
+              <Table.Th>Version</Table.Th>
+              <Table.Th>Size</Table.Th>
+              <Table.Th>Documents</Table.Th>
+              <Table.Th>Created by</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {backups.map((b) => (
+              <Table.Tr key={b.backup_id} data-testid={`backup-row-${b.backup_id}`}>
+                <Table.Td>
+                  <Group gap={6} wrap="nowrap">
+                    <Text size="sm">{formatDateTime(b.created)}</Text>
+                    {!b.has_checksum && (
+                      <Tooltip label="No integrity checksum — restore proceeds unverified">
+                        <Badge color="yellow" variant="light" size="xs">
+                          no checksum
+                        </Badge>
+                      </Tooltip>
+                    )}
+                  </Group>
+                </Table.Td>
+                <Table.Td>
+                  {b.depictio_version ? (
+                    <Text size="sm">{b.depictio_version}</Text>
+                  ) : (
+                    <Text size="sm" c="dimmed">
+                      —
+                    </Text>
+                  )}
+                </Table.Td>
+                <Table.Td>{b.size_mb} MB</Table.Td>
+                <Table.Td>{b.total_documents}</Table.Td>
+                <Table.Td>
+                  <Text size="sm" c="dimmed">
+                    {b.created_by}
+                  </Text>
+                </Table.Td>
+                <Table.Td>
+                  <Group gap="xs" justify="flex-end" wrap="nowrap">
+                    <Tooltip label="Download backup file">
+                      <ActionIcon
+                        variant="subtle"
+                        aria-label={`Download backup ${b.backup_id}`}
+                        onClick={() => void handleDownload(b.backup_id)}
+                        data-testid={`backup-download-${b.backup_id}`}
+                      >
+                        <Icon icon="mdi:download" width={18} />
+                      </ActionIcon>
+                    </Tooltip>
+                    <Button
+                      color="red"
+                      variant="light"
+                      size="xs"
+                      onClick={() =>
+                        setRestoreTarget({
+                          backupId: b.backup_id,
+                          filename: b.filename,
+                          hasChecksum: Boolean(b.has_checksum),
+                        })
+                      }
+                      data-testid={`backup-restore-${b.backup_id}`}
+                    >
+                      Restore
+                    </Button>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+    );
+  };
+
+  return (
+    <Stack gap="lg">
+      <Card withBorder radius="md" p="lg">
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Stack gap={4}>
+            <Group gap="xs">
+              <Icon icon="mdi:database-export" width={20} color="var(--mantine-color-blue-6)" />
+              <Title order={5}>Create backup</Title>
+            </Group>
+            <Text size="sm" c="dimmed">
+              Snapshots every MongoDB collection (users, projects, dashboards, workflows,
+              data collections, files, delta tables, runs, groups). Tokens and temporary
+              users are excluded, so sessions survive a later restore.
+            </Text>
+          </Stack>
+          <Button
+            leftSection={<Icon icon="mdi:database-plus" width={16} />}
+            onClick={() => void handleCreate()}
+            loading={creating}
+            data-testid="backup-create-button"
+          >
+            Create backup
+          </Button>
+        </Group>
+      </Card>
+
+      <Card withBorder radius="md" p="lg">
+        <Stack gap="md">
+          <Group gap="xs">
+            <Icon icon="mdi:database-clock" width={20} color="var(--mantine-color-blue-6)" />
+            <Title order={5}>Backups on the server</Title>
+          </Group>
+          {renderList()}
+        </Stack>
+      </Card>
+
+      <Card withBorder radius="md" p="lg">
+        <Stack gap="md">
+          <Stack gap={4}>
+            <Group gap="xs">
+              <Icon icon="mdi:database-import" width={20} color="var(--mantine-color-orange-6)" />
+              <Title order={5}>Restore from file</Title>
+            </Group>
+            <Text size="sm" c="dimmed">
+              Upload a previously downloaded backup. It is stored on the server and
+              validated against the current data models before any restore is possible.
+            </Text>
+          </Stack>
+          <div data-testid="backup-upload-zone">
+            <FileButton onChange={(file) => void handleUpload(file)} accept="application/json">
+              {(props) => (
+                <UnstyledDropZone {...props} disabled={uploading}>
+                  {uploading ? (
+                    <Group gap="sm" data-testid="backup-upload-status">
+                      <Loader size="sm" />
+                      <Text size="sm" c="dimmed">
+                        Uploading and validating…
+                      </Text>
+                    </Group>
+                  ) : (
+                    <Stack align="center" gap={4}>
+                      <Icon icon="mdi:upload" width={28} color="var(--mantine-color-dimmed)" />
+                      <Text size="sm">Click to select a backup JSON file</Text>
+                    </Stack>
+                  )}
+                </UnstyledDropZone>
+              )}
+            </FileButton>
+          </div>
+        </Stack>
+      </Card>
+
+      <RestoreBackupModal
+        opened={Boolean(restoreTarget)}
+        target={restoreTarget}
+        onClose={() => setRestoreTarget(null)}
+        onRestored={() => void refresh()}
+      />
+    </Stack>
+  );
+};
+
+export default AdminBackupsPanel;

--- a/depictio/viewer/src/admin/AdminBackupsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBackupsPanel.tsx
@@ -12,6 +12,7 @@ import {
   FileButton,
   Group,
   Loader,
+  Modal,
   NumberInput,
   Paper,
   Popover,
@@ -26,6 +27,8 @@ import {
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { TimeInput } from '@mantine/dates';
+
+import UnstyledDropZone from '../components/UnstyledDropZone';
 import { Icon } from '@iconify/react';
 
 import {
@@ -123,6 +126,8 @@ const AdminBackupsPanel: React.FC = () => {
   const [creating, setCreating] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
 
   /** Store the server's answer and reset the editable copy to match it. */
   const applySchedule = useCallback((next: BackupScheduleStatus) => {
@@ -288,6 +293,7 @@ const AdminBackupsPanel: React.FC = () => {
     try {
       const result = await uploadBackup(file);
       await refresh();
+      setUploadOpen(false);
       if (result.backup_id) {
         // Open the restore modal directly on the validation results — the
         // upload endpoint already ran validation server-side.
@@ -568,7 +574,7 @@ const AdminBackupsPanel: React.FC = () => {
                 <Table.Td>
                   <Group gap={6} wrap="nowrap">
                     <Tooltip label={b.filename}>
-                      <Code>{b.backup_id}</Code>
+                      <Code style={{ minWidth: 0, whiteSpace: 'nowrap' }}>{b.backup_id}</Code>
                     </Tooltip>
                     {b.restored_at && (
                       <Tooltip
@@ -576,10 +582,15 @@ const AdminBackupsPanel: React.FC = () => {
                           b.restored_at,
                         )}${b.restored_by ? ` by ${b.restored_by}` : ''}`}
                       >
+                        {/* Without flexShrink the badge is the flex item that
+                            gives way to the id chip, and Mantine truncates a
+                            Badge's label rather than overflowing it, so it
+                            renders as "RESTO…". */}
                         <Badge
                           color="grape"
                           variant="filled"
                           size="xs"
+                          style={{ flexShrink: 0 }}
                           data-testid={`backup-restored-${b.backup_id}`}
                         >
                           restored
@@ -689,21 +700,14 @@ const AdminBackupsPanel: React.FC = () => {
                 section: both are "get a backup into this deployment", and the
                 upload is a one-click action once it is not a dropzone. */}
             <Group gap="sm" style={{ flexShrink: 0 }}>
-              <div data-testid="backup-upload-zone">
-                <FileButton onChange={(file) => void handleUpload(file)} accept="application/json">
-                  {(props) => (
-                    <Button
-                      {...props}
-                      variant="default"
-                      leftSection={<Icon icon="mdi:upload" width={16} />}
-                      loading={uploading}
-                      data-testid="backup-upload-button"
-                    >
-                      Restore from file
-                    </Button>
-                  )}
-                </FileButton>
-              </div>
+              <Button
+                variant="default"
+                leftSection={<Icon icon="mdi:upload" width={16} />}
+                onClick={() => setUploadOpen(true)}
+                data-testid="backup-upload-button"
+              >
+                Restore from file
+              </Button>
               <Button
                 leftSection={<Icon icon="mdi:database-plus" width={16} />}
                 onClick={() => void handleCreate()}
@@ -813,6 +817,57 @@ const AdminBackupsPanel: React.FC = () => {
           {renderSchedule()}
         </Stack>
       </Card>
+
+      <Modal
+        opened={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+        title="Restore from file"
+        centered
+        data-testid="backup-upload-modal"
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Upload a previously downloaded backup. It is stored on the server and validated
+            against the current data models before any restore is possible.
+          </Text>
+          {/* Drag handlers are React props rather than listeners attached in an
+              effect: under StrictMode an effect-attached listener closes over a
+              stale render and silently stops firing. */}
+          <div
+            data-testid="backup-upload-zone"
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragActive(true);
+            }}
+            onDragLeave={() => setDragActive(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragActive(false);
+              void handleUpload(e.dataTransfer.files?.[0] ?? null);
+            }}
+          >
+            <FileButton onChange={(file) => void handleUpload(file)} accept="application/json">
+              {(props) => (
+                <UnstyledDropZone {...props} active={dragActive} disabled={uploading}>
+                  {uploading ? (
+                    <Group gap="sm" data-testid="backup-upload-status">
+                      <Loader size="sm" />
+                      <Text size="sm" c="dimmed">
+                        Uploading and validating…
+                      </Text>
+                    </Group>
+                  ) : (
+                    <Stack align="center" gap={4}>
+                      <Icon icon="mdi:upload" width={28} color="var(--mantine-color-dimmed)" />
+                      <Text size="sm">Drop a backup JSON file here, or click to select one</Text>
+                    </Stack>
+                  )}
+                </UnstyledDropZone>
+              )}
+            </FileButton>
+          </div>
+        </Stack>
+      </Modal>
 
       <RestoreBackupModal
         opened={Boolean(restoreTarget)}

--- a/depictio/viewer/src/admin/AdminBackupsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBackupsPanel.tsx
@@ -1,15 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  ActionIcon,
   Alert,
   Badge,
   Button,
   Card,
   Center,
+  Code,
   FileButton,
   Group,
   Loader,
+  NumberInput,
   Stack,
+  Switch,
   Table,
   Text,
   Title,
@@ -18,13 +20,37 @@ import {
 import { notifications } from '@mantine/notifications';
 import { Icon } from '@iconify/react';
 
-import { createBackup, downloadBackup, listBackups, uploadBackup } from 'depictio-react-core';
-import type { AdminBackupEntry } from 'depictio-react-core';
+import {
+  createBackup,
+  downloadBackup,
+  getBackupSchedule,
+  listBackups,
+  updateBackupSchedule,
+  uploadBackup,
+} from 'depictio-react-core';
+import type { AdminBackupEntry, BackupScheduleStatus } from 'depictio-react-core';
 
 import UnstyledDropZone from '../components/UnstyledDropZone';
 import { formatDateTime } from '../lib/datetime';
 import RestoreBackupModal from './RestoreBackupModal';
 import type { RestoreTarget } from './RestoreBackupModal';
+
+/** The three schedule fields an admin can edit, as held while editing. */
+interface ScheduleDraft {
+  enabled: boolean;
+  interval_hours: number;
+  retention_days: number;
+}
+
+/** One labelled value in the Automated backups summary row. */
+const ScheduleFact: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <Stack gap={0}>
+    <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+      {label}
+    </Text>
+    <Text size="sm">{value}</Text>
+  </Stack>
+);
 
 /**
  * Admin > Backups tab. One-click server-side backup (create + download),
@@ -34,11 +60,33 @@ import type { RestoreTarget } from './RestoreBackupModal';
  */
 const AdminBackupsPanel: React.FC = () => {
   const [backups, setBackups] = useState<AdminBackupEntry[]>([]);
+  const [schedule, setSchedule] = useState<BackupScheduleStatus | null>(null);
+  /** Editable copy of the schedule; `schedule` stays the server's answer so the
+   *  Save button can tell whether anything actually changed. */
+  const [draft, setDraft] = useState<ScheduleDraft | null>(null);
+  const [savingSchedule, setSavingSchedule] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
+
+  /** Store the server's answer and reset the editable copy to match it. */
+  const applySchedule = useCallback((next: BackupScheduleStatus) => {
+    setSchedule(next);
+    setDraft({
+      enabled: next.enabled,
+      interval_hours: next.interval_hours,
+      retention_days: next.retention_days,
+    });
+  }, []);
+
+  const scheduleDirty =
+    !!schedule &&
+    !!draft &&
+    (draft.enabled !== schedule.enabled ||
+      draft.interval_hours !== schedule.interval_hours ||
+      draft.retention_days !== schedule.retention_days);
 
   const refresh = useCallback(async () => {
     setLoadError(null);
@@ -52,9 +100,53 @@ const AdminBackupsPanel: React.FC = () => {
     }
   }, []);
 
+  /** Loaded separately from the backup list, and deliberately not re-read by
+   *  refresh(): the last/next run only move when the *scheduler* runs, so
+   *  re-reading after a manual backup would discard an in-progress edit for
+   *  nothing. A failure here must not blank the list, so it skips loadError. */
+  const loadSchedule = useCallback(async () => {
+    try {
+      applySchedule(await getBackupSchedule());
+    } catch {
+      setSchedule(null);
+      setDraft(null);
+    }
+  }, [applySchedule]);
+
+  const handleSaveSchedule = async () => {
+    if (!draft) return;
+    setSavingSchedule(true);
+    try {
+      applySchedule(
+        await updateBackupSchedule({
+          enabled: draft.enabled,
+          intervalHours: draft.interval_hours,
+          retentionDays: draft.retention_days,
+        }),
+      );
+      notifications.show({
+        color: 'teal',
+        title: 'Schedule saved',
+        message: draft.enabled
+          ? `Automatic backup every ${draft.interval_hours} h.`
+          : 'Automatic backups are off.',
+        autoClose: 2500,
+      });
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not save the schedule',
+        message: err instanceof Error ? err.message : 'Failed to update the backup schedule',
+      });
+    } finally {
+      setSavingSchedule(false);
+    }
+  };
+
   useEffect(() => {
     void refresh();
-  }, [refresh]);
+    void loadSchedule();
+  }, [refresh, loadSchedule]);
 
   const handleCreate = async () => {
     setCreating(true);
@@ -117,6 +209,97 @@ const AdminBackupsPanel: React.FC = () => {
     }
   };
 
+  const renderSchedule = () => {
+    if (!schedule || !draft) {
+      return (
+        <Text size="sm" c="dimmed">
+          Schedule status unavailable.
+        </Text>
+      );
+    }
+    return (
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          {schedule.enabled
+            ? `The server takes a backup on its own every ${schedule.interval_hours} hours.`
+            : 'Nothing is backing this deployment up on a schedule. Backups only exist when an administrator creates one here.'}{' '}
+          Old backups are pruned after every backup, scheduled or manual.
+        </Text>
+
+        <Switch
+          checked={draft.enabled}
+          onChange={(e) => setDraft({ ...draft, enabled: e.currentTarget.checked })}
+          label="Take a backup automatically"
+          description="Applies to every API worker within a few minutes. No restart needed."
+          disabled={savingSchedule}
+          data-testid="backup-schedule-enabled"
+        />
+
+        <Group gap="md" align="flex-start" wrap="wrap">
+          <NumberInput
+            label="Interval"
+            suffix=" hours"
+            min={1}
+            max={8760}
+            clampBehavior="strict"
+            allowDecimal={false}
+            w={150}
+            value={draft.interval_hours}
+            onChange={(v) =>
+              setDraft({ ...draft, interval_hours: typeof v === 'number' ? v : draft.interval_hours })
+            }
+            disabled={savingSchedule}
+            data-testid="backup-schedule-interval"
+          />
+          <NumberInput
+            label="Keep backups for"
+            suffix=" days"
+            description="0 keeps them forever"
+            min={0}
+            max={3650}
+            clampBehavior="strict"
+            allowDecimal={false}
+            w={190}
+            value={draft.retention_days}
+            onChange={(v) =>
+              setDraft({ ...draft, retention_days: typeof v === 'number' ? v : draft.retention_days })
+            }
+            disabled={savingSchedule}
+            data-testid="backup-schedule-retention"
+          />
+          <Button
+            mt={25}
+            onClick={() => void handleSaveSchedule()}
+            loading={savingSchedule}
+            disabled={!scheduleDirty}
+            data-testid="backup-schedule-save"
+          >
+            Save schedule
+          </Button>
+        </Group>
+
+        <Group gap="lg" wrap="wrap">
+          <ScheduleFact
+            label="Last automatic run"
+            value={schedule.last_run ? formatDateTime(schedule.last_run) : 'Never'}
+          />
+          <ScheduleFact
+            label="Next automatic run"
+            value={schedule.next_run ? formatDateTime(schedule.next_run) : 'Not scheduled'}
+          />
+        </Group>
+
+        <Text size="xs" c="dimmed">
+          {schedule.is_customized ? 'Saved here, overriding this' : 'Currently taken from this'}{' '}
+          deployment&apos;s <Code>DEPICTIO_BACKUP_AUTO_BACKUP_ENABLED</Code>,{' '}
+          <Code>DEPICTIO_BACKUP_AUTO_BACKUP_INTERVAL_HOURS</Code> and{' '}
+          <Code>DEPICTIO_BACKUP_BACKUP_FILE_RETENTION_DAYS</Code>. Anything saved on this page wins
+          over those defaults from then on.
+        </Text>
+      </Stack>
+    );
+  };
+
   const renderList = () => {
     if (loading) {
       return (
@@ -163,6 +346,13 @@ const AdminBackupsPanel: React.FC = () => {
                 <Table.Td>
                   <Group gap={6} wrap="nowrap">
                     <Text size="sm">{formatDateTime(b.created)}</Text>
+                    {b.is_automatic && (
+                      <Tooltip label="Taken by the backup scheduler">
+                        <Badge color="blue" variant="light" size="xs">
+                          auto
+                        </Badge>
+                      </Tooltip>
+                    )}
                     {!b.has_checksum && (
                       <Tooltip label="No integrity checksum — restore proceeds unverified">
                         <Badge color="yellow" variant="light" size="xs">
@@ -189,21 +379,26 @@ const AdminBackupsPanel: React.FC = () => {
                   </Text>
                 </Table.Td>
                 <Table.Td>
+                  {/* Both row actions are labelled icon buttons of the same
+                      size: an icon-only download next to a text-only restore
+                      read as two different kinds of control. Colour escalates
+                      with consequence — neutral download, orange restore (it
+                      replaces data), red only on the modal's final confirm. */}
                   <Group gap="xs" justify="flex-end" wrap="nowrap">
-                    <Tooltip label="Download backup file">
-                      <ActionIcon
-                        variant="subtle"
-                        aria-label={`Download backup ${b.backup_id}`}
-                        onClick={() => void handleDownload(b.backup_id)}
-                        data-testid={`backup-download-${b.backup_id}`}
-                      >
-                        <Icon icon="mdi:download" width={18} />
-                      </ActionIcon>
-                    </Tooltip>
                     <Button
-                      color="red"
+                      variant="default"
+                      size="xs"
+                      leftSection={<Icon icon="mdi:download" width={14} />}
+                      onClick={() => void handleDownload(b.backup_id)}
+                      data-testid={`backup-download-${b.backup_id}`}
+                    >
+                      Download
+                    </Button>
+                    <Button
+                      color="orange"
                       variant="light"
                       size="xs"
+                      leftSection={<Icon icon="mdi:backup-restore" width={14} />}
                       onClick={() =>
                         setRestoreTarget({
                           backupId: b.backup_id,
@@ -228,8 +423,12 @@ const AdminBackupsPanel: React.FC = () => {
   return (
     <Stack gap="lg">
       <Card withBorder radius="md" p="lg">
-        <Group justify="space-between" align="flex-start" wrap="nowrap">
-          <Stack gap={4}>
+        {/* The button must not be a shrinkable flex item: Mantine clips a
+            Button's label rather than letting it overflow, so a nowrap Group
+            renders "Create backu". Let the description shrink instead, and let
+            the button wrap onto its own line once the card gets narrow. */}
+        <Group justify="space-between" align="flex-start">
+          <Stack gap={4} style={{ flex: '1 1 320px', minWidth: 0 }}>
             <Group gap="xs">
               <Icon icon="mdi:database-export" width={20} color="var(--mantine-color-blue-6)" />
               <Title order={5}>Create backup</Title>
@@ -244,6 +443,7 @@ const AdminBackupsPanel: React.FC = () => {
             leftSection={<Icon icon="mdi:database-plus" width={16} />}
             onClick={() => void handleCreate()}
             loading={creating}
+            style={{ flexShrink: 0 }}
             data-testid="backup-create-button"
           >
             Create backup
@@ -258,6 +458,25 @@ const AdminBackupsPanel: React.FC = () => {
             <Title order={5}>Backups on the server</Title>
           </Group>
           {renderList()}
+        </Stack>
+      </Card>
+
+      <Card withBorder radius="md" p="lg">
+        <Stack gap="md">
+          <Group gap="xs">
+            <Icon icon="mdi:calendar-clock" width={20} color="var(--mantine-color-blue-6)" />
+            <Title order={5}>Automated backups</Title>
+            {schedule && (
+              <Badge
+                color={schedule.enabled ? 'teal' : 'gray'}
+                variant="light"
+                data-testid="backup-schedule-status"
+              >
+                {schedule.enabled ? 'Enabled' : 'Disabled'}
+              </Badge>
+            )}
+          </Group>
+          {renderSchedule()}
         </Stack>
       </Card>
 

--- a/depictio/viewer/src/admin/AdminBackupsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBackupsPanel.tsx
@@ -25,6 +25,7 @@ import {
   Tooltip,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
+import { TimeInput } from '@mantine/dates';
 import { Icon } from '@iconify/react';
 
 import {
@@ -37,7 +38,6 @@ import {
 } from 'depictio-react-core';
 import type { AdminBackupEntry, BackupScheduleStatus } from 'depictio-react-core';
 
-import UnstyledDropZone from '../components/UnstyledDropZone';
 import { formatDateTime } from '../lib/datetime';
 import RestoreBackupModal from './RestoreBackupModal';
 import type { RestoreTarget } from './RestoreBackupModal';
@@ -50,6 +50,8 @@ interface ScheduleDraft {
   retention_days: number;
   weekly_weeks: number;
   monthly_months: number;
+  /** "HH:MM" UTC, or '' for a rolling schedule. */
+  time_of_day: string;
 }
 
 /** One row of the status panel: a label on the left, its value on the right. */
@@ -130,6 +132,7 @@ const AdminBackupsPanel: React.FC = () => {
       retention_days: next.retention_days,
       weekly_weeks: next.weekly_weeks,
       monthly_months: next.monthly_months,
+      time_of_day: next.time_of_day ?? '',
     });
   }, []);
 
@@ -139,7 +142,8 @@ const AdminBackupsPanel: React.FC = () => {
     (draft.interval_hours !== schedule.interval_hours ||
       draft.retention_days !== schedule.retention_days ||
       draft.weekly_weeks !== schedule.weekly_weeks ||
-      draft.monthly_months !== schedule.monthly_months);
+      draft.monthly_months !== schedule.monthly_months ||
+      draft.time_of_day !== (schedule.time_of_day ?? ''));
 
   const refresh = useCallback(async () => {
     setLoadError(null);
@@ -176,6 +180,7 @@ const AdminBackupsPanel: React.FC = () => {
           retentionDays: draft.retention_days,
           weeklyWeeks: draft.weekly_weeks,
           monthlyMonths: draft.monthly_months,
+          timeOfDay: draft.time_of_day,
         }),
       );
       notifications.show({
@@ -327,6 +332,35 @@ const AdminBackupsPanel: React.FC = () => {
           }
           disabled={savingSchedule}
           data-testid="backup-schedule-interval"
+        />
+
+        {/* Anchoring is optional: without it the schedule stays rolling, which
+            is the behaviour every existing deployment already has. */}
+        <TimeInput
+          label="Preferred time (UTC)"
+          description={
+            d.time_of_day
+              ? `Runs at ${d.time_of_day} UTC, then every ${plural(d.interval_hours, 'hour')}`
+              : 'Leave empty to run whenever an interval has passed'
+          }
+          value={d.time_of_day}
+          onChange={(e) => setDraft({ ...d, time_of_day: e.currentTarget.value })}
+          disabled={savingSchedule}
+          rightSection={
+            d.time_of_day ? (
+              <Tooltip label="Clear the anchor">
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  onClick={() => setDraft({ ...d, time_of_day: '' })}
+                  aria-label="Clear the preferred time"
+                >
+                  <Icon icon="mdi:close" width={14} />
+                </ActionIcon>
+              </Tooltip>
+            ) : undefined
+          }
+          data-testid="backup-schedule-time"
         />
 
         <Divider
@@ -651,15 +685,34 @@ const AdminBackupsPanel: React.FC = () => {
                 users are excluded, so sessions survive a later restore.
               </Text>
             </Stack>
-            <Button
-              leftSection={<Icon icon="mdi:database-plus" width={16} />}
-              onClick={() => void handleCreate()}
-              loading={creating}
-              style={{ flexShrink: 0 }}
-              data-testid="backup-create-button"
-            >
-              Create backup
-            </Button>
+            {/* Restoring from a file is a peer of creating one, not a separate
+                section: both are "get a backup into this deployment", and the
+                upload is a one-click action once it is not a dropzone. */}
+            <Group gap="sm" style={{ flexShrink: 0 }}>
+              <div data-testid="backup-upload-zone">
+                <FileButton onChange={(file) => void handleUpload(file)} accept="application/json">
+                  {(props) => (
+                    <Button
+                      {...props}
+                      variant="default"
+                      leftSection={<Icon icon="mdi:upload" width={16} />}
+                      loading={uploading}
+                      data-testid="backup-upload-button"
+                    >
+                      Restore from file
+                    </Button>
+                  )}
+                </FileButton>
+              </div>
+              <Button
+                leftSection={<Icon icon="mdi:database-plus" width={16} />}
+                onClick={() => void handleCreate()}
+                loading={creating}
+                data-testid="backup-create-button"
+              >
+                Create backup
+              </Button>
+            </Group>
           </Group>
 
           {/* Naming the boundary here rather than in the docs alone: the page
@@ -758,42 +811,6 @@ const AdminBackupsPanel: React.FC = () => {
             )}
           </Group>
           {renderSchedule()}
-        </Stack>
-      </Card>
-
-      <Card withBorder radius="md" p="lg">
-        <Stack gap="md">
-          <Stack gap={4}>
-            <Group gap="xs">
-              <Icon icon="mdi:database-import" width={20} color="var(--mantine-color-orange-6)" />
-              <Title order={5}>Restore from file</Title>
-            </Group>
-            <Text size="sm" c="dimmed">
-              Upload a previously downloaded backup. It is stored on the server and
-              validated against the current data models before any restore is possible.
-            </Text>
-          </Stack>
-          <div data-testid="backup-upload-zone">
-            <FileButton onChange={(file) => void handleUpload(file)} accept="application/json">
-              {(props) => (
-                <UnstyledDropZone {...props} disabled={uploading}>
-                  {uploading ? (
-                    <Group gap="sm" data-testid="backup-upload-status">
-                      <Loader size="sm" />
-                      <Text size="sm" c="dimmed">
-                        Uploading and validating…
-                      </Text>
-                    </Group>
-                  ) : (
-                    <Stack align="center" gap={4}>
-                      <Icon icon="mdi:upload" width={28} color="var(--mantine-color-dimmed)" />
-                      <Text size="sm">Click to select a backup JSON file</Text>
-                    </Stack>
-                  )}
-                </UnstyledDropZone>
-              )}
-            </FileButton>
-          </div>
         </Stack>
       </Card>
 

--- a/depictio/viewer/src/admin/AdminBackupsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBackupsPanel.tsx
@@ -14,6 +14,7 @@ import {
   NumberInput,
   Paper,
   Popover,
+  SegmentedControl,
   SimpleGrid,
   Stack,
   Switch,
@@ -62,18 +63,29 @@ const ScheduleFact: React.FC<{ label: string; value: React.ReactNode }> = ({ lab
   </Group>
 );
 
-/** Plain-language summary of the tiered retention policy, so an admin can read
- *  back what the three numbers add up to without doing the arithmetic. */
+/** The tiers "Smart retention" turns on. Fixed rather than exposed as two more
+ *  number inputs: the value of the mode is that an admin picks thinning without
+ *  having to design a policy, and a wrong pair of tiers is worse than none. */
+const SMART_WEEKLY_WEEKS = 4;
+const SMART_MONTHLY_MONTHS = 12;
+
+type RetentionMode = 'simple' | 'smart';
+
+/** Smart mode is simply "some tier is on", so a policy set through the API or an
+ *  env var still reads back correctly here. */
+const retentionModeOf = (draft: ScheduleDraft): RetentionMode =>
+  draft.weekly_weeks > 0 || draft.monthly_months > 0 ? 'smart' : 'simple';
+
+const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? '' : 's'}`;
+
+/** Plain-language summary, so an admin can read back what the policy keeps
+ *  without doing the arithmetic. */
 const describeRetention = (draft: ScheduleDraft): string => {
   if (draft.retention_days <= 0) return 'Every backup is kept forever.';
-  const parts = [`every backup for ${draft.retention_days} day${draft.retention_days === 1 ? '' : 's'}`];
-  if (draft.weekly_weeks > 0) {
-    parts.push(`then one a week for ${draft.weekly_weeks} week${draft.weekly_weeks === 1 ? '' : 's'}`);
-  }
+  const parts = [`every backup for ${plural(draft.retention_days, 'day')}`];
+  if (draft.weekly_weeks > 0) parts.push(`then one a week for ${plural(draft.weekly_weeks, 'week')}`);
   if (draft.monthly_months > 0) {
-    parts.push(
-      `then one a month for ${draft.monthly_months} month${draft.monthly_months === 1 ? '' : 's'}`,
-    );
+    parts.push(`then one a month for ${plural(draft.monthly_months, 'month')}`);
   }
   return `Keeps ${parts.join(', ')}. Everything older is deleted.`;
 };
@@ -169,6 +181,22 @@ const AdminBackupsPanel: React.FC = () => {
     } finally {
       setSavingSchedule(false);
     }
+  };
+
+  /** Switching mode only turns the weekly/monthly tiers on or off. The days
+   *  field is deliberately left alone: it means something in both modes (in
+   *  smart mode it is the window before thinning starts), so flipping the mode
+   *  never silently rewrites a number the admin chose. */
+  const setRetentionMode = (draft: ScheduleDraft, mode: RetentionMode) => {
+    setDraft(
+      mode === 'smart'
+        ? {
+            ...draft,
+            weekly_weeks: SMART_WEEKLY_WEEKS,
+            monthly_months: SMART_MONTHLY_MONTHS,
+          }
+        : { ...draft, weekly_weeks: 0, monthly_months: 0 },
+    );
   };
 
   /** The header switch commits on the spot rather than waiting for Save: it is
@@ -291,28 +319,31 @@ const AdminBackupsPanel: React.FC = () => {
         <Divider
           my={4}
           label={
-            <Group gap={6} wrap="nowrap">
-              <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
-                Retention policy
-              </Text>
-              <Tooltip
-                multiline
-                w={280}
-                label="Tiered retention: recent backups are all kept, then thinned to one a week, then one a month. Older snapshots stay available without the volume growing forever."
-              >
-                <Icon
-                  icon="mdi:help-circle-outline"
-                  width={14}
-                  color="var(--mantine-color-dimmed)"
-                />
-              </Tooltip>
-            </Group>
+            <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+              Retention policy
+            </Text>
           }
           labelPosition="left"
         />
 
+        {/* Two modes rather than three tier inputs: an admin either caps by age
+            or asks for thinning, and the tier sizes behind "Smart" are not a
+            decision worth making per deployment. */}
+        <SegmentedControl
+          fullWidth
+          size="xs"
+          value={retentionModeOf(d)}
+          onChange={(value) => setRetentionMode(d, value as RetentionMode)}
+          disabled={savingSchedule}
+          data-testid="backup-retention-mode"
+          data={[
+            { label: 'Keep for a fixed time', value: 'simple' },
+            { label: 'Smart retention', value: 'smart' },
+          ]}
+        />
+
         <NumberInput
-          label="Keep every backup for"
+          label={retentionModeOf(d) === 'smart' ? 'Keep every backup for' : 'Keep backups for'}
           description="0 keeps every backup forever"
           suffix=" days"
           min={0}
@@ -327,40 +358,11 @@ const AdminBackupsPanel: React.FC = () => {
           data-testid="backup-schedule-retention"
         />
 
-        {/* The tiers only mean anything past the daily window, so they follow
-            "keep forever" into being irrelevant rather than silently ignored. */}
-        <NumberInput
-          label="Then one a week for"
-          suffix=" weeks"
-          min={0}
-          max={520}
-          clampBehavior="strict"
-          allowDecimal={false}
-          value={d.weekly_weeks}
-          onChange={(v) =>
-            setDraft({ ...d, weekly_weeks: typeof v === 'number' ? v : d.weekly_weeks })
-          }
-          disabled={savingSchedule || d.retention_days <= 0}
-          data-testid="backup-schedule-weekly"
-        />
-
-        <NumberInput
-          label="Then one a month for"
-          suffix=" months"
-          min={0}
-          max={120}
-          clampBehavior="strict"
-          allowDecimal={false}
-          value={d.monthly_months}
-          onChange={(v) =>
-            setDraft({ ...d, monthly_months: typeof v === 'number' ? v : d.monthly_months })
-          }
-          disabled={savingSchedule || d.retention_days <= 0}
-          data-testid="backup-schedule-monthly"
-        />
-
         <Text size="xs" c="dimmed" data-testid="backup-retention-summary">
           {describeRetention(d)}
+          {retentionModeOf(d) === 'smart' && d.retention_days > 0
+            ? ' Older snapshots stay reachable without the volume growing forever.'
+            : ''}
         </Text>
 
         <Group justify="flex-end">
@@ -605,32 +607,53 @@ const AdminBackupsPanel: React.FC = () => {
   return (
     <Stack gap="lg">
       <Card withBorder radius="md" p="lg">
-        {/* The button must not be a shrinkable flex item: Mantine clips a
-            Button's label rather than letting it overflow, so a nowrap Group
-            renders "Create backu". Let the description shrink instead, and let
-            the button wrap onto its own line once the card gets narrow. */}
-        <Group justify="space-between" align="flex-start">
-          <Stack gap={4} style={{ flex: '1 1 320px', minWidth: 0 }}>
-            <Group gap="xs">
-              <Icon icon="mdi:database-export" width={20} color="var(--mantine-color-blue-6)" />
-              <Title order={5}>Create backup</Title>
-            </Group>
-            <Text size="sm" c="dimmed">
-              Snapshots every MongoDB collection (users, projects, dashboards, workflows,
-              data collections, files, delta tables, runs, groups). Tokens and temporary
-              users are excluded, so sessions survive a later restore.
-            </Text>
-          </Stack>
-          <Button
-            leftSection={<Icon icon="mdi:database-plus" width={16} />}
-            onClick={() => void handleCreate()}
-            loading={creating}
-            style={{ flexShrink: 0 }}
-            data-testid="backup-create-button"
+        <Stack gap="md">
+          {/* The button must not be a shrinkable flex item: Mantine clips a
+              Button's label rather than letting it overflow, so a nowrap Group
+              renders "Create backu". Let the description shrink instead, and let
+              the button wrap onto its own line once the card gets narrow. */}
+          <Group justify="space-between" align="flex-start">
+            <Stack gap={4} style={{ flex: '1 1 320px', minWidth: 0 }}>
+              <Group gap="xs">
+                <Icon icon="mdi:database-export" width={20} color="var(--mantine-color-blue-6)" />
+                <Title order={5}>Create database backup</Title>
+              </Group>
+              <Text size="sm" c="dimmed">
+                Snapshots every MongoDB collection (users, projects, dashboards, workflows,
+                data collections, files, delta tables, runs, groups). Tokens and temporary
+                users are excluded, so sessions survive a later restore.
+              </Text>
+            </Stack>
+            <Button
+              leftSection={<Icon icon="mdi:database-plus" width={16} />}
+              onClick={() => void handleCreate()}
+              loading={creating}
+              style={{ flexShrink: 0 }}
+              data-testid="backup-create-button"
+            >
+              Create backup
+            </Button>
+          </Group>
+
+          {/* Naming the boundary here rather than in the docs alone: the page
+              is called "Backups", and an admin who reads that as "everything is
+              backed up" only finds out otherwise during a restore. */}
+          <Alert
+            variant="light"
+            color="blue"
+            icon={<Icon icon="mdi:information-outline" />}
+            data-testid="backup-scope-notice"
           >
-            Create backup
-          </Button>
-        </Group>
+            <Text size="sm">
+              This backs up the <strong>database only</strong>: dashboards, projects and the
+              metadata pointing at your data. The data itself (Delta tables in S3 or MinIO) is
+              not included and is not restored from here. Back it up separately, with your
+              object store&apos;s own replication or with{' '}
+              <Code>depictio-cli backup create --include-s3-data</Code>. See{' '}
+              <Code>docs/backup-restore.md</Code>.
+            </Text>
+          </Alert>
+        </Stack>
       </Card>
 
       <Card withBorder radius="md" p="lg">
@@ -662,7 +685,7 @@ const AdminBackupsPanel: React.FC = () => {
                 </Badge>
               )}
               {schedule && (
-                <Popover width={340} position="bottom-start" withArrow shadow="md">
+                <Popover width={480} position="bottom-start" withArrow shadow="md">
                   <Popover.Target>
                     <ActionIcon
                       variant="subtle"

--- a/depictio/viewer/src/admin/AdminBackupsPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBackupsPanel.tsx
@@ -1,15 +1,20 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
+  ActionIcon,
   Alert,
   Badge,
   Button,
   Card,
   Center,
   Code,
+  Divider,
   FileButton,
   Group,
   Loader,
   NumberInput,
+  Paper,
+  Popover,
+  SimpleGrid,
   Stack,
   Switch,
   Table,
@@ -35,22 +40,43 @@ import { formatDateTime } from '../lib/datetime';
 import RestoreBackupModal from './RestoreBackupModal';
 import type { RestoreTarget } from './RestoreBackupModal';
 
-/** The three schedule fields an admin can edit, as held while editing. */
+/** The schedule fields behind the Save button. `enabled` is deliberately not
+ *  one of them: the header switch is a single unambiguous action and saves on
+ *  the spot, while the numbers need a deliberate commit. */
 interface ScheduleDraft {
-  enabled: boolean;
   interval_hours: number;
   retention_days: number;
+  weekly_weeks: number;
+  monthly_months: number;
 }
 
-/** One labelled value in the Automated backups summary row. */
-const ScheduleFact: React.FC<{ label: string; value: string }> = ({ label, value }) => (
-  <Stack gap={0}>
-    <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+/** One row of the status panel: a label on the left, its value on the right. */
+const ScheduleFact: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+  <Group justify="space-between" wrap="nowrap" gap="md" align="baseline">
+    <Text size="xs" c="dimmed" tt="uppercase" fw={600} style={{ flexShrink: 0 }}>
       {label}
     </Text>
-    <Text size="sm">{value}</Text>
-  </Stack>
+    <Text size="sm" ta="right" style={{ minWidth: 0 }}>
+      {value}
+    </Text>
+  </Group>
 );
+
+/** Plain-language summary of the tiered retention policy, so an admin can read
+ *  back what the three numbers add up to without doing the arithmetic. */
+const describeRetention = (draft: ScheduleDraft): string => {
+  if (draft.retention_days <= 0) return 'Every backup is kept forever.';
+  const parts = [`every backup for ${draft.retention_days} day${draft.retention_days === 1 ? '' : 's'}`];
+  if (draft.weekly_weeks > 0) {
+    parts.push(`then one a week for ${draft.weekly_weeks} week${draft.weekly_weeks === 1 ? '' : 's'}`);
+  }
+  if (draft.monthly_months > 0) {
+    parts.push(
+      `then one a month for ${draft.monthly_months} month${draft.monthly_months === 1 ? '' : 's'}`,
+    );
+  }
+  return `Keeps ${parts.join(', ')}. Everything older is deleted.`;
+};
 
 /**
  * Admin > Backups tab. One-click server-side backup (create + download),
@@ -65,6 +91,7 @@ const AdminBackupsPanel: React.FC = () => {
    *  Save button can tell whether anything actually changed. */
   const [draft, setDraft] = useState<ScheduleDraft | null>(null);
   const [savingSchedule, setSavingSchedule] = useState(false);
+  const [togglingSchedule, setTogglingSchedule] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -75,18 +102,20 @@ const AdminBackupsPanel: React.FC = () => {
   const applySchedule = useCallback((next: BackupScheduleStatus) => {
     setSchedule(next);
     setDraft({
-      enabled: next.enabled,
       interval_hours: next.interval_hours,
       retention_days: next.retention_days,
+      weekly_weeks: next.weekly_weeks,
+      monthly_months: next.monthly_months,
     });
   }, []);
 
   const scheduleDirty =
     !!schedule &&
     !!draft &&
-    (draft.enabled !== schedule.enabled ||
-      draft.interval_hours !== schedule.interval_hours ||
-      draft.retention_days !== schedule.retention_days);
+    (draft.interval_hours !== schedule.interval_hours ||
+      draft.retention_days !== schedule.retention_days ||
+      draft.weekly_weeks !== schedule.weekly_weeks ||
+      draft.monthly_months !== schedule.monthly_months);
 
   const refresh = useCallback(async () => {
     setLoadError(null);
@@ -119,18 +148,17 @@ const AdminBackupsPanel: React.FC = () => {
     try {
       applySchedule(
         await updateBackupSchedule({
-          enabled: draft.enabled,
           intervalHours: draft.interval_hours,
           retentionDays: draft.retention_days,
+          weeklyWeeks: draft.weekly_weeks,
+          monthlyMonths: draft.monthly_months,
         }),
       );
       notifications.show({
         color: 'teal',
         title: 'Schedule saved',
-        message: draft.enabled
-          ? `Automatic backup every ${draft.interval_hours} h.`
-          : 'Automatic backups are off.',
-        autoClose: 2500,
+        message: `Automatic backup every ${draft.interval_hours} h. ${describeRetention(draft)}`,
+        autoClose: 3500,
       });
     } catch (err) {
       notifications.show({
@@ -140,6 +168,32 @@ const AdminBackupsPanel: React.FC = () => {
       });
     } finally {
       setSavingSchedule(false);
+    }
+  };
+
+  /** The header switch commits on the spot rather than waiting for Save: it is
+   *  a single unambiguous choice, and an admin who flips it to stop a runaway
+   *  backup loop should not have to find a second button to make it stick. */
+  const handleToggleSchedule = async (enabled: boolean) => {
+    setTogglingSchedule(true);
+    try {
+      applySchedule(await updateBackupSchedule({ enabled }));
+      notifications.show({
+        color: enabled ? 'teal' : 'gray',
+        title: enabled ? 'Automated backups on' : 'Automated backups off',
+        message: enabled
+          ? `The server will take a backup every ${schedule?.interval_hours ?? 24} hours.`
+          : 'Backups now only exist when an administrator creates one.',
+        autoClose: 2500,
+      });
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not change the schedule',
+        message: err instanceof Error ? err.message : 'Failed to update the backup schedule',
+      });
+    } finally {
+      setTogglingSchedule(false);
     }
   };
 
@@ -209,6 +263,183 @@ const AdminBackupsPanel: React.FC = () => {
     }
   };
 
+  /** Left panel: the policy an admin edits. Interval and the three retention
+   *  tiers, committed together by Save. */
+  const renderPolicyPanel = (d: ScheduleDraft) => (
+    <Paper withBorder radius="sm" p="md">
+      <Stack gap="sm">
+        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+          Schedule &amp; retention
+        </Text>
+
+        <NumberInput
+          label="Interval"
+          description="How often the server takes a backup"
+          suffix=" hours"
+          min={1}
+          max={8760}
+          clampBehavior="strict"
+          allowDecimal={false}
+          value={d.interval_hours}
+          onChange={(v) =>
+            setDraft({ ...d, interval_hours: typeof v === 'number' ? v : d.interval_hours })
+          }
+          disabled={savingSchedule}
+          data-testid="backup-schedule-interval"
+        />
+
+        <Divider
+          my={4}
+          label={
+            <Group gap={6} wrap="nowrap">
+              <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+                Retention policy
+              </Text>
+              <Tooltip
+                multiline
+                w={280}
+                label="Tiered retention: recent backups are all kept, then thinned to one a week, then one a month. Older snapshots stay available without the volume growing forever."
+              >
+                <Icon
+                  icon="mdi:help-circle-outline"
+                  width={14}
+                  color="var(--mantine-color-dimmed)"
+                />
+              </Tooltip>
+            </Group>
+          }
+          labelPosition="left"
+        />
+
+        <NumberInput
+          label="Keep every backup for"
+          description="0 keeps every backup forever"
+          suffix=" days"
+          min={0}
+          max={3650}
+          clampBehavior="strict"
+          allowDecimal={false}
+          value={d.retention_days}
+          onChange={(v) =>
+            setDraft({ ...d, retention_days: typeof v === 'number' ? v : d.retention_days })
+          }
+          disabled={savingSchedule}
+          data-testid="backup-schedule-retention"
+        />
+
+        {/* The tiers only mean anything past the daily window, so they follow
+            "keep forever" into being irrelevant rather than silently ignored. */}
+        <NumberInput
+          label="Then one a week for"
+          suffix=" weeks"
+          min={0}
+          max={520}
+          clampBehavior="strict"
+          allowDecimal={false}
+          value={d.weekly_weeks}
+          onChange={(v) =>
+            setDraft({ ...d, weekly_weeks: typeof v === 'number' ? v : d.weekly_weeks })
+          }
+          disabled={savingSchedule || d.retention_days <= 0}
+          data-testid="backup-schedule-weekly"
+        />
+
+        <NumberInput
+          label="Then one a month for"
+          suffix=" months"
+          min={0}
+          max={120}
+          clampBehavior="strict"
+          allowDecimal={false}
+          value={d.monthly_months}
+          onChange={(v) =>
+            setDraft({ ...d, monthly_months: typeof v === 'number' ? v : d.monthly_months })
+          }
+          disabled={savingSchedule || d.retention_days <= 0}
+          data-testid="backup-schedule-monthly"
+        />
+
+        <Text size="xs" c="dimmed" data-testid="backup-retention-summary">
+          {describeRetention(d)}
+        </Text>
+
+        <Group justify="flex-end">
+          <Button
+            onClick={() => void handleSaveSchedule()}
+            loading={savingSchedule}
+            disabled={!scheduleDirty}
+            data-testid="backup-schedule-save"
+          >
+            Save schedule
+          </Button>
+        </Group>
+      </Stack>
+    </Paper>
+  );
+
+  /** Right panel: what the schedule is actually doing, read-only. */
+  const renderStatusPanel = (s: BackupScheduleStatus, d: ScheduleDraft) => {
+    const totalMb = backups.reduce((sum, b) => sum + (b.size_mb ?? 0), 0);
+    const automatic = backups.filter((b) => b.is_automatic).length;
+
+    return (
+      <Paper withBorder radius="sm" p="md">
+        <Stack gap="sm">
+          <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+            Status
+          </Text>
+
+          <ScheduleFact
+            label="Last automatic run"
+            value={s.last_run ? formatDateTime(s.last_run) : 'Never'}
+          />
+          <ScheduleFact
+            label="Next automatic run"
+            value={
+              s.enabled ? (
+                s.next_run ? (
+                  formatDateTime(s.next_run)
+                ) : (
+                  'As soon as a worker wakes'
+                )
+              ) : (
+                <Text size="sm" c="dimmed">
+                  Not scheduled
+                </Text>
+              )
+            }
+          />
+
+          <Divider my={4} />
+
+          <ScheduleFact
+            label="Backups on server"
+            value={`${backups.length}${automatic ? ` (${automatic} automatic)` : ''}`}
+          />
+          <ScheduleFact label="Disk used" value={`${totalMb.toFixed(1)} MB`} />
+          <ScheduleFact
+            label="Policy in force"
+            value={
+              d.retention_days <= 0
+                ? 'Keep forever'
+                : [
+                    `${d.retention_days}d`,
+                    d.weekly_weeks > 0 ? `${d.weekly_weeks}w` : null,
+                    d.monthly_months > 0 ? `${d.monthly_months}m` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' → ')
+            }
+          />
+          <ScheduleFact
+            label="Settings source"
+            value={s.is_customized ? 'Saved on this page' : 'Deployment environment'}
+          />
+        </Stack>
+      </Paper>
+    );
+  };
+
   const renderSchedule = () => {
     if (!schedule || !draft) {
       return (
@@ -218,85 +449,10 @@ const AdminBackupsPanel: React.FC = () => {
       );
     }
     return (
-      <Stack gap="md">
-        <Text size="sm" c="dimmed">
-          {schedule.enabled
-            ? `The server takes a backup on its own every ${schedule.interval_hours} hours.`
-            : 'Nothing is backing this deployment up on a schedule. Backups only exist when an administrator creates one here.'}{' '}
-          Old backups are pruned after every backup, scheduled or manual.
-        </Text>
-
-        <Switch
-          checked={draft.enabled}
-          onChange={(e) => setDraft({ ...draft, enabled: e.currentTarget.checked })}
-          label="Take a backup automatically"
-          description="Applies to every API worker within a few minutes. No restart needed."
-          disabled={savingSchedule}
-          data-testid="backup-schedule-enabled"
-        />
-
-        <Group gap="md" align="flex-start" wrap="wrap">
-          <NumberInput
-            label="Interval"
-            suffix=" hours"
-            min={1}
-            max={8760}
-            clampBehavior="strict"
-            allowDecimal={false}
-            w={150}
-            value={draft.interval_hours}
-            onChange={(v) =>
-              setDraft({ ...draft, interval_hours: typeof v === 'number' ? v : draft.interval_hours })
-            }
-            disabled={savingSchedule}
-            data-testid="backup-schedule-interval"
-          />
-          <NumberInput
-            label="Keep backups for"
-            suffix=" days"
-            description="0 keeps them forever"
-            min={0}
-            max={3650}
-            clampBehavior="strict"
-            allowDecimal={false}
-            w={190}
-            value={draft.retention_days}
-            onChange={(v) =>
-              setDraft({ ...draft, retention_days: typeof v === 'number' ? v : draft.retention_days })
-            }
-            disabled={savingSchedule}
-            data-testid="backup-schedule-retention"
-          />
-          <Button
-            mt={25}
-            onClick={() => void handleSaveSchedule()}
-            loading={savingSchedule}
-            disabled={!scheduleDirty}
-            data-testid="backup-schedule-save"
-          >
-            Save schedule
-          </Button>
-        </Group>
-
-        <Group gap="lg" wrap="wrap">
-          <ScheduleFact
-            label="Last automatic run"
-            value={schedule.last_run ? formatDateTime(schedule.last_run) : 'Never'}
-          />
-          <ScheduleFact
-            label="Next automatic run"
-            value={schedule.next_run ? formatDateTime(schedule.next_run) : 'Not scheduled'}
-          />
-        </Group>
-
-        <Text size="xs" c="dimmed">
-          {schedule.is_customized ? 'Saved here, overriding this' : 'Currently taken from this'}{' '}
-          deployment&apos;s <Code>DEPICTIO_BACKUP_AUTO_BACKUP_ENABLED</Code>,{' '}
-          <Code>DEPICTIO_BACKUP_AUTO_BACKUP_INTERVAL_HOURS</Code> and{' '}
-          <Code>DEPICTIO_BACKUP_BACKUP_FILE_RETENTION_DAYS</Code>. Anything saved on this page wins
-          over those defaults from then on.
-        </Text>
-      </Stack>
+      <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+        {renderPolicyPanel(draft)}
+        {renderStatusPanel(schedule, draft)}
+      </SimpleGrid>
     );
   };
 
@@ -328,10 +484,11 @@ const AdminBackupsPanel: React.FC = () => {
       );
     }
     return (
-      <Table.ScrollContainer minWidth={720}>
+      <Table.ScrollContainer minWidth={860}>
         <Table withTableBorder fz="sm" data-testid="backup-list-table">
           <Table.Thead>
             <Table.Tr>
+              <Table.Th>Backup</Table.Th>
               <Table.Th>Created</Table.Th>
               <Table.Th>Version</Table.Th>
               <Table.Th>Size</Table.Th>
@@ -343,6 +500,31 @@ const AdminBackupsPanel: React.FC = () => {
           <Table.Tbody>
             {backups.map((b) => (
               <Table.Tr key={b.backup_id} data-testid={`backup-row-${b.backup_id}`}>
+                {/* The id is the filename a download lands under, so it is
+                    what ties a file on the admin's disk back to a row here. */}
+                <Table.Td>
+                  <Group gap={6} wrap="nowrap">
+                    <Tooltip label={b.filename}>
+                      <Code>{b.backup_id}</Code>
+                    </Tooltip>
+                    {b.restored_at && (
+                      <Tooltip
+                        label={`This deployment's data was restored from this backup on ${formatDateTime(
+                          b.restored_at,
+                        )}${b.restored_by ? ` by ${b.restored_by}` : ''}`}
+                      >
+                        <Badge
+                          color="grape"
+                          variant="filled"
+                          size="xs"
+                          data-testid={`backup-restored-${b.backup_id}`}
+                        >
+                          restored
+                        </Badge>
+                      </Tooltip>
+                    )}
+                  </Group>
+                </Table.Td>
                 <Table.Td>
                   <Group gap={6} wrap="nowrap">
                     <Text size="sm">{formatDateTime(b.created)}</Text>
@@ -463,17 +645,58 @@ const AdminBackupsPanel: React.FC = () => {
 
       <Card withBorder radius="md" p="lg">
         <Stack gap="md">
-          <Group gap="xs">
-            <Icon icon="mdi:calendar-clock" width={20} color="var(--mantine-color-blue-6)" />
-            <Title order={5}>Automated backups</Title>
+          {/* Title and the master switch sit on one line: the switch is the
+              section's on/off, not one setting among the others, so it stays
+              out of the panel that needs a Save. */}
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+              <Icon icon="mdi:calendar-clock" width={20} color="var(--mantine-color-blue-6)" />
+              <Title order={5}>Automated backups</Title>
+              {schedule && (
+                <Badge
+                  color={schedule.enabled ? 'teal' : 'gray'}
+                  variant="light"
+                  data-testid="backup-schedule-status"
+                >
+                  {schedule.enabled ? 'Enabled' : 'Disabled'}
+                </Badge>
+              )}
+              {schedule && (
+                <Popover width={340} position="bottom-start" withArrow shadow="md">
+                  <Popover.Target>
+                    <ActionIcon
+                      variant="subtle"
+                      color="gray"
+                      aria-label="Where these settings come from"
+                      data-testid="backup-schedule-info"
+                    >
+                      <Icon icon="mdi:information-outline" width={18} />
+                    </ActionIcon>
+                  </Popover.Target>
+                  <Popover.Dropdown>
+                    <Text size="xs">
+                      {schedule.is_customized ? 'Saved here, overriding this' : 'Currently taken from this'}{' '}
+                      deployment&apos;s <Code>DEPICTIO_BACKUP_AUTO_BACKUP_ENABLED</Code>,{' '}
+                      <Code>DEPICTIO_BACKUP_AUTO_BACKUP_INTERVAL_HOURS</Code>,{' '}
+                      <Code>DEPICTIO_BACKUP_BACKUP_FILE_RETENTION_DAYS</Code>,{' '}
+                      <Code>DEPICTIO_BACKUP_BACKUP_RETENTION_WEEKLY_WEEKS</Code> and{' '}
+                      <Code>DEPICTIO_BACKUP_BACKUP_RETENTION_MONTHLY_MONTHS</Code>. Anything saved
+                      on this page wins over those defaults from then on, and applies to every API
+                      worker within a few minutes — no restart needed.
+                    </Text>
+                  </Popover.Dropdown>
+                </Popover>
+              )}
+            </Group>
             {schedule && (
-              <Badge
-                color={schedule.enabled ? 'teal' : 'gray'}
-                variant="light"
-                data-testid="backup-schedule-status"
-              >
-                {schedule.enabled ? 'Enabled' : 'Disabled'}
-              </Badge>
+              <Switch
+                checked={schedule.enabled}
+                onChange={(e) => void handleToggleSchedule(e.currentTarget.checked)}
+                disabled={togglingSchedule}
+                size="md"
+                aria-label="Take a backup automatically"
+                data-testid="backup-schedule-enabled"
+              />
             )}
           </Group>
           {renderSchedule()}

--- a/depictio/viewer/src/admin/AdminMaintenancePanel.tsx
+++ b/depictio/viewer/src/admin/AdminMaintenancePanel.tsx
@@ -91,8 +91,11 @@ const AdminMaintenancePanel: React.FC = () => {
     <Stack gap="lg">
       <Card withBorder radius="md" p="lg">
         <Stack gap="md">
-          <Group justify="space-between" align="flex-start" wrap="nowrap">
-            <Stack gap={4}>
+          {/* Same shape as the Backups tab's create card: a nowrap Group lets
+              the button shrink, and Mantine clips a Button's label instead of
+              overflowing it, so the label renders as "Delete example proje". */}
+          <Group justify="space-between" align="flex-start">
+            <Stack gap={4} style={{ flex: '1 1 320px', minWidth: 0 }}>
               <Group gap="xs">
                 <Icon icon="mdi:broom" width={20} color="var(--mantine-color-orange-6)" />
                 <Title order={5}>Clean example projects</Title>
@@ -110,6 +113,7 @@ const AdminMaintenancePanel: React.FC = () => {
               leftSection={<Icon icon="tabler:trash" width={16} />}
               onClick={openConfirm}
               disabled={loading || examples.length === 0}
+              style={{ flexShrink: 0 }}
             >
               Delete example projects
             </Button>

--- a/depictio/viewer/src/admin/RestoreBackupModal.tsx
+++ b/depictio/viewer/src/admin/RestoreBackupModal.tsx
@@ -1,0 +1,359 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Center,
+  Group,
+  Loader,
+  Modal,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { Icon } from '@iconify/react';
+
+import { restoreBackup, validateBackup } from 'depictio-react-core';
+import type { BackupRestoreResult, BackupValidationResult } from 'depictio-react-core';
+
+/**
+ * Restore flow modal: validate → typed confirm → restore → result.
+ *
+ * Restore is a per-collection wipe-and-replace, so the confirm step requires
+ * typing RESTORE (mirrors the Maintenance tab's DELETE confirmation). The
+ * server refuses backups that fail Pydantic validation; invalid backups never
+ * even render the confirm UI here — the CLI's --skip-validation escape hatch
+ * is deliberately not exposed in the UI.
+ */
+const CONFIRM_PHRASE = 'RESTORE';
+
+export interface RestoreTarget {
+  backupId: string;
+  filename: string;
+  /** Legacy backups without a .sha256 sidecar restore with allow_unverified. */
+  hasChecksum: boolean;
+  /** Present when the upload endpoint already validated the file. */
+  initialValidation?: BackupValidationResult | null;
+}
+
+interface RestoreBackupModalProps {
+  opened: boolean;
+  target: RestoreTarget | null;
+  onClose: () => void;
+  /** Called after a successful restore so the parent can refresh. */
+  onRestored: () => void;
+}
+
+type Step = 'validating' | 'results' | 'restoring' | 'done' | 'error';
+
+const RestoreBackupModal: React.FC<RestoreBackupModalProps> = ({
+  opened,
+  target,
+  onClose,
+  onRestored,
+}) => {
+  const [step, setStep] = useState<Step>('validating');
+  const [validation, setValidation] = useState<BackupValidationResult | null>(null);
+  const [restoreResult, setRestoreResult] = useState<BackupRestoreResult | null>(null);
+  const [confirmText, setConfirmText] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!opened || !target) return;
+    setConfirmText('');
+    setErrorMessage(null);
+    setRestoreResult(null);
+    if (target.initialValidation) {
+      setValidation(target.initialValidation);
+      setStep('results');
+      return;
+    }
+    setValidation(null);
+    setStep('validating');
+    let cancelled = false;
+    validateBackup(target.backupId)
+      .then((result) => {
+        if (cancelled) return;
+        setValidation(result);
+        setStep('results');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setErrorMessage(err instanceof Error ? err.message : 'Validation failed');
+        setStep('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [opened, target]);
+
+  const busy = step === 'restoring';
+
+  const handleRestore = async () => {
+    if (!target) return;
+    setStep('restoring');
+    setErrorMessage(null);
+    try {
+      const result = await restoreBackup(target.backupId, {
+        dryRun: false,
+        allowUnverified: !target.hasChecksum,
+      });
+      setRestoreResult(result);
+      if (result.success) {
+        setStep('done');
+        onRestored();
+      } else {
+        setErrorMessage(result.message);
+        setStep('error');
+      }
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Restore failed');
+      setStep('error');
+    }
+  };
+
+  const renderValidationSummary = (v: BackupValidationResult) => {
+    const collections = Object.entries(v.collections_validated ?? {});
+    return (
+      <Stack gap="sm">
+        <Group gap="xs">
+          {v.valid ? (
+            <Badge color="green" variant="light" data-testid="backup-validation-valid">
+              Validation passed
+            </Badge>
+          ) : (
+            <Badge color="red" variant="light" data-testid="backup-validation-invalid">
+              Validation failed
+            </Badge>
+          )}
+          <Text size="sm" c="dimmed">
+            {v.valid_documents}/{v.total_documents} documents valid
+          </Text>
+        </Group>
+
+        {collections.length > 0 && (
+          <Table
+            withTableBorder
+            withColumnBorders
+            fz="xs"
+            data-testid="backup-validation-table"
+          >
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Collection</Table.Th>
+                <Table.Th>Documents</Table.Th>
+                <Table.Th>Valid</Table.Th>
+                <Table.Th>Invalid</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {collections.map(([name, stats]) => (
+                <Table.Tr key={name}>
+                  <Table.Td>{name}</Table.Td>
+                  <Table.Td>{stats.total}</Table.Td>
+                  <Table.Td>{stats.valid}</Table.Td>
+                  <Table.Td>
+                    {stats.invalid > 0 ? (
+                      <Text component="span" c="red" fw={600} size="xs">
+                        {stats.invalid}
+                      </Text>
+                    ) : (
+                      stats.invalid
+                    )}
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+
+        {v.warnings?.length > 0 && (
+          <Alert color="yellow" variant="light" icon={<Icon icon="mdi:alert" />}>
+            <Stack gap={2}>
+              {v.warnings.map((w, i) => (
+                <Text key={i} size="xs">
+                  {w}
+                </Text>
+              ))}
+            </Stack>
+          </Alert>
+        )}
+
+        {v.errors?.length > 0 && (
+          <Alert
+            color="red"
+            variant="light"
+            icon={<Icon icon="mdi:alert-circle" />}
+            title="Validation errors"
+            data-testid="backup-validation-errors"
+          >
+            <ScrollArea.Autosize mah={180}>
+              <Stack gap={2}>
+                {v.errors.map((e, i) => (
+                  <Text key={i} size="xs" ff="monospace">
+                    {e}
+                  </Text>
+                ))}
+              </Stack>
+            </ScrollArea.Autosize>
+          </Alert>
+        )}
+      </Stack>
+    );
+  };
+
+  const renderBody = () => {
+    if (!target) return null;
+
+    if (step === 'validating') {
+      return (
+        <Center mih={140}>
+          <Group gap="sm" data-testid="backup-validation-status">
+            <Loader size="sm" />
+            <Text size="sm" c="dimmed">
+              Validating backup {target.backupId}…
+            </Text>
+          </Group>
+        </Center>
+      );
+    }
+
+    if (step === 'done' && restoreResult) {
+      const count = Object.keys(restoreResult.restored_collections ?? {}).length;
+      return (
+        <Stack gap="sm">
+          <Alert
+            color="green"
+            variant="light"
+            icon={<Icon icon="mdi:check-circle" />}
+            title="Restore completed"
+            data-testid="backup-restore-success"
+          >
+            Restored {restoreResult.total_restored} documents across {count} collection
+            {count === 1 ? '' : 's'}.
+          </Alert>
+          <Group justify="flex-end">
+            <Button onClick={onClose}>Close</Button>
+          </Group>
+        </Stack>
+      );
+    }
+
+    if (step === 'error') {
+      return (
+        <Stack gap="sm">
+          <Alert
+            color="red"
+            variant="light"
+            icon={<Icon icon="mdi:alert-circle" />}
+            title="Restore not performed"
+            data-testid="backup-restore-error"
+          >
+            {errorMessage ?? 'Unknown error'}
+          </Alert>
+          {restoreResult && restoreResult.errors?.length > 0 && (
+            <ScrollArea.Autosize mah={140}>
+              <Stack gap={2}>
+                {restoreResult.errors.map((e, i) => (
+                  <Text key={i} size="xs" ff="monospace" c="red">
+                    {e}
+                  </Text>
+                ))}
+              </Stack>
+            </ScrollArea.Autosize>
+          )}
+          <Group justify="flex-end" gap="xs">
+            {validation && (
+              <Button variant="subtle" onClick={() => setStep('results')}>
+                Back
+              </Button>
+            )}
+            <Button onClick={onClose}>Close</Button>
+          </Group>
+        </Stack>
+      );
+    }
+
+    // 'results' and 'restoring'
+    return (
+      <Stack gap="sm">
+        {validation && renderValidationSummary(validation)}
+
+        {!target.hasChecksum && (
+          <Alert color="yellow" variant="light" icon={<Icon icon="mdi:shield-alert" />}>
+            This backup has no integrity checksum; the restore will proceed unverified.
+          </Alert>
+        )}
+
+        {validation?.valid ? (
+          <>
+            <Alert
+              color="red"
+              variant="light"
+              icon={<Icon icon="mdi:alert" />}
+              title="This cannot be undone."
+            >
+              Every listed collection will be wiped and replaced by the backup contents —
+              including collections the backup stores as empty. Active sessions survive
+              (tokens are never part of backups).
+            </Alert>
+
+            <TextInput
+              label={`Type ${CONFIRM_PHRASE} to confirm`}
+              placeholder={CONFIRM_PHRASE}
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.currentTarget.value)}
+              disabled={busy}
+              autoFocus
+              data-testid="backup-restore-confirm-input"
+            />
+
+            <Group justify="flex-end" gap="xs" mt="sm">
+              <Button variant="subtle" onClick={onClose} disabled={busy}>
+                Cancel
+              </Button>
+              <Button
+                color="red"
+                leftSection={<Icon icon="mdi:backup-restore" width={14} />}
+                onClick={handleRestore}
+                loading={busy}
+                disabled={confirmText.trim() !== CONFIRM_PHRASE || busy}
+                data-testid="backup-restore-confirm-button"
+              >
+                Restore backup
+              </Button>
+            </Group>
+          </>
+        ) : (
+          <>
+            <Alert color="red" variant="light" icon={<Icon icon="mdi:cancel" />}>
+              This backup cannot be restored while it fails validation. Fix the backup
+              file and upload it again.
+            </Alert>
+            <Group justify="flex-end">
+              <Button onClick={onClose}>Close</Button>
+            </Group>
+          </>
+        )}
+      </Stack>
+    );
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={() => !busy && onClose()}
+      title={target ? `Restore backup ${target.backupId}` : 'Restore backup'}
+      size="lg"
+      centered
+      closeOnClickOutside={false}
+      data-testid="backup-restore-modal"
+    >
+      {renderBody()}
+    </Modal>
+  );
+};
+
+export default RestoreBackupModal;

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,185 @@
+# Backup and restore
+
+Depictio stores state in two independent places, and they are backed up by two
+independent mechanisms. Reading this page as an operator, the one thing to take
+away is:
+
+> **Admin > Backups covers the database, not your data.**
+> Delta tables in S3/MinIO are a separate backup, with a separate procedure, and
+> they are never restored by the admin UI.
+
+## What lives where
+
+| Store | Holds | Covered by Admin > Backups |
+| --- | --- | --- |
+| MongoDB | users, groups, projects, workflows, dashboards, data collection definitions, file records, delta table *locations*, runs, instance settings, branding assets | Yes |
+| S3 / MinIO | the Delta Lake tables themselves, uploaded images, MultiQC inputs | **No** |
+
+A MongoDB backup records that a data collection's table lives at
+`s3://depictio-bucket/<data_collection_id>/`. It does not contain a single row of
+that table. Restoring the database therefore restores the *pointers*; whether
+they resolve depends entirely on the object store being in a matching state.
+
+## Database backups (Admin > Backups)
+
+### What is included
+
+Eleven collections: `users`, `projects`, `dashboards`, `data_collections`,
+`workflows`, `files`, `deltatables`, `runs`, `groups`, `instance_settings`,
+`branding_assets`.
+
+Deliberately excluded:
+
+- **`tokens`** — restoring them would create a circular dependency, and leaving
+  them out is why an admin session survives a restore performed from the UI.
+- **Temporary users** and the dashboards they own.
+- **Derived or self-expiring collections** — `jbrowse`, `multiqc`,
+  `multiqc_prerender` are regenerated from source data; `task_events`,
+  `app_logs` and `telemetry` expire by design.
+- **`ingestion_runs`** — real audit/lineage data with no TTL. This is a known
+  gap, not a decision that it should never be backed up.
+
+A `check_backup_collections_coverage` test fails CI when a new collection is
+added to settings without being classified, so this list cannot silently drift.
+
+### Backup files
+
+Each backup is a single JSON document written to `DEPICTIO_BACKUP_BACKUP_DIR`
+(`backups/` by default), named `depictio_backup_<YYYYMMDD_HHMMSS>.json`, with a
+`.sha256` sidecar written alongside it. Restore verifies the digest: a missing
+sidecar (legacy backups) can be waived with `allow_unverified`, but a *mismatch*
+is never bypassable.
+
+Because the id is the creation timestamp, retention reads a backup's age from
+its filename rather than its mtime, which does not survive a volume restore or
+an rsync.
+
+### Scheduling and retention
+
+Scheduled backups are **off by default**: a snapshot is the size of the whole
+database, and a deployment that has not sized its backup volume should not start
+filling it on upgrade.
+
+The schedule is read from MongoDB on every tick, so changes made in the UI apply
+to every API worker within a few minutes without a restart. Every worker runs
+the loop; the due time is claimed with a single conditional MongoDB update, so
+exactly one worker takes each backup.
+
+Retention offers two modes in the UI:
+
+- **Keep for a fixed time** — delete anything older than N days. `0` keeps
+  everything forever.
+- **Smart retention** — grandfather-father-son thinning: keep every backup for N
+  days, then one per ISO week for 4 weeks, then one per calendar month for 12
+  months. Bounded output from unbounded input.
+
+Pruning runs after every backup, scheduled or manual. Nothing else prunes the
+directory, and **there is no delete action**: retention is currently the only
+way a backup is ever removed.
+
+### Configuration
+
+Environment variables supply the *defaults*; anything saved from the Backups tab
+overrides them from then on, so an admin's click is never silently reverted on
+the next restart.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `DEPICTIO_BACKUP_AUTO_BACKUP_ENABLED` | `false` | Run scheduled backups |
+| `DEPICTIO_BACKUP_AUTO_BACKUP_INTERVAL_HOURS` | `24` | Hours between scheduled backups |
+| `DEPICTIO_BACKUP_BACKUP_FILE_RETENTION_DAYS` | `30` | Keep every backup for this long; `0` keeps forever |
+| `DEPICTIO_BACKUP_BACKUP_RETENTION_WEEKLY_WEEKS` | `0` | Weekly tier length; `0` disables it |
+| `DEPICTIO_BACKUP_BACKUP_RETENTION_MONTHLY_MONTHS` | `0` | Monthly tier length; `0` disables it |
+
+With both tiers at `0`, retention is a plain age cutoff.
+
+### Restoring
+
+Restore is destructive: each selected collection is emptied and refilled. Before
+anything is touched, the backup is validated against the current Pydantic models
+and the restore is refused if any document in a selected collection fails, unless
+`skip_validation` is set. A failed insert rolls that collection back to its
+previous contents.
+
+The list marks the backup a deployment's data was last restored from, so it is
+possible to tell which snapshot the live data came from.
+
+Backward compatibility is guarded two ways: frozen backup fixtures from v1.0.0
+onward are validated against current models on every run, and a weekly CI job
+boots the previous release, takes a real backup, and restores it into current
+code. Versions before v1.0.0 are out of scope.
+
+## Data backups (S3 / Delta Lake)
+
+**None of the above touches your data.** There are three ways to cover it, in
+descending order of what we would recommend.
+
+### 1. Object store replication (recommended for production)
+
+Let the object store do it. S3 bucket versioning plus Cross-Region Replication,
+or MinIO's `mc mirror` / site replication, gives point-in-time recovery of the
+Delta tables without Depictio being in the path at all. Delta Lake is
+append-structured, so object versioning composes well with it.
+
+This is the only option that scales to a real dataset, and the only one that
+protects you if the Depictio deployment itself is lost.
+
+### 2. The CLI, with `--include-s3-data`
+
+```bash
+depictio-cli backup create --include-s3-data --s3-backup-prefix backup
+```
+
+This takes the database backup *and* copies the Delta tables, driven by
+`DEPICTIO_BACKUP_S3_BACKUP_STRATEGY`:
+
+| Strategy | Effect |
+| --- | --- |
+| `s3_to_s3` (default) | Copy tables into a second bucket (`DEPICTIO_BACKUP_BACKUP_S3_BUCKET`), configured by `DEPICTIO_BACKUP_BACKUP_S3_ENDPOINT_URL` / `_ACCESS_KEY` / `_SECRET_KEY` / `_REGION`, enabled with `DEPICTIO_BACKUP_BACKUP_S3_ENABLED=true` |
+| `local` | Copy tables to `DEPICTIO_BACKUP_S3_LOCAL_BACKUP_DIR` on the server, optionally gzipped via `DEPICTIO_BACKUP_COMPRESS_LOCAL_BACKUPS` |
+| `both` | Both of the above |
+
+The same flag exists on the API's `POST /backup/create`. It is **not** exposed
+in the admin UI, on purpose: it needs a second bucket and credentials that are
+deployment configuration, and it runs synchronously inside the request.
+
+### 3. Snapshot the volume
+
+For single-node MinIO deployments, a filesystem or block-device snapshot of the
+MinIO data volume, taken alongside a database backup, is a coherent pair.
+
+### Restoring data: manual
+
+There is **no S3 restore path in Depictio.** `S3BackupStrategyManager` copies
+tables out; nothing copies them back. Recovering data means restoring the bucket
+yourself, with `mc mirror`, `aws s3 sync`, object-version rollback, or a volume
+snapshot, and then restoring the matching database backup.
+
+## Ordering, and one hazard worth knowing
+
+To recover a deployment consistently:
+
+1. Restore the object store to the state it had at the time of the database
+   backup you intend to use.
+2. Restore the database backup from Admin > Backups.
+3. Confirm dashboards render before letting users back in.
+
+**Restoring the database alone can cause data loss on S3.**
+`periodic_cleanup_orphaned_s3_files` runs on a timer and deletes bucket prefixes
+that no live data collection references. After a restore rewinds the database,
+every Delta table ingested *after* that snapshot is an orphan by that
+definition, and the next cleanup pass deletes it permanently. The task's safety
+check only aborts when *all* prefixes look orphaned, so a partial rewind passes
+straight through it.
+
+Until that interaction is guarded, treat a database restore on a deployment with
+live data as an operation that requires the object store to be rewound to match,
+or the cleanup task to be disabled first.
+
+## Related
+
+- `depictio/api/v1/endpoints/backup_endpoints/routes.py` — endpoints, retention, restore gate
+- `depictio/api/v1/tasks/backup_tasks.py` — the scheduler loop
+- `depictio/api/v1/backup_strategy_manager.py` — S3 copy strategies
+- `depictio/cli/cli/commands/backup.py` — `depictio-cli backup create|list|validate|restore`, plus the hidden maintainer command `depictio-cli dev check-coverage`
+- `depictio/dev_scripts/k8s_mongo_backup.sh` — mongodump straight from a Kubernetes pod

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,5 +1,9 @@
 # Backup and restore
 
+> Engineering reference. The user-facing page is
+> [Backup & Restore](https://depictio.github.io/depictio-docs/latest/usage/administration/backup/)
+> in depictio-docs; keep the two in step when this behaviour changes.
+
 Depictio stores state in two independent places, and they are backed up by two
 independent mechanisms. Reading this page as an operator, the one thing to take
 away is:
@@ -69,9 +73,17 @@ Retention offers two modes in the UI:
 
 - **Keep for a fixed time** — delete anything older than N days. `0` keeps
   everything forever.
-- **Smart retention** — grandfather-father-son thinning: keep every backup for N
-  days, then one per ISO week for 4 weeks, then one per calendar month for 12
-  months. Bounded output from unbounded input.
+- **Smart retention** — a single fixed grandfather-father-son policy, **30 days
+  / 4 weeks / 12 months**: every backup for 30 days, then one per ISO week for 4
+  weeks, then one per calendar month for 12 months. Nothing to configure.
+
+Smart is deliberately 30 days of full fidelity rather than the textbook 7, so
+that it is a strict superset of the default fixed policy (also 30 days).
+Switching a deployment to smart can only ever keep *more* history than it had,
+never less.
+
+The API accepts any tier sizes; the two modes are the UI's opinion about which
+policies are worth offering.
 
 Pruning runs after every backup, scheduled or manual. Nothing else prunes the
 directory, and **there is no delete action**: retention is currently the only

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -69,6 +69,15 @@ to every API worker within a few minutes without a restart. Every worker runs
 the loop; the due time is claimed with a single conditional MongoDB update, so
 exactly one worker takes each backup.
 
+A schedule can be **anchored to a time of day** (`HH:MM`, UTC). Slots then sit on
+a fixed grid running from that time: daily at 03:00 stays at 03:00, and a
+six-hourly schedule anchored at 03:00 runs at 03:00, 09:00, 15:00 and 21:00. The
+grid is anchored to a fixed epoch rather than to the previous run, which is what
+stops a run that fires a few minutes late from pushing every later run back with
+it. Leave the anchor empty for a rolling schedule: due whenever an interval has
+passed since the last run, wherever in the day that lands. Workers poll at most
+every 15 minutes, so an anchored backup starts within that of its slot.
+
 Retention offers two modes in the UI:
 
 - **Keep for a fixed time** — delete anything older than N days. `0` keeps
@@ -99,6 +108,7 @@ the next restart.
 | --- | --- | --- |
 | `DEPICTIO_BACKUP_AUTO_BACKUP_ENABLED` | `false` | Run scheduled backups |
 | `DEPICTIO_BACKUP_AUTO_BACKUP_INTERVAL_HOURS` | `24` | Hours between scheduled backups |
+| `DEPICTIO_BACKUP_AUTO_BACKUP_TIME_OF_DAY` | unset | `HH:MM` UTC anchor for the slot grid; unset means a rolling schedule |
 | `DEPICTIO_BACKUP_BACKUP_FILE_RETENTION_DAYS` | `30` | Keep every backup for this long; `0` keeps forever |
 | `DEPICTIO_BACKUP_BACKUP_RETENTION_WEEKLY_WEEKS` | `0` | Weekly tier length; `0` disables it |
 | `DEPICTIO_BACKUP_BACKUP_RETENTION_MONTHLY_MONTHS` | `0` | Monthly tier length; `0` disables it |

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -3722,6 +3722,9 @@ export interface BackupScheduleStatus {
    *  `monthly_months`. 0 turns a tier off; both at 0 is a plain age cutoff. */
   weekly_weeks: number;
   monthly_months: number;
+  /** "HH:MM" UTC anchor the schedule's slots sit on. Null means a rolling
+   *  schedule: due whenever an interval has passed since the last run. */
+  time_of_day: string | null;
   /** ISO timestamps with an explicit UTC offset; null before the first run. */
   last_run: string | null;
   next_run: string | null;
@@ -3794,6 +3797,8 @@ export async function updateBackupSchedule(update: {
   retentionDays?: number;
   weeklyWeeks?: number;
   monthlyMonths?: number;
+  /** "HH:MM" UTC. Pass the empty string to clear the anchor; omit to leave it. */
+  timeOfDay?: string;
 }): Promise<BackupScheduleStatus> {
   const res = await authFetch(`${API_BASE}/backup/schedule`, {
     method: 'PUT',
@@ -3803,6 +3808,7 @@ export async function updateBackupSchedule(update: {
       retention_days: update.retentionDays,
       weekly_weeks: update.weeklyWeeks,
       monthly_months: update.monthlyMonths,
+      time_of_day: update.timeOfDay,
     }),
   });
   if (!res.ok) await throwHttpDetailError(res, 'Failed to update the backup schedule');

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -3703,6 +3703,10 @@ export interface AdminBackupEntry {
   has_checksum?: boolean;
   /** True for snapshots taken by the scheduler rather than by an admin. */
   is_automatic?: boolean;
+  /** Set only on the backup this deployment's data was last restored from.
+   *  ISO timestamp with an explicit UTC offset. */
+  restored_at?: string | null;
+  restored_by?: string | null;
 }
 
 /** GET/PUT /backup/schedule — the scheduled-backup config in force.
@@ -3713,6 +3717,11 @@ export interface BackupScheduleStatus {
   interval_hours: number;
   /** 0 means backups are kept forever. */
   retention_days: number;
+  /** Grandfather-father-son tiers applied past retention_days: one backup kept
+   *  per ISO week for `weekly_weeks`, then one per calendar month for
+   *  `monthly_months`. 0 turns a tier off; both at 0 is a plain age cutoff. */
+  weekly_weeks: number;
+  monthly_months: number;
   /** ISO timestamps with an explicit UTC offset; null before the first run. */
   last_run: string | null;
   next_run: string | null;
@@ -3783,6 +3792,8 @@ export async function updateBackupSchedule(update: {
   enabled?: boolean;
   intervalHours?: number;
   retentionDays?: number;
+  weeklyWeeks?: number;
+  monthlyMonths?: number;
 }): Promise<BackupScheduleStatus> {
   const res = await authFetch(`${API_BASE}/backup/schedule`, {
     method: 'PUT',
@@ -3790,6 +3801,8 @@ export async function updateBackupSchedule(update: {
       enabled: update.enabled,
       interval_hours: update.intervalHours,
       retention_days: update.retentionDays,
+      weekly_weeks: update.weeklyWeeks,
+      monthly_months: update.monthlyMonths,
     }),
   });
   if (!res.ok) await throwHttpDetailError(res, 'Failed to update the backup schedule');

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -3701,6 +3701,23 @@ export interface AdminBackupEntry {
   /** False for legacy backups without a .sha256 sidecar; restoring those
    *  requires allow_unverified. */
   has_checksum?: boolean;
+  /** True for snapshots taken by the scheduler rather than by an admin. */
+  is_automatic?: boolean;
+}
+
+/** GET/PUT /backup/schedule — the scheduled-backup config in force.
+ *  Env vars supply the deployment default; anything saved from the admin UI
+ *  overrides it and is what the running scheduler reads. */
+export interface BackupScheduleStatus {
+  enabled: boolean;
+  interval_hours: number;
+  /** 0 means backups are kept forever. */
+  retention_days: number;
+  /** ISO timestamps with an explicit UTC offset; null before the first run. */
+  last_run: string | null;
+  next_run: string | null;
+  /** True once a value has been saved from the UI, overriding the env default. */
+  is_customized?: boolean;
 }
 
 export interface BackupCollectionValidation {
@@ -3752,6 +3769,31 @@ export async function listBackups(): Promise<AdminBackupEntry[]> {
   if (!res.ok) await throwHttpError(res, 'Failed to list backups');
   const data = await res.json();
   return Array.isArray(data?.backups) ? (data.backups as AdminBackupEntry[]) : [];
+}
+
+export async function getBackupSchedule(): Promise<BackupScheduleStatus> {
+  const res = await authFetch(`${API_BASE}/backup/schedule`);
+  if (!res.ok) await throwHttpError(res, 'Failed to load the backup schedule');
+  return res.json();
+}
+
+/** Change the schedule. Only the provided fields are updated; the response is
+ *  the schedule in force afterwards. Takes effect without an API restart. */
+export async function updateBackupSchedule(update: {
+  enabled?: boolean;
+  intervalHours?: number;
+  retentionDays?: number;
+}): Promise<BackupScheduleStatus> {
+  const res = await authFetch(`${API_BASE}/backup/schedule`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      enabled: update.enabled,
+      interval_hours: update.intervalHours,
+      retention_days: update.retentionDays,
+    }),
+  });
+  if (!res.ok) await throwHttpDetailError(res, 'Failed to update the backup schedule');
+  return res.json();
 }
 
 export async function createBackup(): Promise<BackupCreateResult> {

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -3682,6 +3682,141 @@ export async function cleanExampleProjects(): Promise<{ deleted: ExampleProject[
   return { deleted };
 }
 
+// ---- Admin backup & restore (/backup) -----------------------------------
+//
+// Back the admin Backups tab. All endpoints are admin-gated server side.
+// Restore is destructive (per-collection wipe-and-replace) — the UI runs
+// validation first and gates the real restore behind a typed confirmation.
+
+/** One entry from GET /backup/list. */
+export interface AdminBackupEntry {
+  backup_id: string;
+  filename: string;
+  size_mb: number;
+  created: string;
+  created_by: string;
+  total_documents: number;
+  collections: string[];
+  depictio_version?: string | null;
+  /** False for legacy backups without a .sha256 sidecar; restoring those
+   *  requires allow_unverified. */
+  has_checksum?: boolean;
+}
+
+export interface BackupCollectionValidation {
+  total: number;
+  valid: number;
+  invalid: number;
+  errors: string[];
+}
+
+export interface BackupValidationResult {
+  success: boolean;
+  message: string;
+  valid: boolean;
+  total_documents: number;
+  valid_documents: number;
+  invalid_documents: number;
+  collections_validated: Record<string, BackupCollectionValidation>;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface BackupCreateResult {
+  success: boolean;
+  message: string;
+  backup_id: string | null;
+  total_documents: number;
+  collections_backed_up: string[];
+  filename: string | null;
+}
+
+export interface BackupUploadResult {
+  success: boolean;
+  message: string;
+  backup_id: string | null;
+  filename: string | null;
+  validation: BackupValidationResult | null;
+}
+
+export interface BackupRestoreResult {
+  success: boolean;
+  message: string;
+  restored_collections: Record<string, { count: number; status: string }>;
+  total_restored: number;
+  errors: string[];
+}
+
+export async function listBackups(): Promise<AdminBackupEntry[]> {
+  const res = await authFetch(`${API_BASE}/backup/list`);
+  if (!res.ok) await throwHttpError(res, 'Failed to list backups');
+  const data = await res.json();
+  return Array.isArray(data?.backups) ? (data.backups as AdminBackupEntry[]) : [];
+}
+
+export async function createBackup(): Promise<BackupCreateResult> {
+  const res = await authFetch(`${API_BASE}/backup/create`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) await throwHttpDetailError(res, 'Failed to create backup');
+  return res.json();
+}
+
+/** Download a backup file to the browser (blob + anchor click, like
+ *  `exportProjectZip`). */
+export async function downloadBackup(backupId: string): Promise<void> {
+  const res = await authFetch(`${API_BASE}/backup/download/${backupId}`);
+  if (!res.ok) await throwHttpDetailError(res, 'Failed to download backup');
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `depictio_backup_${backupId}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/** Upload a backup file; the server stores it as a first-class backup and
+ *  returns the validation result alongside the new server-side backup_id. */
+export async function uploadBackup(file: File): Promise<BackupUploadResult> {
+  const fd = new FormData();
+  fd.append('file', file, file.name);
+  const res = await authFetch(`${API_BASE}/backup/upload`, { method: 'POST', body: fd });
+  if (!res.ok) await throwHttpDetailError(res, 'Failed to upload backup');
+  return res.json();
+}
+
+export async function validateBackup(backupId: string): Promise<BackupValidationResult> {
+  const res = await authFetch(`${API_BASE}/backup/validate`, {
+    method: 'POST',
+    body: JSON.stringify({ backup_id: backupId }),
+  });
+  if (!res.ok) await throwHttpDetailError(res, 'Failed to validate backup');
+  return res.json();
+}
+
+/** Restore a backup. DESTRUCTIVE unless dryRun — wipes and replaces every
+ *  restored collection. The server refuses backups that fail Pydantic
+ *  validation (no skip escape hatch is exposed to the UI on purpose). */
+export async function restoreBackup(
+  backupId: string,
+  opts: { dryRun?: boolean; allowUnverified?: boolean } = {},
+): Promise<BackupRestoreResult> {
+  const res = await authFetch(`${API_BASE}/backup/restore`, {
+    method: 'POST',
+    body: JSON.stringify({
+      backup_id: backupId,
+      dry_run: opts.dryRun ?? false,
+      allow_unverified: opts.allowUnverified ?? false,
+    }),
+  });
+  if (!res.ok) await throwHttpDetailError(res, 'Failed to restore backup');
+  return res.json();
+}
+
 // ---- Admin "Log & Task" monitoring (/monitoring) ------------------------
 //
 // Back the admin Monitoring tab. All read endpoints are admin-gated server

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -260,6 +260,13 @@ export {
   listAllDashboards,
   listExampleProjects,
   cleanExampleProjects,
+  // Admin backup & restore
+  listBackups,
+  createBackup,
+  downloadBackup,
+  uploadBackup,
+  validateBackup,
+  restoreBackup,
   // Admin monitoring (Log & Task)
   fetchMonitoringTasks,
   fetchMonitoringTask,
@@ -561,6 +568,13 @@ export type {
   AdminProject,
   AdminDashboard,
   ExampleProject,
+  // Admin backup & restore types
+  AdminBackupEntry,
+  BackupCollectionValidation,
+  BackupValidationResult,
+  BackupCreateResult,
+  BackupUploadResult,
+  BackupRestoreResult,
   // Admin monitoring types
   MonitoringTaskEvent,
   MonitoringIngestionRun,

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -262,6 +262,8 @@ export {
   cleanExampleProjects,
   // Admin backup & restore
   listBackups,
+  getBackupSchedule,
+  updateBackupSchedule,
   createBackup,
   downloadBackup,
   uploadBackup,
@@ -570,6 +572,7 @@ export type {
   ExampleProject,
   // Admin backup & restore types
   AdminBackupEntry,
+  BackupScheduleStatus,
   BackupCollectionValidation,
   BackupValidationResult,
   BackupCreateResult,


### PR DESCRIPTION
Admin > Backups: create, download, upload, validate and restore a MongoDB backup
from the UI, plus a background scheduler with a retention policy.

## What's here

**Backup and restore from the admin UI.** One-click server-side backup, a list of
the backups on the server, and a restore flow gated behind validation and a typed
confirmation. Restore is destructive, so it verifies the SHA-256 sidecar, refuses
any backup whose documents fail the current Pydantic models, and rolls a
collection back to its previous contents if an insert fails.

**Scheduled backups**, off by default. Every API worker runs the loop; the due
time is claimed with a single conditional MongoDB update, so exactly one worker
takes each backup. The config is re-read on every tick, so a change made in the
UI applies without a restart.

**A schedule can be anchored to a time of day** (`HH:MM`, UTC). Slots sit on a
fixed grid from that time, so daily at 03:00 stays at 03:00 and a six-hourly
schedule runs at 03:00, 09:00, 15:00 and 21:00. The grid is anchored to a fixed
epoch rather than to the previous run, so a late run never pushes later ones
back. An empty anchor keeps the rolling behaviour.

**Retention, in two modes.** Either a fixed age cutoff, or "Smart retention": a
single fixed grandfather-father-son policy of 30 days, then weekly for 4 weeks,
then monthly for 12 months. Smart is 30 days rather than the textbook 7 so that
it is a strict superset of the default fixed policy, and switching to it can only
ever keep more history than before. Pruning runs after every backup.

**The list says which backup is which.** The backup id is what ties a downloaded
`depictio_backup_<id>.json` back to a row, and a badge marks the snapshot this
deployment's data was last restored from. The marker is written only when a
restore completes without errors, and lives outside the collections a restore
overwrites.

## Screenshots

The full loop, captured from the Playwright run at `4f8cf911`. CI keeps
screenshots only on failure, so these come from the artifacts of the run that
caught the assertion bug fixed in `fb7f7394`.

**1. Create.** Create and Restore-from-file as peer actions, the scope notice
naming the database/data boundary, and the backup landing in the list. The
Automated backups card below it is the two-panel layout: schedule and retention
on the left, live status on the right, with the master switch in the header.

<img width="800" alt="Backups tab after creating a backup" src="https://github.com/user-attachments/assets/3778f509-ea91-40a1-b0a4-8e8c1e0a589b" />

**2. The restore gate.** Per-collection validation counts, the irreversibility
warning, and the typed `RESTORE` confirmation that unlocks the button.

<img width="800" alt="Restore confirmation modal" src="https://github.com/user-attachments/assets/69c38222-853f-458d-8bda-a24246e804e4" />

**3. Done.** What was actually written, per collection.

<img width="800" alt="Restore completed" src="https://github.com/user-attachments/assets/06ef372d-b5e4-4558-9897-10bd6750b311" />

**4. The list afterwards**, keyed by backup id, with the `restored` marker on
the snapshot the live data came from.

<img width="1280" alt="Backups list with the restored marker" src="https://github.com/user-attachments/assets/f31a6a7e-b50f-435c-9100-3587b5100c81" />

> The marker reads `RESTO…` in this capture. That truncation is fixed in
> `867a1780`: Mantine clips a Badge's label rather than overflowing it, and the
> badge was the flex item giving way to the id chip.

Still not captured: the Automated backups panel in full, and the
restore-from-file drop zone added in `867a1780`. Both need scrolling or a state
the e2e run never reaches.

## The database/data split

The snapshot covers MongoDB and leaves the Delta tables in S3 untouched, and
nothing restores them. This is now stated on the card that creates a backup,
rather than left for an admin to discover during a recovery.

`docs/backup-restore.md` is the engineering reference: what each store holds, the
three ways to cover the object store, the recovery ordering, and the
orphan-cleanup interaction below.

## Known gaps, deliberately not in this PR

- [ ] **Update the backup docs on depictio-docs.** `usage/administration/backup.md`
      is CLI-only today: it does not mention the admin UI, scheduling or
      retention, and it references `--include-s3-data` without saying there is no
      restore counterpart. Content is ready in `docs/backup-restore.md`.
- [ ] **A database-only restore can delete live data from S3.**
      `periodic_cleanup_orphaned_s3_files` deletes bucket prefixes no live data
      collection references. After a restore rewinds the database, every Delta
      table ingested since that snapshot is an orphan by that definition. The
      task's safety check only aborts when *all* prefixes look orphaned, so a
      partial rewind passes through it. The restore marker added here gives that
      guard something to key off.
- [ ] `ingestion_runs` (audit/lineage, no TTL) is still not backed up.
- [ ] No delete action: retention is the only way a backup is removed.
- [ ] Upload is capped at 200 MB and read into memory; `create` serializes the
      whole database synchronously inside the request.

## Testing

95 backup tests pass (`depictio/tests/api/v1/endpoints/backup_endpoints/`,
`depictio/tests/api/v1/tasks/`), covering the retention policy over dates, the
slot grid, the claim, the validation gate and the restore marker. The Playwright
spec drives the full create → download → upload → validate → restore loop and
asserts the restored badge. `tsc` and `pre-commit` are clean.

The UI has not been verified against a running stack in this branch.
