### PR TITLE
fix(screenshots): reject admin tokens the current keypair cannot verify

### DIFF
--- a/depictio/api/v1/endpoints/user_endpoints/utils.py
+++ b/depictio/api/v1/endpoints/user_endpoints/utils.py
@@ -1,11 +1,9 @@
-import json
 import time
 from datetime import datetime, timedelta
 
 import jwt
 from beanie import PydanticObjectId
 from bson import ObjectId
-from fastapi import HTTPException
 from pydantic import validate_call
 
 from depictio.api.v1.configs.config import ALGORITHM, PRIVATE_KEY_PATH
@@ -15,7 +13,6 @@ from depictio.models.models.base import PyObjectId
 from depictio.models.models.users import (
     Group,
     GroupBeanie,
-    TokenBeanie,
     TokenData,
     UserBeanie,
 )
@@ -204,35 +201,3 @@ def login_user(email: str):
 def logout_user():
     """Return logout payload."""
     return {"logged_in": False, "access_token": None}
-
-
-async def _get_admin_token_localstorage_payload() -> str:
-    """Return the JSON string that the frontend expects in `localStorage['local-store']`.
-
-    Used by the Playwright-driven screenshot endpoint and by the standalone
-    docs-screenshot CLI to inject admin auth into a fresh browser context.
-    """
-    admin_user = await UserBeanie.find_one({"is_admin": True, "is_anonymous": {"$ne": True}})
-    if not admin_user:
-        raise HTTPException(status_code=404, detail="Admin user not found")
-
-    token = await TokenBeanie.find_one(
-        {
-            "user_id": admin_user.id,
-            "refresh_expire_datetime": {"$gt": datetime.now()},
-        }
-    )
-    if not token:
-        raise HTTPException(status_code=404, detail="Valid token not found")
-
-    token_data = token.model_dump(exclude_none=True)
-    token_data["_id"] = str(token_data.pop("id", None))
-    token_data["user_id"] = str(token_data["user_id"])
-    token_data["logged_in"] = True
-
-    if isinstance(token_data.get("expire_datetime"), datetime):
-        token_data["expire_datetime"] = token_data["expire_datetime"].strftime("%Y-%m-%d %H:%M:%S")
-    if isinstance(token_data.get("created_at"), datetime):
-        token_data["created_at"] = token_data["created_at"].strftime("%Y-%m-%d %H:%M:%S")
-
-    return json.dumps(token_data)

--- a/depictio/api/v1/endpoints/utils_endpoints/CLAUDE.md
+++ b/depictio/api/v1/endpoints/utils_endpoints/CLAUDE.md
@@ -96,3 +96,31 @@ let Plotly finish drawing before the capture.
   at `:5173`). Uses the file-based token loader and the shared helpers.
 - **`dev/advanced_viz_docs_screenshots/capture_react_screenshots.py`** —
   hits `/screenshot-react-dual/{id}` over HTTP, one viz_kind at a time.
+
+## Session Guards
+
+The capture session authenticates by seeding the admin token into
+`localStorage` before navigation, so two failure modes are handled
+explicitly in `screenshot_service.py`:
+
+- **Token selection** — `get_admin_auth_token()` walks the admin's
+  unexpired tokens newest-first and returns the first one whose signature
+  verifies against the current public key (`_signed_by_current_keypair`).
+  Expiry is not a disqualifier: the SPA refreshes an expired access token
+  from its refresh token. A *signature* failure is terminal — it means the
+  token was minted under a previous keypair, which happens when a fresh
+  `keys` volume is deployed against a database that outlived it. Without
+  the check, the oldest token (the seeded `default_token`) wins natural
+  order and the whole pipeline runs against a credential the backend
+  refuses.
+- **`/auth` redirect** — an unusable session does not fail the navigation.
+  `bootstrapSession` reads `user: null` from `/auth/me/optional` and
+  replaces the URL with `/auth`, so the capture would silently write the
+  login form over a good thumbnail. `_is_auth_redirect(page.url)` aborts
+  the run before any capture, returns `status="error"`, and leaves the
+  existing PNGs on disk (Celery only bumps `screenshot_ts` on success, so
+  the listing keeps serving the previous shot).
+
+Recovering a deployment in that state means re-minting the admin token —
+`initialize_db` is gated on `initialization_complete` and will not do it
+on restart.

--- a/depictio/api/v1/services/screenshot_service.py
+++ b/depictio/api/v1/services/screenshot_service.py
@@ -17,13 +17,16 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import TypedDict, cast
+from urllib.parse import urlparse
 
+import jwt
 from bson import ObjectId
 from playwright.async_api import Page, async_playwright
 
-from depictio.api.v1.configs.config import settings
+from depictio.api.v1.configs.config import ALGORITHM, PUBLIC_KEY_PATH, settings
 from depictio.api.v1.configs.logging_init import logger
 from depictio.api.v1.db import dashboards_collection, projects_collection
+from depictio.api.v1.key_utils import get_public_key
 from depictio.api.v1.services.screenshot_helpers import (
     HOST_UNREACHABLE_MARKERS,
     apply_init_script,
@@ -132,6 +135,28 @@ async def check_dashboard_owner_permission(dashboard_id: str, user_id: str) -> b
     return check_dashboard_owner_permission_sync(dashboard_id, user_id)
 
 
+def _signed_by_current_keypair(access_token: str) -> bool:
+    """Whether ``access_token`` verifies against the API's current public key.
+
+    Expiry is deliberately NOT checked: the SPA refreshes an expired access
+    token from its refresh token, so an expired-but-authentic token still
+    yields a usable capture session. A signature failure is the one that no
+    amount of refreshing recovers from — it means the token was minted under
+    a previous keypair and the backend will never accept it.
+    """
+    try:
+        jwt.decode(
+            access_token,
+            get_public_key(PUBLIC_KEY_PATH),
+            algorithms=[ALGORITHM],
+            options={"verify_exp": False},
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — any decode failure disqualifies the token
+        logger.debug(f"Screenshot token rejected by current keypair: {exc}")
+        return False
+
+
 async def get_admin_auth_token() -> dict[str, str]:
     """
     Retrieve admin authentication token from MongoDB.
@@ -151,13 +176,30 @@ async def get_admin_auth_token() -> dict[str, str]:
     if not current_user:
         raise ValueError("Admin user not found")
 
-    token = await TokenBeanie.find_one(
-        {
-            "user_id": current_user.id,
-            "refresh_expire_datetime": {"$gt": datetime.now()},
-        }
+    # Newest first, and only tokens the *current* keypair can verify. Natural
+    # order hands back the oldest, which is exactly the seeded `default_token`
+    # a keys-volume reset leaves cryptographically stranded (fresh keys against
+    # a surviving database). Nothing about that failure is loud: Playwright
+    # seeds the dead token, the SPA reads `user: null` from /auth/me/optional
+    # and replaces the URL with /auth, and the login form becomes the thumbnail.
+    candidates = (
+        await TokenBeanie.find(
+            {
+                "user_id": current_user.id,
+                "refresh_expire_datetime": {"$gt": datetime.now()},
+            }
+        )
+        .sort("-created_at")
+        .to_list()
     )
+    token = next((t for t in candidates if _signed_by_current_keypair(t.access_token)), None)
     if not token:
+        if candidates:
+            raise ValueError(
+                f"Admin has {len(candidates)} unexpired token(s), none of them signed by "
+                "the current keypair — re-mint the admin token (the keys volume was "
+                "regenerated against a database that outlived it)"
+            )
         raise ValueError("Valid token not found for admin user")
 
     # Prepare token data for localStorage
@@ -342,6 +384,11 @@ async def generate_dual_theme_screenshots(
         return error_result
 
 
+def _is_auth_redirect(url: str) -> bool:
+    """True when the capture has been bounced to the SPA's login page."""
+    return urlparse(url).path.startswith("/auth")
+
+
 async def _try_open_viz_settings(page: Page) -> bool:
     """Click the first advanced-viz settings cog so the popover shows in the shot.
 
@@ -499,6 +546,30 @@ async def generate_react_dual_theme_screenshots(
                         f"React: timeout waiting for {theme} theme attribute "
                         f"on dashboard {dashboard_id}"
                     )
+
+                # An unusable session doesn't fail the navigation — the SPA's
+                # `bootstrapSession` quietly replaces the URL with /auth. Capturing
+                # anyway overwrites a good thumbnail with the login form, and every
+                # dashboard on the listing ends up showing the same sign-in card.
+                # Bail out instead and leave the existing PNGs alone.
+                if _is_auth_redirect(page.url):
+                    await context.close()
+                    await browser.close()
+                    logger.error(
+                        f"React screenshot for {dashboard_id} landed on {page.url} — the "
+                        "admin token seeded into localStorage is not accepted by the "
+                        "backend. Existing screenshots left untouched."
+                    )
+                    return {
+                        "status": "error",
+                        "dashboard_id": dashboard_id,
+                        "light_screenshot": None,
+                        "dark_screenshot": None,
+                        "error": (
+                            "SPA redirected to /auth — the admin screenshot session is "
+                            "not authenticated"
+                        ),
+                    }
 
                 try:
                     await wait_for_dashboard_content(page)

--- a/depictio/tests/api/v1/test_screenshot_stale_token.py
+++ b/depictio/tests/api/v1/test_screenshot_stale_token.py
@@ -1,0 +1,157 @@
+"""Regression tests for the screenshot session's admin-token selection.
+
+A deployment whose keys volume is recreated against a database that outlives
+it (fresh `keys` PVC, retained MongoDB) keeps serving a `default_token` that
+no longer verifies. The screenshot service used to hand that token straight
+to Playwright: the SPA bootstrapped, read `user: null` from
+`/auth/me/optional`, replaced the URL with `/auth`, and the login form was
+captured over every dashboard thumbnail.
+
+Two guards are pinned here — pick a token the current keypair actually
+signed, and refuse to capture at all once the page has landed on `/auth`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from depictio.api.v1.services import screenshot_service
+
+
+@pytest.fixture(scope="module")
+def keypairs() -> tuple[rsa.RSAPrivateKey, rsa.RSAPrivateKey]:
+    """A "current" keypair and a stale one from a previous keys volume."""
+    return (
+        rsa.generate_private_key(public_exponent=65537, key_size=2048),
+        rsa.generate_private_key(public_exponent=65537, key_size=2048),
+    )
+
+
+def _sign(private_key: rsa.RSAPrivateKey, **claims) -> str:
+    return jwt.encode({"sub": "admin", **claims}, private_key, algorithm="RS256")
+
+
+def _use_current_key(monkeypatch, current: rsa.RSAPrivateKey) -> None:
+    monkeypatch.setattr(screenshot_service, "ALGORITHM", "RS256")
+    monkeypatch.setattr(screenshot_service, "get_public_key", lambda _path: current.public_key())
+
+
+def test_accepts_token_signed_by_current_keypair(monkeypatch, keypairs) -> None:
+    current, _stale = keypairs
+    _use_current_key(monkeypatch, current)
+
+    assert screenshot_service._signed_by_current_keypair(_sign(current)) is True
+
+
+def test_rejects_token_signed_by_previous_keypair(monkeypatch, keypairs) -> None:
+    current, stale = keypairs
+    _use_current_key(monkeypatch, current)
+
+    assert screenshot_service._signed_by_current_keypair(_sign(stale)) is False
+
+
+def test_accepts_expired_but_authentic_token(monkeypatch, keypairs) -> None:
+    """An expired access token is refreshable in the browser — keep it."""
+    current, _stale = keypairs
+    _use_current_key(monkeypatch, current)
+
+    expired = _sign(current, exp=int((datetime.now() - timedelta(days=1)).timestamp()))
+    assert screenshot_service._signed_by_current_keypair(expired) is True
+
+
+class _FakeToken:
+    """Minimal stand-in for a TokenBeanie document."""
+
+    def __init__(self, name: str, access_token: str) -> None:
+        self.id = f"id-{name}"
+        self.name = name
+        self.access_token = access_token
+        self.refresh_token = "refresh"
+        self.user_id = "6a8c335fc04c657c3a615529"
+
+    def model_dump(self, exclude_none: bool = False) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "user_id": self.user_id,
+        }
+
+
+def _stub_token_store(monkeypatch, tokens: list[_FakeToken]) -> None:
+    """Stub UserBeanie/TokenBeanie so the loader runs without MongoDB.
+
+    `find(...).sort(...).to_list()` is reproduced verbatim: the service asks
+    for newest-first and the ordering is what makes it prefer a live token
+    over the seeded one.
+    """
+
+    class _Admin:
+        id = "admin-id"
+
+    class _Query:
+        def sort(self, _spec):
+            return self
+
+        async def to_list(self):
+            return tokens
+
+    class _UserBeanie:
+        @staticmethod
+        async def find_one(_query):
+            return _Admin()
+
+    class _TokenBeanie:
+        @staticmethod
+        def find(_query):
+            return _Query()
+
+    monkeypatch.setattr(screenshot_service, "UserBeanie", _UserBeanie)
+    monkeypatch.setattr(screenshot_service, "TokenBeanie", _TokenBeanie)
+
+
+@pytest.mark.asyncio
+async def test_skips_stale_token_for_a_verifiable_one(monkeypatch, keypairs) -> None:
+    """The stale `default_token` is listed first; the live one must win."""
+    current, stale = keypairs
+    _use_current_key(monkeypatch, current)
+    _stub_token_store(
+        monkeypatch,
+        [
+            _FakeToken("default_token", _sign(stale)),
+            _FakeToken("google_oauth_20260824", _sign(current)),
+        ],
+    )
+
+    token_data = await screenshot_service.get_admin_auth_token()
+
+    assert token_data["name"] == "google_oauth_20260824"
+    assert token_data["logged_in"] is True
+
+
+@pytest.mark.asyncio
+async def test_raises_when_every_token_is_stale(monkeypatch, keypairs) -> None:
+    current, stale = keypairs
+    _use_current_key(monkeypatch, current)
+    _stub_token_store(monkeypatch, [_FakeToken("default_token", _sign(stale))])
+
+    with pytest.raises(ValueError, match="re-mint the admin token"):
+        await screenshot_service.get_admin_auth_token()
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://depictio-viewer:80/auth", True),
+        ("http://depictio-viewer:80/auth/google/callback?code=x", True),
+        ("http://depictio-viewer:80/dashboard/abc?no-walkthrough=1", False),
+        ("http://depictio-viewer:80/dashboards", False),
+    ],
+)
+def test_auth_redirect_detection(url: str, expected: bool) -> None:
+    assert screenshot_service._is_auth_redirect(url) is expected


### PR DESCRIPTION
## Problem

Every dashboard thumbnail on the EMBL internal dev deployment (`dev.depictio.embl.org`, namespace `datasci-depictio-internal-dev`) was showing the `/auth` login form.

The capture session authenticates by seeding the admin token into `localStorage` before navigation. On that deployment the `keys` PVC was recreated while the MongoDB PVCs survived, so the seeded `default_token` had been signed by a keypair that no longer exists:

- `GET /auth/me` with that token returns `401 Invalid token`, while a newer OAuth token returns `200`.
- The SPA reads `user: null` from `/auth/me/optional`, `bootstrapSession` calls `window.location.replace('/auth')`, and Playwright captures the login page.
- The Celery task still reported `success` and wrote the login-page PNG over the good thumbnail. The only trace was two warnings per capture: `timeout waiting for <theme> theme attribute` and `timeout waiting for grid items`.

`get_admin_auth_token()` used `find_one` with no ordering and no verification, so natural order handed back the oldest token, which is exactly the stranded one.

## Changes

- `get_admin_auth_token()` walks the admin's unexpired tokens newest-first and returns the first whose signature verifies against the current public key (`_signed_by_current_keypair`). Expiry is deliberately not a disqualifier, since the SPA refreshes an expired access token from its refresh token. When nothing verifies, the raised error says what to do.
- The React capture aborts when `page.url` has landed on `/auth`, returns `status="error"` and leaves the existing PNGs on disk. Celery only bumps `screenshot_ts` on success, so the listing keeps serving the previous shot.
- Removes `_get_admin_token_localstorage_payload()` from `user_endpoints/utils.py`, a caller-less copy of the same unchecked lookup.
- Documents both guards in `utils_endpoints/CLAUDE.md`, including the recovery note: `initialize_db` is gated on `initialization_complete`, so a restart will not re-mint the token.

## Tests

`depictio/tests/api/v1/test_screenshot_stale_token.py`, 9 cases: current keypair accepted, previous keypair rejected, expired but authentic token kept, stale token skipped in favour of a live one, explicit error when all are stale, and `/auth` redirect detection.

Ran `depictio/tests/api -k "token or user or auth"` (171 passed) plus the three screenshot test modules (20 passed). `pre-commit run` clean on the touched files.

## Deployment note

The affected deployment was repaired separately: the stale `default_token` row was deleted, a fresh long-lived one minted via `POST /auth/me/tokens`, and the three affected dashboards re-captured. Their PNGs went from ~55 KB (login form) to 142-173 KB and render correctly.