### PR TITLE
fix(e2e): scope #196 component-picker selector to exact-match (unbreaks main)

### DIFF
--- a/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
@@ -80,7 +80,13 @@ test.describe("Active filters propagate into the builder and new components", ()
     // --- Add a MultiSelect interactive filter on `variety` via the builder ---
     await page.locator("[data-tour-id='editor-add-component']").click();
     await page.waitForURL(/\/component\/add\//, { timeout: 15_000 });
-    await page.locator(".component-selection-card").filter({ hasText: "Interactive" }).click();
+    // Exact match: "Interactive" is also a substring of the Figure ("Interactive
+    // data visualizations") and Image ("Interactive image grid...") card
+    // descriptions, so a plain hasText match resolves to 3 cards.
+    await page
+      .locator(".component-selection-card")
+      .filter({ has: page.getByText("Interactive", { exact: true }) })
+      .click();
     await pickIrisDataCollection(page);
     await page.getByRole("button", { name: "Next Step" }).click();
 


### PR DESCRIPTION
## Summary

`main`'s `e2e-playwright` job has failed deterministically (all 3 auth-mode variants, 3/3 retries each) since #977 merged.

Root cause: `filters-into-builder.spec.ts` picks the "Interactive" component-type card via `.component-selection-card` + `hasText: "Interactive"` — a substring match. "Interactive" is also a substring of the **Figure** card's description ("Interactive data visualizations") and the **Image** card's description ("Interactive image grid with modal viewer"). The locator resolves to 3 elements and `.click()` throws a Playwright strict-mode violation:

```
Error: locator.click: Error: strict mode violation: locator('.component-selection-card').filter({ hasText: 'Interactive' }) resolved to 3 elements
```

This isn't a flake — it fails identically on every retry, and would fail on any run against current `main` (`depictio/viewer/src/builder/componentTypes.ts` has carried those overlapping descriptions since before #977 was written; the PR's own testing only ran `--list` + a selector audit, never a live click, so this never executed for real until CI did).

## Fix

Filter on a locator whose full text is *exactly* "Interactive" (the card's title `<Text>`), which only the Interactive card itself matches, instead of a substring match against the whole card (title + description).

The other locator in this file (`hasText: "Table"`, line ~110) is safe as-is — no other card's label or description contains "table".

## Type of change
- [x] Bugfix (CI / test only — no application code touched)

## How was this tested?
- Read the full `COMPONENT_TYPES` registry to confirm exactly which cards' text contains "Interactive" as a substring (Figure, Interactive, Image) and that no other card collides with the "Table" locator.
- Could not run the Playwright suite live in this sandbox (no docker stack); the fix targets the exact strict-mode violation message from the failing CI run and uses documented Playwright API (`locator.filter({ has })`, `getByText(text, { exact: true })`).

## Checklist
- [x] Code follows project style
- [ ] Tests added/updated and passing — fixes an existing test, no new coverage needed
- [ ] Docs updated if needed — n/a


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aaq9GNSUUxcQ6FiHL2N37e)_