### PR TITLE
fix(s3): create the bucket before validating it at startup

### DIFF
--- a/depictio/api/v1/initialization.py
+++ b/depictio/api/v1/initialization.py
@@ -40,14 +40,6 @@ async def run_initialization(
     if s3_config_input is None:
         s3_config_input = settings.minio
 
-    # "bucket" (HeadBucket) + "write" (put/delete a test object) are scoped to
-    # the configured bucket and are what actually matters for startup. "s3"
-    # (ListBuckets) is account-wide and fails outright against a
-    # least-privilege, bucket-scoped credential (e.g. EMBL's NetApp S3
-    # buckets, which only ever issue per-bucket keys) even when that
-    # credential works fine for everything the app actually does.
-    S3_storage_checks(s3_config_input, checks or ["bucket", "write"])
-
     admin_user = await initialize_db(wipe=bool(settings.mongodb.wipe))
 
     if admin_user:
@@ -58,6 +50,20 @@ async def run_initialization(
             logger.error(f"Error creating bucket: {e}")
     else:
         logger.warning("No admin user available, skipping bucket creation")
+
+    # Verify storage only once the bucket exists: on a fresh deployment nothing
+    # provisions it ahead of the app, so create_bucket() above is what creates
+    # it. Checking any earlier fails startup on empty storage. create_bucket()
+    # logs and swallows its own errors, so these checks are still what turns
+    # genuinely broken storage into a refusal to start.
+    #
+    # "bucket" (HeadBucket) + "write" (put/delete a test object) are scoped to
+    # the configured bucket and are what actually matters for startup. "s3"
+    # (ListBuckets) is account-wide and fails outright against a
+    # least-privilege, bucket-scoped credential (e.g. EMBL's NetApp S3
+    # buckets, which only ever issue per-bucket keys) even when that
+    # credential works fine for everything the app actually does.
+    S3_storage_checks(s3_config_input, checks or ["bucket", "write"])
 
     from depictio.api.v1.db import initialization_collection
 

--- a/depictio/tests/api/v1/test_initialization.py
+++ b/depictio/tests/api/v1/test_initialization.py
@@ -347,3 +347,72 @@ async def initialization_test():
 #     #             os.environ.pop(var, None)
 #     #         else:
 #     #             os.environ[var] = value
+
+
+class TestInitializationOrder:
+    """The startup S3 checks must run *after* the bucket has been created.
+
+    ``run_initialization`` verifies the configured bucket with HeadBucket +
+    a write round trip. On a fresh deployment that bucket does not exist yet —
+    nothing provisions it ahead of the app, and ``create_bucket()`` inside this
+    very function is what creates it. Checking first means the API never starts
+    against empty storage.
+    """
+
+    @staticmethod
+    def _patches():
+        return {
+            "s3_checks": patch("depictio.api.v1.initialization.S3_storage_checks"),
+            "initialize_db": patch("depictio.api.v1.initialization.initialize_db"),
+            "create_bucket": patch("depictio.api.v1.initialization.create_bucket"),
+            "settings": patch("depictio.api.v1.initialization.settings"),
+            # Imported inside run_initialization, so patch it at the source.
+            "collection": patch("depictio.api.v1.db.initialization_collection"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_bucket_is_created_before_it_is_checked(self):
+        from depictio.api.v1.initialization import run_initialization
+
+        patchers = self._patches()
+        mocks = {name: p.start() for name, p in patchers.items()}
+        try:
+            mocks["settings"].mongodb.wipe = False
+            mocks["settings"].auth.requires_anonymous_user = False
+            mocks["initialize_db"].return_value = MagicMock(email="admin@example.com")
+
+            order = MagicMock()
+            order.attach_mock(mocks["create_bucket"], "create_bucket")
+            order.attach_mock(mocks["s3_checks"], "s3_checks")
+
+            await run_initialization()
+
+            called = [name for name, _, _ in order.mock_calls]
+            assert called.index("create_bucket") < called.index("s3_checks"), (
+                "S3_storage_checks ran before create_bucket: a fresh deployment would "
+                "fail startup on a bucket that does not exist yet"
+            )
+        finally:
+            for p in patchers.values():
+                p.stop()
+
+    @pytest.mark.asyncio
+    async def test_storage_is_still_checked_when_bucket_creation_fails(self):
+        # create_bucket() swallows its own errors, so the checks that follow are
+        # what turns genuinely broken storage into a refusal to start.
+        from depictio.api.v1.initialization import run_initialization
+
+        patchers = self._patches()
+        mocks = {name: p.start() for name, p in patchers.items()}
+        try:
+            mocks["settings"].mongodb.wipe = False
+            mocks["settings"].auth.requires_anonymous_user = False
+            mocks["initialize_db"].return_value = MagicMock(email="admin@example.com")
+            mocks["create_bucket"].side_effect = Exception("S3 unreachable")
+
+            await run_initialization()
+
+            mocks["s3_checks"].assert_called_once()
+        finally:
+            for p in patchers.values():
+                p.stop()


### PR DESCRIPTION
> Follow-up to [#992](https://github.com/depictio/depictio/pull/992) (now merged as `6cdc5c6`). This branch has been updated from `main`, so its diff is just the S3 commit.

## Summary

**A fresh Depictio deployment against empty S3/MinIO cannot start.** This is not a CI-only problem; CI is just where it became visible.

`run_initialization()` in `depictio/api/v1/initialization.py` ran in this order:

| # | step |
| --- | --- |
| 1 | `S3_storage_checks(s3_config_input, checks or ["bucket", "write"])` — HeadBucket + write round trip, hard-fails if the bucket is absent |
| 2 | `initialize_db(...)` |
| 3 | `create_bucket(admin_user)` — **this is what creates the bucket** |

Nothing provisions the bucket ahead of the app. `docker-compose.dev.yaml` starts MinIO on an empty `/data` with no init sidecar, and step 3 is the only thing that ever creates it. So on any first-ever deployment step 1 404s and the API dies before reaching step 3:

```
depictio-backend | ERROR - s3_utils.py:64 - Bucket 'depictio-bucket' does not exist.
depictio-backend | ERROR - s3_utils.py:85 - Write policy check failed: The specified bucket does not exist
depictio-backend | Exception: S3 storage is not correctly configured.
depictio-backend | ERROR:    Application startup failed. Exiting.
```

Observed on [run 32851190849](https://github.com/depictio/depictio/actions/runs/32851190849) (#992's run), where it took down `docker-system-init`, `e2e-playwright` ×3, `cli-comprehensive-test` and `backup-s3-strategies` ×3 — every job that starts the compose stack. Those jobs had been *skipped* since 24 August behind the red `quality` job that #992 fixed, which is why this went unnoticed.

**Origin.** [#990](https://github.com/depictio/depictio/pull/990) (`ff207d5`) changed the default:

```diff
-    S3_storage_checks(s3_config_input, checks or ["s3"])
+    S3_storage_checks(s3_config_input, checks or ["bucket", "write"])
```

`["s3"]` was ListBuckets — bucket-agnostic, so it passed against an empty MinIO. `["bucket", "write"]` requires the bucket to already exist. #990's goal is right and is preserved here: the ordering was the bug, not the choice of checks.

**Fix.** Move the checks after `create_bucket()`. Both deployment models work:

- *Fresh MinIO (CI, local, first install)* — bucket absent → `create_bucket()` creates it → checks pass.
- *Bucket-scoped credential (EMBL NetApp S3)* — bucket pre-provisioned → `check_bucket_exists` is true → `create_bucket()` returns "Bucket already exists" without calling CreateBucket → checks pass. Still zero ListBuckets, which is exactly what #990 set out to avoid.

`create_bucket()` logs and swallows its own errors, so the checks that now follow it are still what turns genuinely broken storage into a refusal to start — only the moment moves (after `initialize_db` instead of before).

**Coverage gap.** Nothing could have caught this. `test_initialization.py:13`, `test_unauthenticated_mode.py:565` and `:601` all `patch("depictio.api.v1.initialization.S3_storage_checks")`, so the call order was never observed; the docker/e2e jobs were the only guard. This PR adds the two tests that close it.

(The pre-existing `initialization_test` fixture in `test_initialization.py` is dead code — everything consuming it is commented out and it patches `generate_keys`/`BASE_PATH`, names that no longer exist in the module. The new tests are self-contained and leave it alone.)

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
None — regression from #990.

## How was this tested?

Locally, with the project's own dev environment:

- The order test fails against the current code (`['s3_checks', 'create_bucket']`) and passes after the reorder — written before the fix, confirmed red then green.
- Second test covers the safety net: when `create_bucket()` raises, `S3_storage_checks` still runs.
- Full suite: **2258 passed, 15 skipped** (2256 before, plus the two new tests). The only remaining errors are the three `test_s3_backup_integration.py::TestS3BackupIntegration` cases, which fail at fixture setup because testcontainers cannot reach a Docker daemon in that environment — unrelated.
- `pre-commit run --all-files`: `ruff`, `ruff format`, `check yaml`, `trim trailing whitespace`, `nbstripout` and the thumbnail guard pass on this diff. `shellcheck`, `helm-lint` and `ty check models` fail, none of them on these files and all already failing on `main` (the latter two for want of the `helm`/`ty` binaries locally; CI's own `ty check depictio/models/` step passes). `end-of-file-fixer` wanted to strip a trailing blank line from the unrelated `.github/workflows/minimal-deploy.yaml`; reverted, not part of this commit.

The claim local testing cannot settle — that the eight downstream docker/e2e jobs actually go green once the backend starts — is what CI on this PR is for. It is the first full pipeline run in this repository since 6 August.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed
