### PR TITLE
fix(helm): forward DEPICTIO_BRANDING_* to the backend and worker configmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,6 +334,9 @@ benchmark_datasets/
 # Sensitive Helm values files
 helm-charts/depictio/values-*-secrets.yaml
 helm-charts/depictio/*secrets*.yaml
+# Snapshots of live releases (helm get values/manifest) — carry the same
+# secrets the files above do, since the release has them already merged in.
+.helm-backups/
 
 # Profiling
 prof_files/

--- a/helm-charts/depictio/templates/configmaps.yaml
+++ b/helm-charts/depictio/templates/configmaps.yaml
@@ -61,6 +61,19 @@ data:
   DEPICTIO_AUTH_GOOGLE_OAUTH_REDIRECT_URI: ""
   {{- end }}
 
+  # Instance branding (issue #397) — see examples/values-branding.yaml.
+  # Forwarded by prefix rather than as an explicit key list: BrandingConfig
+  # (api/v1/configs/settings_models.py, env_prefix DEPICTIO_BRANDING_) already
+  # owns which names are valid, and a second copy here would drift from it.
+  # Only keys the operator actually set are emitted — "" is not "unset" to
+  # pydantic, it is an invalid colour, and one of those discards the whole
+  # flat branding layer with a warning.
+  {{- range $key, $value := .Values.backend.env }}
+  {{- if and (hasPrefix "DEPICTIO_BRANDING_" $key) $value }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+
   # Performance
   DEPICTIO_FASTAPI_WORKERS: {{ .Values.backend.env.DEPICTIO_FASTAPI_WORKERS | quote }}
   # Analytics
@@ -145,6 +158,16 @@ data:
   DEPICTIO_AUTH_REGISTRATION_DISABLED: {{ .Values.backend.env.DEPICTIO_AUTH_REGISTRATION_DISABLED | default "false" | quote }}
   DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL: {{ .Values.backend.env.DEPICTIO_AUTH_ANONYMOUS_USER_EMAIL | default "anonymous@example.com" | quote }}
   DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS: {{ .Values.backend.env.DEPICTIO_AUTH_TEMPORARY_USER_EXPIRY_HOURS | default "24" | quote }}
+
+  # Branding — must mirror the backend for the same reason the auth block
+  # does: the worker renders figures too, and the brand colorway/template is
+  # applied on that render path. Without these the worker would fall back to
+  # the stock palette and screenshots would not match the live dashboard.
+  {{- range $key, $value := .Values.backend.env }}
+  {{- if and (hasPrefix "DEPICTIO_BRANDING_" $key) $value }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 
   # Redis/Celery broker settings
   {{- if .Values.redis.enabled }}

--- a/helm-charts/depictio/values-embl-internal-dev-trec.yaml
+++ b/helm-charts/depictio/values-embl-internal-dev-trec.yaml
@@ -1,0 +1,58 @@
+# EMBL Internal Dev, TREC skin - dev.depictio.embl.org
+#
+# Layered on top of:
+#   - values.yaml (base configuration)
+#   - values-embl-internal-dev.yaml (hosts, namespace, mongo/redis, sizing)
+#   - values-embl-internal-secrets.yaml (S3 + OAuth + mongo credentials)
+#
+# Deltas only. Everything about *where* this runs stays in
+# values-embl-internal-dev.yaml, which is deliberately kept generic so the
+# environment can be deployed unbranded by simply dropping this file from the
+# -f list. Drop it and you get plain Depictio back, with registration open.
+#
+# Example deployment command:
+# helm upgrade --install devinternal ./helm-charts/depictio \
+#   -f ./helm-charts/depictio/values.yaml \
+#   -f ./helm-charts/depictio/values-embl-internal-dev.yaml \
+#   -f ./helm-charts/depictio/values-embl-internal-secrets.yaml \
+#   -f ./helm-charts/depictio/values-embl-internal-dev-trec.yaml \
+#   -n datasci-depictio-internal-dev
+
+backend:
+  env:
+    # No self-service accounts. /register returns 403 and the Register button
+    # is hidden, AND the OAuth callback stops provisioning: the route passes
+    # allow_create=not registration_disabled, so an unknown Google email gets
+    # 403 rather than a new account. Google OAuth (enabled in the base file)
+    # stays a login-only door for people who already have an account here.
+    #
+    # Note this leaves email+password login itself open: there is no flag to
+    # make the instance OAuth-only. In practice OAuth-created accounts are
+    # stored with a placeholder that is not the bcrypt hash of any password,
+    # so only pre-existing password accounts can use the form.
+    DEPICTIO_AUTH_REGISTRATION_DISABLED: "true"
+
+    # ── TREC branding ────────────────────────────────────────────────────
+    # Deployment defaults only: /admin -> Branding overrides any of this live
+    # without a redeploy, and a dashboard can override it again for itself.
+    #
+    # The shipped preset carries the whole palette (primary #00a550, secondary
+    # #1a4f8f, tertiary #f5a11b, tint_mode full - see models/models/branding.py).
+    # Deliberately not restated as flat vars: sampling the official TREC tag
+    # gives #009f4d / #183e8f / #f49e17, within 2-3 units of the preset and
+    # indistinguishable on screen, so pinning a local copy would only stop this
+    # deployment from following a later correction to the preset.
+    DEPICTIO_BRANDING_PRESET: "trec"
+
+    # Substituted into the literal "Depictio" of the login heading
+    # (AuthCard.tsx: heading.replace('Depictio', app_name)), so the page reads
+    # "Welcome to Depictio for TREC :" rather than dropping Depictio's name.
+    # Also the browser tab title.
+    DEPICTIO_BRANDING_APP_NAME: "Depictio for TREC"
+
+    # Official TREC tag from embl.org. Remote https images are allowed by the
+    # CSP on both the API and the viewer's nginx, so no local copy is needed.
+    # It is a 620x620 JPEG on white, with no alpha, so it sits in a white
+    # square in dark mode - upload a transparent PNG via /admin -> Branding
+    # to fix that without touching this file.
+    DEPICTIO_BRANDING_LOGO_URL: "https://www.embl.org/about/info/trec/wp-content/uploads/2023/02/20230126_TREC_Tag_RGB-s.jpg"

--- a/helm-charts/depictio/values-embl-internal-dev.yaml
+++ b/helm-charts/depictio/values-embl-internal-dev.yaml
@@ -3,6 +3,10 @@
 # values-embl-internal-prod.yaml with dev hostnames/namespace, including
 # 3-replica Percona PSMDB HA mongo.
 #
+# Diverges from prod on two points, both under backend.env below: registration
+# is disabled (so no account can be created here, by form or by OAuth) and the
+# instance carries TREC branding.
+#
 # Namespace: datasci-depictio-internal-dev
 #   (Tenant: datasci-depictio-internal, 64 CPU / 128 GiB, shared with -prod)
 #
@@ -101,8 +105,35 @@ backend:
     # Google OAuth Configuration
     DEPICTIO_AUTH_GOOGLE_OAUTH_ENABLED: "true"
 
+    # No self-service accounts on this instance. /register returns 403 and the
+    # Register button is hidden, AND the OAuth callback stops provisioning:
+    # google_oauth_routes.py passes allow_create=not registration_disabled, so
+    # an unknown Google email gets 403 instead of a new account. OAuth stays a
+    # login-only door for people who already have one here.
+    DEPICTIO_AUTH_REGISTRATION_DISABLED: "true"
+
     # Celery Configuration - Disabled for now
     # DEPICTIO_CELERY_ENABLED: "false"
+
+    # ── TREC branding ────────────────────────────────────────────────────
+    # Deployment defaults only: /admin -> Branding overrides any of this live,
+    # without a redeploy, and a dashboard can override it again for itself.
+    #
+    # The shipped preset is the whole palette — primary #00a550, secondary
+    # #1a4f8f, tertiary #f5a11b, tint_mode full (models/models/branding.py).
+    # Deliberately not restated as flat vars here: sampling the official tag
+    # gives #009f4d / #183e8f / #f49e17, within 2-3 units of the preset and
+    # indistinguishable on screen, so pinning our own copy would only mean the
+    # preset could be refined upstream without this deployment following.
+    DEPICTIO_BRANDING_PRESET: "trec"
+    # Substituted into the literal "Depictio" of the login heading
+    # (AuthCard.tsx: heading.replace('Depictio', app_name)), so this reads
+    # "Welcome to Depictio for TREC :" rather than dropping Depictio's name.
+    # Also the browser tab title.
+    DEPICTIO_BRANDING_APP_NAME: "Depictio for TREC"
+    # 620x620 JPEG on white — no alpha, so it sits in a white square in dark
+    # mode. Upload a transparent PNG via /admin -> Branding to fix that.
+    DEPICTIO_BRANDING_LOGO_URL: "https://www.embl.org/about/info/trec/wp-content/uploads/2023/02/20230126_TREC_Tag_RGB-s.jpg"
 
 # Client ID/secret come from values-embl-secrets.yaml's top-level `auth:` map
 # (same OAuth app across environments — deep-merged with this block). The

--- a/helm-charts/depictio/values-embl-internal-dev.yaml
+++ b/helm-charts/depictio/values-embl-internal-dev.yaml
@@ -3,10 +3,6 @@
 # values-embl-internal-prod.yaml with dev hostnames/namespace, including
 # 3-replica Percona PSMDB HA mongo.
 #
-# Diverges from prod on two points, both under backend.env below: registration
-# is disabled (so no account can be created here, by form or by OAuth) and the
-# instance carries TREC branding.
-#
 # Namespace: datasci-depictio-internal-dev
 #   (Tenant: datasci-depictio-internal, 64 CPU / 128 GiB, shared with -prod)
 #
@@ -105,35 +101,8 @@ backend:
     # Google OAuth Configuration
     DEPICTIO_AUTH_GOOGLE_OAUTH_ENABLED: "true"
 
-    # No self-service accounts on this instance. /register returns 403 and the
-    # Register button is hidden, AND the OAuth callback stops provisioning:
-    # google_oauth_routes.py passes allow_create=not registration_disabled, so
-    # an unknown Google email gets 403 instead of a new account. OAuth stays a
-    # login-only door for people who already have one here.
-    DEPICTIO_AUTH_REGISTRATION_DISABLED: "true"
-
     # Celery Configuration - Disabled for now
     # DEPICTIO_CELERY_ENABLED: "false"
-
-    # ── TREC branding ────────────────────────────────────────────────────
-    # Deployment defaults only: /admin -> Branding overrides any of this live,
-    # without a redeploy, and a dashboard can override it again for itself.
-    #
-    # The shipped preset is the whole palette — primary #00a550, secondary
-    # #1a4f8f, tertiary #f5a11b, tint_mode full (models/models/branding.py).
-    # Deliberately not restated as flat vars here: sampling the official tag
-    # gives #009f4d / #183e8f / #f49e17, within 2-3 units of the preset and
-    # indistinguishable on screen, so pinning our own copy would only mean the
-    # preset could be refined upstream without this deployment following.
-    DEPICTIO_BRANDING_PRESET: "trec"
-    # Substituted into the literal "Depictio" of the login heading
-    # (AuthCard.tsx: heading.replace('Depictio', app_name)), so this reads
-    # "Welcome to Depictio for TREC :" rather than dropping Depictio's name.
-    # Also the browser tab title.
-    DEPICTIO_BRANDING_APP_NAME: "Depictio for TREC"
-    # 620x620 JPEG on white — no alpha, so it sits in a white square in dark
-    # mode. Upload a transparent PNG via /admin -> Branding to fix that.
-    DEPICTIO_BRANDING_LOGO_URL: "https://www.embl.org/about/info/trec/wp-content/uploads/2023/02/20230126_TREC_Tag_RGB-s.jpg"
 
 # Client ID/secret come from values-embl-secrets.yaml's top-level `auth:` map
 # (same OAuth app across environments — deep-merged with this block). The


### PR DESCRIPTION
## Problem

Both configmaps in `templates/configmaps.yaml` are a hand-written allowlist of `KEY: {{ .Values.backend.env.KEY }}` lines. There is no generic passthrough of `backend.env`, so a key with no matching template line is dropped at render time, silently: nothing warns at `helm template`, at `helm upgrade`, or at pod start.

`examples/values-branding.yaml` documents putting `DEPICTIO_BRANDING_*` under `backend.env`. It had no template line, so instance branding (#397) was inert on Kubernetes. Setting a preset, a logo or a palette produced an unbranded deployment with no diagnostic anywhere.

## Fix

Forward the block by prefix instead of adding one allowlist line per variable. `BrandingConfig` (`env_prefix="DEPICTIO_BRANDING_"`) already owns which names are valid, and a second copy in the chart would drift from it as new branding fields land.

Only keys the operator actually set are emitted. `""` is not "unset" to pydantic, it is an invalid colour, and a single one of those discards the whole flat branding layer with a warning.

The celery configmap gets the same block. The worker renders figures, and the brand colorway and Plotly template are applied on that path, so without it dashboard screenshots would keep the stock palette while the live dashboard is branded.

## New values file

`values-embl-internal-dev-trec.yaml` is the first consumer: a thin overlay appended last to the `-f` list that applies the `trec` preset, names the instance, points at the official TREC logo, and disables self-service registration.

It follows the base/overlay shape the demo environments already use, so `values-embl-internal-dev.yaml` stays generic and is **not touched by this PR**. Dropping the overlay from the deploy command is the whole "deploy this environment unbranded" operation.

Note that `DEPICTIO_AUTH_REGISTRATION_DISABLED` already worked before this change, and gates both `/register` and OAuth account creation. Only the branding variables were affected by the bug.

## Also

`.gitignore` gets `.helm-backups/`. Snapshots taken with `helm get values` carry the same secrets as the already-ignored `*secrets*.yaml` files, since the release has them merged in.

## Verification

Rendered both compositions with `helm template`:

- without the overlay, no `DEPICTIO_BRANDING_*` key is emitted at all and registration stays open
- with it, the three branding keys plus the registration gate appear in **both** `-backend-config` and `-celery-config`

Deployed to `datasci-depictio-internal-dev` and confirmed on the live instance that `/utils/public-config` serves the resolved theme (`primary #00a550`, `tint_mode full`, custom logo, `app_name "Depictio for TREC"`) and that `POST /auth/register` returns 403.