### PR TITLE
fix(auth): share Google OAuth state across workers instead of per-process memory

### DIFF
--- a/depictio/api/v1/endpoints/auth_endpoints/google_oauth_routes.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/google_oauth_routes.py
@@ -15,7 +15,6 @@ from fastapi import APIRouter, HTTPException, Query
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
 from depictio.api.v1.endpoints.auth_endpoints.utils import (
-    cleanup_expired_states,
     create_or_get_user,
     exchange_code_for_token,
     fetch_google_user_info,
@@ -56,11 +55,9 @@ async def google_oauth_login() -> GoogleOAuthLoginResponse:
     ):
         raise HTTPException(status_code=500, detail="Google OAuth configuration incomplete")
 
-    # Clean up expired states
-    cleanup_expired_states()
-
-    # Generate state parameter for CSRF protection
-    state = generate_oauth_state()
+    # Generate state parameter for CSRF protection. Expired states are reaped
+    # by the collection's TTL index, so there is nothing to sweep here.
+    state = await generate_oauth_state()
 
     # Build Google OAuth authorization URL
     auth_params = {
@@ -75,7 +72,7 @@ async def google_oauth_login() -> GoogleOAuthLoginResponse:
 
     authorization_url = f"https://accounts.google.com/o/oauth2/auth?{urlencode(auth_params)}"
 
-    logger.info(f"Generated OAuth login URL with state: {state}")
+    logger.info("Generated OAuth login URL")
 
     return GoogleOAuthLoginResponse(authorization_url=authorization_url, state=state)
 
@@ -111,8 +108,7 @@ async def google_oauth_callback(
         raise HTTPException(status_code=400, detail="Missing authorization code")
 
     # Validate state parameter (CSRF protection)
-    if not validate_oauth_state(state):
-        logger.warning(f"Invalid or expired OAuth state: {state}")
+    if not await validate_oauth_state(state):
         raise HTTPException(status_code=400, detail="Invalid or expired state parameter")
 
     try:

--- a/depictio/api/v1/endpoints/auth_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/auth_endpoints/utils.py
@@ -14,61 +14,48 @@ from fastapi import HTTPException
 
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
-from depictio.models.models.google_oauth import GoogleUserInfo
+from depictio.models.models.google_oauth import GoogleUserInfo, OAuthStateBeanie
 from depictio.models.models.users import UserBeanie
 
-# In-memory state storage (in production, use Redis or database)
-_oauth_states: dict[str, datetime] = {}
+# How long a user has to finish the Google consent screen before the state
+# minted for their login attempt stops being accepted.
+OAUTH_STATE_EXPIRY_MINUTES = 10
 
 
-def generate_oauth_state() -> str:
-    """Generate a secure random state parameter for OAuth CSRF protection."""
-    from depictio.api.v1.configs.logging_init import logger
+async def generate_oauth_state() -> str:
+    """Mint a secure random state parameter for OAuth CSRF protection.
 
+    The nonce is persisted so the callback — which may be served by any
+    worker or replica — can recognise it. Expired rows are reaped by the
+    collection's TTL index, so there is nothing to clean up here.
+    """
     state = secrets.token_urlsafe(32)
-    # Store state with expiration (10 minutes)
-    expiry = datetime.now() + timedelta(minutes=10)
-    _oauth_states[state] = expiry
-    logger.debug(f"Generated OAuth state: {state}, expires at: {expiry}")
+    expiry = datetime.now() + timedelta(minutes=OAUTH_STATE_EXPIRY_MINUTES)
+    await OAuthStateBeanie(state=state, expire_datetime=expiry).save()
+    logger.debug(f"Generated OAuth state, expires at: {expiry}")
     return state
 
 
-def validate_oauth_state(state: str) -> bool:
-    """Validate OAuth state parameter and remove if valid."""
-    import os
+async def validate_oauth_state(state: str) -> bool:
+    """Consume an OAuth state: it is valid once, and only before it expires.
 
-    from depictio.api.v1.configs.logging_init import logger
+    The lookup and the delete are a single atomic operation, so two callbacks
+    racing on the same nonce cannot both be accepted — exactly one wins.
+    """
+    # find_one_and_delete rather than Beanie's read-then-delete: the latter
+    # leaves a window in which a replayed callback could pass validation.
+    consumed = await OAuthStateBeanie.get_pymongo_collection().find_one_and_delete({"state": state})
 
-    # In development mode, skip state validation due to multi-worker issues
-    if os.getenv("DEPICTIO_DEV_MODE", "false").lower() == "true":
-        logger.debug(f"DEPICTIO_DEV_MODE: Skipping OAuth state validation for: {state}")
-        return True
-
-    logger.debug(f"Validating OAuth state: {state}")
-    logger.debug(f"Current stored states: {list(_oauth_states.keys())}")
-
-    if state not in _oauth_states:
-        logger.warning(f"State {state} not found in stored states")
+    if consumed is None:
+        logger.warning("OAuth state not found: already used, expired, or never issued")
         return False
 
-    # Check if state is expired
-    if _oauth_states[state] < datetime.now():
-        logger.warning(f"State {state} has expired")
-        del _oauth_states[state]
+    if consumed["expire_datetime"] <= datetime.now():
+        logger.warning("OAuth state has expired")
         return False
 
-    # Remove used state
-    del _oauth_states[state]
-    logger.debug(f"State {state} validated successfully")
+    logger.debug("OAuth state validated successfully")
     return True
-
-
-def cleanup_expired_states() -> None:
-    """Clean up expired OAuth states."""
-    now = datetime.now()
-    expired_states = [state for state, expiry in _oauth_states.items() if expiry < now]
-    for state in expired_states:
-        del _oauth_states[state]
 
 
 async def exchange_code_for_token(code: str) -> dict[str, Any]:

--- a/depictio/api/v1/services/lifespan.py
+++ b/depictio/api/v1/services/lifespan.py
@@ -35,6 +35,7 @@ from depictio.api.v1.services.yaml_sync import (
 from depictio.api.v1.tasks.cleanup_tasks import start_cleanup_tasks
 from depictio.api.v1.utils import clean_screenshots
 from depictio.models.models.analytics import UserActivity, UserSession
+from depictio.models.models.google_oauth import OAuthStateBeanie
 from depictio.models.models.projects import ProjectBeanie
 from depictio.models.models.users import (
     GroupBeanie,
@@ -68,6 +69,7 @@ async def init_motor_beanie() -> None:
             GroupBeanie,
             UserBeanie,
             MagicLinkTicketBeanie,
+            OAuthStateBeanie,
             ProjectBeanie,
             UserSession,
             UserActivity,

--- a/depictio/models/models/google_oauth.py
+++ b/depictio/models/models/google_oauth.py
@@ -4,9 +4,14 @@ Pydantic models for Google OAuth authentication.
 These models define the data structures used for Google OAuth 2.0 authentication flow.
 """
 
+from datetime import datetime
 from typing import Any
 
+from beanie import Document
 from pydantic import BaseModel, EmailStr, Field, field_validator
+from pymongo import IndexModel
+
+from depictio.models.models.base import MongoModel
 
 
 class GoogleOAuthRequest(BaseModel):
@@ -78,3 +83,30 @@ class GoogleOAuthLoginResponse(BaseModel):
 
     authorization_url: str = Field(..., description="Google OAuth authorization URL")
     state: str = Field(..., description="State parameter for CSRF protection")
+
+
+class OAuthState(MongoModel):
+    """A short-lived, single-use CSRF state for the Google OAuth round-trip.
+
+    The state minted by ``/auth/google/login`` has to still be recognisable
+    when Google redirects the browser to ``/auth/google/callback`` — a
+    separate request that a multi-worker (and multi-replica) deployment is
+    free to route to a different process. Storing it in MongoDB is what makes
+    both halves of the flow agree; process-local storage only ever worked on a
+    single worker.
+    """
+
+    state: str  # the opaque nonce echoed back by Google
+    expire_datetime: datetime
+
+
+class OAuthStateBeanie(OAuthState, Document):
+    class Settings:
+        name = "oauth_states"  # Collection name
+        indexes = [
+            # States are looked up by their nonce and must be unique.
+            IndexModel([("state", 1)], unique=True),
+            # TTL index: MongoDB drops a state once it passes ``expire_datetime``,
+            # so abandoned login attempts never accumulate — no cleanup job needed.
+            IndexModel([("expire_datetime", 1)], expireAfterSeconds=0),
+        ]

--- a/depictio/tests/api/v1/endpoints/auth_endpoints/test_google_oauth.py
+++ b/depictio/tests/api/v1/endpoints/auth_endpoints/test_google_oauth.py
@@ -10,8 +10,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from depictio.api.v1.endpoints.auth_endpoints.utils import (
+    generate_oauth_state,
+    validate_oauth_state,
+)
 from depictio.models.models.base import PyObjectId
+from depictio.models.models.google_oauth import OAuthStateBeanie
 from depictio.models.models.users import User
+from depictio.tests.api.v1.endpoints.user_endpoints.conftest import beanie_setup
 
 
 @pytest.fixture
@@ -83,7 +89,14 @@ def client():
 class TestGoogleOAuthLogin:
     """Test Google OAuth login initiation endpoint."""
 
-    def test_google_oauth_login_redirect_url_generation(self, client, google_oauth_config):
+    @patch(
+        "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.generate_oauth_state",
+        new_callable=AsyncMock,
+        return_value="test-state",
+    )
+    def test_google_oauth_login_redirect_url_generation(
+        self, _mock_generate_state, client, google_oauth_config
+    ):
         """Test that Google OAuth login generates correct redirect URL."""
         with patch(
             "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.settings"
@@ -139,7 +152,10 @@ class TestGoogleOAuthLogin:
 class TestGoogleOAuthCallback:
     """Test Google OAuth callback endpoint."""
 
-    @patch("depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state")
+    @patch(
+        "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state",
+        new_callable=AsyncMock,
+    )
     @patch(
         "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.fetch_google_user_info",
         new_callable=AsyncMock,
@@ -247,7 +263,10 @@ class TestGoogleOAuthCallback:
             mock_user_beanie.assert_called()
             new_user_mock.save.assert_called_once()
 
-    @patch("depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state")
+    @patch(
+        "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state",
+        new_callable=AsyncMock,
+    )
     @patch(
         "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.fetch_google_user_info",
         new_callable=AsyncMock,
@@ -339,7 +358,10 @@ class TestGoogleOAuthCallback:
         assert response.status_code == 422
         assert "field required" in str(response.json()["detail"]).lower()
 
-    @patch("depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state")
+    @patch(
+        "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state",
+        new_callable=AsyncMock,
+    )
     @patch("depictio.api.v1.endpoints.auth_endpoints.utils.httpx.AsyncClient")
     def test_google_oauth_callback_token_exchange_failure(
         self, mock_httpx_client, mock_validate_state, client, google_oauth_config
@@ -379,7 +401,10 @@ class TestGoogleOAuthCallback:
             assert response.status_code == 400
             assert "Failed to exchange authorization code" in response.json()["detail"]
 
-    @patch("depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state")
+    @patch(
+        "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state",
+        new_callable=AsyncMock,
+    )
     @patch(
         "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.fetch_google_user_info",
         new_callable=AsyncMock,
@@ -497,7 +522,15 @@ class TestGoogleOAuthModels:
 class TestGoogleOAuthIntegration:
     """Integration tests for Google OAuth flow."""
 
-    @patch("depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state")
+    @patch(
+        "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.generate_oauth_state",
+        new_callable=AsyncMock,
+        return_value="test-state",
+    )
+    @patch(
+        "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.validate_oauth_state",
+        new_callable=AsyncMock,
+    )
     @patch(
         "depictio.api.v1.endpoints.auth_endpoints.google_oauth_routes.fetch_google_user_info",
         new_callable=AsyncMock,
@@ -518,6 +551,7 @@ class TestGoogleOAuthIntegration:
         mock_exchange_code,
         mock_fetch_user_info,
         mock_validate_state,
+        _mock_generate_state,
         client,
         google_oauth_config,
         google_token_response,
@@ -617,3 +651,49 @@ class TestGoogleOAuthIntegration:
                 "/auth/google/callback", params={"code": "test", "state": "test"}
             )
             assert callback_response.status_code == 403
+
+
+class TestOAuthStateStore:
+    """The CSRF state must survive the hop between the two OAuth requests.
+
+    ``/auth/google/login`` and ``/auth/google/callback`` are separate HTTP
+    requests, and a deployment running several uvicorn workers (or several
+    replicas) will route them to different processes. These tests pin the
+    state to shared storage rather than process memory.
+    """
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=[OAuthStateBeanie])
+    async def test_state_is_readable_by_another_process(self):
+        # Minting and validating never share module state here — a fresh
+        # import is exactly what a second worker would see.
+        state = await generate_oauth_state()
+
+        assert await validate_oauth_state(state) is True
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=[OAuthStateBeanie])
+    async def test_state_is_single_use(self):
+        state = await generate_oauth_state()
+
+        assert await validate_oauth_state(state) is True
+        # Replaying the same callback must not authenticate a second time.
+        assert await validate_oauth_state(state) is False
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=[OAuthStateBeanie])
+    async def test_expired_state_is_rejected_and_burned(self):
+        expired = OAuthStateBeanie(
+            state="stale-state",
+            expire_datetime=datetime.now() - timedelta(minutes=1),
+        )
+        await expired.save()
+
+        assert await validate_oauth_state("stale-state") is False
+        # Rejected states are consumed too, so they cannot be retried.
+        assert await OAuthStateBeanie.find_one({"state": "stale-state"}) is None
+
+    @pytest.mark.asyncio
+    @beanie_setup(models=[OAuthStateBeanie])
+    async def test_unknown_state_is_rejected(self):
+        assert await validate_oauth_state("never-issued") is False

--- a/depictio/viewer/src/auth/components/GoogleOAuthCallback.tsx
+++ b/depictio/viewer/src/auth/components/GoogleOAuthCallback.tsx
@@ -1,5 +1,5 @@
 import { Anchor, Loader, Stack, Text } from '@mantine/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { handleGoogleCallback, persistSession } from 'depictio-react-core';
 import AuthCard from './AuthCard';
 
@@ -32,8 +32,16 @@ function safePostAuthTarget(candidate: string | null | undefined): string {
  */
 export default function GoogleOAuthCallback() {
   const [error, setError] = useState<string | null>(null);
+  // Run exactly once. React StrictMode invokes effects twice in dev, and both
+  // the authorization code and the CSRF state are single-use — a second
+  // exchange is guaranteed to fail and would surface as a spurious error on
+  // an otherwise successful sign-in.
+  const handledRef = useRef(false);
 
   useEffect(() => {
+    if (handledRef.current) return;
+    handledRef.current = true;
+
     const url = new URL(window.location.href);
     const code = url.searchParams.get('code');
     const state = url.searchParams.get('state');
@@ -48,10 +56,8 @@ export default function GoogleOAuthCallback() {
       return;
     }
 
-    let cancelled = false;
     (async () => {
       const result = await handleGoogleCallback(code, state);
-      if (cancelled) return;
       if (result.success && result.session) {
         persistSession(result.session);
         window.location.assign(safePostAuthTarget(result.redirect_url));
@@ -59,8 +65,6 @@ export default function GoogleOAuthCallback() {
       }
       setError(result.message || 'Google sign-in failed.');
     })();
-
-    return () => { cancelled = true; };
   }, []);
 
   return (


### PR DESCRIPTION
## Problem

Signing in with Google on a multi-worker deployment fails with:

```json
{"detail":"Invalid or expired state parameter"}
```

The CSRF state minted by `/auth/google/login` was stored in a module-level dict:

```python
_oauth_states: dict[str, datetime] = {}
```

Login and callback are two separate HTTP requests, so only the process that issued the state could recognise it. EMBL runs `backend.replicas: 2` with `DEPICTIO_FASTAPI_WORKERS: "4"`, which is 8 independent processes: the callback landed on the right one roughly 1 time in 8 and otherwise returned 400. This is not a Google configuration problem, a bad `redirect_uri` or bad credentials would surface as an error from Google rather than from our own API.

Someone had already hit this. `validate_oauth_state` carried a bypass reading `# In development mode, skip state validation due to multi-worker issues`, which papers over it locally while leaving real deployments broken and disabling CSRF protection wherever it is set.

## Fix

Move the state to MongoDB, mirroring the `MagicLinkTicketBeanie` pattern already used in this codebase for the same shape of problem (short-lived, single-use, must be shared across replicas):

- New `OAuthStateBeanie` with a unique index on the nonce and a TTL index on `expire_datetime`, so abandoned login attempts are reaped by the database. The old `cleanup_expired_states` sweep is gone.
- Validation consumes the state with `find_one_and_delete`, so it stays single-use even when two callbacks race on the same nonce.
- The `DEPICTIO_DEV_MODE` bypass is removed. It existed only to work around the multi-worker problem, which no longer exists.
- The raw nonce is no longer written to the logs.

## Viewer

`GoogleOAuthCallback` now runs its exchange exactly once, matching the guard `MagicLinkCallback` already carries. StrictMode invokes the effect twice in dev, and the previous `cancelled` flag ignored the first *response* without preventing the second *request*. Since both the authorization code and the state are single-use, that second exchange fails and surfaces as an error on an otherwise successful sign-in.

## Testing

- Four new tests covering the actual failure mode: a state minted in one place is redeemable elsewhere, single-use, expiry rejects and burns the row, unknown state rejected.
- Existing OAuth tests updated for the now-async helpers.
- `depictio/tests/api` + `depictio/tests/models`: 1543 passed. The 3 errors are pre-existing S3 integration tests that need a live MinIO.
- `ruff`, `ty check depictio/models/`, and `tsc --noEmit` on the viewer are clean.

## Deploying

The fix lives in the backend image, so `datasci-depictio-internal-dev` needs a redeploy with a rebuilt image. No migration is needed: `oauth_states` is a new collection and its indexes are created by `init_beanie` at boot.
