### PR TITLE
fix(filters): propagate active dashboard filters to builder previews (#329) and newly added components (#196)

### DIFF
--- a/depictio/api/v1/celery_tasks.py
+++ b/depictio/api/v1/celery_tasks.py
@@ -583,29 +583,37 @@ def build_multiqc_preview(payload: dict) -> dict:
 
 @celery_app.task(name="depictio.deltatables.preview", soft_time_limit=60, time_limit=120)
 def preview_deltatable(payload: dict) -> dict:
-    """Heavy body of `GET /deltatables/preview/{id}`.
+    """Heavy body of `GET`/`POST /deltatables/preview/{id}`.
 
     Input shape:
-        {"delta_table_location": str, "limit": int}
+        {"delta_table_location": str, "limit": int,
+         "filter_metadata": [...]}    # optional, cleaned InteractiveFilter list
+
+    With ``filter_metadata``, both the returned rows and ``total_rows`` are
+    computed on the filtered frame, so the builder's "Showing X of N rows"
+    reflects the dashboard's active filters.
     """
     import polars as pl
 
+    from depictio.api.v1.deltatables_utils import apply_filters_to_scan
     from depictio.api.v1.endpoints.deltatables_endpoints.routes import sanitize_for_json
     from depictio.api.v1.s3 import polars_s3_config
 
     delta_loc = payload["delta_table_location"]
     limit = max(1, min(int(payload.get("limit", 100)), 1000))
+    filter_metadata = payload.get("filter_metadata") or []
 
     started = time.monotonic()
-    df = pl.scan_delta(delta_loc, storage_options=polars_s3_config).head(limit).collect()
-    total_rows, total_cols = (
-        pl.scan_delta(delta_loc, storage_options=polars_s3_config).collect().shape
+    scan = apply_filters_to_scan(
+        pl.scan_delta(delta_loc, storage_options=polars_s3_config), filter_metadata
     )
+    df = scan.head(limit).collect()
+    total_rows, total_cols = scan.collect().shape
     rows = sanitize_for_json(df.to_dicts())
     elapsed_ms = int((time.monotonic() - started) * 1000)
     logger.info(
         f"celery_tasks.preview_deltatable rows={limit}/{total_rows} cols={total_cols} "
-        f"elapsed_ms={elapsed_ms}"
+        f"filters={len(filter_metadata)} elapsed_ms={elapsed_ms}"
     )
 
     return {
@@ -613,6 +621,7 @@ def preview_deltatable(payload: dict) -> dict:
         "rows": rows,
         "total_rows": total_rows,
         "total_columns": total_cols,
+        "filter_applied": bool(filter_metadata),
     }
 
 

--- a/depictio/api/v1/deltatables_utils.py
+++ b/depictio/api/v1/deltatables_utils.py
@@ -1197,6 +1197,78 @@ def _apply_scan_filters(
     return delta_scan
 
 
+def clean_filter_payload(filters: list[dict] | None) -> list[dict]:
+    """Convert React ``InteractiveFilter`` payloads into ``filter_metadata`` entries.
+
+    Same contract as the dashboards render endpoints (their
+    ``_build_filter_metadata`` delegates here): reads ``column_name`` /
+    ``interactive_component_type`` from the top level or the nested
+    ``metadata`` dict, drops entries missing a column or carrying an empty
+    value (``None`` / ``[]`` / ``""`` — those wouldn't survive
+    ``process_metadata_and_filter`` anyway), and carries ``filter_expr``
+    through so the source's row scoping is applied alongside the selection.
+    """
+    out: list[dict] = []
+    for f in filters or []:
+        meta = f.get("metadata") or {}
+        column_name = f.get("column_name") or meta.get("column_name")
+        if not column_name or f.get("value") in (None, [], ""):
+            continue
+        entry: dict = {
+            "interactive_component_type": f.get("interactive_component_type")
+            or meta.get("interactive_component_type"),
+            "column_name": column_name,
+            "value": f.get("value"),
+        }
+        filter_expr = f.get("filter_expr") or meta.get("filter_expr")
+        if filter_expr:
+            entry["filter_expr"] = filter_expr
+        out.append(entry)
+    return out
+
+
+def apply_filters_to_scan(scan: pl.LazyFrame, filter_metadata: list[dict] | None) -> pl.LazyFrame:
+    """AND ``filter_metadata`` onto a lazy frame, schema-guarded.
+
+    The preview flavour of ``_apply_scan_filters``: reads the schema straight
+    off the scan instead of the DC dtype cache, so it works for any lazy frame
+    (a projected scan, an in-memory test frame) without a DC id.
+
+    Filters whose column is absent from the frame are skipped rather than
+    failing the whole load. This is the deliberate cross-DC policy for the
+    builder-preview endpoints (matching ``/advanced_viz/data``): a dashboard's
+    filter on another DC's column can't be link-resolved here because these
+    endpoints have no dashboard context — link resolution needs the project
+    and the dashboard's stored metadata. The one blind spot is a same-named
+    column in a different DC, which will be applied; acceptable for a preview.
+    """
+    if not filter_metadata:
+        return scan
+
+    try:
+        schema = dict(scan.collect_schema())
+    except Exception as e:
+        logger.warning(f"apply_filters_to_scan: cannot read scan schema ({e}); skipping filters")
+        return scan
+
+    usable: list[dict] = []
+    for component in filter_metadata:
+        meta = component.get("metadata") or {}
+        col = component.get("column_name") or meta.get("column_name")
+        if col and col not in schema:
+            logger.info(
+                "apply_filters_to_scan: skipping filter on column %r — not in frame",
+                col,
+            )
+            continue
+        usable.append(component)
+
+    filter_expressions = process_metadata_and_filter(usable, schema)
+    for expr in filter_expressions:
+        scan = scan.filter(expr)
+    return scan
+
+
 def _estimate_frame_size_bytes(delta_scan: pl.LazyFrame) -> int:
     """Cheaply estimate a lazy frame's materialised footprint (bytes).
 

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -1763,24 +1763,13 @@ def _build_filter_metadata(filters: list[dict]) -> list[dict]:
     Carries ``filter_expr`` through (top-level or under ``metadata``) so the
     server-side pipeline can AND the source's row-scoping expression alongside
     the user-supplied value.
+
+    Delegates to the shared ``clean_filter_payload`` so the render endpoints
+    and the builder-preview endpoints clean filters identically.
     """
-    out: list[dict] = []
-    for f in filters:
-        meta = f.get("metadata") or {}
-        column_name = f.get("column_name") or meta.get("column_name")
-        if not column_name or f.get("value") in (None, [], ""):
-            continue
-        entry: dict = {
-            "interactive_component_type": f.get("interactive_component_type")
-            or meta.get("interactive_component_type"),
-            "column_name": column_name,
-            "value": f.get("value"),
-        }
-        filter_expr = f.get("filter_expr") or meta.get("filter_expr")
-        if filter_expr:
-            entry["filter_expr"] = filter_expr
-        out.append(entry)
-    return out
+    from depictio.api.v1.deltatables_utils import clean_filter_payload
+
+    return clean_filter_payload(filters)
 
 
 @dataclass(frozen=True)

--- a/depictio/api/v1/endpoints/deltatables_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/deltatables_endpoints/routes.py
@@ -703,6 +703,107 @@ async def get_unique_values(
         raise HTTPException(status_code=500, detail=f"Failed to read unique values: {e}")
 
 
+def _resolve_delta_location(data_collection_id: PyObjectId, current_user: User) -> str:
+    """Permission-check ``data_collection_id`` and return its Delta location.
+
+    The shared opening of every read endpoint below: aggregate the permission
+    pipeline, find the DC's deltatable document, pull the table location.
+    Raises the same 404s those endpoints raised inline.
+    """
+    pipeline = _build_permission_pipeline(data_collection_id, current_user)
+    if not list(projects_collection.aggregate(pipeline)):
+        raise HTTPException(status_code=404, detail="Data collection not found or access denied.")
+
+    deltatables_list = list(deltatables_collection.find({"data_collection_id": data_collection_id}))
+    if not deltatables_list:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No DeltaTable found for Data Collection ID {data_collection_id}.",
+        )
+    delta_table_location = deltatables_list[-1].get("delta_table_location")
+    if not delta_table_location:
+        raise HTTPException(
+            status_code=404, detail="Delta table location not found in deltatable document."
+        )
+    return delta_table_location
+
+
+def _breakdown_response(
+    data_collection_id: PyObjectId,
+    column: str,
+    breakdown_col: str,
+    aggregation: str,
+    top_n_count: int,
+    filter_metadata: list[dict],
+    current_user: User,
+):
+    """Shared body of the breakdown GET (unfiltered) and POST (filtered) routes."""
+    delta_table_location = _resolve_delta_location(data_collection_id, current_user)
+
+    # The builder re-requests this on every keystroke-ish config change (layout
+    # switch, breakdown column, top-N). Salting on the aggregation version means
+    # an ingest invalidates it for free, same contract as ``unique_values``.
+    # Filtered requests skip the cache entirely: the key doesn't encode filter
+    # state, and salting it would fill the cache with transient combinations.
+    from depictio.api.v1.deltatables_utils import _get_aggregation_version, apply_filters_to_scan
+
+    dc_id_str = str(data_collection_id)
+    cache_key = (
+        f"breakdown_{dc_id_str}_{column}_{breakdown_col}_{aggregation}_{top_n_count}_"
+        f"{_get_aggregation_version(dc_id_str)}"
+    )
+    if not filter_metadata:
+        try:
+            from depictio.api.cache import get_cache
+
+            cached = get_cache().get(cache_key)
+            if cached is not None:
+                return cached
+        except Exception as exc:  # the cache is an optimisation, never a dependency
+            logger.debug(f"breakdown: cache read failed for {cache_key}: {exc}")
+
+    try:
+        lazy = pl.scan_delta(delta_table_location, storage_options=polars_s3_config)
+        # Project before grouping: a breakdown reads two columns, and on a wide
+        # collection loading the rest is the whole cost of the request. Filter
+        # columns must ride along in the projection or the filters would be
+        # applied to a frame that no longer contains them.
+        filter_cols = [
+            c
+            for f in filter_metadata
+            if (c := f.get("column_name") or (f.get("metadata") or {}).get("column_name"))
+        ]
+        wanted = list(dict.fromkeys([c for c in (breakdown_col, column) if c]))
+        available = set(lazy.collect_schema().names())
+        missing = [c for c in wanted if c not in available]
+        if missing:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Column(s) {missing} not found in data collection {dc_id_str}.",
+            )
+        projected = list(dict.fromkeys(wanted + [c for c in filter_cols if c in available]))
+        payload = compute_breakdown(
+            apply_filters_to_scan(lazy.select(projected), filter_metadata).select(wanted),
+            column=column,
+            breakdown_col=breakdown_col,
+            aggregation=aggregation,
+            top_n_count=top_n_count,
+        )
+        if not filter_metadata:
+            try:
+                from depictio.api.cache import get_cache
+
+                get_cache().set(cache_key, payload)
+            except Exception as exc:
+                logger.debug(f"breakdown: cache write failed for {cache_key}: {exc}")
+        return payload
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error computing breakdown on {breakdown_col!r} for {dc_id_str}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to compute breakdown: {e}")
+
+
 @deltatables_endpoint_router.get("/breakdown/{data_collection_id}")
 async def get_breakdown(
     data_collection_id: PyObjectId,
@@ -721,9 +822,9 @@ async def get_breakdown(
     33/33/34; the names and the shape were both invented, which made a correct
     builder look broken.
 
-    Computed against the *unfiltered* table: the builder has no interactive
-    filter state, and the saved card recomputes under whatever filters the
-    dashboard carries.
+    Computed against the *unfiltered* table. When the builder carries active
+    dashboard filters it uses the POST variant below instead, so the preview
+    matches what the saved card will show under those filters.
 
     Args:
         data_collection_id: Target data collection.
@@ -741,72 +842,47 @@ async def get_breakdown(
         HTTPException: 404 if the DC / delta table / column is missing, 403 if
         the user may not read it, 500 on a read error.
     """
-    pipeline = _build_permission_pipeline(data_collection_id, current_user)
-    if not list(projects_collection.aggregate(pipeline)):
-        raise HTTPException(status_code=404, detail="Data collection not found or access denied.")
-
-    deltatables_list = list(deltatables_collection.find({"data_collection_id": data_collection_id}))
-    if not deltatables_list:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No DeltaTable found for Data Collection ID {data_collection_id}.",
-        )
-    delta_table_location = deltatables_list[-1].get("delta_table_location")
-    if not delta_table_location:
-        raise HTTPException(
-            status_code=404, detail="Delta table location not found in deltatable document."
-        )
-
-    # The builder re-requests this on every keystroke-ish config change (layout
-    # switch, breakdown column, top-N). Salting on the aggregation version means
-    # an ingest invalidates it for free, same contract as ``unique_values``.
-    from depictio.api.v1.deltatables_utils import _get_aggregation_version
-
-    dc_id_str = str(data_collection_id)
-    cache_key = (
-        f"breakdown_{dc_id_str}_{column}_{breakdown_col}_{aggregation}_{top_n_count}_"
-        f"{_get_aggregation_version(dc_id_str)}"
+    return _breakdown_response(
+        data_collection_id,
+        column,
+        breakdown_col,
+        aggregation,
+        top_n_count,
+        filter_metadata=[],
+        current_user=current_user,
     )
-    try:
-        from depictio.api.cache import get_cache
 
-        cached = get_cache().get(cache_key)
-        if cached is not None:
-            return cached
-    except Exception as exc:  # the cache is an optimisation, never a dependency
-        logger.debug(f"breakdown: cache read failed for {cache_key}: {exc}")
 
-    try:
-        lazy = pl.scan_delta(delta_table_location, storage_options=polars_s3_config)
-        # Project before grouping: a breakdown reads two columns, and on a wide
-        # collection loading the rest is the whole cost of the request.
-        wanted = list(dict.fromkeys([c for c in (breakdown_col, column) if c]))
-        available = set(lazy.collect_schema().names())
-        missing = [c for c in wanted if c not in available]
-        if missing:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Column(s) {missing} not found in data collection {dc_id_str}.",
-            )
-        payload = compute_breakdown(
-            lazy.select(wanted),
-            column=column,
-            breakdown_col=breakdown_col,
-            aggregation=aggregation,
-            top_n_count=top_n_count,
-        )
-        try:
-            from depictio.api.cache import get_cache
+@deltatables_endpoint_router.post("/breakdown/{data_collection_id}")
+async def get_breakdown_filtered(
+    data_collection_id: PyObjectId,
+    request: dict,
+    current_user: User = Depends(get_user_or_anonymous),
+):
+    """Filtered flavour of the breakdown preview.
 
-            get_cache().set(cache_key, payload)
-        except Exception as exc:
-            logger.debug(f"breakdown: cache write failed for {cache_key}: {exc}")
-        return payload
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error computing breakdown on {breakdown_col!r} for {dc_id_str}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to compute breakdown: {e}")
+    Body: ``{"column", "breakdown_col", "aggregation", "top_n_count",
+    "filters": [InteractiveFilter, ...]}``. Same payload as the GET, computed
+    under the dashboard's active filters so the card builder previews the
+    distribution the saved card will actually show (#329). Filters whose
+    column isn't in this DC are skipped (see ``apply_filters_to_scan``);
+    filtered responses bypass the breakdown cache.
+    """
+    from depictio.api.v1.deltatables_utils import clean_filter_payload
+
+    column = str(request.get("column") or "")
+    breakdown_col = str(request.get("breakdown_col") or "")
+    if not column or not breakdown_col:
+        raise HTTPException(status_code=400, detail="column and breakdown_col are required.")
+    return _breakdown_response(
+        data_collection_id,
+        column,
+        breakdown_col,
+        str(request.get("aggregation") or "count"),
+        int(request.get("top_n_count") or 3),
+        filter_metadata=clean_filter_payload(request.get("filters")),
+        current_user=current_user,
+    )
 
 
 @deltatables_endpoint_router.post("/card_metric/{data_collection_id}")
@@ -830,36 +906,34 @@ async def get_card_metric(
     Returns the layout's payload, or ``null`` when the config is incomplete or
     the data cannot support it (a constant column has no histogram). The
     builder then renders no strip rather than a misleading one.
+
+    ``filters`` (optional, ``InteractiveFilter`` list) narrows the frame first,
+    so the builder can preview the strip under the dashboard's active filters
+    (#329). ``layout: "hero"`` is a preview-only pseudo-layout returning
+    ``{"value": <scalar>}`` — the card's hero aggregation computed on the
+    (possibly filtered) frame, replacing the static precomputed spec value the
+    builder shows when no filters are active.
     """
+    from depictio.api.v1.deltatables_utils import apply_filters_to_scan, clean_filter_payload
+    from depictio.api.v1.services.card_metrics import hero_value
+
     layout = str(request.get("layout") or "")
     column = str(request.get("column") or "")
-    if layout not in NUMERIC_LAYOUTS or not column:
+    if (layout not in NUMERIC_LAYOUTS and layout != "hero") or not column:
         raise HTTPException(
             status_code=400,
-            detail=f"layout must be one of {NUMERIC_LAYOUTS} and column is required.",
+            detail=f"layout must be 'hero' or one of {NUMERIC_LAYOUTS} and column is required.",
         )
 
-    pipeline = _build_permission_pipeline(data_collection_id, current_user)
-    if not list(projects_collection.aggregate(pipeline)):
-        raise HTTPException(status_code=404, detail="Data collection not found or access denied.")
-
-    deltatables_list = list(deltatables_collection.find({"data_collection_id": data_collection_id}))
-    if not deltatables_list:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No DeltaTable found for Data Collection ID {data_collection_id}.",
-        )
-    delta_table_location = deltatables_list[-1].get("delta_table_location")
-    if not delta_table_location:
-        raise HTTPException(
-            status_code=404, detail="Delta table location not found in deltatable document."
-        )
+    delta_table_location = _resolve_delta_location(data_collection_id, current_user)
+    filter_metadata = clean_filter_payload(request.get("filters"))
 
     try:
         lazy = pl.scan_delta(delta_table_location, storage_options=polars_s3_config)
         # Project to the columns this layout reads. ``attrition`` walks a list
         # of stage columns and ``trend`` needs its axis alongside the hero
-        # column; the rest read the hero column alone.
+        # column; the rest read the hero column alone. Filter columns must ride
+        # along or the filters would target a frame that no longer has them.
         wanted = [
             column,
             *[str(c) for c in (request.get("attrition_cols") or []) if c],
@@ -872,7 +946,17 @@ async def get_card_metric(
                 status_code=404,
                 detail=f"Column {column!r} not found in data collection {data_collection_id}.",
             )
-        return numeric_layout_payload(lazy.select(wanted), request, column, layout)
+        filter_cols = [
+            c
+            for f in filter_metadata
+            if (c := f.get("column_name") or (f.get("metadata") or {}).get("column_name"))
+            and c in available
+        ]
+        projected = list(dict.fromkeys(wanted + filter_cols))
+        frame = apply_filters_to_scan(lazy.select(projected), filter_metadata).select(wanted)
+        if layout == "hero":
+            return {"value": hero_value(frame, column, str(request.get("aggregation") or ""))}
+        return numeric_layout_payload(frame, request, column, layout)
     except HTTPException:
         raise
     except Exception as e:
@@ -942,23 +1026,7 @@ async def get_preview(
     Heavy work (Polars scan + collect) runs on Celery when
     `settings.celery.offload_preview` is true (default).
     """
-    pipeline = _build_permission_pipeline(data_collection_id, current_user)
-    project_result = list(projects_collection.aggregate(pipeline))
-    if not project_result:
-        raise HTTPException(status_code=404, detail="Data collection not found or access denied.")
-
-    deltatables_list = list(deltatables_collection.find({"data_collection_id": data_collection_id}))
-    if not deltatables_list:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No DeltaTable found for Data Collection ID {data_collection_id}.",
-        )
-
-    delta_table_location = deltatables_list[-1].get("delta_table_location")
-    if not delta_table_location:
-        raise HTTPException(
-            status_code=404, detail="Delta table location not found in deltatable document."
-        )
+    delta_table_location = _resolve_delta_location(data_collection_id, current_user)
 
     offload = settings.celery.offload_preview
     response.headers["X-Celery-Path"] = "offloaded" if offload else "inline"
@@ -973,6 +1041,50 @@ async def get_preview(
         raise
     except Exception as e:
         logger.error(f"Error reading delta table preview: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to read delta table preview: {e}")
+
+
+@deltatables_endpoint_router.post("/preview/{data_collection_id}")
+async def get_preview_filtered(
+    response: Response,
+    data_collection_id: PyObjectId,
+    request: dict,
+    current_user: User = Depends(get_user_or_anonymous),
+):
+    """Filtered flavour of the preview above, for the component builder.
+
+    Body: ``{"limit": int = 100, "filters": [InteractiveFilter, ...]}``. The
+    rows AND ``total_rows`` reflect the filtered frame, so the builder's
+    "Showing X of N rows" matches what the dashboard's components show under
+    the same filters (#329). Filters whose column isn't in this DC are skipped
+    (cross-DC filters can't be link-resolved without dashboard context — see
+    ``apply_filters_to_scan``). The GET stays for unfiltered callers.
+    """
+    from depictio.api.v1.deltatables_utils import clean_filter_payload
+
+    delta_table_location = _resolve_delta_location(data_collection_id, current_user)
+    filter_metadata = clean_filter_payload(request.get("filters"))
+    limit = int(request.get("limit") or 100)
+
+    offload = settings.celery.offload_preview
+    response.headers["X-Celery-Path"] = "offloaded" if offload else "inline"
+    try:
+        return await offload_or_run(
+            preview_deltatable_task,
+            (
+                {
+                    "delta_table_location": delta_table_location,
+                    "limit": limit,
+                    "filter_metadata": filter_metadata,
+                },
+            ),
+            offload=offload,
+            label=f"deltatable_preview dc={data_collection_id} filters={len(filter_metadata)}",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error reading filtered delta table preview: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to read delta table preview: {e}")
 
 

--- a/depictio/api/v1/services/card_metrics.py
+++ b/depictio/api/v1/services/card_metrics.py
@@ -553,3 +553,39 @@ def numeric_layout_payload(
         return compute_attrition(frame, stages, str(card.get("aggregation") or "sum"))
 
     return None
+
+
+def hero_value(frame: pl.DataFrame | pl.LazyFrame, column: str, aggregation: str) -> Any:
+    """A card's hero scalar, computed live on ``frame``.
+
+    Exists for the builder preview under active dashboard filters: the static
+    precomputed spec (``col.specs[aggregation]``) describes the unfiltered
+    collection, so a filtered preview needs the reduction evaluated against the
+    filtered frame instead. Reuses the exact expression + coercion pair the
+    saved-card pushdown path uses (``_agg_expr`` / ``_coerce_agg_result``), so
+    the preview's hero and the saved card's value cannot disagree. Imported at
+    call time: that module imports this one at module level.
+
+    Returns ``None`` when the column is missing or the aggregation has no lazy
+    expression form (``mode``, ``box_plot_stats`` — the fallback paths need
+    materialised values, which a preview shouldn't force).
+    """
+    from depictio.api.v1.endpoints.dashboards_endpoints.routes import (
+        _agg_expr,
+        _coerce_agg_result,
+    )
+
+    available = set(
+        frame.collect_schema().names() if isinstance(frame, pl.LazyFrame) else frame.columns
+    )
+    if column not in available:
+        return None
+    expr = _agg_expr(column, aggregation)
+    if expr is None:
+        return None
+    lazy = frame if isinstance(frame, pl.LazyFrame) else frame.lazy()
+    try:
+        raw = lazy.select(expr.alias("__hero__")).collect().row(0)[0]
+    except Exception:
+        return None
+    return _coerce_agg_result(raw, aggregation)

--- a/depictio/tests/api/v1/test_card_metrics_filters.py
+++ b/depictio/tests/api/v1/test_card_metrics_filters.py
@@ -1,0 +1,97 @@
+"""Card preview under active dashboard filters (#329).
+
+``hero_value`` computes a card's hero scalar live on a (possibly filtered)
+frame using the exact expression + coercion pair the saved-card pushdown path
+uses, so the builder preview and the saved card cannot disagree. The other
+tests pin that the numeric-strip and breakdown helpers, fed a pre-filtered
+scan (as the filtered ``card_metric`` / ``breakdown`` endpoints now do),
+return the filtered distribution rather than the whole collection's.
+
+Style matches ``test_card_breakdown.py``: in-memory Polars frames, no HTTP.
+"""
+
+import polars as pl
+import pytest
+
+from depictio.api.v1.deltatables_utils import apply_filters_to_scan
+from depictio.api.v1.services.card_breakdown import compute_breakdown
+from depictio.api.v1.services.card_metrics import hero_value, numeric_layout_payload
+
+
+@pytest.fixture
+def frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "variety": ["Setosa"] * 4 + ["Versicolor"] * 4 + ["Virginica"] * 2,
+            "petal_length": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        }
+    )
+
+
+SETOSA_FILTER = [
+    {
+        "interactive_component_type": "MultiSelect",
+        "column_name": "variety",
+        "value": ["Setosa"],
+    }
+]
+
+
+class TestHeroValue:
+    @pytest.mark.parametrize(
+        ("aggregation", "expected"),
+        [
+            ("count", 10),
+            ("sum", 55.0),
+            ("mean", 5.5),
+            ("average", 5.5),
+            ("min", 1.0),
+            ("max", 10.0),
+            ("median", 5.5),
+            ("nunique", 10),
+        ],
+    )
+    def test_unfiltered(self, frame, aggregation, expected):
+        assert hero_value(frame.lazy(), "petal_length", aggregation) == expected
+
+    def test_filtered_scan(self, frame):
+        filtered = apply_filters_to_scan(frame.lazy(), SETOSA_FILTER)
+        assert hero_value(filtered, "petal_length", "count") == 4
+        assert hero_value(filtered, "petal_length", "sum") == 10.0
+        assert hero_value(filtered, "petal_length", "mean") == 2.5
+
+    def test_missing_column(self, frame):
+        assert hero_value(frame.lazy(), "nope", "count") is None
+
+    def test_expressionless_aggregation(self, frame):
+        # ``mode`` deliberately has no lazy expression form (tie-order isn't
+        # guaranteed); the preview returns None rather than approximating.
+        assert hero_value(frame.lazy(), "petal_length", "mode") is None
+
+    def test_eager_frame_accepted(self, frame):
+        assert hero_value(frame, "petal_length", "count") == 10
+
+
+class TestFilteredStripHelpers:
+    def test_histogram_differs_under_filter(self, frame):
+        full = numeric_layout_payload(frame.lazy(), {}, "petal_length", "histogram")
+        filtered = numeric_layout_payload(
+            apply_filters_to_scan(frame.lazy(), SETOSA_FILTER), {}, "petal_length", "histogram"
+        )
+        assert full is not None and filtered is not None
+        assert full["total"] == 10
+        assert sum(full["bins"]) == 10
+        assert filtered["total"] == 4
+        assert sum(filtered["bins"]) == 4
+
+    def test_breakdown_reflects_filter(self, frame):
+        filtered = compute_breakdown(
+            apply_filters_to_scan(frame.lazy(), SETOSA_FILTER),
+            column="petal_length",
+            breakdown_col="variety",
+            aggregation="count",
+            top_n_count=3,
+        )
+        assert filtered is not None
+        assert filtered["total"] == 4
+        assert [g["name"] for g in filtered["top"]] == ["Setosa"]

--- a/depictio/tests/api/v1/test_preview_filters.py
+++ b/depictio/tests/api/v1/test_preview_filters.py
@@ -1,0 +1,229 @@
+"""Filter support for the builder-preview endpoints (#329 / #196).
+
+Covers the pure helpers the filtered previews are built on —
+``clean_filter_payload`` (React ``InteractiveFilter`` payload → cleaned
+``filter_metadata``) and ``apply_filters_to_scan`` (schema-guarded filter
+application on a lazy frame) — plus the ``preview_deltatable`` Celery task
+against a local Delta table.
+
+Style matches ``test_card_breakdown.py`` / ``test_deltatables_utils.py``:
+in-memory Polars frames, no HTTP client, no database.
+"""
+
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+
+from depictio.api.v1.deltatables_utils import apply_filters_to_scan, clean_filter_payload
+
+
+@pytest.fixture
+def iris_like() -> pl.DataFrame:
+    """A small frame shaped like the seeded Iris DC: one categorical column
+    with three balanced groups, one numeric column."""
+    return pl.DataFrame(
+        {
+            "variety": ["Setosa"] * 3 + ["Versicolor"] * 3 + ["Virginica"] * 3,
+            "petal_length": [1.4, 1.3, 1.5, 4.5, 4.7, 4.4, 6.0, 5.8, 6.1],
+        }
+    )
+
+
+class TestCleanFilterPayload:
+    def test_flat_shape(self):
+        filters = [
+            {
+                "interactive_component_type": "MultiSelect",
+                "column_name": "variety",
+                "value": ["Setosa"],
+            }
+        ]
+        assert clean_filter_payload(filters) == [
+            {
+                "interactive_component_type": "MultiSelect",
+                "column_name": "variety",
+                "value": ["Setosa"],
+            }
+        ]
+
+    def test_nested_metadata_shape(self):
+        """The React payload keeps column/type under ``metadata`` — the shape
+        every interactive component emits at runtime."""
+        filters = [
+            {
+                "index": "abc-123",
+                "value": ["Setosa"],
+                "metadata": {
+                    "interactive_component_type": "MultiSelect",
+                    "column_name": "variety",
+                    "dc_id": "000000000000000000000001",
+                },
+            }
+        ]
+        out = clean_filter_payload(filters)
+        assert out == [
+            {
+                "interactive_component_type": "MultiSelect",
+                "column_name": "variety",
+                "value": ["Setosa"],
+            }
+        ]
+
+    @pytest.mark.parametrize("empty", [None, [], ""])
+    def test_empty_values_dropped(self, empty):
+        filters = [
+            {"column_name": "variety", "interactive_component_type": "MultiSelect", "value": empty}
+        ]
+        assert clean_filter_payload(filters) == []
+
+    def test_missing_column_dropped(self):
+        assert clean_filter_payload([{"value": ["Setosa"], "metadata": {}}]) == []
+
+    def test_filter_expr_carried_through(self):
+        filters = [
+            {
+                "column_name": "variety",
+                "interactive_component_type": "MultiSelect",
+                "value": ["Setosa"],
+                "metadata": {"filter_expr": "col('petal_length') > 1.0"},
+            }
+        ]
+        assert clean_filter_payload(filters)[0]["filter_expr"] == "col('petal_length') > 1.0"
+
+    def test_none_input(self):
+        assert clean_filter_payload(None) == []
+
+
+class TestApplyFiltersToScan:
+    def test_multiselect_narrows(self, iris_like):
+        out = apply_filters_to_scan(
+            iris_like.lazy(),
+            [
+                {
+                    "interactive_component_type": "MultiSelect",
+                    "column_name": "variety",
+                    "value": ["Setosa"],
+                }
+            ],
+        ).collect()
+        assert out.height == 3
+        assert set(out["variety"].to_list()) == {"Setosa"}
+
+    def test_rangeslider_narrows(self, iris_like):
+        out = apply_filters_to_scan(
+            iris_like.lazy(),
+            [
+                {
+                    "interactive_component_type": "RangeSlider",
+                    "column_name": "petal_length",
+                    "value": [4.0, 5.0],
+                }
+            ],
+        ).collect()
+        assert out.height == 3
+        assert set(out["variety"].to_list()) == {"Versicolor"}
+
+    def test_filters_and_together(self, iris_like):
+        out = apply_filters_to_scan(
+            iris_like.lazy(),
+            [
+                {
+                    "interactive_component_type": "MultiSelect",
+                    "column_name": "variety",
+                    "value": ["Setosa", "Virginica"],
+                },
+                {
+                    "interactive_component_type": "RangeSlider",
+                    "column_name": "petal_length",
+                    "value": [5.9, 7.0],
+                },
+            ],
+        ).collect()
+        assert out.height == 2
+        assert set(out["variety"].to_list()) == {"Virginica"}
+
+    def test_absent_column_skipped_valid_cofilter_applies(self, iris_like):
+        """The cross-DC contract: a filter on a column this frame doesn't have
+        is skipped rather than raising ColumnNotFoundError, while the valid
+        co-supplied filter still narrows the frame."""
+        out = apply_filters_to_scan(
+            iris_like.lazy(),
+            [
+                {
+                    "interactive_component_type": "MultiSelect",
+                    "column_name": "habitat",  # not in this DC
+                    "value": ["marine"],
+                },
+                {
+                    "interactive_component_type": "MultiSelect",
+                    "column_name": "variety",
+                    "value": ["Setosa"],
+                },
+            ],
+        ).collect()
+        assert out.height == 3
+        assert set(out["variety"].to_list()) == {"Setosa"}
+
+    @pytest.mark.parametrize("metadata", [None, []])
+    def test_no_filters_is_noop(self, iris_like, metadata):
+        out = apply_filters_to_scan(iris_like.lazy(), metadata).collect()
+        assert out.equals(iris_like)
+
+    def test_nested_metadata_shape(self, iris_like):
+        """Entries can also arrive in the nested runtime shape (column under
+        ``metadata``) — ``process_metadata_and_filter`` handles both."""
+        out = apply_filters_to_scan(
+            iris_like.lazy(),
+            [
+                {
+                    "value": ["Versicolor"],
+                    "metadata": {
+                        "interactive_component_type": "MultiSelect",
+                        "column_name": "variety",
+                    },
+                }
+            ],
+        ).collect()
+        assert set(out["variety"].to_list()) == {"Versicolor"}
+
+
+class TestPreviewDeltatableTask:
+    """End-to-end through the Celery task body against a local Delta table."""
+
+    @pytest.fixture
+    def delta_location(self, tmp_path, iris_like) -> str:
+        loc = str(tmp_path / "iris_delta")
+        iris_like.write_delta(loc)
+        return loc
+
+    def _run(self, delta_location: str, **payload):
+        from depictio.api.v1.celery_tasks import preview_deltatable
+
+        # Local paths take no S3 storage options.
+        with patch("depictio.api.v1.s3.polars_s3_config", {}):
+            return preview_deltatable({"delta_table_location": delta_location, **payload})
+
+    def test_unfiltered(self, delta_location):
+        out = self._run(delta_location, limit=5)
+        assert out["total_rows"] == 9
+        assert len(out["rows"]) == 5
+        assert out["filter_applied"] is False
+
+    def test_filtered_rows_and_total(self, delta_location):
+        out = self._run(
+            delta_location,
+            limit=100,
+            filter_metadata=[
+                {
+                    "interactive_component_type": "MultiSelect",
+                    "column_name": "variety",
+                    "value": ["Setosa"],
+                }
+            ],
+        )
+        # Both the page and the "of N rows" total reflect the filtered frame.
+        assert out["total_rows"] == 3
+        assert len(out["rows"]) == 3
+        assert {r["variety"] for r in out["rows"]} == {"Setosa"}
+        assert out["filter_applied"] is True

--- a/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression spec for #329 + #196 — dashboard filter propagation across the
+ * component builder's full-page round-trip.
+ *
+ * #329: with a dashboard filter active, the component design view's data
+ *       previews must reflect that filter (they used to always show the
+ *       unfiltered dataset — the builder never received filter state).
+ * #196: a component added while filters are active must render already
+ *       filtered when the editor comes back (filters used to die on the
+ *       page navigation, so the whole grid reloaded unfiltered).
+ *
+ * One flow covers both: build a fresh dashboard on the seeded Iris project
+ * (150 rows, `variety` ∈ {Setosa, Versicolor, Virginica} × 50), add a
+ * MultiSelect filter on `variety` through the builder, select Setosa, then
+ * add a Table component — the builder preview must say "of 50 rows" (#329,
+ * togglable back to 150), and the saved table must come up showing 50 rows
+ * with the Setosa filter still applied (#196).
+ */
+
+import { test, expect } from "@fixtures/auth";
+import { createDashboard, deleteDashboard } from "@fixtures/dashboard";
+import type { Page } from "@playwright/test";
+
+/** Pick an option from an open Mantine Select/MultiSelect portal listbox. */
+async function pickOption(page: Page, text: string | RegExp): Promise<void> {
+  await page
+    .locator("[role='option']")
+    .filter({ hasText: text })
+    .first()
+    .click();
+}
+
+/** StepData: choose the Iris data collection. Basic projects render a single
+ *  "Data Collection" select; advanced ones add a "Workflow" select first. */
+async function pickIrisDataCollection(page: Page): Promise<void> {
+  const workflowSelect = page.getByLabel("Workflow");
+  if (await workflowSelect.isVisible().catch(() => false)) {
+    await workflowSelect.click();
+    await page.locator("[role='option']").first().click();
+  }
+  const dcSelect = page.getByLabel("Data Collection");
+  await expect(dcSelect).toBeEnabled({ timeout: 15_000 });
+  await dcSelect.click();
+  await page.locator("[role='option']").first().click();
+  // The DC info card fetch confirms the pick registered before Next.
+  await expect(page.getByText("Data Collection Information").first()).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test.describe("Active filters propagate into the builder and new components", () => {
+  test.skip(
+    process.env.UNAUTHENTICATED_MODE === "true",
+    "Component creation requires an authenticated dashboard owner.",
+  );
+
+  test("filter → builder preview is filtered (#329) → new component pre-filtered (#196)", async ({
+    loginAsAdmin,
+    page,
+  }) => {
+    test.setTimeout(240_000);
+    await loginAsAdmin();
+    await page.goto("/dashboards");
+
+    const uniqueTitle = `Filter Propagation ${new Date()
+      .toISOString()
+      .replace(/:/g, "-")}`;
+    await createDashboard(page, uniqueTitle);
+
+    // Open the new dashboard and switch to edit mode.
+    await page
+      .locator("[data-testid='dashboard-card']")
+      .filter({ hasText: uniqueTitle })
+      .first()
+      .click();
+    await page.waitForURL(/\/dashboard\//, { timeout: 15_000 });
+    await page.locator("[data-tour-id='enter-edit-mode']").click();
+    await page.waitForURL(/\/dashboard-edit\//, { timeout: 15_000 });
+
+    // --- Add a MultiSelect interactive filter on `variety` via the builder ---
+    await page.locator("[data-tour-id='editor-add-component']").click();
+    await page.waitForURL(/\/component\/add\//, { timeout: 15_000 });
+    await page.locator(".component-selection-card").filter({ hasText: "Interactive" }).click();
+    await pickIrisDataCollection(page);
+    await page.getByRole("button", { name: "Next Step" }).click();
+
+    await page.getByLabel("Select your column").click();
+    await pickOption(page, "variety");
+    await page.getByLabel("Select your interactive component").click();
+    await pickOption(page, "Multi-select");
+    await page.locator("[data-tour-id='component-save']").click();
+    await page.waitForURL(/\/dashboard-edit\/[^/]+$/, { timeout: 20_000 });
+
+    // --- Apply the filter: variety = Setosa ---
+    const filterInput = page.getByPlaceholder(/Select variety/).first();
+    await expect(filterInput).toBeVisible({ timeout: 20_000 });
+    await filterInput.click();
+    await pickOption(page, "Setosa");
+    await page.keyboard.press("Escape");
+
+    // --- Add a Table component while the filter is active ---
+    await page.locator("[data-tour-id='editor-add-component']").click();
+    await page.waitForURL(/\/component\/add\//, { timeout: 15_000 });
+    await page.locator(".component-selection-card").filter({ hasText: "Table" }).click();
+    await pickIrisDataCollection(page);
+    await page.getByRole("button", { name: "Next Step" }).click();
+
+    // #329 — the design view carries the dashboard's active filter and the
+    // data preview reflects it: 50 Setosa rows, not the full 150.
+    const banner = page.locator("[data-testid='builder-filter-banner']");
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await expect(banner).toContainText("1 active dashboard filter");
+    await expect(page.getByText(/of 50 rows/)).toBeVisible({ timeout: 30_000 });
+
+    // The toggle flips the preview back to the unfiltered dataset and back.
+    const toggle = page.locator("[data-testid='builder-filter-toggle']");
+    await toggle.click({ force: true });
+    await expect(page.getByText(/of 150 rows/)).toBeVisible({ timeout: 30_000 });
+    await toggle.click({ force: true });
+    await expect(page.getByText(/of 50 rows/)).toBeVisible({ timeout: 30_000 });
+
+    await page.locator("[data-tour-id='component-save']").click();
+    await page.waitForURL(/\/dashboard-edit\/[^/]+$/, { timeout: 20_000 });
+
+    // #196 — back in the editor, the filter survived the round-trip…
+    await expect(page.getByText("Setosa").first()).toBeVisible({ timeout: 20_000 });
+
+    // …and the freshly added table renders pre-filtered: its row-count badge
+    // says 50, never 150. (Row-content assertions would be unsound here —
+    // iris.csv lists all 50 Setosa rows first, so page one of an UNfiltered
+    // table also shows only Setosa.)
+    const tableItem = page
+      .locator(".react-grid-item")
+      .filter({ hasText: /rows/ })
+      .first();
+    await expect(tableItem).toBeVisible({ timeout: 30_000 });
+    await expect(tableItem.getByText(/^50 rows$/)).toBeVisible({ timeout: 30_000 });
+    await expect(tableItem.getByText(/^150 rows$/)).toHaveCount(0);
+
+    // Cleanup.
+    await page.goto("/dashboards");
+    await deleteDashboard(page, uniqueTitle);
+  });
+});

--- a/depictio/viewer/src/EditorApp.tsx
+++ b/depictio/viewer/src/EditorApp.tsx
@@ -81,6 +81,8 @@ import {
   MapPanelSurface,
   FILTER_PANEL_RAIL_WIDTH,
   countActiveFilters,
+  readEditorFilters,
+  writeEditorFilters,
 } from 'depictio-react-core';
 import type {
   DashboardData,
@@ -163,7 +165,15 @@ const EditorApp: React.FC = () => {
   const [allDashboards, setAllDashboards] = useState<DashboardSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [filters, setFilters] = useState<InteractiveFilter[]>([]);
+  // Seed synchronously from the per-tab store so a builder round-trip (add or
+  // edit a component — a full page navigation) comes back with the filters
+  // still active and every tile's FIRST fetch already filtered (#196). An
+  // effect-time hydrate would let the grid fetch once unfiltered first, which
+  // is exactly the bug this fixes.
+  const [filters, setFilters] = useState<InteractiveFilter[]>(() => {
+    const id = extractDashboardId();
+    return id ? readEditorFilters(id) : [];
+  });
   const [cardValues, setCardValues] = useState<Record<string, unknown>>({});
   const [cardSecondaryValues, setCardSecondaryValues] = useState<
     Record<string, Record<string, unknown>>
@@ -264,6 +274,15 @@ const EditorApp: React.FC = () => {
       .then(([dash, all]) => {
         applyDashboard(dash);
         setAllDashboards(all);
+        // Drop seeded filters whose emitting component no longer exists (it
+        // was deleted while the user was in the builder) — a ghost filter
+        // would keep narrowing the grid with nothing on screen to release it.
+        // Floating-map selections are exempt: a floating component lives on
+        // another tab's stored_metadata, so an unknown index is expected there.
+        const known = new Set((dash.stored_metadata || []).map((m) => m.index));
+        setFilters((prev) =>
+          prev.filter((f) => known.has(f.index) || f.source === 'map_selection'),
+        );
       })
       .catch((err) => {
         setError(`Failed to load dashboard: ${err.message || err}`);
@@ -301,6 +320,15 @@ const EditorApp: React.FC = () => {
     return () => clearTimeout(timer);
   }, [dashboard, dashboardId, stableFilterKey(filters)]);
 
+  // Mirror the live filters into the per-tab store so they survive the
+  // builder's full-page round-trip (see editorFilters.ts). Writing on every
+  // change (rather than at the navigation sites) keeps AddComponentButton /
+  // GridItemEditOverlay free of filter plumbing; clearing all filters removes
+  // the entry, so "Reset" leaves nothing behind.
+  useEffect(() => {
+    if (dashboardId) writeEditorFilters(dashboardId, filters);
+  }, [dashboardId, stableFilterKey(filters)]);
+
   const handleFilterChange = useCallback(
     (update: InteractiveFilter) => {
       const enriched = enrichFilterWithDcId(update, dashboard?.stored_metadata);
@@ -309,9 +337,12 @@ const EditorApp: React.FC = () => {
     [dashboard],
   );
 
-  // Authors see the panel as viewers will. Cross-tab filter persistence is
-  // deliberately viewer-only: an editing session's filter state is scratch, and
-  // carrying it between tabs would be surprising here.
+  // Authors see the panel as viewers will. Cross-tab (floating) filter
+  // persistence is deliberately viewer-only: an editing session's filter state
+  // is scratch across dashboards, and carrying it between tabs would be
+  // surprising here. Same-dashboard persistence within this browser tab is a
+  // different matter — see editorFilters.ts, which keeps filters alive across
+  // the builder round-trip.
   const mapPanel = useMapPanel({
     dashboardId: dashboardId ?? '',
     filters,

--- a/depictio/viewer/src/builder/advanced_viz/AdvancedVizPreview.tsx
+++ b/depictio/viewer/src/builder/advanced_viz/AdvancedVizPreview.tsx
@@ -3,8 +3,9 @@
  *
  * Builds a synthetic StoredMetadata from the current viz_kind + column mapping
  * and dispatches it through ComponentRenderer (same path the dashboard viewer
- * uses at runtime), with no interactive filters. Debounces config edits so
- * each keystroke in the Select dropdowns doesn't fire a fetch.
+ * uses at runtime), under the dashboard's active filters carried into the
+ * builder (see useBuilderPreviewFilters). Debounces config edits so each
+ * keystroke in the Select dropdowns doesn't fire a fetch.
  *
  * `onReady` fires (true) once the bindings are valid AND the debounce has
  * fired — i.e. the synthetic config is structurally complete and the renderer
@@ -19,6 +20,7 @@ import { ComponentRenderer } from 'depictio-react-core';
 import type { StoredMetadata } from 'depictio-react-core';
 
 import { buildAdvancedVizConfigBlob } from './configBlob';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 
 interface Props {
   vizKind: string;
@@ -43,6 +45,7 @@ const AdvancedVizPreview: React.FC<Props> = ({
   onReady,
   presetConfig,
 }) => {
+  const previewFilters = useBuilderPreviewFilters();
   const cmKey = JSON.stringify(columnMapping);
   const presetKey = JSON.stringify(presetConfig ?? null);
   const [debouncedConfig, setDebouncedConfig] = useState<Record<string, unknown> | null>(
@@ -97,7 +100,7 @@ const AdvancedVizPreview: React.FC<Props> = ({
             <ComponentRenderer
               dashboardId="__preview__"
               metadata={metadata}
-              filters={[]}
+              filters={previewFilters}
               showDragHandle={false}
             />
           </div>

--- a/depictio/viewer/src/builder/card/CardPreview.tsx
+++ b/depictio/viewer/src/builder/card/CardPreview.tsx
@@ -22,15 +22,18 @@ import React, { useEffect, useState } from 'react';
 import { Center, Text } from '@mantine/core';
 import { DepictioCard } from 'depictio-components';
 import { useBuilderStore } from '../store/useBuilderStore';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 import PreviewPanel from '../shared/PreviewPanel';
 import { autoCardTitle } from './cardTitle';
 import {
   SecondaryMetrics,
   fetchBreakdown,
+  fetchCardHeroValue,
   fetchCardMetric,
   isBreakdownLayout,
   isNumericLayout,
   type BreakdownPayloadDTO,
+  type InteractiveFilter,
   type SecondaryLayout,
 } from 'depictio-react-core';
 
@@ -114,10 +117,12 @@ function useBreakdownPreview(
   aggregation: string | undefined,
   topNCount: number,
   enabled: boolean,
+  filters: InteractiveFilter[],
 ): { payload: BreakdownPayloadDTO | null; loading: boolean; error: string | null } {
   const [payload, setPayload] = useState<BreakdownPayloadDTO | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const filterKey = JSON.stringify(filters);
 
   useEffect(() => {
     if (!enabled || !dcId || !column || !breakdownCol) {
@@ -129,7 +134,15 @@ function useBreakdownPreview(
     const ctrl = new AbortController();
     setLoading(true);
     setError(null);
-    fetchBreakdown(dcId, column, breakdownCol, aggregation || 'count', topNCount, ctrl.signal)
+    fetchBreakdown(
+      dcId,
+      column,
+      breakdownCol,
+      aggregation || 'count',
+      topNCount,
+      ctrl.signal,
+      filters,
+    )
       .then((res) => {
         setPayload(res);
         setLoading(false);
@@ -141,7 +154,8 @@ function useBreakdownPreview(
         setLoading(false);
       });
     return () => ctrl.abort();
-  }, [enabled, dcId, column, breakdownCol, aggregation, topNCount]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, dcId, column, breakdownCol, aggregation, topNCount, filterKey]);
 
   return { payload, loading, error };
 }
@@ -159,11 +173,13 @@ function useNumericPreview(
   layout: SecondaryLayout,
   layoutConfig: Record<string, unknown>,
   enabled: boolean,
+  filters: InteractiveFilter[],
 ): { payload: Record<string, unknown> | null; loading: boolean; error: string | null } {
   const [payload, setPayload] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const configKey = JSON.stringify(layoutConfig);
+  const filterKey = JSON.stringify(filters);
 
   useEffect(() => {
     if (!enabled || !dcId || !column) {
@@ -175,7 +191,7 @@ function useNumericPreview(
     const ctrl = new AbortController();
     setLoading(true);
     setError(null);
-    fetchCardMetric(dcId, layout, column, JSON.parse(configKey), ctrl.signal)
+    fetchCardMetric(dcId, layout, column, JSON.parse(configKey), ctrl.signal, filters)
       .then((res) => {
         setPayload(res);
         setLoading(false);
@@ -187,9 +203,51 @@ function useNumericPreview(
         setLoading(false);
       });
     return () => ctrl.abort();
-  }, [enabled, dcId, column, layout, configKey]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, dcId, column, layout, configKey, filterKey]);
 
   return { payload, loading, error };
+}
+
+/** The hero scalar under active dashboard filters.
+ *
+ *  With no filters this stays inert (``value: undefined``) and the component
+ *  keeps its zero-request static path — the precomputed ``col.specs`` value.
+ *  With filters active, the hero is recomputed server-side on the filtered
+ *  frame so it cannot contradict the (also filtered) secondary strip. */
+function useHeroValue(
+  dcId: string | null,
+  column: string | undefined,
+  aggregation: string | undefined,
+  filters: InteractiveFilter[],
+): { value: unknown; loading: boolean } {
+  const [value, setValue] = useState<unknown>(undefined);
+  const [loading, setLoading] = useState(false);
+  const filterKey = JSON.stringify(filters);
+
+  useEffect(() => {
+    if (filters.length === 0 || !dcId || !column || !aggregation) {
+      setValue(undefined);
+      setLoading(false);
+      return;
+    }
+    const ctrl = new AbortController();
+    setLoading(true);
+    fetchCardHeroValue(dcId, column, aggregation, filters, ctrl.signal)
+      .then((v) => {
+        setValue(v);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string })?.name === 'AbortError') return;
+        setValue(undefined);
+        setLoading(false);
+      });
+    return () => ctrl.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dcId, column, aggregation, filterKey]);
+
+  return { value, loading };
 }
 
 const CardPreview: React.FC = () => {
@@ -215,6 +273,7 @@ const CardPreview: React.FC = () => {
   };
   const cols = useBuilderStore((s) => s.cols);
   const dcId = useBuilderStore((s) => s.dcId);
+  const previewFilters = useBuilderPreviewFilters();
 
   const layout: SecondaryLayout = config.secondary_layout ?? 'vertical';
   // Hooks must run unconditionally, so this sits above the early return for an
@@ -230,6 +289,7 @@ const CardPreview: React.FC = () => {
     config.aggregation,
     config.top_n_count ?? 3,
     isBreakdownLayout(layout),
+    previewFilters,
   );
 
   const {
@@ -249,6 +309,14 @@ const CardPreview: React.FC = () => {
       trend_col: config.trend_col ?? null,
     },
     isNumericLayout(layout),
+    previewFilters,
+  );
+
+  const { value: filteredHero } = useHeroValue(
+    dcId,
+    config.column_name,
+    config.aggregation,
+    previewFilters,
   );
 
   if (!config.column_name || !config.aggregation) {
@@ -262,7 +330,15 @@ const CardPreview: React.FC = () => {
   }
 
   const col = cols.find((c) => c.name === config.column_name);
-  const rawValue = col?.specs?.[config.aggregation as string];
+  // Static path: the precomputed spec describes the unfiltered collection.
+  // Under active dashboard filters the server-computed hero replaces it (kept
+  // as the placeholder while the fetch is in flight, so the value doesn't
+  // flash to "—" on every filter toggle).
+  const staticValue = col?.specs?.[config.aggregation as string];
+  const rawValue =
+    previewFilters.length > 0 && filteredHero !== undefined && filteredHero !== null
+      ? filteredHero
+      : staticValue;
   const value = formatValue(rawValue);
 
   const effectiveTitle =

--- a/depictio/viewer/src/builder/data/DataPreviewTable.tsx
+++ b/depictio/viewer/src/builder/data/DataPreviewTable.tsx
@@ -20,6 +20,7 @@ import { AgGridReact } from 'ag-grid-react';
 import type { ColDef } from 'ag-grid-community';
 import { fetchDataCollectionPreview } from 'depictio-react-core';
 import type { PreviewResult } from 'depictio-react-core';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-quartz.css';
 
@@ -36,16 +37,19 @@ const DataPreviewTable: React.FC<Props> = ({ dcId, dcType, shape }) => {
   const [data, setData] = useState<PreviewResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const previewFilters = useBuilderPreviewFilters();
+  const filterKey = JSON.stringify(previewFilters);
 
   useEffect(() => {
     if (isMultiQC || !dcId) return;
     setLoading(true);
     setError(null);
-    fetchDataCollectionPreview(dcId, 100)
+    fetchDataCollectionPreview(dcId, 100, previewFilters)
       .then((res) => setData(res))
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoading(false));
-  }, [dcId, isMultiQC]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dcId, isMultiQC, filterKey]);
 
   const columnDefs = useMemo<ColDef[]>(() => {
     if (!data?.columns) return [];
@@ -125,7 +129,11 @@ const DataPreviewTable: React.FC<Props> = ({ dcId, dcType, shape }) => {
     );
   }
 
-  const totalRowsAll = shape?.num_rows ?? data.total_rows ?? data.rows.length;
+  // Under active dashboard filters the server's total is the filtered count;
+  // the static shape (whole collection) would contradict the rows on screen.
+  const totalRowsAll = data.filter_applied
+    ? (data.total_rows ?? data.rows.length)
+    : (shape?.num_rows ?? data.total_rows ?? data.rows.length);
   const totalCols = shape?.num_columns ?? data.columns.length;
 
   return (

--- a/depictio/viewer/src/builder/figure/FigurePreview.tsx
+++ b/depictio/viewer/src/builder/figure/FigurePreview.tsx
@@ -13,6 +13,7 @@ import Plot from 'react-plotly.js';
 import { previewFigure } from 'depictio-react-core';
 import type { FigureResponse } from 'depictio-react-core';
 import { useBuilderStore } from '../store/useBuilderStore';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 import { buildMetadata } from '../buildMetadata';
 
 const DEBOUNCE_MS = 400;
@@ -26,8 +27,11 @@ const FigurePreview: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const reqId = useRef(0);
 
+  const previewFilters = useBuilderPreviewFilters();
+
   // Inputs that affect UI-mode preview rendering. Code mode is excluded so
-  // typing in the editor doesn't trigger a request.
+  // typing in the editor doesn't trigger a request. The active dashboard
+  // filters are part of the key: toggling "Apply to preview" must refire.
   const inputKey = JSON.stringify({
     componentType: state.componentType,
     wfId: state.wfId,
@@ -35,6 +39,7 @@ const FigurePreview: React.FC = () => {
     visuType: state.visuType,
     figureMode: state.figureMode,
     dictKwargs: state.dictKwargs,
+    filters: previewFilters,
   });
 
   useEffect(() => {
@@ -54,7 +59,7 @@ const FigurePreview: React.FC = () => {
       const id = ++reqId.current;
       setLoading(true);
       setError(null);
-      previewFigure({ metadata: buildMetadata(state) })
+      previewFigure({ metadata: buildMetadata(state), filters: previewFilters })
         .then((res) => {
           if (reqId.current !== id) return;
           setFigure(res);

--- a/depictio/viewer/src/builder/image/ImagePreview.tsx
+++ b/depictio/viewer/src/builder/image/ImagePreview.tsx
@@ -15,6 +15,7 @@ import { Icon } from '@iconify/react';
 import { fetchDataCollectionPreview } from 'depictio-react-core';
 import type { PreviewResult } from 'depictio-react-core';
 import { useBuilderStore } from '../store/useBuilderStore';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 import PreviewPanel from '../shared/PreviewPanel';
 
 const ImagePreview: React.FC = () => {
@@ -28,6 +29,8 @@ const ImagePreview: React.FC = () => {
   const [data, setData] = useState<PreviewResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const previewFilters = useBuilderPreviewFilters();
+  const filterKey = JSON.stringify(previewFilters);
 
   useEffect(() => {
     if (!dcId || !config.image_column) {
@@ -37,7 +40,7 @@ const ImagePreview: React.FC = () => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    fetchDataCollectionPreview(dcId, 24)
+    fetchDataCollectionPreview(dcId, 24, previewFilters)
       .then((res) => {
         if (!cancelled) setData(res);
       })
@@ -50,7 +53,8 @@ const ImagePreview: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [dcId, config.image_column]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dcId, config.image_column, filterKey]);
 
   if (!config.image_column) {
     return (

--- a/depictio/viewer/src/builder/interactive/InteractiveBuilder.tsx
+++ b/depictio/viewer/src/builder/interactive/InteractiveBuilder.tsx
@@ -42,6 +42,7 @@ import {
 } from 'depictio-react-core';
 import type { StoredMetadata } from 'depictio-react-core';
 import { useBuilderStore } from '../store/useBuilderStore';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 import ColumnSelect from '../shared/ColumnSelect';
 import DesignShell from '../shared/DesignShell';
 import PreviewPanel from '../shared/PreviewPanel';
@@ -129,6 +130,7 @@ const InteractivePreview: React.FC = () => {
   const config = useBuilderStore((s) => s.config) as InteractiveConfig;
   const dcId = useBuilderStore((s) => s.dcId);
   const wfId = useBuilderStore((s) => s.wfId);
+  const previewFilters = useBuilderPreviewFilters();
 
   const { interactive_component_type, column_name, column_type, title, color, icon_name } =
     config;
@@ -166,28 +168,30 @@ const InteractivePreview: React.FC = () => {
     } as StoredMetadata['default_state'],
   };
 
+  // The dashboard's active filters (minus this component's own) so the
+  // control previews the option sets / ranges viewers will actually see.
   let renderer: React.ReactNode;
   switch (interactive_component_type) {
     case 'MultiSelect':
     case 'Select':
-      renderer = <MultiSelectRenderer metadata={metadata} filters={[]} />;
+      renderer = <MultiSelectRenderer metadata={metadata} filters={previewFilters} />;
       break;
     case 'RangeSlider':
-      renderer = <RangeSliderRenderer metadata={metadata} filters={[]} />;
+      renderer = <RangeSliderRenderer metadata={metadata} filters={previewFilters} />;
       break;
     case 'Slider':
-      renderer = <SliderRenderer metadata={metadata} filters={[]} />;
+      renderer = <SliderRenderer metadata={metadata} filters={previewFilters} />;
       break;
     case 'DateRangePicker':
     case 'DatePicker':
-      renderer = <DatePickerRenderer metadata={metadata} filters={[]} />;
+      renderer = <DatePickerRenderer metadata={metadata} filters={previewFilters} />;
       break;
     case 'SegmentedControl':
-      renderer = <SegmentedControlRenderer metadata={metadata} filters={[]} />;
+      renderer = <SegmentedControlRenderer metadata={metadata} filters={previewFilters} />;
       break;
     case 'Switch':
     case 'Checkbox':
-      renderer = <CheckboxSwitchRenderer metadata={metadata} filters={[]} />;
+      renderer = <CheckboxSwitchRenderer metadata={metadata} filters={previewFilters} />;
       break;
     default:
       renderer = null;

--- a/depictio/viewer/src/builder/map/MapPreview.tsx
+++ b/depictio/viewer/src/builder/map/MapPreview.tsx
@@ -13,6 +13,7 @@ import Plot from 'react-plotly.js';
 import { collapseMapAttribution, fetchDataCollectionPreview } from 'depictio-react-core';
 import type { PreviewResult } from 'depictio-react-core';
 import { useBuilderStore } from '../store/useBuilderStore';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 import PreviewPanel from '../shared/PreviewPanel';
 
 interface MapConfig {
@@ -33,6 +34,8 @@ const MapPreview: React.FC = () => {
   const [data, setData] = useState<PreviewResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const previewFilters = useBuilderPreviewFilters();
+  const filterKey = JSON.stringify(previewFilters);
 
   useEffect(() => {
     if (!dcId || !config.lat_column || !config.lon_column) {
@@ -42,7 +45,7 @@ const MapPreview: React.FC = () => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    fetchDataCollectionPreview(dcId, 200)
+    fetchDataCollectionPreview(dcId, 200, previewFilters)
       .then((res) => {
         if (!cancelled) setData(res);
       })
@@ -55,7 +58,8 @@ const MapPreview: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [dcId, config.lat_column, config.lon_column]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dcId, config.lat_column, config.lon_column, filterKey]);
 
   const fig = useMemo(() => {
     if (!data?.rows?.length || !config.lat_column || !config.lon_column) return null;

--- a/depictio/viewer/src/builder/steps/StepDesign.tsx
+++ b/depictio/viewer/src/builder/steps/StepDesign.tsx
@@ -3,7 +3,7 @@
  * Used by both CreateComponentPage (final step) and EditComponentPage (only step).
  */
 import React, { useEffect, useMemo, useState } from 'react';
-import { Alert, Button, Center, Paper, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Center, Group, Paper, Stack, Switch, Text, Title } from '@mantine/core';
 import { Icon } from '@iconify/react';
 import { notifications } from '@mantine/notifications';
 import { fetchSpecs, upsertComponent } from 'depictio-react-core';
@@ -17,6 +17,14 @@ import { getComponentTypeMeta } from '../componentTypes';
 const StepDesign: React.FC = () => {
   const state = useBuilderStore();
   const [savedRedirect, setSavedRedirect] = useState(false);
+
+  // Filters the previews can apply: the dashboard's active ones minus any this
+  // component emitted itself (mirrors useBuilderPreviewFilters, but unhooked
+  // from the toggle — the banner must keep showing the count while the toggle
+  // is off, or there'd be no way to turn it back on).
+  const carriedFilters = state.dashboardFilters.filter(
+    (f) => String(f.index) !== String(state.componentId),
+  );
 
   // Safety net: if user lands on this step without cols loaded (e.g. StepData
   // didn't run to completion before they clicked Next, or edit mode skipped
@@ -109,6 +117,38 @@ const StepDesign: React.FC = () => {
           Customize the appearance and behavior of your component
         </Text>
       </Stack>
+
+      {/* MultiQC previews render pre-aggregated report plots (no row-filter
+          concept) and text components have no data at all — no banner there. */}
+      {carriedFilters.length > 0 &&
+        state.componentType !== 'text' &&
+        state.componentType !== 'multiqc' && (
+          <Paper withBorder radius="md" p="sm" data-testid="builder-filter-banner">
+            <Group justify="space-between" wrap="nowrap">
+              <Group gap="xs" wrap="nowrap">
+                <Icon icon="mdi:filter-variant" width={18} />
+                <Text size="sm">
+                  Previewing with {carriedFilters.length} active dashboard filter
+                  {carriedFilters.length === 1 ? '' : 's'}
+                </Text>
+              </Group>
+              <Switch
+                size="sm"
+                checked={state.applyDashboardFilters}
+                onChange={(e) => state.setApplyDashboardFilters(e.currentTarget.checked)}
+                label="Apply to preview"
+                data-testid="builder-filter-toggle"
+              />
+            </Group>
+            {state.applyDashboardFilters && (
+              <Text size="xs" c="dimmed" mt={4}>
+                A heavily filtered preview can be empty — toggle off to preview the
+                full dataset. The saved component always follows the dashboard's
+                live filters.
+              </Text>
+            )}
+          </Paper>
+        )}
 
       <ComponentBuilder />
 

--- a/depictio/viewer/src/builder/store/useBuilderStore.ts
+++ b/depictio/viewer/src/builder/store/useBuilderStore.ts
@@ -10,7 +10,9 @@
  * depictio/models/components/{card,figure,interactive,table,multiqc,image,map}.py.
  */
 import { create } from 'zustand';
+import { readEditorFilters } from 'depictio-react-core';
 import type {
+  InteractiveFilter,
   StoredMetadata,
   FigureVisualizationDefinition,
   FigureVisualizationSummary,
@@ -89,6 +91,16 @@ export interface BuilderState {
   // Existing component snapshot (edit mode only)
   existing: StoredMetadata | null;
 
+  // Active dashboard filters carried across the full-page navigation into the
+  // builder (seeded from the editor's per-tab store on init — see
+  // editorFilters.ts). Previews apply them so the design view shows the data
+  // the component will actually render under the dashboard's current filters.
+  dashboardFilters: InteractiveFilter[];
+  // Preview-only toggle for the banner in StepDesign: a heavily filtered
+  // preview can be legitimately empty, so authors can flip back to the full
+  // dataset. Never persisted into the component metadata.
+  applyDashboardFilters: boolean;
+
   // 'unset' = mode choice screen; 'manual' = stepper; 'catalog' = catalog browser or pre-fill
   sourceMode: 'unset' | 'manual' | 'catalog';
   // Set true when the builder was initiated from a catalog suggestion. Steps
@@ -144,6 +156,7 @@ export interface BuilderActions {
     source: { toolName: string; outputId: string; description?: string };
   }) => void;
   loadExisting: (m: StoredMetadata) => void;
+  setApplyDashboardFilters: (b: boolean) => void;
   setSaving: (b: boolean) => void;
   setSaveError: (e: string | null) => void;
   setPreviewReady: (b: boolean) => void;
@@ -176,6 +189,8 @@ const INITIAL: BuilderState = {
       "Enter code and click 'Execute Code' to see preview on the left.",
   },
   existing: null,
+  dashboardFilters: [],
+  applyDashboardFilters: true,
   sourceMode: 'unset',
   catalogMode: false,
   catalogSource: null,
@@ -192,6 +207,9 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set) => ({
       mode,
       dashboardId,
       componentId,
+      // Seeded here rather than by the pages so the INITIAL spread can never
+      // clobber it — init() is the one entry point both pages share.
+      dashboardFilters: readEditorFilters(dashboardId),
       step: mode === 'edit' ? 2 : 0,
     }),
   setStep: (n) => set({ step: n }),
@@ -265,6 +283,10 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set) => ({
       mode: 'create',
       dashboardId: s.dashboardId,
       componentId: s.componentId,
+      // Catalog pre-fill replaces the config, not the visit — the dashboard's
+      // filter carry-over must survive this INITIAL spread too.
+      dashboardFilters: s.dashboardFilters,
+      applyDashboardFilters: s.applyDashboardFilters,
       componentType,
       wfId,
       dcId,
@@ -316,6 +338,7 @@ export const useBuilderStore = create<BuilderState & BuilderActions>((set) => ({
       config,
     });
   },
+  setApplyDashboardFilters: (b) => set({ applyDashboardFilters: b }),
   setSaving: (b) => set({ saving: b }),
   setSaveError: (e) => set({ saveError: e }),
   setPreviewReady: (b) => set({ previewReady: b }),

--- a/depictio/viewer/src/builder/table/TablePreview.tsx
+++ b/depictio/viewer/src/builder/table/TablePreview.tsx
@@ -11,6 +11,7 @@ import { ScrollArea, Table, Text } from '@mantine/core';
 import { fetchDataCollectionPreview } from 'depictio-react-core';
 import type { PreviewResult } from 'depictio-react-core';
 import { useBuilderStore } from '../store/useBuilderStore';
+import { useBuilderPreviewFilters } from '../useBuilderPreviewFilters';
 import PreviewPanel from '../shared/PreviewPanel';
 
 type ColCfg = { hide?: boolean; pinned?: 'left' | 'right' | null };
@@ -25,6 +26,8 @@ const TablePreview: React.FC = () => {
     striped?: boolean;
     compact?: boolean;
   };
+  const previewFilters = useBuilderPreviewFilters();
+  const filterKey = JSON.stringify(previewFilters);
 
   const [preview, setPreview] = useState<PreviewResult | null>(null);
   const [loading, setLoading] = useState(false);
@@ -40,7 +43,7 @@ const TablePreview: React.FC = () => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    fetchDataCollectionPreview(dcId, PREVIEW_FETCH_LIMIT)
+    fetchDataCollectionPreview(dcId, PREVIEW_FETCH_LIMIT, previewFilters)
       .then((res) => {
         if (cancelled) return;
         setPreview(res);
@@ -55,7 +58,8 @@ const TablePreview: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [dcId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dcId, filterKey]);
 
   if (!dcId) {
     return (

--- a/depictio/viewer/src/builder/useBuilderPreviewFilters.ts
+++ b/depictio/viewer/src/builder/useBuilderPreviewFilters.ts
@@ -1,0 +1,28 @@
+/**
+ * The filters a builder preview should apply: the dashboard's active filters
+ * carried into the builder (see editorFilters.ts), minus any emitted by the
+ * component being edited itself, gated by the "Apply to preview" toggle.
+ *
+ * Excluding ALL own-index filters (not just selection sources) is the safe
+ * superset of the runtime rule: at runtime a figure drops only its own
+ * `scatter_selection` (FigureRenderer), but here the edited component may
+ * also be the interactive control that emitted the filter — and no control
+ * filters itself. In create mode the componentId is a fresh UUID, so nothing
+ * matches and this is a no-op.
+ */
+import { useMemo } from 'react';
+import type { InteractiveFilter } from 'depictio-react-core';
+import { useBuilderStore } from './store/useBuilderStore';
+
+export function useBuilderPreviewFilters(): InteractiveFilter[] {
+  const dashboardFilters = useBuilderStore((s) => s.dashboardFilters);
+  const apply = useBuilderStore((s) => s.applyDashboardFilters);
+  const componentId = useBuilderStore((s) => s.componentId);
+  return useMemo(
+    () =>
+      apply
+        ? dashboardFilters.filter((f) => String(f.index) !== String(componentId))
+        : [],
+    [apply, dashboardFilters, componentId],
+  );
+}

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -477,7 +477,27 @@ export async function fetchBreakdown(
   aggregation = 'count',
   topNCount = 3,
   signal?: AbortSignal,
+  filters: InteractiveFilter[] = [],
 ): Promise<BreakdownPayloadDTO> {
+  // The POST variant computes the same payload under the dashboard's active
+  // filters (and bypasses the server-side breakdown cache); unfiltered
+  // callers keep the cached GET.
+  if (filters.length > 0) {
+    const res = await authFetch(`${API_BASE}/deltatables/breakdown/${dcId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        column,
+        breakdown_col: breakdownCol,
+        aggregation,
+        top_n_count: topNCount,
+        filters,
+      }),
+      signal,
+    });
+    if (!res.ok) throw new Error(`Failed to fetch breakdown: ${res.status}`);
+    return res.json();
+  }
   const params = new URLSearchParams({
     column,
     breakdown_col: breakdownCol,
@@ -508,15 +528,39 @@ export async function fetchCardMetric(
   column: string,
   config: Record<string, unknown> = {},
   signal?: AbortSignal,
+  filters: InteractiveFilter[] = [],
 ): Promise<Record<string, unknown> | null> {
   const res = await authFetch(`${API_BASE}/deltatables/card_metric/${dcId}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...config, layout, column }),
+    body: JSON.stringify({ ...config, layout, column, filters }),
     signal,
   });
   if (!res.ok) throw new Error(`Failed to fetch card metric: ${res.status}`);
   return res.json();
+}
+
+/** A card's hero scalar computed live under the dashboard's active filters.
+ *  Backs the builder preview when filters are carried in: the static
+ *  precomputed spec describes the unfiltered collection, so a filtered
+ *  preview needs the reduction evaluated on the filtered frame. Resolves to
+ *  ``null`` when the column/aggregation can't be computed. */
+export async function fetchCardHeroValue(
+  dcId: string,
+  column: string,
+  aggregation: string,
+  filters: InteractiveFilter[],
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const res = await authFetch(`${API_BASE}/deltatables/card_metric/${dcId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ layout: 'hero', column, aggregation, filters }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`Failed to fetch card hero value: ${res.status}`);
+  const payload = (await res.json()) as { value?: unknown } | null;
+  return payload?.value ?? null;
 }
 
 /** What a numeric slider needs to know about its column: the bounds, plus the
@@ -1692,15 +1736,29 @@ export async function fetchDeltaShape(dcId: string): Promise<DcShapeResponse> {
 export interface PreviewResult {
   columns: string[];
   rows: Array<Record<string, unknown>>;
+  /** Filtered row count when `filter_applied`, else the full table's. */
   total_rows: number;
   total_columns: number;
+  /** True when the server narrowed the frame with dashboard filters. */
+  filter_applied?: boolean;
 }
 
 export async function fetchDataCollectionPreview(
   dcId: string,
   limit = 100,
+  filters: InteractiveFilter[] = [],
 ): Promise<PreviewResult> {
-  const res = await authFetch(`${API_BASE}/deltatables/preview/${dcId}?limit=${limit}`);
+  // Unfiltered callers keep the existing GET; the POST variant applies the
+  // dashboard's active filters server-side so builder previews match what the
+  // dashboard's components show (rows AND total_rows are filtered).
+  const res =
+    filters.length === 0
+      ? await authFetch(`${API_BASE}/deltatables/preview/${dcId}?limit=${limit}`)
+      : await authFetch(`${API_BASE}/deltatables/preview/${dcId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ limit, filters }),
+        });
   if (!res.ok) {
     throw new Error(`Failed to fetch preview: ${res.status}`);
   }

--- a/packages/depictio-react-core/src/editorFilters.ts
+++ b/packages/depictio-react-core/src/editorFilters.ts
@@ -1,0 +1,68 @@
+/**
+ * Per-tab persistence for the editor's interactive filter state.
+ *
+ * The component add/edit builder is a separate document reached by full page
+ * navigation (`window.location.assign`), so the editor's in-memory filter
+ * array dies twice on every builder round-trip: once on the way in (the
+ * builder previews then had no filter state to apply — #329) and once on the
+ * way back (the whole grid, including the freshly added component, remounted
+ * unfiltered — #196).
+ *
+ * `sessionStorage` gives exactly the lifetime wanted (same reasoning as
+ * `floatingFilters.ts`): it survives navigation within a browser tab and dies
+ * when the tab closes, so an editing session's filters never leak into a
+ * fresh visit. The stored dashboard id keeps them from leaking into a
+ * *different* dashboard opened in the same tab — cross-dashboard filter
+ * state stays scratch, only the same-dashboard round-trip survives.
+ */
+
+import type { InteractiveFilter } from './api';
+
+const KEY = 'depictio:editor-filters';
+
+export interface EditorFilterPayload {
+  dashboardId: string;
+  filters: InteractiveFilter[];
+}
+
+/** Filters persisted for `dashboardId` in this tab; `[]` when the stored
+ *  entry belongs to another dashboard or cannot be parsed (the stale entry is
+ *  dropped so it can't resurface later). */
+export function readEditorFilters(dashboardId: string): InteractiveFilter[] {
+  try {
+    const raw = window.sessionStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Partial<EditorFilterPayload>;
+    if (parsed?.dashboardId !== dashboardId || !Array.isArray(parsed.filters)) {
+      window.sessionStorage.removeItem(KEY);
+      return [];
+    }
+    return parsed.filters;
+  } catch {
+    return [];
+  }
+}
+
+export function writeEditorFilters(
+  dashboardId: string,
+  filters: InteractiveFilter[],
+): void {
+  try {
+    if (filters.length === 0) {
+      window.sessionStorage.removeItem(KEY);
+      return;
+    }
+    window.sessionStorage.setItem(KEY, JSON.stringify({ dashboardId, filters }));
+  } catch {
+    // Storage unavailable: filters simply won't survive the builder round-trip.
+  }
+}
+
+export function clearEditorFilters(): void {
+  try {
+    window.sessionStorage.removeItem(KEY);
+  } catch {
+    // Nothing to do — a failed clear leaves a stale entry that the
+    // dashboard-id check on the next read discards anyway.
+  }
+}

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -148,6 +148,7 @@ export {
   fetchUniqueValues,
   fetchBreakdown,
   fetchCardMetric,
+  fetchCardHeroValue,
   fetchColumnRange,
   fetchComponentData,
   bulkComputeCards,
@@ -337,6 +338,12 @@ export {
   persistableFloatingFilters,
 } from './floatingFilters';
 export type { FloatingFilterPayload } from './floatingFilters';
+export {
+  readEditorFilters,
+  writeEditorFilters,
+  clearEditorFilters,
+} from './editorFilters';
+export type { EditorFilterPayload } from './editorFilters';
 
 // Cross-DC available-values intersection (powers greying-out unavailable
 // options in interactive filter dropdowns).


### PR DESCRIPTION
## Summary

Fixes two long-standing filter-propagation bugs that turned out to share one root cause.

**Root cause (reconstructed — both issues are title-only).** The dashboard's interactive filter state lives in per-page React state (`useState` in `EditorApp.tsx` / `App.tsx`), and every add/edit-component flow is a **full page navigation** (`window.location.assign` into `/component/add|edit/…`, which mounts `CreateComponentPage`/`EditComponentPage` *instead of* `EditorApp` — there is no client-side router). So filter state died twice on every builder round-trip:

- **on the way in** → #329: the builder never had filter state, and every preview hardcoded it away (`FigurePreview` called `previewFigure()` without `filters` even though `POST /figure/preview` already applies them; `AdvancedVizPreview`/`InteractiveBuilder` passed literal `filters={[]}`; table/map/image/data previews used `GET /deltatables/preview/{dc}`, which had no filter support at all).
- **on the way back** → #196: `EditorApp` remounted with `filters = []`, so the whole grid — including the freshly added component — rendered unfiltered until a filter was re-touched. (Contrast that proves the mechanism: `handleDuplicateComponent` adds a component *without* navigation, and the clone picks up live filters correctly.)

### Fix

**#196 — carry filters across the round-trip** (`packages/depictio-react-core/src/editorFilters.ts`, new; `EditorApp.tsx`):
- Per-tab `sessionStorage` persistence keyed by dashboard id (same pattern and rationale as the existing `floatingFilters.ts`): `EditorApp` mirrors its filters into storage on every change and seeds its `useState` synchronously from it on mount, so every tile's *first* fetch is already filtered. A dashboard-id mismatch drops the entry (no cross-dashboard leak — the "editor filter state is scratch across tabs" design note is preserved and updated). Filters whose emitting component was deleted mid-round-trip are pruned after the dashboard fetch (floating-map selections exempt, since their emitter legitimately lives on another tab).

**#329 — builder previews respect active filters** (`useBuilderStore` + new `useBuilderPreviewFilters` hook + all preview components):
- `init()` seeds `dashboardFilters` from the same store; a `useBuilderPreviewFilters()` hook exposes them minus any filter emitted by the component being edited itself (superset of the runtime's own-`scatter_selection` exclusion — an interactive control must not filter its own preview), gated by a new **"Apply to preview"** toggle.
- Figure preview now sends `filters` to `POST /figure/preview` (backend was already filter-capable); advanced-viz and interactive previews replace their hardcoded `filters={[]}`.
- Table / map / image / data-step previews go through a new **`POST /deltatables/preview/{dc}`** (`{limit, filters}`); the Celery task applies the filters on the lazy scan, and `total_rows` reflects the *filtered* frame, so "Showing X of N rows" matches the dashboard. The GET stays untouched for unfiltered callers.
- Card preview: breakdown + numeric-strip endpoints accept `filters` (new `POST /deltatables/breakdown` variant bypasses the cache, whose key doesn't encode filters; `card_metric` folds filter columns into its projection so filters can't silently no-op), and a new `layout: "hero"` pseudo-layout computes the hero scalar on the filtered frame via the same `_agg_expr`/`_coerce_agg_result` pair the saved-card pushdown uses — so the hero number can't contradict the (filtered) strip. With no filters active, the zero-request static-specs path is unchanged.
- A Mantine banner in `StepDesign` ("Previewing with N active dashboard filter(s)" + Switch, default ON) makes the state visible, since a heavily filtered preview can be legitimately empty.
- Shared backend helpers `clean_filter_payload` / `apply_filters_to_scan` in `deltatables_utils.py`; the dashboards render endpoints' `_build_filter_metadata` now delegates to the former so the two paths can't drift.

### Scope notes / limitations
- **MultiQC preview is out of scope**: `POST /multiqc/preview` renders pre-aggregated QC-report plots keyed by module/plot/dataset — there is no row-filter concept to apply. The banner is suppressed for MultiQC (and text) components.
- **Cross-DC filters** in the preview endpoints are schema-guard skipped (a filter on a column the previewed DC doesn't have is ignored) rather than link-resolved — link resolution needs dashboard context these DC-scoped endpoints don't have. This matches the existing `/advanced_viz/data` behavior; a same-named column in a different DC will be applied.
- The card preview's multi-aggregation (vertical/compact) scalar rows still read static specs — same "estimated" caveat that already applies to box_plot quartiles.

### Overlap with #975 — checked, none
`claude/multiqc-mapping-funnel-filter-tmi1aq` (funnel filtering #939 + mapping inspector #938, +2953/−314) touches **zero** files under `depictio/viewer/src/builder/`, no renderer fetch paths, and none of the deltatables/figure-preview endpoints; its `availableValues.tsx` funnel layer only greys options *inside* interactive widgets and never feeds a data fetch. Neither #196 nor #329 changes behavior on that branch. This PR is independent of it (conflict surface is a few lines in `EditorApp.tsx`).

## Screenshots

Captured on the seeded Iris project (150 rows, `variety` = Setosa / Versicolor / Virginica, 50 each) on a dashboard holding a MultiSelect filter on `variety`, a Card ("Average on sepal.length") and a Table. The filter picks **Virginica** on purpose: `iris.csv` lists the 50 Setosa rows first, so an unfiltered page one looks exactly like a Setosa-filtered one, and only a non-leading value makes the filtered content visibly different.

**Baseline, no filter active.** The card averages all 150 rows: 5.8433.

<img width="1600" height="285" alt="Editor with no filter active, card at 5.8433" src="https://github.com/user-attachments/assets/be62fdd6-9e59-4cc3-b93e-c62a0e3e8e45" />

**#329, the design step follows the active filter.** Selecting `variety = Virginica` moves the card to 6.588, and the new banner shows up above the component builder. The table preview reads "Showing 10 of 50 rows" and lists Virginica rows.

<img width="1600" height="288" alt="Editor with variety = Virginica, card at 6.588" src="https://github.com/user-attachments/assets/6d3f64b4-84f3-40ef-b121-eaafc4490ab0" />

<img width="1600" height="1300" alt="Component design step, filter applied, preview showing 10 of 50 Virginica rows" src="https://github.com/user-attachments/assets/13029060-34fc-46c0-b448-4d50c7f180c8" />

**The toggle brings the full dataset back.** With "Apply to preview" off the same preview returns to "Showing 10 of 150 rows", back to the Setosa rows the unfiltered scan starts with, so a filter combination that empties a preview is never a dead end.

<img width="1600" height="1300" alt="Same step with Apply to preview off, showing 10 of 150 rows" src="https://github.com/user-attachments/assets/67ca5c19-86cb-415b-8cd9-7c9f4075f190" />

**#196, a component added under an active filter comes back pre-filtered.** After saving the table, the editor reloads with Virginica still applied: the card is still 6.588 and the new table renders "1 to 50 of 50" Virginica rows on its first fetch, with no unfiltered 150-row flash on the way.

<img width="1600" height="805" alt="Editor after save, filter preserved, new table showing 1 to 50 of 50 Virginica rows" src="https://github.com/user-attachments/assets/583b8131-1c4c-42f8-b635-ac6d932ef8d6" />

**No active filter, no banner** (also suppressed for text and MultiQC components, which have no row-filter concept).

<img width="1600" height="1300" alt="Card builder with no dashboard filter active and no banner" src="https://github.com/user-attachments/assets/7bbad6ce-5159-4093-a842-1128f4f0f1e8" />

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
Closes #196
Closes #329

## How was this tested?
- **New unit/API tests** (pure-polars style, matching `test_card_breakdown.py` / `test_deltatables_utils.py`):
  - `depictio/tests/api/v1/test_preview_filters.py` — `clean_filter_payload` (flat + nested payload shapes, empty-value drops, `filter_expr` carry-through), `apply_filters_to_scan` (MultiSelect/RangeSlider narrowing, AND semantics, absent-column skip with valid co-filters still applying, no-op on empty), and the `preview_deltatable` Celery task end-to-end against a local Delta table (filtered rows **and** filtered `total_rows`, `filter_applied` flag).
  - `depictio/tests/api/v1/test_card_metrics_filters.py` — `hero_value` across aggregations on filtered/unfiltered frames, filtered `numeric_layout_payload` histogram, filtered `compute_breakdown`.
- **New Playwright spec** `depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts` — one flow covering both issues on the seeded Iris project: create dashboard → add a MultiSelect on `variety` through the builder → select Setosa → add a Table → assert the design preview says "of 50 rows" (not 150), toggle off/on flips 150 ↔ 50 (#329) → save → assert the filter survived and the new table's row badge says "50 rows" (#196). Row-content assertions are deliberately avoided (iris.csv lists all 50 Setosa rows first, so page one of an *unfiltered* table also shows only Setosa). Validated via `--list` + selector audit here (no Docker in this sandbox); runs against the compose stack in CI.
- Full `pytest` suite (2240 passed, 15 skipped; 3 errors are the pre-existing testcontainers MinIO suite, which needs a Docker daemon this sandbox doesn't have), `ruff format`/`ruff check`, `ty check depictio/models/`, `pre-commit run --all-files` (helm-lint/shellcheck failures are environment/pre-existing, in files untouched here), and a full viewer `pnpm run build` (tsc across the linked packages) all pass.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vytFCdXypnxVXAL8eTPWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016vytFCdXypnxVXAL8eTPWJ)_