### PR TITLE
fix(ci): bump polars-lts-cpu pin to 1.33.1 to fix deltalake write_delta() skew

### DIFF
--- a/.github/workflows/catalog-ci.yaml
+++ b/.github/workflows/catalog-ci.yaml
@@ -43,7 +43,7 @@ jobs:
           uv pip install -e ".[dev]"
           # MultiQC/recipes need polars-lts-cpu (same pin as the quality job)
           uv pip uninstall -y polars polars-runtime-32 2>/dev/null || true
-          uv pip install --force-reinstall "polars-lts-cpu[numpy,pandas,pyarrow,excel,deltalake]==1.19.0"
+          uv pip install --force-reinstall "polars-lts-cpu[numpy,pandas,pyarrow,excel,deltalake]==1.33.1"
 
       - name: Validate bio-catalog
         # schema + component/roles + renders grounded against fixtures/recipes +

--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -87,13 +87,13 @@ jobs:
           uv pip uninstall -y polars polars-runtime-32 2>/dev/null || true
 
           # Ensure correct polars-lts-cpu version is installed (required for MultiQC)
-          echo "📦 Installing polars-lts-cpu 1.19.0..."
-          uv pip install --force-reinstall "polars-lts-cpu[numpy,pandas,pyarrow,excel,deltalake]==1.19.0"
+          echo "📦 Installing polars-lts-cpu 1.33.1..."
+          uv pip install --force-reinstall "polars-lts-cpu[numpy,pandas,pyarrow,excel,deltalake]==1.33.1"
 
           # Verify only polars-lts-cpu is installed
           echo "✅ Verifying polars installation..."
           uv pip list | grep -i polars
-          python -c "import polars; assert '1.19' in polars.__version__, f'Wrong version: {polars.__version__}'; print(f'✅ Polars {polars.__version__} verified')"
+          python -c "import polars; assert '1.33' in polars.__version__, f'Wrong version: {polars.__version__}'; print(f'✅ Polars {polars.__version__} verified')"
 
       - name: Run Ruff formatting check
         run: |

--- a/.github/workflows/nfcore-release-monitor.yaml
+++ b/.github/workflows/nfcore-release-monitor.yaml
@@ -100,7 +100,7 @@ jobs:
           uv pip install -e ".[dev]"
           # Recipes need polars-lts-cpu (same pin as the quality/catalog jobs)
           uv pip uninstall -y polars polars-runtime-32 2>/dev/null || true
-          uv pip install --force-reinstall "polars-lts-cpu[numpy,pandas,pyarrow,excel,deltalake]==1.19.0"
+          uv pip install --force-reinstall "polars-lts-cpu[numpy,pandas,pyarrow,excel,deltalake]==1.33.1"
 
       - name: Generate megatest drift report
         id: gen

--- a/.github/workflows/test-cli-with-local-instance.yaml
+++ b/.github/workflows/test-cli-with-local-instance.yaml
@@ -32,7 +32,7 @@ jobs:
           else
             echo "⚠️ Fallback to LTS polars"
             uv pip uninstall polars || true
-            uv pip install "polars-lts-cpu==1.22.0"
+            uv pip install "polars-lts-cpu==1.33.1"
           fi
           python -c "import polars; print(f'Polars {polars.__version__}')"
       - name: Test CLI


### PR DESCRIPTION
## Summary

Stacked on #984 so `quality`'s CI can actually validate this fix end-to-end (it gets short-circuited by the backup-coverage gate otherwise). Once #984 merges, this PR's base auto-retargets to `main` and the diff collapses to just this change.

`quality`'s CI-only `polars-lts-cpu` pin (`1.19.0`, kept for the AVX-safe MultiQC parsing path on GitHub Actions runners) predates `pyproject.toml`'s `deltalake==1.6.2`. `polars-lts-cpu==1.19.0`'s `DataFrame.write_delta()` still calls the pre-1.6 deltalake API (`write_deltalake(..., schema=...)`); `deltalake==1.6.2` dropped that kwarg in favor of `schema_mode`, so every delta write through the lts-cpu path crashed with `write_deltalake() got an unexpected keyword argument 'schema'`. This was hidden until now because the backup-coverage gate (fixed in #984) stopped the run before reaching `test_preview_filters.py::test_unfiltered`.

`polars-lts-cpu` has no release matching `pyproject.toml`'s `polars==1.43.2` (PyPI tops out at `1.33.1`), so bumped to `1.33.1` instead — applied consistently to the three other jobs sharing this exact pin (`catalog-ci`, `nfcore-release-monitor`) plus the fallback in `test-cli-with-local-instance.yaml` (was `1.22.0`).

## Type of change
- [x] Bugfix
- [x] Build / CI / deps

## Related issue
Second, independent CI blocker surfaced after #984 (surfaced via PR #973).

## How was this tested?

Verified in an isolated worktree at `origin/main`, replicating the CI install sequence exactly (fresh venv, `uv pip uninstall polars polars-runtime-32`, `--force-reinstall "polars-lts-cpu[...]==1.33.1"`):
- `polars.__version__` reports `1.33.1` as expected by the CI assertion.
- The previously-failing `write_delta()` call now succeeds.
- All 41 MultiQC processor/figures/parse-parallel tests still pass — the actual reason this CI-only pin exists.
- 805 further tests pass before the run stops on an unrelated Docker-dependent integration test (no daemon in the sandbox used for verification, not a regression from this change).

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [x] Docs updated if needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj3YT74DUzCyjwGmzmD2op)_