### PR TITLE
fix(e2e): unbreak the filter-propagation spec — locators, Switch actuation, row-total assertion

### DIFF
--- a/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
@@ -150,17 +150,17 @@ test.describe("Active filters propagate into the builder and new components", ()
     // #196 — back in the editor, the filter survived the round-trip…
     await expect(page.getByText("Setosa").first()).toBeVisible({ timeout: 20_000 });
 
-    // …and the freshly added table renders pre-filtered: its row-count badge
-    // says 50, never 150. (Row-content assertions would be unsound here —
-    // iris.csv lists all 50 Setosa rows first, so page one of an UNfiltered
-    // table also shows only Setosa.)
-    const tableItem = page
-      .locator(".react-grid-item")
-      .filter({ hasText: /rows/ })
-      .first();
-    await expect(tableItem).toBeVisible({ timeout: 30_000 });
-    await expect(tableItem.getByText(/^50 rows$/)).toBeVisible({ timeout: 30_000 });
-    await expect(tableItem.getByText(/^150 rows$/)).toHaveCount(0);
+    // …and the freshly added table renders pre-filtered. The grid's table carries
+    // its total in the pager, not in a "N rows" badge — that wording only exists
+    // in the builder's preview. "1 to 50 of 50" on a single page is the filtered
+    // set; unfiltered, the same table reads "of 150" across three pages.
+    // (Row-content assertions would be unsound here — iris.csv lists all 50
+    // Setosa rows first, so page one of an UNfiltered table also shows only
+    // Setosa. The total is what discriminates.)
+    await expect(page.getByText(/1 to 50 of 50/).first()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByText(/of 150/)).toHaveCount(0);
 
     // Cleanup.
     await page.goto("/dashboards");

--- a/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
@@ -38,15 +38,23 @@ async function pickComponentType(page: Page, type: string): Promise<void> {
   await page.locator(`[data-testid='component-type-${type}']`).click();
 }
 
+/** A Mantine Select's field label is wired to both the input and the popup
+ *  listbox (`aria-labelledby`), so getByLabel() resolves to two elements and
+ *  every call on it fails Playwright's strict mode. Address the input by role:
+ *  the listbox is role="listbox", so only the input matches. */
+function selectInput(page: Page, label: string) {
+  return page.getByRole("textbox", { name: label });
+}
+
 /** StepData: choose the Iris data collection. Basic projects render a single
  *  "Data Collection" select; advanced ones add a "Workflow" select first. */
 async function pickIrisDataCollection(page: Page): Promise<void> {
-  const workflowSelect = page.getByLabel("Workflow");
+  const workflowSelect = selectInput(page, "Workflow");
   if (await workflowSelect.isVisible().catch(() => false)) {
     await workflowSelect.click();
     await page.locator("[role='option']").first().click();
   }
-  const dcSelect = page.getByLabel("Data Collection");
+  const dcSelect = selectInput(page, "Data Collection");
   await expect(dcSelect).toBeEnabled({ timeout: 15_000 });
   await dcSelect.click();
   await page.locator("[role='option']").first().click();
@@ -92,9 +100,9 @@ test.describe("Active filters propagate into the builder and new components", ()
     await pickIrisDataCollection(page);
     await page.getByRole("button", { name: "Next Step" }).click();
 
-    await page.getByLabel("Select your column").click();
+    await selectInput(page, "Select your column").click();
     await pickOption(page, "variety");
-    await page.getByLabel("Select your interactive component").click();
+    await selectInput(page, "Select your interactive component").click();
     await pickOption(page, "Multi-select");
     await page.locator("[data-tour-id='component-save']").click();
     await page.waitForURL(/\/dashboard-edit\/[^/]+$/, { timeout: 20_000 });

--- a/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/dashboards/filters-into-builder.spec.ts
@@ -46,6 +46,16 @@ function selectInput(page: Page, label: string) {
   return page.getByRole("textbox", { name: label });
 }
 
+/** Mantine's Switch forwards data-testid to its real <input>, which it keeps
+ *  visually hidden (1×1 and clipped). Clicking that input fails with "Element
+ *  is outside of the viewport" — `force` skips the actionability checks but
+ *  still clicks at the element's coordinates. Click the <label> bound to it
+ *  instead: that is the visible track, and what a user actually hits. */
+async function flipSwitch(page: Page, testId: string): Promise<void> {
+  const id = await page.locator(`[data-testid='${testId}']`).getAttribute("id");
+  await page.locator(`label[for='${id}']`).click();
+}
+
 /** StepData: choose the Iris data collection. Basic projects render a single
  *  "Data Collection" select; advanced ones add a "Workflow" select first. */
 async function pickIrisDataCollection(page: Page): Promise<void> {
@@ -129,10 +139,9 @@ test.describe("Active filters propagate into the builder and new components", ()
     await expect(page.getByText(/of 50 rows/)).toBeVisible({ timeout: 30_000 });
 
     // The toggle flips the preview back to the unfiltered dataset and back.
-    const toggle = page.locator("[data-testid='builder-filter-toggle']");
-    await toggle.click({ force: true });
+    await flipSwitch(page, "builder-filter-toggle");
     await expect(page.getByText(/of 150 rows/)).toBeVisible({ timeout: 30_000 });
-    await toggle.click({ force: true });
+    await flipSwitch(page, "builder-filter-toggle");
     await expect(page.getByText(/of 50 rows/)).toBeVisible({ timeout: 30_000 });
 
     await page.locator("[data-tour-id='component-save']").click();


### PR DESCRIPTION
> Last of three defects that were stacked behind the red `quality` job, each hiding the next. [#992](https://github.com/depictio/depictio/pull/992) fixed `quality`; [#993](https://github.com/depictio/depictio/pull/993) fixed the S3 startup ordering. Both merged. **CI on this PR is green** — the first full pipeline in this repository since 6 August ([run 32877084573](https://github.com/depictio/depictio/actions/runs/32877084573)).

## Summary

`dashboards/filters-into-builder.spec.ts` failed all three `e2e-playwright` variants. It carried **three independent test-harness defects**, only reachable one at a time because each aborted the run before the next.

**The product was never at fault.** Getting the spec to run proved that both behaviours it guards work correctly — see *What this established* below.

### 1. `getByLabel()` is ambiguous on a Mantine Select

```
expect(locator).toBeEnabled() failed
Locator: getByLabel('Data Collection')
strict mode violation: resolved to 2 elements:
    1) <input value="iris_table" placeholder="Select data collection..."/>
       aka getByRole('textbox', { name: 'Data Collection' })
    2) <div role="listbox" aria-labelledby="mantine-0lfaeui9j-label">…</div>
```

Mantine wires the field label to both the input and the popup listbox via `aria-labelledby`. Address the input by role instead — the listbox is `role="listbox"`, so only the input matches `role="textbox"`. Pulled into a named helper so the trap is documented where someone would reintroduce it.

Three more Selects carried the same bug. `"Workflow"` was the quietest: its strict-mode error was swallowed by an `isVisible().catch(() => false)`, so on an advanced project the workflow step would silently never be picked. The `catch` now means what it says.

### 2. A Mantine Switch cannot be clicked through its input

```
locator.click: Element is outside of the viewport
  locator resolved to <input checked role="switch" data-checked="true"
    data-testid="builder-filter-toggle" class="mantine-Switch-input"/>
  - scrolling into view if needed
  - done scrolling
```

`Switch` forwards `data-testid` to its real `<input>`, which Mantine keeps visually hidden (1×1, clipped). `force: true` skips the actionability checks but still clicks at the element's coordinates, so a hidden input fails the viewport check regardless — the `force` in the original code was a band-aid that never covered this. Click the `<label>` bound to the input: that is the visible track, and what a user actually hits.

### 3. The final assertion targeted a badge that does not exist

```
expect(locator).toBeVisible() failed
Locator: locator('.react-grid-item').filter({ hasText: /rows/ }).first()
Error: element(s) not found
```

The spec looked for a `50 rows` badge on the table component in the dashboard grid. That wording is rendered only by the builder's previews (`DataPreviewTable.tsx:159`, `TablePreview.tsx:126`), never on a component in the grid — the word "rows" appears nowhere in that page. Assert the pager total instead: `1 to 50 of 50` on a single page is the filtered set; unfiltered the same table reads `of 150` across three pages. This also removes the suite's only use of `.react-grid-item`.

The author's warning about row-content assertions is kept verbatim — it is still correct (iris.csv lists all 50 Setosa rows first, so page one of an *unfiltered* table also shows only Setosa), and it is precisely why the *total* is the right discriminator.

## What this established

Running the spec for the first time confirmed both behaviours it guards, against a live stack:

| guarded behaviour | evidence from the run |
| --- | --- |
| **#329** — the builder preview honours the dashboard filter | `Previewing with 1 active dashboard filter`, `Showing 10 of 50 rows, 7 columns` |
| **#196** — a component added under an active filter comes up pre-filtered | 48 `Setosa` rows, zero `Versicolor`, zero `Virginica`, pager `1 to 50 of 50. Page 1 of 1`, all paging buttons disabled |

## Why it went unnoticed

This is the only spec in the suite that drives the component builder, and the only one that used `getByLabel()` at all — no working neighbour ever challenged the idiom. And it had **never passed in CI**: it landed in `faccc81` (#977, 24 Aug), was patched once by `25f46d6` (#989, `fix(ci): unbreak the e2e builder spec`), and from then on `e2e-playwright` was either skipped behind the red `quality` job or dead at service startup.

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
None — test-only defect. The spec guards #329 and #196.

## How was this tested?

- **CI is green**: all three `e2e-playwright` variants pass, alongside `docker-system-init`, `cli-comprehensive-test` and `backup-s3-strategies` ×3. (`quality` shows as *skipped* — the intended `check-quality-cache` hit, since no Python changed.)
- Each root cause was read off the failure artifact (`playwright-results-*` → `error-context.md`), never inferred: every one of the three errors above is quoted from a real run, and the ARIA snapshot showed the page state at the moment of failure.
- Per round, before pushing: `npx tsc --noEmit` clean, `npx playwright test … --list` parses, `pre-commit run --files <spec>` passes. The spec itself cannot be executed outside CI (it needs the full compose stack), so CI was the check each time.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed
