### PR TITLE
fix(ci): unbreak the e2e builder spec and the weekly telemetry snapshot

### DIFF
--- a/.github/workflows/telemetry-metrics.yaml
+++ b/.github/workflows/telemetry-metrics.yaml
@@ -57,22 +57,50 @@ jobs:
           # Reported as a number rather than the raw response body: a property that
           # is a blob of JSON cannot be charted or compared week to week.
           #
-          # Every fetch here retries, because collection failures are now fatal to
-          # the run: pypistats answers 429 readily enough that a single unlucky
-          # request would otherwise turn a Monday morning red for no reason.
-          for pkg in depictio-cli depictio; do
+          # depictio-cli is the only package this project publishes to PyPI — the
+          # server ships as container images and a Helm chart. `depictio` used to be
+          # polled here too and answered 404 every single week, which pinned the
+          # final gate red permanently over a distribution channel that does not
+          # exist.
+          #
+          # pypistats throttles by source IP and hosted runners share theirs, so 429
+          # is routine rather than exceptional: a descriptive User-Agent and a slow
+          # backoff get through it far more often than the default curl UA and a 5s
+          # delay did. When a fetch is throttled anyway it is recorded as throttled,
+          # not failed — see the gate at the end of the job for why that distinction
+          # decides the colour of the run.
+          ua="depictio-telemetry/1.0 (+https://github.com/${GITHUB_REPOSITORY})"
+          for pkg in depictio-cli; do
             url="https://pypistats.org/api/packages/${pkg}/recent"
-            if body=$(curl -sSf --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors "$url"); then
-              downloads=$(jq -r '.data.last_month' <<<"$body")
-              echo "${pkg}: ${downloads} downloads last month"
-              echo "${pkg}=${downloads}" >> "$GITHUB_OUTPUT"
-            else
-              echo "::error::Could not fetch PyPI stats for ${pkg}"
-              # $RUNNER_TEMP, not a job-level env var: the `runner` context is
-              # not available where job env is evaluated, so hoisting this path
-              # would silently resolve it to /collection-errors.txt.
-              echo "pypi/${pkg}" >> "$RUNNER_TEMP/collection-errors.txt"
-            fi
+            body="$RUNNER_TEMP/pypistats-${pkg}.json"
+            # The status comes out of the same request that fetches the body, via
+            # -w. Re-probing the URL after a failure would race the throttle
+            # window: the retries can exhaust on 429 and a second request seconds
+            # later answer 200, which would file a throttle as a hard error and
+            # turn the run red for the opposite of the reason it failed.
+            # `|| true` keeps -w's output while swallowing curl's exit 22, which
+            # -f raises on any HTTP error.
+            status=$(curl -sSf --max-time 30 --retry 5 --retry-delay 20 --retry-all-errors \
+              -H "User-Agent: ${ua}" -H "Accept: application/json" \
+              -o "$body" -w '%{http_code}' "$url" || true)
+            # $RUNNER_TEMP, not a job-level env var: the `runner` context is
+            # not available where job env is evaluated, so hoisting this path
+            # would silently resolve it to /collection-errors.txt.
+            case "$status" in
+              200)
+                downloads=$(jq -r '.data.last_month' <"$body")
+                echo "${pkg}: ${downloads} downloads last month"
+                echo "${pkg}=${downloads}" >> "$GITHUB_OUTPUT"
+                ;;
+              429)
+                echo "::warning::pypistats throttled the runner (429) for ${pkg}"
+                echo "pypi/${pkg}" >> "$RUNNER_TEMP/collection-throttled.txt"
+                ;;
+              *)
+                echo "::error::Could not fetch PyPI stats for ${pkg} (HTTP ${status:-000})"
+                echo "pypi/${pkg}" >> "$RUNNER_TEMP/collection-errors.txt"
+                ;;
+            esac
           done
 
       - name: Collect repository traffic
@@ -128,7 +156,6 @@ jobs:
         if: always() && env.POSTHOG_API_KEY != ''
         env:
           PYPI_DEPICTIO_CLI: ${{ steps.pypi.outputs.depictio-cli }}
-          PYPI_DEPICTIO: ${{ steps.pypi.outputs.depictio }}
           TRAFFIC_CLONES: ${{ steps.traffic.outputs.clones }}
           TRAFFIC_CLONES_UNIQUES: ${{ steps.traffic.outputs.clones_uniques }}
           TRAFFIC_VIEWS: ${{ steps.traffic.outputs.views }}
@@ -156,8 +183,16 @@ jobs:
               # metrics that were fine.
               return int(raw) if raw and raw != "null" else None
 
-          errors = pathlib.Path(os.environ["RUNNER_TEMP"]) / "collection-errors.txt"
-          uncollected = errors.read_text().split() if errors.exists() else []
+          # Throttled collectors are as absent from the snapshot as failed ones,
+          # so both land in `uncollected`: the chart must show the same gap
+          # either way. The split only decides whether the run goes red.
+          temp = pathlib.Path(os.environ["RUNNER_TEMP"])
+          uncollected = [
+              name
+              for f in ("collection-errors.txt", "collection-throttled.txt")
+              if (temp / f).exists()
+              for name in (temp / f).read_text().split()
+          ]
 
           body = {
               "api_key": os.environ["POSTHOG_API_KEY"],
@@ -165,7 +200,6 @@ jobs:
               "distinct_id": "depictio-ci-metrics",
               "properties": {
                   "pypi_depictio_cli": metric("PYPI_DEPICTIO_CLI"),
-                  "pypi_depictio": metric("PYPI_DEPICTIO"),
                   "github_clones": metric("TRAFFIC_CLONES"),
                   "github_clones_unique": metric("TRAFFIC_CLONES_UNIQUES"),
                   "github_views": metric("TRAFFIC_VIEWS"),
@@ -192,13 +226,27 @@ jobs:
         # run red. A `::warning::` in a workflow that runs unattended on Mondays is
         # a failure nobody ever sees, which is how two of these three metrics went
         # uncollected without anyone noticing.
+        #
+        # Upstream throttling is the one thing that does not go red. A weekly job
+        # that is red every single week teaches the project to ignore it, which
+        # costs exactly the signal this gate exists to give. A 429 also loses
+        # nothing permanently: PyPI download windows are re-fetchable next Monday,
+        # unlike the traffic API's 14-day retention. So a throttled collector is
+        # reported as a warning and still shows as a gap in the chart, while a
+        # collector that is genuinely broken — a 404, a 5xx, a bad token — is what
+        # actually fails the run.
         if: always()
         run: |
           set -euo pipefail
           errors="$RUNNER_TEMP/collection-errors.txt"
+          throttled="$RUNNER_TEMP/collection-throttled.txt"
+          if [ -s "$throttled" ]; then
+            echo "Metrics throttled upstream this run (retried next Monday):"
+            cat "$throttled"
+          fi
           if [ -s "$errors" ]; then
             echo "Metrics that could not be collected this run:"
             cat "$errors"
             exit 1
           fi
-          echo "All distribution metrics collected."
+          echo "No distribution metric failed to collect."

--- a/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
@@ -30,6 +30,14 @@ async function pickOption(page: Page, text: string | RegExp): Promise<void> {
     .click();
 }
 
+/** StepType: pick a component type card by its type, not by its text.
+ *  Several cards mention another card's label in their description (Figure is
+ *  "Interactive data visualizations", Image is an "Interactive image grid"), so
+ *  filtering .component-selection-card by text matches three cards, not one. */
+async function pickComponentType(page: Page, type: string): Promise<void> {
+  await page.locator(`[data-testid='component-type-${type}']`).click();
+}
+
 /** StepData: choose the Iris data collection. Basic projects render a single
  *  "Data Collection" select; advanced ones add a "Workflow" select first. */
 async function pickIrisDataCollection(page: Page): Promise<void> {
@@ -80,7 +88,7 @@ test.describe("Active filters propagate into the builder and new components", ()
     // --- Add a MultiSelect interactive filter on `variety` via the builder ---
     await page.locator("[data-tour-id='editor-add-component']").click();
     await page.waitForURL(/\/component\/add\//, { timeout: 15_000 });
-    await page.locator(".component-selection-card").filter({ hasText: "Interactive" }).click();
+    await pickComponentType(page, "interactive");
     await pickIrisDataCollection(page);
     await page.getByRole("button", { name: "Next Step" }).click();
 
@@ -101,7 +109,7 @@ test.describe("Active filters propagate into the builder and new components", ()
     // --- Add a Table component while the filter is active ---
     await page.locator("[data-tour-id='editor-add-component']").click();
     await page.waitForURL(/\/component\/add\//, { timeout: 15_000 });
-    await page.locator(".component-selection-card").filter({ hasText: "Table" }).click();
+    await pickComponentType(page, "table");
     await pickIrisDataCollection(page);
     await page.getByRole("button", { name: "Next Step" }).click();
 

--- a/depictio/viewer/src/builder/steps/StepType.tsx
+++ b/depictio/viewer/src/builder/steps/StepType.tsx
@@ -113,6 +113,11 @@ const TypeCard: React.FC<TypeCardProps> = ({
       shadow={selected ? 'md' : 'sm'}
       onClick={onClick}
       className="component-selection-card"
+      // Type-scoped hook for e2e: several cards mention another card's label in
+      // their description ("Interactive data visualizations" on Figure,
+      // "Interactive image grid" on Image), so a text filter over
+      // .component-selection-card cannot address one card unambiguously.
+      data-testid={`component-type-${meta.type}`}
       style={{
         cursor: disabled ? 'not-allowed' : 'pointer',
         opacity: disabled ? 0.5 : 1,


### PR DESCRIPTION
## Summary

Two workflows were red on `main` for unrelated reasons. On the latest `main` (`7d2ede1`) 3 of 12 jobs failed; everything else (quality, ruff, ty, pytest, pixi, docker-build, CLI, backup) passes.

**`e2e-playwright` — all three auth modes (standard, single-user, public-demo)**

```
Error: locator.click: strict mode violation:
locator('.component-selection-card').filter({ hasText: 'Interactive' })
resolved to 3 elements
```

`filters-into-builder.spec.ts` picks component type cards by their text, and `hasText: "Interactive"` matches three cards, not one:

| Card | Text containing "Interactive" |
| --- | --- |
| Figure | description "**Interactive** data visualizations" |
| Interactive | label "**Interactive**" |
| Image | description "**Interactive** image grid with modal viewer" |

Deterministic — the initial attempt and both retries, in all three jobs.

`StepType` now stamps each card with `data-testid="component-type-<type>"`, and the spec addresses that hook through a `pickComponentType()` helper instead of prose other cards happen to share. This also secures the `"Table"` pick, which was unique only by luck.

**`telemetry-metrics` — red every Monday since it was added (3/3 runs)**

Two compounding causes:

- The workflow polled pypistats for `depictio-cli` *and* `depictio`, but only the CLI is published — the server ships as container images and a Helm chart. `pypi.org/pypi/depictio/json` returns 404, so that collector failed permanently and pinned the final gate red over a distribution channel that does not exist.
- pypistats throttles by source IP and hosted runners share theirs, so both packages were 429'd on all four attempts.

So: drop the package that does not exist, send a descriptive User-Agent and back off more slowly (5×20s), and split throttling from breakage. A 429 is now a `::warning::` and is still reported as `uncollected`, so the chart keeps the same gap — a PyPI download window is re-fetchable next Monday, unlike the traffic API's 14-day retention. A 404, a 5xx or a bad token still fails the run.

The HTTP status is read from the fetch itself via `-w` rather than from a follow-up probe, which would otherwise race the throttle window and misfile an exhausted 429 as a hard error.

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [x] Build / CI / deps
- [ ] Documentation

## Related issue

None — found by triaging the red runs on `main`.

## How was this tested?

Telemetry workflow, exercised locally by extracting each `run:` block from the YAML:

- `bash -n` clean on all five steps; YAML parses.
- pypi step, success path: `depictio-cli: 1178 downloads last month`, exit 0, `depictio-cli=1178` written to `$GITHUB_OUTPUT`.
- pypi step, hard-failure path (forcing the 404 package): routes to `collection-errors.txt` with `HTTP 404`.
- Verified `curl -w '%{http_code}'` emits the status under `-f` on both 200 and 404, which is what the single-call status capture relies on.
- Final gate, all three outcomes: nothing failed → exit 0; throttled only → prints the throttle notice, exit 0; hard failure → exit 1.
- Forwarded payload shape: `pypi_depictio` gone, throttled collector present in `uncollected`.

E2E spec: not run here — no `node_modules` in `depictio/viewer` and no Docker stack in this environment. The change removes the strict-mode violation itself (a `data-testid` matches exactly one card); real validation comes from the CI run on this PR.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing — existing e2e spec fixed; telemetry steps verified locally as above
- [ ] Docs updated if needed — no doc change needed; README PyPI badges already point at `depictio-cli` only

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbS7DbiVS2dzyBUpESS2az)_