### PR TITLE
feat(helm): Percona-operator HA mongo for EMBL internal tenant

### DIFF
--- a/helm-charts/depictio/templates/deployments.yaml
+++ b/helm-charts/depictio/templates/deployments.yaml
@@ -388,6 +388,42 @@ spec:
             {{- toYaml .Values.backend.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.initContainerResources | nindent 12 }}
+        {{- if .Values.mongo.useOperator }}
+        - name: wait-for-mongo-auth
+          # A TCP-open port only proves mongod is listening — with the Percona
+          # operator the replica set can report "ready" (and accept TCP) before
+          # its separate spec.users reconcile pass has actually created this DB
+          # user, or before a primary is elected. A backend/celery pod that
+          # starts inside that window gets "Authentication failed" or "No
+          # replica set members match selector Primary()", crashes internally,
+          # and — because the container's PID 1 survives the crash — stays
+          # Running/Ready with a dead app and nothing ever retries. Block here
+          # on a real authenticated ping so the pod is never marked Ready until
+          # the connection Depictio itself will use actually works.
+          image: "{{ .Values.mongo.image.repository }}:{{ .Values.mongo.image.tag }}"
+          imagePullPolicy: {{ .Values.mongo.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              until mongosh \
+                  "mongodb://{{ .Values.mongo.auth.username }}:${MONGO_PASSWORD}@{{ .Release.Name }}-mongo-rs0.{{ .Release.Namespace }}.{{ .Values.mongo.clusterServiceDNSSuffix }}:27017/admin?replicaSet=rs0" \
+                  --quiet --eval 'db.runCommand({ ping: 1 })' > /dev/null 2>&1; do
+                echo "Waiting for mongo replica set + {{ .Values.mongo.auth.username }} user to be ready..."
+                sleep 3
+              done
+              echo "Mongo authenticated ping OK"
+          env:
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-mongo-password
+                  key: password
+          securityContext:
+            {{- toYaml .Values.backend.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.initContainerResources | nindent 12 }}
+        {{- end }}
         {{- if .Values.minio.enabled }}
         - name: wait-for-minio
           image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
@@ -718,6 +754,34 @@ spec:
             {{- toYaml .Values.celery.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.initContainerResources | nindent 12 }}
+        {{- if .Values.mongo.useOperator }}
+        # STEP 1b: Wait for the depictio DB user to actually be usable (see
+        # backend's wait-for-mongo-auth for why the TCP check above isn't enough)
+        - name: wait-for-mongo-auth
+          image: "{{ .Values.mongo.image.repository }}:{{ .Values.mongo.image.tag }}"
+          imagePullPolicy: {{ .Values.mongo.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              until mongosh \
+                  "mongodb://{{ .Values.mongo.auth.username }}:${MONGO_PASSWORD}@{{ .Release.Name }}-mongo-rs0.{{ .Release.Namespace }}.{{ .Values.mongo.clusterServiceDNSSuffix }}:27017/admin?replicaSet=rs0" \
+                  --quiet --eval 'db.runCommand({ ping: 1 })' > /dev/null 2>&1; do
+                echo "Waiting for mongo replica set + {{ .Values.mongo.auth.username }} user to be ready..."
+                sleep 3
+              done
+              echo "Mongo authenticated ping OK"
+          env:
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-mongo-password
+                  key: password
+          securityContext:
+            {{- toYaml .Values.celery.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.initContainerResources | nindent 12 }}
+        {{- end }}
         # STEP 2: Wait for Redis
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis

--- a/helm-charts/depictio/values-embl-internal-dev.yaml
+++ b/helm-charts/depictio/values-embl-internal-dev.yaml
@@ -1,4 +1,22 @@
-# EMBL specific values with no authentication (values-embl-unauth.yaml)
+# EMBL Internal Dev Environment - dev.depictio.embl.org (values-embl-internal-dev.yaml)
+# Google OAuth (EMBL staff only, no public/demo mode). Mirrors
+# values-embl-internal-prod.yaml with dev hostnames/namespace, including
+# 3-replica Percona PSMDB HA mongo.
+#
+# Namespace: datasci-depictio-internal-dev
+#   (Tenant: datasci-depictio-internal, 64 CPU / 128 GiB, shared with -prod)
+#
+# IMPORTANT: DEPICTIO_AUTH_GOOGLE_OAUTH_REDIRECT_URI below must be registered
+# as an authorized redirect URI on the Google Cloud OAuth client (same client
+# ID as prod, per values-embl-secrets.yaml) — this file cannot do that part,
+# only the Google Cloud Console can. Until it's added there, login on this
+# environment will fail with redirect_uri_mismatch even though everything
+# else in this file is correct.
+
+# EMBL ops-k1 uses a custom cluster DNS domain (not cluster.local) — required
+# for the viewer nginx → backend proxy FQDN to resolve.
+clusterDomain: "ops-k1.embl.de"
+
 ## Storage
 storageClass: basic-csi
 persistence:
@@ -29,6 +47,24 @@ initContainerResources:
   limits:
     memory: "128Mi"
     cpu: "100m"
+
+# Viewer (nginx SPA) — stateless and tiny, so run 2 replicas for HA + a
+# zero-downtime rolling deploy. Mirrors values-embl-internal-prod.yaml.
+viewer:
+  replicas: 2
+  strategy: "RollingUpdate"
+
+# Protect the multi-replica workloads during node drains / cluster upgrades.
+# backend, viewer AND celery all run >1 replica once this file's changes
+# apply, so all three get a PDB (the template only emits one for components
+# with >1 replica — see values.yaml).
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Celery worker — same HA bump as prod.
+celery:
+  replicas: 2
 
 ## SecurityContext
 backend:
@@ -68,11 +104,28 @@ backend:
     # Celery Configuration - Disabled for now
     # DEPICTIO_CELERY_ENABLED: "false"
 
+# Client ID/secret come from values-embl-secrets.yaml's top-level `auth:` map
+# (same OAuth app across environments — deep-merged with this block). The
+# redirect URI is env-specific though, so it's set here, not in secrets — it
+# must match the ingress host below or Google rejects the callback. NOTE:
+# read from top-level .Values.auth, NOT backend.env (templates/configmaps.yaml:57).
+auth:
+  # Must be /auth/google/callback, not bare /auth — see values-embl-internal-prod.yaml
+  DEPICTIO_AUTH_GOOGLE_OAUTH_REDIRECT_URI: "https://dev.depictio.embl.org/auth/google/callback"
 
 mongo:
-  replicas: 1  # Temporarily single replica to get system working
+  useOperator: true     # Use Percona PSMDB Operator for HA replica set
+  replicas: 3           # 3-member replica set managed by the operator
+  auth:
+    enabled: true
+    username: depictio
+    # password must be set in values-embl-secrets.yaml (never commit)
+    password: ""
   image:
+    repository: percona/percona-server-mongodb
+    tag: "6.0.9-7"
     pullPolicy: Always
+  clusterServiceDNSSuffix: "svc.ops-k1.embl.de"
   resources:
     requests:
       memory: "1Gi"
@@ -80,6 +133,11 @@ mongo:
     limits:
       memory: "2Gi"
       cpu: "1"
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
   securityContext:
     runAsNonRoot: true
     runAsUser: 999
@@ -147,48 +205,30 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: harica-issuer
 
-  # Host configuration for split frontend/backend setup
-  # NOTE: Two approaches are available:
-  # 1. Use the global.urlPattern configuration (set above) to auto-generate URLs
-  #    - Remove or comment out the 'hosts' section below
-  #    - The pattern will automatically generate URLs like:
-  #      * dev.demo.depictio.embl.org (frontend)
-  #      * dev.api.demo.depictio.embl.org (backend)
-  # 2. Explicitly define hosts (current approach - takes precedence over urlPattern)
-  #    - Keeps full control over exact hostnames
-  #    - Useful for non-standard patterns or multiple environments
   hosts:
-    - host: "depictio.embl.org"
+    - host: "dev.depictio.embl.org"
       paths:
         - path: /
           pathType: Prefix
           service:
             name: depictio-viewer
             portName: http
-    - host: "api.depictio.embl.org"
+    - host: "dev.api.depictio.embl.org"
       paths:
         - path: /
           pathType: Prefix
           service:
             name: depictio-backend
             portName: http
-    # - host: "minio.demo.depictio.embl.org"
-    #   paths:
-    #     - path: /
-    #       pathType: Prefix
-    #       service:
-    #         name: minio
-    #         portName: http
 
   # TLS configuration
-  # Note: The secret name should be created by cert-manager based on the cluster-issuer
-  # Format: {release-name}-depictio-tls allows deployment with any release name
+  # Note: distinct secretName from prod's depictio-tls — separate namespace
+  # so it wouldn't collide either way, but kept distinct for clarity.
   tls:
     - hosts:
-        - "depictio.embl.org"
-        - "api.depictio.embl.org"
-        # - "minio.depictio.embl.org"
-      secretName: depictio-tls  # Will be created by cert-manager with harica-issuer
+        - "dev.depictio.embl.org"
+        - "dev.api.depictio.embl.org"
+      secretName: dev-depictio-tls  # Will be created by cert-manager with harica-issuer
 
 global:
   domain: "depictio.embl.org"  # Global domain for all services
@@ -199,15 +239,14 @@ global:
   urlPattern:
     type: "custom"
     templates:
-      api: "api.depictio.embl.org"
-      frontend: "depictio.embl.org"
-      # minio: "minio.depictio.embl.org"  # In case MinIO is needed later
+      api: "dev.api.depictio.embl.org"
+      frontend: "dev.depictio.embl.org"
 
 
 # Example deployment command:
 # IMPORTANT: You must also load the secrets file (values-embl-secrets.yaml)
-# helm upgrade --install demo ./helm-charts/depictio \
+# helm upgrade --install devinternal ./helm-charts/depictio \
 #   -f ./helm-charts/depictio/values.yaml \
-#   -f ./helm-charts/depictio/values-embl-unauth.yaml \
+#   -f ./helm-charts/depictio/values-embl-internal-dev.yaml \
 #   -f ./helm-charts/depictio/values-embl-secrets.yaml \
-#   -n datasci-depictio-project-demo
+#   -n datasci-depictio-internal-dev

--- a/helm-charts/depictio/values-embl-internal-prod.yaml
+++ b/helm-charts/depictio/values-embl-internal-prod.yaml
@@ -1,0 +1,279 @@
+# EMBL Internal Environment - depictio.embl.org (values-embl-internal-prod.yaml)
+# Google OAuth (EMBL staff only, no public/demo mode). Formerly named
+# values-embl-auth.yaml; the old header calling this "no authentication" was
+# stale — DEPICTIO_AUTH_GOOGLE_OAUTH_ENABLED is set below.
+#
+# Namespace: datasci-depictio-internal-prod
+#   (Tenant: datasci-depictio-internal, 64 CPU / 128 GiB)
+#
+# Mongo runs 3-replica HA via the Percona PSMDB Operator, same pattern as
+# values-embl-demo-base.yaml (same cluster-wide operator, confirmed available
+# for this tenant too — no separate IT install needed).
+#
+# IMPORTANT: DEPICTIO_AUTH_GOOGLE_OAUTH_REDIRECT_URI below must be registered
+# as an authorized redirect URI on the Google Cloud OAuth client — this file
+# cannot do that part, only kubeportal/Google Cloud Console can.
+
+# EMBL ops-k1 uses a custom cluster DNS domain (not cluster.local) — required
+# for the viewer nginx → backend proxy FQDN to resolve (nginx's resolver
+# ignores resolv.conf search domains). Was missing here before (silently
+# defaulted to values.yaml's "cluster.local", wrong for this cluster).
+clusterDomain: "ops-k1.embl.de"
+
+## Storage
+storageClass: basic-csi
+persistence:
+  mongo:
+    size: 1Gi
+    accessMode: ReadWriteOnce
+  minio:
+    size: 1Gi
+    accessMode: ReadWriteOnce
+  screenshots:
+    size: 100Mi
+    accessMode: ReadWriteMany
+  keys:
+    size: 1Mi
+    accessMode: ReadWriteMany
+  config:
+    size: 10Mi
+    accessMode: ReadWriteMany
+  uploads:
+    size: 5Gi
+    accessMode: ReadWriteMany
+
+## Init Container Resources
+initContainerResources:
+  requests:
+    memory: "64Mi"
+    cpu: "10m"
+  limits:
+    memory: "128Mi"
+    cpu: "100m"
+
+# Viewer (nginx SPA) — stateless and tiny, so run 2 replicas for HA + a
+# zero-downtime rolling deploy. Was left at the values.yaml default of 1
+# (no HA) — never backported here, same story as the celery/PDB gaps below.
+viewer:
+  replicas: 2
+  strategy: "RollingUpdate"
+
+# Protect the multi-replica workloads during node drains / cluster upgrades.
+# backend, viewer AND celery all run >1 replica once this file's changes
+# apply, so all three get a PDB (the template only emits one for components
+# with >1 replica — see values.yaml). Was disabled (values.yaml default)
+# despite backend already running 2 replicas.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Celery worker — same story: left at the values.yaml default of 1 replica.
+celery:
+  replicas: 2
+
+## SecurityContext
+backend:
+  replicas: 2  # Multiple replicas for high availability with anti-affinity
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+  resources:
+    requests:
+      memory: "2Gi"     # Balanced for multiple replicas
+      cpu: "500m"       # Balanced CPU allocation
+    limits:
+      memory: "4Gi"     # Reasonable limit for multiple replicas
+      cpu: "2"          # Balanced CPU limit
+
+  env:
+    # Anonymous user configuration
+    DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL: "anonymous@depict.io"
+    DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS: "1"
+
+    # Performance - Balanced workers for multiple replicas
+    DEPICTIO_FASTAPI_WORKERS: "4"
+
+    # Analytics Configuration
+    DEPICTIO_ANALYTICS_ENABLED: "true"
+    DEPICTIO_GOOGLE_ANALYTICS_ENABLED: "true"
+
+    # Google OAuth Configuration
+    DEPICTIO_AUTH_GOOGLE_OAUTH_ENABLED: "true"
+
+    # Celery Configuration - Disabled for now
+    # DEPICTIO_CELERY_ENABLED: "false"
+
+# Client ID/secret come from values-embl-secrets.yaml's top-level `auth:` map
+# (same OAuth app across environments — deep-merged with this block). The
+# redirect URI is env-specific though, so it's set here, not in secrets — it
+# must match the ingress host below or Google rejects the callback. NOTE:
+# read from top-level .Values.auth, NOT backend.env (templates/configmaps.yaml:57).
+auth:
+  # Must be /auth/google/callback, not bare /auth — AuthApp.tsx's detectView()
+  # only renders the code/state-processing GoogleOAuthCallback component at
+  # that exact path; bare /auth just shows the login form again with the
+  # code/state sitting unused in the URL (silent failure, no redirect).
+  DEPICTIO_AUTH_GOOGLE_OAUTH_REDIRECT_URI: "https://depictio.embl.org/auth/google/callback"
+
+mongo:
+  useOperator: true     # Use Percona PSMDB Operator for HA replica set
+  replicas: 3           # 3-member replica set managed by the operator
+  auth:
+    enabled: true
+    username: depictio
+    # password must be set in values-embl-secrets.yaml (never commit)
+    password: ""
+  image:
+    repository: percona/percona-server-mongodb
+    tag: "6.0.9-7"
+    pullPolicy: Always
+  clusterServiceDNSSuffix: "svc.ops-k1.embl.de"
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+
+# Redis configuration (required for EMBL Capsule admission controller)
+redis:
+  enabled: true
+  image:
+    pullPolicy: Always  # EMBL infrastructure requires Always policy
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+
+# External S3 service configuration
+minio:
+  enabled: false  # Using external EMBL S3 service instead of local MinIO
+  # NOTE: S3 credentials are defined in values-embl-secrets.yaml
+  # This file should be loaded separately and not committed to version control
+
+  # Security context override for PodSecurity "restricted" policy compliance
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+
+  # External MinIO/S3 environment configuration (placeholder values)
+  # These will be overridden by values-embl-secrets.yaml
+  env:
+    DEPICTIO_MINIO_PUBLIC_URL: "https://s3.embl.de"
+    DEPICTIO_MINIO_ROOT_USER: "placeholder-user"
+    DEPICTIO_MINIO_ROOT_PASSWORD: "placeholder-password"
+    DEPICTIO_MINIO_BUCKET: "depictio-bucket"
+    DEPICTIO_MINIO_SERVICE_PORT: "9000"
+
+## Ingress
+ingress:
+  enabled: true
+  ingressClassName: "internal-users"
+
+  # EMBL specific annotations
+  annotations:
+    cert-manager.io/cluster-issuer: harica-issuer
+
+  # Host configuration for split frontend/backend setup
+  # NOTE: Two approaches are available:
+  # 1. Use the global.urlPattern configuration (set above) to auto-generate URLs
+  #    - Remove or comment out the 'hosts' section below
+  #    - The pattern will automatically generate URLs like:
+  #      * dev.demo.depictio.embl.org (frontend)
+  #      * dev.api.demo.depictio.embl.org (backend)
+  # 2. Explicitly define hosts (current approach - takes precedence over urlPattern)
+  #    - Keeps full control over exact hostnames
+  #    - Useful for non-standard patterns or multiple environments
+  hosts:
+    - host: "depictio.embl.org"
+      paths:
+        - path: /
+          pathType: Prefix
+          service:
+            name: depictio-viewer
+            portName: http
+    - host: "api.depictio.embl.org"
+      paths:
+        - path: /
+          pathType: Prefix
+          service:
+            name: depictio-backend
+            portName: http
+    # - host: "minio.demo.depictio.embl.org"
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+    #       service:
+    #         name: minio
+    #         portName: http
+
+  # TLS configuration
+  # Note: The secret name should be created by cert-manager based on the cluster-issuer
+  # Format: {release-name}-depictio-tls allows deployment with any release name
+  tls:
+    - hosts:
+        - "depictio.embl.org"
+        - "api.depictio.embl.org"
+        # - "minio.depictio.embl.org"
+      secretName: depictio-tls  # Will be created by cert-manager with harica-issuer
+
+global:
+  domain: "depictio.embl.org"  # Global domain for all services
+
+  # URL pattern configuration for EMBL deployment
+  # Using "custom" pattern to match explicit ingress hosts
+  # This ensures ConfigMap public URLs match the ingress routing
+  urlPattern:
+    type: "custom"
+    templates:
+      api: "api.depictio.embl.org"
+      frontend: "depictio.embl.org"
+      # minio: "minio.depictio.embl.org"  # In case MinIO is needed later
+
+
+# Example deployment command:
+# IMPORTANT: You must also load the secrets file (values-embl-secrets.yaml)
+# helm upgrade --install internal ./helm-charts/depictio \
+#   -f ./helm-charts/depictio/values.yaml \
+#   -f ./helm-charts/depictio/values-embl-internal-prod.yaml \
+#   -f ./helm-charts/depictio/values-embl-secrets.yaml \
+#   -n datasci-depictio-internal-prod


### PR DESCRIPTION
## Why

The `devinternal` / EMBL-internal releases (`datasci-depictio-internal-dev`, `datasci-depictio-internal-prod`) already run on the cluster using these chart changes — they were only ever applied by hand from an uncommitted local checkout, never landed on `main`. This PR just catches git up with what's actually deployed, split out from a separate, still-WIP demo-tenant namespace migration.

## Changes

- `deployments.yaml`: `wait-for-mongo-auth` init container (backend + celery), gated on `mongo.useOperator`. Blocks pod readiness on an authenticated mongo ping instead of a bare TCP check — with the Percona operator, the replica set can report ready (and accept TCP) before its `spec.users` reconcile pass creates the DB user or a primary is elected, so a pod starting in that window would crash internally and, since PID 1 survives, stay marked Ready with a dead app.
- `values-embl-auth.yaml` → `values-embl-internal-prod.yaml`: renamed (the old "no authentication" header was stale — Google OAuth is enabled) and extended with 3-replica Percona PSMDB HA mongo, 2 replicas each for backend/viewer/celery, and PodDisruptionBudgets.
- `values-embl-internal-dev.yaml` added: mirrors internal-prod with dev hostnames/namespace.

## Not in scope

The `datasci-depictio-demo` tenant namespace migration (`deploy-embl-selfhosted.yaml`, `values-embl-demo-*.yaml`) stays out — it has its own prerequisites not yet done (new namespaces reachable by the runner, old ingresses scaled to 0).