### PR TITLE
fix(s3): startup check no longer requires account-wide ListBuckets

### DIFF
--- a/depictio/api/v1/initialization.py
+++ b/depictio/api/v1/initialization.py
@@ -40,7 +40,13 @@ async def run_initialization(
     if s3_config_input is None:
         s3_config_input = settings.minio
 
-    S3_storage_checks(s3_config_input, checks or ["s3"])
+    # "bucket" (HeadBucket) + "write" (put/delete a test object) are scoped to
+    # the configured bucket and are what actually matters for startup. "s3"
+    # (ListBuckets) is account-wide and fails outright against a
+    # least-privilege, bucket-scoped credential (e.g. EMBL's NetApp S3
+    # buckets, which only ever issue per-bucket keys) even when that
+    # credential works fine for everything the app actually does.
+    S3_storage_checks(s3_config_input, checks or ["bucket", "write"])
 
     admin_user = await initialize_db(wipe=bool(settings.mongodb.wipe))
 


### PR DESCRIPTION
## Summary
Server startup ran `S3_storage_checks(s3_config_input, checks or ["s3"])` — only the `"s3"` check, i.e. `list_buckets()`, an account-wide S3 operation. Least-privilege, bucket-scoped credentials (e.g. EMBL's NetApp S3 buckets, which only ever issue per-bucket access keys, never account-wide ones) get `AccessDenied` on that call and the app fails to start entirely — even though `HeadBucket` and put/delete on the actually-configured bucket work fine with the same credential.

## Fix
Default startup checks to `["bucket", "write"]` instead of `["s3"]`: `HeadBucket` on the configured bucket + a put/delete round trip. That's what startup actually needs to verify (the bucket in use is reachable and writable), and it works with both a full-account credential and a bucket-scoped one.

## How was this tested?
- `ruff format` / `ruff check`: clean
- Reproduced live against an EMBL NetApp S3 bucket (bucket-scoped access key): before the fix, backend startup failed with `AccessDenied` on `ListBuckets`; the `HeadBucket`/put-delete checks this switches to succeed against the same credential.

## Type of change
- [x] Bugfix