### PR TITLE
feat(cli,viewer): ingest bundled template seeds + open the ingestion report to every project

### DIFF
--- a/depictio/api/v1/db_init_reference_datasets.py
+++ b/depictio/api/v1/db_init_reference_datasets.py
@@ -9,7 +9,11 @@ from typing import Any, cast
 from bson import ObjectId
 
 from depictio.api.v1.configs.logging_init import logger
-from depictio.cli.cli.utils.templates import _apply_conditionals, substitute_template_variables
+from depictio.cli.cli.utils.templates import (
+    _apply_conditionals,
+    materialize_recipe_seeds,
+    substitute_template_variables,
+)
 from depictio.models.models.base import PyObjectId
 from depictio.models.models.templates import TemplateConditional
 from depictio.models.models.users import Permission, UserBase, UserBeanie
@@ -482,62 +486,17 @@ class ReferenceDatasetRegistry:
                 and lnk.get("target_dc_tag") not in skipped_dc_tags
             ]
 
-        # 5. Convert recipe DCs → file-scan DCs (skipping any whose seed file is missing)
-        missing_seed_dc_tags: set[str] = set()
-        for workflow in config.get("workflows", []):
-            surviving = []
-            for dc in workflow.get("data_collections", []):
-                dc_config = dc.get("config", {})
-                if dc_config.get("source") == "transformed" and "transform" in dc_config:
-                    dc_tag = dc["data_collection_tag"]
-                    # Convention: pre-computed files are named {dc_tag}.tsv
-                    pre_computed_path = os.path.join(data_root, f"{dc_tag}.tsv")
-                    if not os.path.exists(pre_computed_path):
-                        # Drop the DC rather than letting the workflow scan abort on a
-                        # missing recipe seed (one missing file otherwise sinks every
-                        # other DC in the workflow — see scan_files_for_data_collection).
-                        missing_seed_dc_tags.add(dc_tag)
-                        logger.warning(
-                            f"Init resolver: skipping recipe DC '{dc_tag}' — "
-                            f"pre-computed seed not found at {pre_computed_path}"
-                        )
-                        continue
-                    # Keep ``source: transformed`` on the DC so the React
-                    # viewer (data-source info card, admin panel, builder
-                    # dropdown) surfaces the lineage — the data IS the output
-                    # of a recipe, just materialised as a seed file rather
-                    # than computed at scan time. Only the ``transform`` step
-                    # itself is dropped (it's been replaced with the file scan).
-                    dc_config.pop("transform", None)
-                    dc_config["scan"] = {
-                        "mode": "single",
-                        "scan_parameters": {"filename": pre_computed_path},
-                    }
-                    # Bundled recipe seeds are tab-separated by convention
-                    # ({data_root}/{dc_tag}.tsv). The template's original
-                    # `dc_specific_properties.format` describes the recipe's
-                    # *input* source (e.g. summary_metrics consumes a real
-                    # CSV from multiqc), which is irrelevant once we've
-                    # replaced the recipe with a file_scan. Force the seed
-                    # format to TSV so polars uses the right separator —
-                    # otherwise a CSV-declared, TSV-bundled DC parses the
-                    # whole tab-row as one column.
-                    dc_specific = dc_config.get("dc_specific_properties") or {}
-                    dc_specific["format"] = "tsv"
-                    dc_config["dc_specific_properties"] = dc_specific
-                    logger.debug(
-                        f"Init resolver: converted recipe DC '{dc_tag}' → file scan: {pre_computed_path}"
-                    )
-                surviving.append(dc)
-            workflow["data_collections"] = surviving
-
+        # 5. Convert recipe DCs → file-scan DCs (dropping any whose seed is missing).
+        #    Shared with the CLI's --template path so the two producers cannot
+        #    drift; `drop_missing=True` keeps the init behaviour where one absent
+        #    seed would otherwise sink every other DC in the workflow (see
+        #    scan_files_for_data_collection).
+        _, missing_seed_dc_tags = materialize_recipe_seeds(config, data_root, drop_missing=True)
         if missing_seed_dc_tags:
-            config["links"] = [
-                lnk
-                for lnk in config.get("links", [])
-                if lnk.get("source_dc_tag") not in missing_seed_dc_tags
-                and lnk.get("target_dc_tag") not in missing_seed_dc_tags
-            ]
+            logger.warning(
+                f"Init resolver: dropped {len(missing_seed_dc_tags)} recipe DC(s) "
+                f"without a pre-computed seed: {', '.join(missing_seed_dc_tags)}"
+            )
 
         return config
 

--- a/depictio/cli/cli/utils/templates.py
+++ b/depictio/cli/cli/utils/templates.py
@@ -237,6 +237,111 @@ def _prune_missing_optional_single_file_dcs(
     return config, sorted(removed)
 
 
+def prune_links_for_tags(config: dict[str, Any], tags: set[str]) -> None:
+    """Drop every link whose source or target is one of ``tags``. In place.
+
+    Removing a DC without removing the links that name it leaves the config
+    referencing a collection that no longer exists, so the two always move
+    together.
+    """
+    if not tags:
+        return
+    config["links"] = [
+        link
+        for link in config.get("links", [])
+        if link.get("source_dc_tag") not in tags and link.get("target_dc_tag") not in tags
+    ]
+
+
+def materialize_recipe_seeds(
+    config: dict[str, Any],
+    data_root: str,
+    *,
+    drop_missing: bool,
+) -> tuple[list[str], list[str]]:
+    """Rewrite ``source: transformed`` DCs into file scans over pre-computed seeds.
+
+    A reference template ships the output of each of its recipes as a committed
+    ``{data_root}/{dc_tag}.tsv``. When that seed is present the recipe is
+    short-circuited entirely: the ``transform`` block is dropped and replaced by a
+    single-file scan of the seed. This is what makes a bundled project ingestible
+    from its own directory even though it does not ship the recipes' raw inputs.
+
+    Shared by the boot-time reference seeding (``resolve_template_for_init``) and
+    the CLI's ``--template`` path so the two cannot drift. The seed always wins
+    over the recipe, which keeps both producers byte-identical.
+
+    Args:
+        config: Resolved project config dict. Modified in place.
+        data_root: Absolute path the seed convention is resolved against.
+        drop_missing: What to do with a recipe DC that has no seed. ``True``
+            removes it (and its links) — the init behaviour, where one missing
+            seed would otherwise abort the whole workflow scan. ``False`` leaves
+            it untouched so its recipe runs normally — the CLI behaviour.
+
+    Returns:
+        ``(materialized_tags, missing_seed_tags)``, both sorted.
+    """
+    materialized: list[str] = []
+    missing: set[str] = set()
+
+    for workflow in config.get("workflows", []):
+        surviving = []
+        for dc in workflow.get("data_collections", []):
+            dc_config = dc.get("config", {})
+            if dc_config.get("source") != "transformed" or "transform" not in dc_config:
+                surviving.append(dc)
+                continue
+
+            dc_tag = dc["data_collection_tag"]
+            # Convention: pre-computed files are named {dc_tag}.tsv
+            seed_path = str(Path(data_root) / f"{dc_tag}.tsv")
+            if not Path(seed_path).exists():
+                if drop_missing:
+                    missing.add(dc_tag)
+                    logger.warning(
+                        f"Seed resolver: skipping recipe DC '{dc_tag}' — "
+                        f"pre-computed seed not found at {seed_path}"
+                    )
+                    continue
+                # No seed and the caller wants the recipe: leave the DC exactly
+                # as the template declared it.
+                surviving.append(dc)
+                continue
+
+            # Keep ``source: transformed`` on the DC so the React viewer
+            # (data-source info card, admin panel, builder dropdown) surfaces the
+            # lineage — the data IS the output of a recipe, just materialised as a
+            # seed file rather than computed at scan time. Only the ``transform``
+            # step itself is dropped (it's been replaced with the file scan), and
+            # that absence is exactly what tells the CLI's deltatable path to treat
+            # the DC as a plain file scan.
+            dc_config.pop("transform", None)
+            dc_config["scan"] = {
+                "mode": "single",
+                "scan_parameters": {"filename": seed_path},
+            }
+            # Bundled recipe seeds are tab-separated by convention
+            # ({data_root}/{dc_tag}.tsv). The template's original
+            # `dc_specific_properties.format` describes the recipe's *input*
+            # source (e.g. summary_metrics consumes a real CSV from multiqc),
+            # which is irrelevant once we've replaced the recipe with a file
+            # scan. Force the seed format to TSV so polars uses the right
+            # separator — otherwise a CSV-declared, TSV-bundled DC parses the
+            # whole tab-row as one column.
+            dc_specific = dc_config.get("dc_specific_properties") or {}
+            dc_specific["format"] = "tsv"
+            dc_config["dc_specific_properties"] = dc_specific
+            materialized.append(dc_tag)
+            logger.debug(f"Seed resolver: converted recipe DC '{dc_tag}' → file scan: {seed_path}")
+            surviving.append(dc)
+
+        workflow["data_collections"] = surviving
+
+    prune_links_for_tags(config, missing)
+    return sorted(materialized), sorted(missing)
+
+
 def _collect_dc_superset(config: dict[str, Any]) -> list[dict[str, Any]]:
     """Snapshot every DC across all workflows as {tag, type, optional}.
 
@@ -451,7 +556,14 @@ def _check_dc_source_files(
     dc: dict[str, Any],
     data_root: str,
 ) -> str | None:
-    """Check if a DC's source files exist. Return missing path or None if all OK."""
+    """Check if a DC's source files exist. Return missing path or None if all OK.
+
+    Unused: recipe DCs are handled by `materialize_recipe_seeds`, which
+    short-circuits the recipe when a seed is present and otherwise leaves it to
+    fail loudly at processing time. Kept — with `_remove_dcs_with_missing_files`
+    and `_log_removal_report` — pending a decision on whether to wire up
+    source-existence pruning or delete the three of them.
+    """
     config = dc.get("config", {})
     source = config.get("source")
 
@@ -735,6 +847,7 @@ def resolve_template(
     4. Validates required variables; skips optional vars gracefully if absent
     5. Substitutes template variables in all paths
     6. Applies conditional rules (remove DCs, prune links, select dashboards)
+    6c. Materializes recipe DCs that ship a pre-computed seed
     7. Strips hardcoded IDs
     8. Sets project name
     9. Builds TemplateOrigin for DB tracking
@@ -873,6 +986,26 @@ def resolve_template(
         )
         for tag in pruned_optional:
             removal_reasons.setdefault(tag, "optional source file not found")
+
+    # 6c. Materialize recipe DCs that ship a pre-computed seed
+    #     ({data_root}/{dc_tag}.tsv). Parity with the boot-time reference
+    #     resolver: the seed short-circuits the recipe, so a bundled template is
+    #     ingestible from its own directory even though it does not ship the
+    #     recipes' raw inputs. A DC with no seed is left untouched and its recipe
+    #     runs exactly as before.
+    #
+    #     Placement is constrained on both sides: after `_apply_conditionals` so a
+    #     gated-out DC stays gated out even when a seed sits next to it, and
+    #     before `_strip_ids` / `_build_expected_dcs` so tags and links are still
+    #     intact and the manifest reflects the final config.
+    materialized_seeds, _ = materialize_recipe_seeds(
+        resolved_config, data_root_abs, drop_missing=False
+    )
+    if materialized_seeds:
+        logger.info(
+            f"Materialized {len(materialized_seeds)} recipe DC(s) from pre-computed seeds: "
+            f"{', '.join(materialized_seeds)}"
+        )
 
     # 7. Strip hardcoded IDs (fresh project gets new ones)
     resolved_config = _strip_ids(resolved_config)

--- a/depictio/tests/cli/utils/test_templates.py
+++ b/depictio/tests/cli/utils/test_templates.py
@@ -23,6 +23,7 @@ from depictio.cli.cli.utils.templates import (
     _strip_ids,
     latest_template_version,
     locate_template,
+    materialize_recipe_seeds,
     substitute_template_variables,
 )
 from depictio.models.models.templates import (
@@ -382,3 +383,98 @@ class TestApplyConditionals:
         for wf in result["workflows"]:
             tags = [dc["data_collection_tag"] for dc in wf["data_collections"]]
             assert "dc_optional_a" not in tags
+
+
+class TestMaterializeRecipeSeeds:
+    """The shared recipe→seed conversion used by both the CLI and boot seeding."""
+
+    @staticmethod
+    def _config(source: str = "transformed", *, tag: str = "taxonomy", **extra) -> dict:
+        dc_config: dict = {"source": source, **extra}
+        if source == "transformed":
+            dc_config.setdefault("transform", {"recipe": "some_recipe"})
+        return {
+            "workflows": [
+                {
+                    "name": "wf",
+                    "data_collections": [
+                        {"data_collection_tag": tag, "config": dc_config},
+                        {
+                            "data_collection_tag": "plain",
+                            "config": {"source": "native", "scan": {"mode": "recursive"}},
+                        },
+                    ],
+                }
+            ],
+            "links": [{"source_dc_tag": tag, "target_dc_tag": "plain"}],
+        }
+
+    def test_seed_present_replaces_recipe_with_file_scan(self, tmp_path: Path) -> None:
+        """A recipe DC with a committed seed becomes a single-file TSV scan."""
+        (tmp_path / "taxonomy.tsv").write_text("a\tb\n1\t2\n")
+        config = self._config(dc_specific_properties={"format": "csv"})
+
+        materialized, missing = materialize_recipe_seeds(config, str(tmp_path), drop_missing=False)
+
+        assert (materialized, missing) == (["taxonomy"], [])
+        dc_config = config["workflows"][0]["data_collections"][0]["config"]
+        # `source` survives so the viewer still shows the recipe lineage; the
+        # absent `transform` is what marks the DC as materialised.
+        assert dc_config["source"] == "transformed"
+        assert "transform" not in dc_config
+        assert dc_config["scan"] == {
+            "mode": "single",
+            "scan_parameters": {"filename": str(tmp_path / "taxonomy.tsv")},
+        }
+        # The template's format described the recipe's *input*, not the seed.
+        assert dc_config["dc_specific_properties"]["format"] == "tsv"
+
+    def test_seed_missing_keeps_recipe_when_not_dropping(self, tmp_path: Path) -> None:
+        """The CLI contract: no seed means the recipe runs exactly as before."""
+        config = self._config()
+
+        materialized, missing = materialize_recipe_seeds(config, str(tmp_path), drop_missing=False)
+
+        assert (materialized, missing) == ([], [])
+        dc_config = config["workflows"][0]["data_collections"][0]["config"]
+        assert dc_config["transform"] == {"recipe": "some_recipe"}
+        assert "scan" not in dc_config
+        assert len(config["workflows"][0]["data_collections"]) == 2
+        assert config["links"] == [{"source_dc_tag": "taxonomy", "target_dc_tag": "plain"}]
+
+    def test_seed_missing_drops_dc_and_its_links(self, tmp_path: Path) -> None:
+        """The init contract: no seed means the DC goes, links included."""
+        config = self._config()
+
+        materialized, missing = materialize_recipe_seeds(config, str(tmp_path), drop_missing=True)
+
+        assert (materialized, missing) == ([], ["taxonomy"])
+        tags = [dc["data_collection_tag"] for dc in config["workflows"][0]["data_collections"]]
+        assert tags == ["plain"]
+        assert config["links"] == []
+
+    def test_native_dc_with_matching_tsv_is_untouched(self, tmp_path: Path) -> None:
+        """A root `{dc_tag}.tsv` next to a non-recipe DC is a name collision.
+
+        viralrecon ships mosdepth_*.tsv beside `source: native` recursive-scan
+        DCs of the same tag — "root TSV present" must never on its own mean
+        "this DC has a seed".
+        """
+        (tmp_path / "mosdepth_genome_coverage.tsv").write_text("a\tb\n")
+        config = self._config("native", tag="mosdepth_genome_coverage", scan={"mode": "recursive"})
+
+        materialized, missing = materialize_recipe_seeds(config, str(tmp_path), drop_missing=True)
+
+        assert (materialized, missing) == ([], [])
+        dc_config = config["workflows"][0]["data_collections"][0]["config"]
+        assert dc_config["scan"] == {"mode": "recursive"}
+
+    def test_absent_dc_specific_properties_is_created(self, tmp_path: Path) -> None:
+        """A DC declaring no (or null) dc_specific_properties still gets the format."""
+        (tmp_path / "taxonomy.tsv").write_text("a\tb\n")
+        config = self._config(dc_specific_properties=None)
+
+        materialize_recipe_seeds(config, str(tmp_path), drop_missing=False)
+
+        dc_config = config["workflows"][0]["data_collections"][0]["config"]
+        assert dc_config["dc_specific_properties"] == {"format": "tsv"}

--- a/depictio/viewer/src/builder/buildMetadata.ts
+++ b/depictio/viewer/src/builder/buildMetadata.ts
@@ -25,7 +25,7 @@ export function buildMetadata(state: BuilderState): StoredMetadata {
     dc_id: state.dcId || undefined,
     project_id: state.projectId || undefined,
     // Set here rather than in each per-type branch: `section` lives on the base
-    // component model, `SectionSelect` is mounted once for every builder, and
+    // component model, `PlacementSection` is offered by every builder, and
     // `base` is spread after `existing` everywhere — so the picker's choice
     // always wins, including clearing it back to unsectioned. Empty string from
     // a cleared Select means "no section", which must persist as undefined.

--- a/depictio/viewer/src/builder/figure/FigureUIMode.tsx
+++ b/depictio/viewer/src/builder/figure/FigureUIMode.tsx
@@ -263,7 +263,7 @@ const FigureUIMode: React.FC = () => {
         </Alert>
       )}
 
-      {cachedSpec && (
+      {(cachedSpec || isPointPlot) && (
         <Accordion
           variant="separated"
           radius="md"
@@ -318,7 +318,7 @@ const FigureUIMode: React.FC = () => {
            *  per-bin envelopes with no useful filter target, so we hide the
            *  toggle entirely on those. FigureRenderer + ComponentRenderer
            *  enforce the same gate defensively for legacy metadata. */}
-          {(visuType === 'scatter' || visuType === 'scatter_3d') && (
+          {cachedSpec && (visuType === 'scatter' || visuType === 'scatter_3d') && (
             <CrossFilterSection
               enabled={Boolean(config.selection_enabled)}
               onEnabledChange={(checked) =>
@@ -329,23 +329,36 @@ const FigureUIMode: React.FC = () => {
               columnDescription="Column to extract from selected points"
             />
           )}
-        </Accordion>
-      )}
 
-      {isPointPlot && (
-        <NumberInput
-          label="Max points"
-          description="Downsample above this count (blank = global default). Viewers can still load all points on demand."
-          // min 1: blank means "use the global default"; disabling the cap
-          // entirely is a viewer-side action ("Load all"), not an authoring one.
-          min={1}
-          step={1000}
-          placeholder="Global default"
-          value={typeof config.max_points === 'number' ? config.max_points : ''}
-          onChange={(v) =>
-            patchConfig({ max_points: typeof v === 'number' && v > 0 ? v : null })
-          }
-        />
+          {isPointPlot && (
+            <Accordion.Item value="performance">
+              <Accordion.Control
+                icon={<Icon icon="mdi:speedometer" width={18} height={18} />}
+              >
+                <Text fw={700} size="sm">
+                  Performance
+                </Text>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <Stack gap="sm">
+                  <NumberInput
+                    label="Max points"
+                    description="Downsample above this count (blank = global default). Viewers can still load all points on demand."
+                    // min 1: blank means "use the global default"; disabling the cap
+                    // entirely is a viewer-side action ("Load all"), not an authoring one.
+                    min={1}
+                    step={1000}
+                    placeholder="Global default"
+                    value={typeof config.max_points === 'number' ? config.max_points : ''}
+                    onChange={(v) =>
+                      patchConfig({ max_points: typeof v === 'number' && v > 0 ? v : null })
+                    }
+                  />
+                </Stack>
+              </Accordion.Panel>
+            </Accordion.Item>
+          )}
+        </Accordion>
       )}
     </Stack>
   );

--- a/depictio/viewer/src/builder/figure/FigureUIMode.tsx
+++ b/depictio/viewer/src/builder/figure/FigureUIMode.tsx
@@ -36,6 +36,7 @@ import {
 } from './visuTypes';
 import ParameterField from './ParameterField';
 import CrossFilterSection from '../shared/CrossFilterSection';
+import PlacementSection from '../shared/PlacementSection';
 
 type CategoryKey = 'core' | 'common' | 'specific' | 'advanced';
 
@@ -263,103 +264,112 @@ const FigureUIMode: React.FC = () => {
         </Alert>
       )}
 
-      {(cachedSpec || isPointPlot) && (
-        <Accordion
-          variant="separated"
-          radius="md"
-          multiple
-          defaultValue={['core']}
-        >
-          {FIXED_CATEGORIES.map((c) => {
-            const items = byCategory[c.category];
-            if (!items.length) return null;
-            return (
-              <Accordion.Item key={c.key} value={c.key}>
-                <Accordion.Control
-                  icon={<Icon icon={c.icon} width={18} height={18} />}
-                >
-                  <Text fw={700} size="sm">
-                    {c.title}
-                  </Text>
-                </Accordion.Control>
-                <Accordion.Panel>
-                  <Stack gap="sm">
-                    {items.map((p) => (
-                      <ParameterField key={p.name} param={p} />
-                    ))}
-                  </Stack>
-                </Accordion.Panel>
-              </Accordion.Item>
-            );
-          })}
-
-          {byCategory.specific.length > 0 && (
-            <Accordion.Item value="specific">
+      {/* Rendered unconditionally: every item inside guards itself (the
+          spec-driven ones are empty without a spec, Placement hides when the
+          dashboard has no sections), so an accordion with nothing to show
+          collapses to an empty box rather than taking a gate of its own —
+          which is what used to make "Max points" vanish on a spec load
+          failure. */}
+      <Accordion
+        variant="separated"
+        radius="md"
+        multiple
+        defaultValue={['core']}
+      >
+        {FIXED_CATEGORIES.map((c) => {
+          const items = byCategory[c.category];
+          if (!items.length) return null;
+          return (
+            <Accordion.Item key={c.key} value={c.key}>
               <Accordion.Control
-                icon={<Icon icon={specificIcon} width={18} height={18} />}
+                icon={<Icon icon={c.icon} width={18} height={18} />}
               >
                 <Text fw={700} size="sm">
-                  {specificTitle}
+                  {c.title}
                 </Text>
               </Accordion.Control>
               <Accordion.Panel>
                 <Stack gap="sm">
-                  {byCategory.specific.map((p) => (
+                  {items.map((p) => (
                     <ParameterField key={p.name} param={p} />
                   ))}
                 </Stack>
               </Accordion.Panel>
             </Accordion.Item>
-          )}
+          );
+        })}
 
-          {/* Cross-filtering only carries per-row identity for scatter
-           *  traces (their customdata lines up 1:1 with input rows).
-           *  Aggregated visus — histogram, bar, box, pie — would emit
-           *  per-bin envelopes with no useful filter target, so we hide the
-           *  toggle entirely on those. FigureRenderer + ComponentRenderer
-           *  enforce the same gate defensively for legacy metadata. */}
-          {cachedSpec && (visuType === 'scatter' || visuType === 'scatter_3d') && (
-            <CrossFilterSection
-              enabled={Boolean(config.selection_enabled)}
-              onEnabledChange={(checked) =>
-                patchConfig({ selection_enabled: checked })
-              }
-              column={config.selection_column}
-              onColumnChange={(name) => patchConfig({ selection_column: name })}
-              columnDescription="Column to extract from selected points"
-            />
-          )}
+        {byCategory.specific.length > 0 && (
+          <Accordion.Item value="specific">
+            <Accordion.Control
+              icon={<Icon icon={specificIcon} width={18} height={18} />}
+            >
+              <Text fw={700} size="sm">
+                {specificTitle}
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Stack gap="sm">
+                {byCategory.specific.map((p) => (
+                  <ParameterField key={p.name} param={p} />
+                ))}
+              </Stack>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
 
-          {isPointPlot && (
-            <Accordion.Item value="performance">
-              <Accordion.Control
-                icon={<Icon icon="mdi:speedometer" width={18} height={18} />}
-              >
-                <Text fw={700} size="sm">
-                  Performance
-                </Text>
-              </Accordion.Control>
-              <Accordion.Panel>
-                <Stack gap="sm">
-                  <NumberInput
-                    label="Max points"
-                    description="Downsample above this count (blank = global default). Viewers can still load all points on demand."
-                    // min 1: blank means "use the global default"; disabling the cap
-                    // entirely is a viewer-side action ("Load all"), not an authoring one.
-                    min={1}
-                    step={1000}
-                    placeholder="Global default"
-                    value={typeof config.max_points === 'number' ? config.max_points : ''}
-                    onChange={(v) =>
-                      patchConfig({ max_points: typeof v === 'number' && v > 0 ? v : null })
-                    }
-                  />
-                </Stack>
-              </Accordion.Panel>
-            </Accordion.Item>
-          )}
-        </Accordion>
-      )}
+        {/* Cross-filtering only carries per-row identity for scatter
+         *  traces (their customdata lines up 1:1 with input rows).
+         *  Aggregated visus — histogram, bar, box, pie — would emit
+         *  per-bin envelopes with no useful filter target, so we hide the
+         *  toggle entirely on those. FigureRenderer + ComponentRenderer
+         *  enforce the same gate defensively for legacy metadata. */}
+        {cachedSpec && (visuType === 'scatter' || visuType === 'scatter_3d') && (
+          <CrossFilterSection
+            enabled={Boolean(config.selection_enabled)}
+            onEnabledChange={(checked) =>
+              patchConfig({ selection_enabled: checked })
+            }
+            column={config.selection_column}
+            onColumnChange={(name) => patchConfig({ selection_column: name })}
+            columnDescription="Column to extract from selected points"
+          />
+        )}
+
+        {isPointPlot && (
+          <Accordion.Item value="performance">
+            <Accordion.Control
+              icon={<Icon icon="mdi:speedometer" width={18} height={18} />}
+            >
+              <Text fw={700} size="sm">
+                Performance
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Stack gap="sm">
+                <NumberInput
+                  label="Max points"
+                  description="Downsample above this count (blank = global default). Viewers can still load all points on demand."
+                  // min 1: blank means "use the global default"; disabling the cap
+                  // entirely is a viewer-side action ("Load all"), not an authoring one.
+                  min={1}
+                  step={1000}
+                  placeholder="Global default"
+                  value={typeof config.max_points === 'number' ? config.max_points : ''}
+                  onChange={(v) =>
+                    patchConfig({ max_points: typeof v === 'number' && v > 0 ? v : null })
+                  }
+                />
+              </Stack>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+
+        {/* Placement lives in the right-hand control column with everything
+            else, not full-width beneath the preview. Self-hiding when the
+            dashboard declares no sections. */}
+        <PlacementSection />
+      </Accordion>
     </Stack>
   );
 };

--- a/depictio/viewer/src/builder/interactive/InteractiveBuilder.tsx
+++ b/depictio/viewer/src/builder/interactive/InteractiveBuilder.tsx
@@ -216,7 +216,7 @@ const InteractiveBuilder: React.FC = () => {
   // The dashboard's other interactive components, used only to suggest the
   // group names already in use. Group stays free text, so a failed fetch
   // degrades to "no suggestions" rather than blocking authoring. (Section is
-  // picked from the dashboard's declared list by `SectionSelect` instead.)
+  // picked from the dashboard's declared list by `PlacementSection` instead.)
   const [siblings, setSiblings] = useState<StoredMetadata[]>([]);
   useEffect(() => {
     if (!dashboardId) return;

--- a/depictio/viewer/src/builder/shared/DesignShell.tsx
+++ b/depictio/viewer/src/builder/shared/DesignShell.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { Box, Center, Grid, Stack } from '@mantine/core';
 import { Icon } from '@iconify/react';
 import ColumnsDescription from './ColumnsDescription';
+import PlacementSection from './PlacementSection';
 
 interface Props {
   formSlot: React.ReactNode;
@@ -26,7 +27,13 @@ const DesignShell: React.FC<Props> = ({
     <Stack gap="lg" pt="md">
       <Grid columns={24} gutter="md" align="stretch">
         <Grid.Col span={{ base: 24, md: 10 }}>
-          <Box style={{ height: '100%' }}>{formSlot}</Box>
+          {/* Placement rides at the bottom of the control column, with the rest
+              of this builder's settings, rather than full-width under both
+              columns. It hides itself when the dashboard has no sections. */}
+          <Stack gap="md" style={{ height: '100%' }}>
+            <Box>{formSlot}</Box>
+            <PlacementSection standalone />
+          </Stack>
         </Grid.Col>
         <Grid.Col span={{ base: 24, md: 1 }} visibleFrom="md">
           <Center style={{ height: '100%' }}>

--- a/depictio/viewer/src/builder/shared/PlacementSection.tsx
+++ b/depictio/viewer/src/builder/shared/PlacementSection.tsx
@@ -1,16 +1,28 @@
 /**
- * The section a component joins, offered by every builder.
+ * Where a component lands: the section it joins.
  *
- * Mounted once in `StepDesign` rather than per builder: `section` lives on the
- * base component model, so it means the same thing for a card as for a filter,
- * and duplicating the control into nine builders would guarantee they drift.
+ * Presented as a collapsed accordion section inside each builder's control
+ * column rather than a full-width block of its own, because placement is a
+ * secondary, optional choice — the primary way to set it is the "Move to
+ * section" menu on the placed component, which knows the current section and
+ * moves a whole group at once.
+ *
+ * Renders nothing when the dashboard declares no sections. Offering a picker
+ * with only "No section" in it is a dead end, the same reason
+ * `GridItemEditOverlay` hides its own menu in that case.
+ *
+ * One component, two mount points: `DesignShell` supplies its own surrounding
+ * `Accordion` for the seven builders that go through it, and the figure builder
+ * slots the item into the accordion already in its right-hand panel. `section`
+ * lives on the base component model, so duplicating the control per builder
+ * would only guarantee drift.
  *
  * Which list is offered depends on the component's type, exactly as the two
  * render paths are fed: interactive components join the filter panel's sections,
  * everything else joins the grid's.
  */
 import React, { useEffect, useMemo, useState } from 'react';
-import { Group, Select, Text } from '@mantine/core';
+import { Accordion, Group, Select, Stack, Text } from '@mantine/core';
 import { Icon } from '@iconify/react';
 import { fetchDashboard, SectionIcon } from 'depictio-react-core';
 import type { DashboardData, FilterSectionSpec } from 'depictio-react-core';
@@ -19,7 +31,19 @@ import { useBuilderStore } from '../store/useBuilderStore';
 import { implicitNames, sectionsFor } from '../../components/sections/sectionMutations';
 import type { SectionKind } from '../../components/sections/sectionMutations';
 
-const SectionSelect: React.FC = () => {
+export interface PlacementSectionProps {
+  /** Accordion item value — keep it out of the accordion's `defaultValue` so
+   *  the section stays collapsed. */
+  itemValue?: string;
+  /** Wrap the item in its own `Accordion`. Callers that already own one
+   *  (the figure builder) leave this off and slot the item into theirs. */
+  standalone?: boolean;
+}
+
+const PlacementSection: React.FC<PlacementSectionProps> = ({
+  itemValue = 'placement',
+  standalone = false,
+}) => {
   const componentType = useBuilderStore((s) => s.componentType);
   const dashboardId = useBuilderStore((s) => s.dashboardId);
   const config = useBuilderStore((s) => s.config) as {
@@ -39,7 +63,7 @@ const SectionSelect: React.FC = () => {
       })
       .catch((err) => {
         // Degrades to "no sections offered" rather than blocking authoring.
-        console.warn('[SectionSelect] section list unavailable:', err);
+        console.warn('[PlacementSection] section list unavailable:', err);
       });
     return () => {
       cancelled = true;
@@ -77,7 +101,12 @@ const SectionSelect: React.FC = () => {
   // sections at all.
   const disabled = componentType === 'interactive' && config.placement === 'top';
 
-  return (
+  // Nothing to place into: the Sections manager is where that starts, so a
+  // disabled picker here would be pure noise on every dashboard that never
+  // declared a section.
+  if (options.length === 0) return null;
+
+  const select = (
     <Select
       label="Section"
       description={
@@ -89,7 +118,7 @@ const SectionSelect: React.FC = () => {
               : 'Groups this filter under a collapsible header in the filter panel.'
             : 'Groups this component under a collapsible header in the dashboard.'
       }
-      placeholder={options.length === 0 ? 'No sections yet' : 'No section'}
+      placeholder="No section"
       data={options}
       value={current || null}
       onChange={(v) => {
@@ -109,9 +138,8 @@ const SectionSelect: React.FC = () => {
       }}
       clearable
       searchable
-      disabled={disabled || options.length === 0}
+      disabled={disabled}
       comboboxProps={{ withinPortal: false }}
-      leftSection={<Icon icon="mdi:format-list-group" width={14} />}
       renderOption={({ option }) => (
         <Group gap="xs" wrap="nowrap">
           <SectionIcon
@@ -124,6 +152,33 @@ const SectionSelect: React.FC = () => {
       )}
     />
   );
+
+  const item = (
+    <Accordion.Item value={itemValue}>
+      <Accordion.Control icon={<Icon icon="mdi:format-list-group" width={18} height={18} />}>
+        <Text fw={700} size="sm">
+          Placement
+        </Text>
+      </Accordion.Control>
+      <Accordion.Panel>
+        <Stack gap="sm">
+          {select}
+          <Text size="xs" c="dimmed">
+            Optional — you can also move this component between sections later,
+            from its menu on the dashboard.
+          </Text>
+        </Stack>
+      </Accordion.Panel>
+    </Accordion.Item>
+  );
+
+  return standalone ? (
+    <Accordion variant="separated" radius="md">
+      {item}
+    </Accordion>
+  ) : (
+    item
+  );
 };
 
-export default SectionSelect;
+export default PlacementSection;

--- a/depictio/viewer/src/builder/steps/StepDesign.tsx
+++ b/depictio/viewer/src/builder/steps/StepDesign.tsx
@@ -10,7 +10,6 @@ import { fetchSpecs, upsertComponent } from 'depictio-react-core';
 import { useBuilderStore } from '../store/useBuilderStore';
 import type { ColumnSpec } from '../store/useBuilderStore';
 import ComponentBuilder from '../ComponentBuilder';
-import SectionSelect from '../shared/SectionSelect';
 import { buildMetadata } from '../buildMetadata';
 import { getComponentTypeMeta } from '../componentTypes';
 
@@ -151,13 +150,6 @@ const StepDesign: React.FC = () => {
         )}
 
       <ComponentBuilder />
-
-      {/* Placement, not appearance — so it sits outside the per-type builder,
-          which keeps it identical for every component type instead of nine
-          near-copies. */}
-      <Paper withBorder radius="md" p="md">
-        <SectionSelect />
-      </Paper>
 
       {state.saveError && (
         <Alert color="red" title="Save error">

--- a/depictio/viewer/src/chrome/DashboardInfoBody.tsx
+++ b/depictio/viewer/src/chrome/DashboardInfoBody.tsx
@@ -121,7 +121,19 @@ const DashboardInfoBody: React.FC<DashboardInfoBodyProps> = ({ dashboard, active
           color="teal"
           label="Project"
           value={
-            projectName ? (
+            projectName && projectId ? (
+              <Tooltip label={`Open project: ${projectName}`} withArrow withinPortal>
+                <Anchor
+                  href={`/projects/${projectId}`}
+                  size="sm"
+                  fw={500}
+                  style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                >
+                  {projectName}
+                  <Icon icon="mdi:open-in-new" width={12} />
+                </Anchor>
+              </Tooltip>
+            ) : projectName ? (
               <Text size="sm" fw={500}>
                 {projectName}
               </Text>

--- a/depictio/viewer/src/chrome/DashboardInfoBody.tsx
+++ b/depictio/viewer/src/chrome/DashboardInfoBody.tsx
@@ -140,7 +140,7 @@ const DashboardInfoBody: React.FC<DashboardInfoBodyProps> = ({ dashboard, active
             value={<TemplateChip parsed={parsedTemplate} verbose />}
           />
         )}
-        {parsedTemplate && projectId && (
+        {projectId && (
           <MetaRow
             icon="mdi:clipboard-check-outline"
             color="indigo"

--- a/depictio/viewer/src/projects/detail/IngestionReportPanel.tsx
+++ b/depictio/viewer/src/projects/detail/IngestionReportPanel.tsx
@@ -49,6 +49,10 @@ const LEGEND: Array<{ key: string; desc: string }> = [
   { key: 'gated_out', desc: 'Excluded by a template condition (hover for the reason)' },
 ];
 
+// `gated_out` is dropped from the legend without a manifest: no row can carry
+// that status, so explaining it would describe something the reader cannot see.
+
+
 const HEALTH_META: Record<string, { color: string; icon: string; label: string }> = {
   ok: { color: 'green', icon: 'mdi:check-circle', label: 'Healthy' },
   partial: { color: 'yellow', icon: 'mdi:alert', label: 'Partial' },
@@ -108,23 +112,39 @@ const SummaryStat: React.FC<{
   value: React.ReactNode;
   icon: string;
   color: string;
-}> = ({ label, value, icon, color }) => (
-  <Card withBorder padding="md" radius="md">
-    <Group gap="sm" wrap="nowrap">
-      <ThemeIcon size={40} radius="md" variant="light" color={color}>
-        <Icon icon={icon} width={22} />
-      </ThemeIcon>
-      <Stack gap={0} style={{ minWidth: 0 }}>
-        <Text size="xl" fw={700} c={color === 'gray' ? undefined : color}>
-          {value}
-        </Text>
-        <Text size="xs" c="dimmed">
-          {label}
-        </Text>
-      </Stack>
-    </Group>
-  </Card>
-);
+  /** Explains a value the tile cannot state outright (e.g. an unknown count). */
+  hint?: string;
+}> = ({ label, value, icon, color, hint }) => {
+  const card = (
+    <Card withBorder padding="md" radius="md">
+      <Group gap="sm" wrap="nowrap">
+        <ThemeIcon size={40} radius="md" variant="light" color={color}>
+          <Icon icon={icon} width={22} />
+        </ThemeIcon>
+        <Stack gap={0} style={{ minWidth: 0 }}>
+          <Text size="xl" fw={700} c={color === 'gray' ? undefined : color}>
+            {value}
+          </Text>
+          <Group gap={4} wrap="nowrap">
+            <Text size="xs" c="dimmed">
+              {label}
+            </Text>
+            {hint && (
+              <Icon icon="mdi:help-circle-outline" width={12} color="var(--mantine-color-dimmed)" />
+            )}
+          </Group>
+        </Stack>
+      </Group>
+    </Card>
+  );
+  return hint ? (
+    <Tooltip label={hint} withArrow multiline maw={320} withinPortal>
+      {card}
+    </Tooltip>
+  ) : (
+    card
+  );
+};
 
 /** A compact inline "icon · label · value" metadata chip for the header row. */
 const InlineMeta: React.FC<{ icon: string; label: string; value?: string | null }> = ({
@@ -409,6 +429,27 @@ const IngestionReportPanel: React.FC<IngestionReportPanelProps> = ({
 
   const health = HEALTH_META[report.summary.health] ?? HEALTH_META.ok;
   const { summary, template } = report;
+  // No frozen manifest: the report is assembled from the collections the project
+  // currently declares. What a template excluded or pruned was never recorded,
+  // so "gated out" is unknown here — not zero — and the expected-vs-found
+  // framing has no baseline to compare against.
+  const isLive = report.manifest_source === 'live_project';
+  // A template project predating the manifest is a different story from a
+  // project that never had a template: only the former can be re-imported.
+  const isLegacyTemplate = isLive && !!template;
+  const provenance = isLive
+    ? {
+        color: 'blue',
+        icon: 'mdi:database-eye-outline',
+        label: 'Live project',
+        tip: "Built from the project's current data collections — there is no template manifest to compare against.",
+      }
+    : {
+        color: 'gray',
+        icon: 'mdi:file-document-check-outline',
+        label: 'Template manifest',
+        tip: 'Compared against the expected-collection manifest frozen when the template was applied.',
+      };
 
   return (
     <Stack gap="md">
@@ -431,22 +472,36 @@ const IngestionReportPanel: React.FC<IngestionReportPanelProps> = ({
               )}
             </div>
           </Group>
-          <Badge
-            size="lg"
-            radius="sm"
-            variant="light"
-            color={health.color}
-            leftSection={<Icon icon={health.icon} width={14} />}
-            style={{ flexShrink: 0 }}
-          >
-            {health.label}
-          </Badge>
+          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+            <Tooltip label={provenance.tip} withArrow multiline maw={320} withinPortal>
+              <Badge
+                size="lg"
+                radius="sm"
+                variant="default"
+                color={provenance.color}
+                leftSection={<Icon icon={provenance.icon} width={14} />}
+              >
+                {provenance.label}
+              </Badge>
+            </Tooltip>
+            <Badge
+              size="lg"
+              radius="sm"
+              variant="light"
+              color={health.color}
+              leftSection={<Icon icon={health.icon} width={14} />}
+            >
+              {health.label}
+            </Badge>
+          </Group>
         </Group>
 
         <Divider my="xs" />
 
         <Group gap="lg" wrap="wrap">
-          <InlineMeta icon="mdi:calendar-check" label="Applied" value={template?.applied_at} />
+          {template?.applied_at && (
+            <InlineMeta icon="mdi:calendar-check" label="Applied" value={template.applied_at} />
+          )}
           <InlineMeta icon="mdi:clock-outline" label="Last scan" value={report.scanned_at} />
           <InlineMeta icon="mdi:database-outline" label="Runs" value={String(report.runs.length)} />
           {template?.data_root && (
@@ -482,12 +537,20 @@ const IngestionReportPanel: React.FC<IngestionReportPanelProps> = ({
           )}
         </Group>
 
-        {report.manifest_source === 'live_project' && (
+        {isLegacyTemplate && (
           <Alert mt="xs" color="yellow" variant="light" icon={<Icon icon="mdi:information" />}>
             This project was created before ingestion-report tracking was added, so the collections
             the template skipped or gated out weren't recorded — only the collections actually
             present are listed below. Re-import it from its template (depictio run --template …) to
             get the full expected-vs-found breakdown.
+          </Alert>
+        )}
+        {isLive && !template && (
+          <Alert mt="xs" color="blue" variant="light" icon={<Icon icon="mdi:information" />}>
+            This project wasn't created from a template, so there is no manifest of expected
+            collections. Everything below is read from the collections the project declares today:
+            it shows which of them have data, but it cannot tell you whether a collection is
+            missing entirely.
           </Alert>
         )}
       </Paper>
@@ -496,8 +559,14 @@ const IngestionReportPanel: React.FC<IngestionReportPanelProps> = ({
       <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="sm">
         <SummaryStat
           icon="mdi:shield-check"
-          label="Required identified"
-          value={`${summary.required_identified}/${summary.required_total}`}
+          label={isLive ? 'Required with data' : 'Required identified'}
+          // Without a manifest the denominator is just "the collections that
+          // exist", so the ratio compares a number to itself. Show the count.
+          value={
+            isLive
+              ? summary.required_identified
+              : `${summary.required_identified}/${summary.required_total}`
+          }
           color={summary.required_missing > 0 ? 'orange' : 'green'}
         />
         <SummaryStat
@@ -508,15 +577,26 @@ const IngestionReportPanel: React.FC<IngestionReportPanelProps> = ({
         />
         <SummaryStat
           icon="mdi:check-circle-outline"
-          label="Optional identified"
-          value={`${summary.optional_identified}/${summary.optional_total}`}
+          label={isLive ? 'Optional with data' : 'Optional identified'}
+          value={
+            isLive
+              ? summary.optional_identified
+              : `${summary.optional_identified}/${summary.optional_total}`
+          }
           color="teal"
         />
         <SummaryStat
           icon="mdi:filter-remove-outline"
           label="Gated out"
-          value={summary.gated}
+          // A manifest is the only thing that records what a conditional
+          // excluded. Reporting 0 without one would assert something unverified.
+          value={isLive ? '—' : summary.gated}
           color="gray"
+          hint={
+            isLive
+              ? 'Unknown without a template manifest — exclusions were never recorded for this project.'
+              : undefined
+          }
         />
       </SimpleGrid>
 
@@ -626,7 +706,7 @@ const IngestionReportPanel: React.FC<IngestionReportPanelProps> = ({
       )}
 
       <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="xs">
-        {LEGEND.map(({ key, desc }) => {
+        {LEGEND.filter(({ key }) => !(isLive && key === 'gated_out')).map(({ key, desc }) => {
           const m = STATUS_META[key];
           return (
             <Paper key={key} withBorder radius="md" p="xs">

--- a/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
+++ b/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
@@ -383,10 +383,6 @@ const ProjectDetailApp: React.FC = () => {
   const projectType: 'basic' | 'advanced' =
     project?.project_type === 'advanced' ? 'advanced' : 'basic';
 
-  // The ingestion report only makes sense for template-instantiated projects
-  // (it compares against the frozen expected-DC manifest). Surface a tab when so.
-  const hasTemplate = useMemo(() => !!(project && parseTemplate(project)), [project]);
-
   // Tag → DC id, so identified ingestion rows can lazily list their files.
   const dcIdByTag = useMemo(() => {
     const map: Record<string, string> = {};
@@ -582,7 +578,7 @@ const ProjectDetailApp: React.FC = () => {
               return (
                 <Stack gap="lg">
                   <ProjectHeader project={project} projectType={projectType} />
-                  {hasTemplate && projectId ? (
+                  {projectId ? (
                     <Tabs value={activeTab} onChange={setActiveTab} keepMounted={false}>
                       <Tabs.List mb="md">
                         <Tabs.Tab

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -2601,8 +2601,13 @@ export interface IngestionReport {
     applied_at: string | null;
     data_root: string | null;
   } | null;
-  /** 'template_manifest' (faithful) | 'live_project' (legacy fallback) */
-  manifest_source: string;
+  /**
+   * Where the expected-collection list came from. 'template_manifest' compares
+   * against the manifest frozen when the template was applied; 'live_project'
+   * is assembled from the project's current collections, so gated-out
+   * collections are unknown rather than zero.
+   */
+  manifest_source: 'template_manifest' | 'live_project';
   variables: Array<{ name: string; value: string }>;
   data_collections: IngestionDataCollection[];
   runs: IngestionRun[];


### PR DESCRIPTION
## Summary

Five thematic commits: one shared-helper change that makes bundled templates re-ingestible, one that opens the ingestion report to every project, and three UX fixes.

### 1. Bundled template seeds are now consumable by `depictio-cli`

A reference template ships each recipe's output as a committed `{data_root}/{dc_tag}.tsv`. Two consumers read that layout and **only one understood the convention**:

| | behaviour |
| --- | --- |
| `resolve_template_for_init` (`db_init_reference_datasets.py:485-540`) | rewrites every `source: transformed` DC into a single-file scan of its seed, drops the `transform` block |
| `resolve_template` (`cli/utils/templates.py`) | leaves the DC alone, so the recipe goes looking for its `SOURCES` — the pipeline's **raw** inputs |

No bundled project ships the full set of raw recipe inputs (ampliseq commits `input/`, `multiqc/`, `qiime2/tree.nwk`, but not the qiime2 abundance tables the recipes consume). So none was re-ingestible from its own directory, and the failure was doubly misleading: it landed late, at processing time (`RecipeError: file not found`, `depictio/recipes/__init__.py:208-211`), naming an absent raw file while the data sat right next to it under its seed name.

Extracted into **`materialize_recipe_seeds`**, called by both. Placed in `cli/utils/templates.py` because the init resolver already imports from that module (`substitute_template_variables`, `_apply_conditionals`), so no new cross-package dependency — and the diff stays out of `depictio/models/`, the only `ty`-gated directory.

**The seed wins over the recipe**, matching the init resolver exactly, so CLI ingestion and boot seeding produce identical tables. The two callers differ on one axis only, `drop_missing`: init removes a seedless DC (one missing seed would otherwise sink the whole workflow scan in `scan_files_for_data_collection`), the CLI leaves it untouched so its recipe runs exactly as before.

Wired into `resolve_template` as step 6c, constrained on both sides — after `_apply_conditionals`, so a gated-out DC stays gated out even with a seed beside it; before `_strip_ids` and `_build_expected_dcs`, so tags and links are intact and the manifest reflects the final config.

`prune_links_for_tags` factors out the drop-DC-then-prune-links pattern the two sites duplicated.

Scope, as agreed: `--template` only. `--project-config-path` is mutually exclusive with it (`run.py:337-344`) and the two paths converge only at `run.py:576`, on an already-validated `Project` — too late for anything that prunes. The helper is parameterised by `data_root`, so extending it later needs no rewrite.

### 2. The ingestion report is offered for every project

`ProjectDetailApp.tsx:585` gated the whole `Tabs` block on the project carrying a `template_origin`, even though the backend has always handled the other case: with no frozen manifest, `_expected_entries` (`ingestion_report.py:295-323`) falls back to the project's live collections and marks `manifest_source: 'live_project'`. The report worked for plain projects — it just had no way in, and the `#ingestion` deep link was silently swallowed there.

Tabs now render for any project, and the panel is explicit about which of the two sources it is showing. Without a manifest you cannot know what a conditional excluded or what was pruned at import, so:

- a **provenance badge** in the header, "Template manifest" vs "Live project", each explaining in a tooltip what it can and cannot tell you;
- **"Gated out" reads `—`, not `0`** — only a manifest records exclusions, and reporting zero without one asserts something unverified;
- the required/optional tiles **drop their denominator**, which in `live_project` is just "the collections that exist" and compares a number to itself;
- `gated_out` leaves the legend, since no row can carry that status;
- the "Applied" row is hidden instead of rendering `Applied —`;
- the yellow *"re-import from its template"* alert now fires **only** for a template project predating the manifest — the one case where that advice applies. A project that never had a template gets copy describing what the report is actually built from.

`manifest_source` is typed as its real union instead of `string`, so those comparisons are checked by `tsc`. The drawer's "View ingestion report" row loses its template gate for the same reason the tab did.

### 3-5. UX

- **Project link in the settings drawer.** The drawer named the dashboard's project but gave no way to reach it, though `projectId` was already in scope and the row below already linked to `/projects/{id}#ingestion`. The name is now an anchor, reusing the affordance the dashboard cards already use for the same jump. Shared with the inspector's Info tab, so it appears in both.
- **Figure "Max points" is in a section.** Every other figure setting lives in a titled accordion item; this one was a bare `NumberInput` floating after the accordion closed. The table builder already puts its analogous "Rows per page" cap inside a section. Moved into a "Performance" item.
- **"Section" → collapsed "Placement".** The picker sat full-width between the builder and Save, for every component type. It was detached from the controls it belongs with (for figures it landed *under* both columns of a two-column layout); it rendered even when the dashboard declared no sections at all, disabled, reading "No sections yet" — something `GridItemEditOverlay:100-103` already refuses to do, for the stated reason that offering only "No section" is a dead end; and it duplicated "Move to section", available on every placed component for both the grid and the filter panel, which knows the current section and moves a whole group at once where this picker just clears the group. Renamed `PlacementSection`, presented as a collapsed accordion item inside each builder's control column, hidden entirely when there is nothing to place into. The picker itself is unchanged — same options, same group-clearing rule (`validate_interactive_groups`), same disabled footer-controls case. Two mount points, not nine: `DesignShell` for the seven builders that go through it, and the figure builder's own right-hand accordion.

## Type of change
- [ ] Bugfix
- [x] Feature
- [x] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue
None.

## How was this tested?

**Automated, all green:**

- **2260 passed, 15 skipped** across `depictio/tests/{api,models,cli,unit}`.
- The three existing init-resolver invariant tests (`test_db_init_resolver.py`) pass **without being modified** — that is what pins the extraction as iso-behaviour, and it was the point of doing it that way.
- 5 new tests for the helper (`test_templates.py`): seed present → file scan with forced TSV format and `source` preserved; seed absent + `drop_missing=False` → DC untouched; seed absent + `drop_missing=True` → DC and its links dropped; a `source: native` DC with a matching root TSV left alone; absent/`None` `dc_specific_properties` created rather than crashing.
- `tsc --noEmit` clean, `ty check depictio/models/` clean, `ruff` and `ruff format` clean across the tree. All re-run after the rebase onto `d7cffd7`.

That fourth test guards a real trap: viralrecon ships `mosdepth_amplicon_coverage.tsv`, `mosdepth_genome_coverage.tsv` and `mosdepth_amplicon_heatmap.tsv` at project root next to `source: native` recursive-scan DCs of the same tag. "Root TSV present" must never on its own mean "this DC has a seed".

**Pre-existing failures, verified against the original branch base `316bb71` so they are not from this PR:** `test_google_oauth.py::TestOAuthStateStore::test_expired_state_is_rejected_and_burned` (the beanie/mongomock TTL issue) and the three `test_s3_backup_integration.py` cases (no reachable MinIO). `pre-commit run --all-files`: `ruff`, `ruff format`, `check yaml`, whitespace/EOF hooks, `nbstripout` and the thumbnail guard pass; `shellcheck` fails on untouched `depictio/projects/**/*.sh` and `scripts/security_audit_compose.sh`, `helm-lint` and `ty check models` fail for want of the `helm`/`ty` binaries in the hook env (running `ty check depictio/models/` directly passes). `end-of-file-fixer` wanted to strip a trailing blank line from the unrelated `.github/workflows/minimal-deploy.yaml`; reverted, not in this diff.

**Not run here — no Docker, MongoDB/MinIO or CLI venv in this environment:**

- Real CLI ingestion. Expected: `nf-core/viralrecon/3.0.0` → 10/10 transformed DCs materialised (10 seeds present); `nf-core/ampliseq/latest` → 16 of 19 (`sintax_rel_abundance`, `sidle_reconstructed`, `sidle_reconstruction_qc` ship no seed and should be removed by the conditionals before step 6c is reached; if they survive, they fail on their recipe as before). Needs `cd depictio/cli && uv sync --extra multiqc` first, or every MultiQC DC fails on `No module named 'multiqc'` and it looks like a data problem.
- Boot seeding unchanged, and the panel rendered against iris / penguins / advanced_viz_showcase / viralrecon / ampliseq.

## Notes for the reviewer

Rebased onto `main` at `d7cffd7` so CI runs against the e2e locator fixes from #995. The three `e2e-playwright` jobs that were red on the first run of this PR were the same single hard failure then present on `main` itself (`filters-into-builder.spec.ts:65`, `getByLabel('Data Collection') resolved to 2 elements` — the input plus its own open listbox), not anything from this diff. `main` at `fb03800` showed `1 failed, 34 passed`; this PR showed `1 failed, 1 flaky, 33 passed` — the flaky one being `logout.spec.ts`, which passed on retry. No viewer source changed on `main` in between, and no e2e spec references the controls this PR moves.

Two scope facts worth knowing before checking against the original description:

- **`catalog_conformance` does not exist on this branch** (zero occurrences anywhere in the tree), so the "24/24 collections" target was replaced by ampliseq and viralrecon.
- **Boot-seeded template projects have no manifest.** `db_init_reference_datasets.py:633-644` builds a `TemplateOrigin` without `expected_data_collections`, so seeded ampliseq and viralrecon will show the `live_project` treatment, not the manifest rendering. Only a project imported through `depictio-cli run --template` carries a manifest. Left out of scope deliberately; filling it in would mean reusing `_collect_dc_superset` / `_build_expected_dcs` in the init resolver.

Also unchanged on purpose: `_check_dc_source_files` / `_remove_dcs_with_missing_files` / `_log_removal_report` (`templates.py`) are dead code — never called from anywhere. The seed-precedence decision makes them unnecessary rather than wrong, so they carry a comment saying so and are left for a separate delete-or-wire-up decision instead of being churned here.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed
