### PR TITLE
fix(builder): make the MultiQC badge visible on the data source step

### DIFF
--- a/depictio/viewer/src/builder/componentTypes.ts
+++ b/depictio/viewer/src/builder/componentTypes.ts
@@ -12,6 +12,11 @@ export interface ComponentTypeMeta {
   description: string;
   icon: string;
   iconBg: string; // background color for icon tile
+  /** Background for the step-2 "Selected Component" badge. Defaults to
+   *  `iconBg`; set it where `iconBg` is transparent because the tile shows an
+   *  SVG that carries its own colours — a transparent badge leaves the filled
+   *  Badge's white label on the white page, i.e. invisible. */
+  badgeBg?: string;
   /** Whether MultiQC routing applies (figure on a multiqc DC switches to multiqc). */
   multiqcAware?: boolean;
 }
@@ -54,6 +59,7 @@ export const COMPONENT_TYPES: ComponentTypeMeta[] = [
     // multiqc icon class to honor light/dark theming.
     icon: 'mdi:chart-line',
     iconBg: 'transparent',
+    badgeBg: '#201637', // MultiQC brand purple, from multiqc_icon_color.svg
   },
   {
     type: 'image',

--- a/depictio/viewer/src/builder/steps/StepData.tsx
+++ b/depictio/viewer/src/builder/steps/StepData.tsx
@@ -448,9 +448,15 @@ const StepData: React.FC = () => {
             size="lg"
             variant="filled"
             color="blue"
-            style={{ background: componentMeta.iconBg }}
+            style={{ background: componentMeta.badgeBg ?? componentMeta.iconBg }}
             leftSection={
-              componentMeta.type === 'multiqc' ? null : (
+              componentMeta.type === 'multiqc' ? (
+                <img
+                  src="/dashboard/logos/multiqc_icon_white.svg"
+                  alt=""
+                  style={{ width: 14, height: 14, objectFit: 'contain' }}
+                />
+              ) : (
                 <Icon icon={componentMeta.icon} width={14} color="white" />
               )
             }


### PR DESCRIPTION
Found while screenshotting the builder for the MultiQC docs.

Pick **MultiQC** in step 1 and step 2 renders `Selected Component:` followed by nothing — no badge, no icon, just a gap. Every other type shows a coloured pill.

`COMPONENT_TYPES` gives MultiQC `iconBg: 'transparent'`, which is right for the type grid: that tile renders `multiqc_icon_dark.svg`, an SVG with its own colours, so the 48px container behind it must not be painted. `StepData` then reuses `iconBg` as the badge background. A Mantine `variant="filled"` Badge draws its label in white, so the label lands white-on-transparent over a white page. `leftSection` was also `null` for MultiQC, so nothing at all remains visible.

The label was never missing — it just could not be seen.

**Fix**: add an optional `badgeBg` to `ComponentTypeMeta`, defaulting to `iconBg`, and set it for MultiQC to `#201637`, the brand purple already in `multiqc_icon_color.svg`. The `null` leftSection becomes the white MultiQC mark, the same asset `Header`, `Sidebar` and `MultiQCPreview` use on a dark ground.

No other type changes: `badgeBg` is optional and every other entry keeps falling back to `iconBg`.

`tsc --noEmit` clean on `depictio/viewer`.