### PR TITLE
fix(tests): unbreak main — assert seed visibility pass-through, not a fixed flag

### DIFF
--- a/depictio/tests/api/v1/test_demo_mode_regressions.py
+++ b/depictio/tests/api/v1/test_demo_mode_regressions.py
@@ -16,6 +16,7 @@ Covers behaviors tightened after the #779 security work:
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -70,9 +71,12 @@ async def test_reference_dashboard_seeding_defers_visibility_to_save(
         await db_init.create_dashboard_from_json(admin_user, str(IRIS_SEED), static_dc_id="")
 
     # Whatever the auth mode, the seeding path passes the seed JSON's value
-    # through unchanged (iris ships is_public=True) — the authoritative value
-    # is stamped from the parent project by save_dashboard's insert branch.
-    assert captured["data"].is_public is True
+    # through unchanged — the authoritative value is stamped from the parent
+    # project by save_dashboard's insert branch (and converged at startup by
+    # reconcile_dashboard_visibility), so the seed's own flag is incidental and
+    # must not be read as an assertion about the deployed visibility.
+    seeded_is_public = json.loads(IRIS_SEED.read_text())["is_public"]
+    assert captured["data"].is_public is seeded_is_public
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Main CI is red: run [#1966](https://github.com/depictio/depictio/actions/runs/32972130354) fails in `quality` on `test_reference_dashboard_seeding_defers_visibility_to_save`, and since that job runs `pytest -x`, every downstream job (`docker-build`, `e2e-playwright`, `docker-system-init`, backup and CLI suites) is skipped.

The test hardcoded `assert captured["data"].is_public is True`, pinning the iris seed's value at the time it was written. The seed was regenerated in `3ee81f6` and now ships `is_public: false`, so both parametrizations fail.

No production bug. Visibility is project-driven: `create_dashboard_from_json` passes the seed through untouched, `save_dashboard`'s insert branch stamps `is_public` from the parent project, and `reconcile_dashboard_visibility()` converges drift at startup — the seed's own flag is incidental. The test now asserts pass-through of whatever the seed ships, which is the behavior it set out to cover and is robust to future seed regeneration.

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [ ] Build / CI / deps
- [ ] Documentation

## Related issue

None.

## How was this tested?

- Failure reproduced locally, then both parametrizations pass.
- Full suite as CI runs it: 2327 passed, 15 skipped. `test_s3_backup_integration.py` errors locally only — it needs a Docker daemon for testcontainers/MinIO, which the sandbox lacks; it passes in CI.
- `ruff format --check`, `ruff check`, and `ty check depictio/models/` all clean.
- `pre-commit run --all-files`: all content hooks pass. `helm-lint`, `ty-check-models` and `shellcheck` fail/skip for sandbox reasons only (no `helm` binary, hook envs could not fetch their binaries) and none touch the changed file.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvXNVY62SMDYzGPUGe1yY5)_