### PR TITLE
fix(tests): unbreak the `quality` job — insert the expired OAuth state instead of `save()`

### DIFF
--- a/depictio/tests/api/v1/endpoints/auth_endpoints/test_google_oauth.py
+++ b/depictio/tests/api/v1/endpoints/auth_endpoints/test_google_oauth.py
@@ -687,7 +687,7 @@ class TestOAuthStateStore:
             state="stale-state",
             expire_datetime=datetime.now() - timedelta(minutes=1),
         )
-        await expired.save()
+        await expired.insert()
 
         assert await validate_oauth_state("stale-state") is False
         # Rejected states are consumed too, so they cannot be retried.


### PR DESCRIPTION
## Summary

One-line test fix that turns the `quality` job of `depictio-ci` green again on `main`.

**Symptom.** `quality` has been red on `main` since #991 landed (`2863e0d`, merge `526e535`, Aug 24 12:48) and has never recovered — `main` is still at `316bb71`. Every run fails at the same place ([latest run on `main`](https://github.com/depictio/depictio/actions/runs/32733790342)):

```
FAILED depictio/tests/api/v1/endpoints/auth_endpoints/test_google_oauth.py::
       TestOAuthStateStore::test_expired_state_is_rejected_and_burned

  test_google_oauth.py:690: await expired.save()
  beanie/odm/documents.py:616: in save   → return await self.update(
  beanie/odm/documents.py:745: in update → merge_models(self, result)
  left  = OAuthStateBeanie(id=ObjectId('6a8c49505b6ba3e312524788'), state='stale-state', …)
  right = None
E AttributeError: 'NoneType' object has no attribute '__iter__'
```

**Cause.** The test builds an `OAuthStateBeanie` and calls `save()` on a document that was never inserted. `MongoModel` always assigns an `id` at construction (`depictio/models/models/base.py:71`), so beanie 2.0.0 never takes the `insert()` branch of `save()`: it routes to `update(..., upsert=True)`, whose `find_one_and_update` reads the document back after writing it. `OAuthStateBeanie` carries a TTL index on `expire_datetime`, and this test's state is deliberately already expired — so mongomock filters the read-back out, `update()` receives `None`, and `merge_models(self, None)` raises. `insert()` writes without reading back, which is the correct call for a never-persisted document.

Isolated the trigger to confirm it is the TTL index and not `save()` in general:

| document | `save()` |
| --- | --- |
| `OAuthStateBeanie`, `expire_datetime` in the future | OK |
| `OAuthStateBeanie`, `expire_datetime` in the past (this test) | **AttributeError** |
| `TokenBeanie` (no `Settings.indexes`) | OK |

That is also why the two sibling tests pass: they mint their state through `generate_oauth_state()`, whose expiry is 10 minutes out.

**Why this unblocks the repo.** `docker-build` declares `needs: [check-quality-cache, quality]`, so this single failure cascades. On the run above, `quality` → `failure` and then `docker-build`, `e2e-playwright`, `cli-comprehensive-test`, `backup-s3-strategies-comprehensive-tests` and `docker-system-init` → **skipped**. That happens on every PR in the repository, not just on `main`.

**Scope.** Only the one failing call site. The construct-then-`save()` idiom appears at 38 other places in the test suite (`test_core_functions.py`, `test_users.py`, `test_unauthenticated_mode.py`, `test_agent_config_utils.py`), but all of them target models with no TTL index and all of them pass; they are not the same failure mode. No production code is touched — `generate_oauth_state()` uses the same idiom but always with a future expiry, on real MongoDB and under mongomock alike.

Note for #968, which reworks this same area: it does not touch `test_google_oauth.py`, so this lands ahead of it without interfering.

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
None — regression from #991.

## How was this tested?

- Reproduced the failure first, unmodified, on this branch's base: `TestOAuthStateStore` → `1 failed, 3 passed`, same `AttributeError`.
- After the change: `4 passed`.
- Full suite: **2256 passed, 15 skipped**. The only remaining errors are the three `test_s3_backup_integration.py::TestS3BackupIntegration` cases, which fail at fixture setup because testcontainers cannot reach a Docker daemon in this environment — unrelated to this change.
- `pre-commit run --all-files`: `ruff`, `ruff format`, `check yaml`, `trim trailing whitespace`, `fix end of files`, `nbstripout` and the thumbnail guard all pass. Three hooks fail, none of them on this diff and all of them already failing on `main`: `shellcheck` (findings in `depictio/projects/**/*.sh` and `scripts/security_audit_compose.sh`), `helm-lint` (`helm` not installed here) and `ty check models` (`ty` binary not installed here — CI's own `ty check depictio/models/` step passes). `end-of-file-fixer` wanted to strip a trailing blank line from the unrelated `.github/workflows/minimal-deploy.yaml`; that edit was reverted and is not part of this commit.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyjfEYzvGCPizVLPioW7GR)_