### PR TITLE
Scope the Depictio attribution, persist brand logos, and add two sign-in gates

### DIFF
--- a/depictio/api/main.py
+++ b/depictio/api/main.py
@@ -267,8 +267,10 @@ app.mount(
     name="dashboard-screenshots",
 )
 
-# Dashboard logos — uploaded via /dashboards/upload_logo (editor Settings
-# drawer) and referenced by the dashboard's `logo_url` field.
+# Dashboard logos — legacy mount. Uploads now go to MongoDB
+# (services/branding.py) and are served by /dashboards/logo/{id}; this stays so
+# that `logo_url`s written before that move still resolve on deployments where
+# the files happen to have survived. Removable once no stored URL points here.
 _DASHBOARD_LOGOS_DIR = Path(__file__).resolve().parent / "static" / "dashboard_logos"
 _DASHBOARD_LOGOS_DIR.mkdir(parents=True, exist_ok=True)
 app.mount(
@@ -277,8 +279,8 @@ app.mount(
     name="dashboard-logos",
 )
 
-# Instance branding logos — uploaded via /utils/branding/logo/{variant} (admin
-# Branding panel) and referenced by the branding overrides' logo URLs.
+# Instance branding logos — legacy mount, same story as the dashboard logos
+# above: uploads live in MongoDB and are served by /utils/branding/logo/{variant}.
 _BRANDING_DIR = Path(__file__).resolve().parent / "static" / "branding"
 _BRANDING_DIR.mkdir(parents=True, exist_ok=True)
 app.mount(

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -1,5 +1,6 @@
 import os
 import re
+import secrets
 from pathlib import Path
 from typing import Any, Literal, Optional
 
@@ -206,6 +207,13 @@ class MongoDBConfig(ServiceConfig):
         task_events_collection: str = Field(default="task_events")
         ingestion_runs_collection: str = Field(default="ingestion_runs")
         app_logs_collection: str = Field(default="app_logs")
+        # Instance branding: the singleton overrides document and the uploaded
+        # logo bytes. Named here so backup/restore can reach them like any other
+        # collection — a restored deployment that kept every dashboard's
+        # `brand_theme` but lost the instance brand they inherit from is worse
+        # than one that kept neither.
+        instance_settings_collection: str = Field(default="instance_settings")
+        branding_assets_collection: str = Field(default="branding_assets")
         # Holds the anonymous installation identity and the per-day send guards.
         # Deliberately its own collection: the wipe path in lifespan.py clears
         # everything except the init lock out of `initialization`, so an identity
@@ -323,6 +331,24 @@ class AuthConfig(BaseSettings):
         "pre-provisioned accounts can log in. Independent of public/single-user "
         "mode — use for private, login-required public-facing instances.",
     )
+    password_login_disabled: bool = Field(
+        default=False,
+        description="Block email + password sign-in. When True the /auth/login "
+        "endpoint returns 403 and the password form is hidden, leaving Google "
+        "OAuth as the only door in. Pairs with registration_disabled for an "
+        "instance whose accounts all come from one identity provider. Ignored "
+        "unless google_oauth_enabled is set, so a half-done configuration "
+        "cannot lock every user out.",
+    )
+    public_access_code: Optional[SecretStr] = Field(
+        default=None,
+        description="Shared access code gating public mode. Public mode otherwise "
+        "hands a temporary session to anyone who loads the page; with this set, a "
+        "visitor must enter the code first, so a deployment can be link-shareable "
+        "without being world-open. Ignored outside public/demo mode. It is a shared "
+        "secret, not an account: everyone who passes it still gets their own "
+        "throwaway user.",
+    )
     anonymous_user_email: str = Field(
         default="anonymous@depict.io",
         description="Default anonymous user email",
@@ -387,6 +413,10 @@ class AuthConfig(BaseSettings):
         if env_registration_disabled in ("true", "1", "yes"):
             object.__setattr__(self, "registration_disabled", True)
 
+        env_password_login_disabled = os.getenv("DEPICTIO_AUTH_PASSWORD_LOGIN_DISABLED", "").lower()
+        if env_password_login_disabled in ("true", "1", "yes"):
+            object.__setattr__(self, "password_login_disabled", True)
+
     @computed_field
     @property
     def is_single_user_mode(self) -> bool:
@@ -419,6 +449,39 @@ class AuthConfig(BaseSettings):
     def requires_anonymous_user(self) -> bool:
         """Returns True if any mode requiring anonymous user is enabled."""
         return self.is_single_user_mode or self.is_public_mode
+
+    @computed_field
+    @property
+    def is_public_access_code_required(self) -> bool:
+        """Returns True if public mode should ask for the shared access code.
+
+        Only meaningful in public mode: outside it the code gates nothing, and
+        reporting it as required would put a lock on a door that is not there.
+        """
+        return bool(self.public_access_code and self.is_public_mode)
+
+    def verify_public_access_code(self, candidate: str | None) -> bool:
+        """Constant-time check of a submitted access code."""
+        if not self.is_public_access_code_required:
+            return True
+        if not candidate:
+            return False
+        return secrets.compare_digest(
+            candidate,
+            self.public_access_code.get_secret_value(),  # type: ignore[possibly-unbound-attribute]
+        )
+
+    @computed_field
+    @property
+    def is_password_login_disabled(self) -> bool:
+        """Returns True if email + password sign-in should be refused.
+
+        Conditioned on Google OAuth actually being configured: the flag on its
+        own would leave a deployment with no way in at all, and an operator who
+        sets it while forgetting the OAuth vars should get their password form
+        back rather than a locked front door. Read this, not the raw flag.
+        """
+        return self.password_login_disabled and self.google_oauth_enabled
 
     @computed_field
     @property
@@ -1288,7 +1351,9 @@ class BrandingConfig(BaseSettings):
        no flat env var of their own.
     3. The flat vars below.
 
-    The "Powered by Depictio" header badge is deliberately not affected.
+    The "Powered by Depictio" attribution follows the logo: it is shown exactly
+    when the depictio wordmark is not, i.e. once a layer sets ``logo_mode`` to
+    ``custom`` or ``none``. A stock deployment shows the wordmark and no badge.
     """
 
     preset: Optional[str] = Field(

--- a/depictio/api/v1/db.py
+++ b/depictio/api/v1/db.py
@@ -63,5 +63,7 @@ multiqc_prerender_collection = db[settings.mongodb.collections.multiqc_prerender
 task_events_collection = db[settings.mongodb.collections.task_events_collection]
 ingestion_runs_collection = db[settings.mongodb.collections.ingestion_runs_collection]
 app_logs_collection = db[settings.mongodb.collections.app_logs_collection]
+instance_settings_collection = db[settings.mongodb.collections.instance_settings_collection]
+branding_assets_collection = db[settings.mongodb.collections.branding_assets_collection]
 telemetry_collection = db[settings.mongodb.collections.telemetry_collection]
 test_collection = db[settings.mongodb.collections.test_collection]

--- a/depictio/api/v1/db_init.py
+++ b/depictio/api/v1/db_init.py
@@ -675,11 +675,28 @@ async def _bootstrap_admin_and_test_user() -> tuple[UserBeanie | None, dict | No
                     "(no DEPICTIO_BOOTSTRAP_ADMIN_* set)",
                     admin_email,
                 )
+            elif settings.auth.is_password_login_disabled and admin_email:
+                # Google OAuth is the only door in, so this admin's password
+                # can never be used to reach it: /auth/login refuses every
+                # attempt. Requiring one anyway would make an operator invent a
+                # secret whose only job is to be unusable. The email is still
+                # required — it is what the OAuth login matches the admin on
+                # (`create_or_get_user` looks the account up by email), so
+                # setting it to your own Google address is what makes you the
+                # admin without any seeded local account.
+                admin_password = secrets.token_urlsafe(32)
+                logger.info(
+                    "Password sign-in disabled: seeding admin '%s' with an unusable "
+                    "random password; sign in to it with Google",
+                    admin_email,
+                )
             else:
                 raise RuntimeError(
                     "No admin user exists in MongoDB and DEPICTIO_BOOTSTRAP_ADMIN_EMAIL / "
                     "DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD are not set. Set both env vars (via a "
-                    "Kubernetes Secret in production) so the first-boot admin can be created."
+                    "Kubernetes Secret in production) so the first-boot admin can be created. "
+                    "With DEPICTIO_AUTH_PASSWORD_LOGIN_DISABLED=true, the email alone is "
+                    "enough: set it to the Google address that should own the instance."
                 )
 
         logger.info(

--- a/depictio/api/v1/endpoints/backup_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/backup_endpoints/routes.py
@@ -13,11 +13,13 @@ from pymongo.collection import Collection
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
 from depictio.api.v1.db import (
+    branding_assets_collection,
     dashboards_collection,
     data_collections_collection,
     deltatables_collection,
     files_collection,
     groups_collection,
+    instance_settings_collection,
     projects_collection,
     runs_collection,
     users_collection,
@@ -179,6 +181,12 @@ async def _create_mongodb_backup(current_user: User) -> dict:
         "deltatables": {"collection": deltatables_collection, "exclude_filter": {}},
         "runs": {"collection": runs_collection, "exclude_filter": {}},
         "groups": {"collection": groups_collection, "exclude_filter": {}},
+        # Instance branding: the overrides singleton and the uploaded logo
+        # bytes it points at. Both are needed, or a restore brings back every
+        # dashboard's `brand_theme` while losing the instance identity those
+        # themes inherit from.
+        "instance_settings": {"collection": instance_settings_collection, "exclude_filter": {}},
+        "branding_assets": {"collection": branding_assets_collection, "exclude_filter": {}},
     }
 
     # First, get list of temporary user IDs to exclude their resources
@@ -594,6 +602,8 @@ async def restore_backup(
             "deltatables": deltatables_collection,
             "runs": runs_collection,
             "groups": groups_collection,
+            "instance_settings": instance_settings_collection,
+            "branding_assets": branding_assets_collection,
         }
 
         collections_to_restore = request.collections or list(data_section.keys())

--- a/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/dashboards_endpoints/routes.py
@@ -6,7 +6,6 @@ import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 from typing import Annotated, Any
 from uuid import UUID
 
@@ -33,7 +32,14 @@ from depictio.api.v1.endpoints.user_endpoints.routes import (
     oauth2_scheme_optional,
 )
 from depictio.api.v1.filter_links import extend_filters_via_links
-from depictio.api.v1.services.branding import validate_logo_upload
+from depictio.api.v1.services.branding import (
+    LOGO_CACHE_CONTROL,
+    dashboard_logo_key,
+    delete_logo_asset,
+    read_logo_asset,
+    store_logo_asset,
+    validate_logo_upload,
+)
 from depictio.api.v1.services.card_breakdown import (
     BREAKDOWN_LAYOUTS,
     compute_breakdown,
@@ -710,12 +716,6 @@ async def save_dashboard(
         raise HTTPException(status_code=404, detail="Failed to insert or update dashboard data.")
 
 
-# Dashboard logos — uploaded through the editor's Settings drawer and served
-# by the /static/dashboard_logos mount (api/main.py). Derived from __file__ so
-# the path holds both in Docker (/app/depictio/...) and local runs.
-_DASHBOARD_LOGOS_DIR = Path(__file__).resolve().parents[3] / "static" / "dashboard_logos"
-
-
 def _require_dashboard_editor(dashboard_id: PyObjectId, current_user: User) -> dict:
     """The dashboard document, or the right HTTP error. Editor rights required."""
     if hasattr(current_user, "is_anonymous") and current_user.is_anonymous:
@@ -767,10 +767,10 @@ async def upload_dashboard_logo(
 ):
     """Store a dashboard logo image and stamp it on the document's brand theme.
 
-    File write and field update happen in one ownership-checked call so the
-    stored URL can never point at a file that was rejected. Removal goes
-    through `/appearance` (`logo_mode: "inherit"` or `"none"`); the file on
-    disk is simply overwritten by the next upload for this dashboard.
+    Asset write and field update happen in one ownership-checked call so the
+    stored URL can never point at an image that was rejected. Removal goes
+    through `/appearance` (`logo_mode: "inherit"` or `"none"`); the stored
+    bytes are simply overwritten by the next upload for this dashboard.
 
     Validation is the shared one from `services/branding.py` — same PNG/JPEG/
     WebP + magic-byte + 2MB rules as the instance logo, deliberately not a
@@ -780,19 +780,13 @@ async def upload_dashboard_logo(
 
     content = await file.read()
     try:
-        ext = validate_logo_upload(file.content_type, content)
+        validate_logo_upload(file.content_type, content)
     except ValueError as exc:
         raise HTTPException(status_code=415, detail=str(exc))
 
-    _DASHBOARD_LOGOS_DIR.mkdir(parents=True, exist_ok=True)
-    # One logo per dashboard — drop whatever extension the previous upload had.
-    for old in _DASHBOARD_LOGOS_DIR.glob(f"{dashboard_id}.*"):
-        old.unlink(missing_ok=True)
-    (_DASHBOARD_LOGOS_DIR / f"{dashboard_id}{ext}").write_bytes(content)
-
-    # `?v=` cache-busts the browser after a replacement (same idiom as the
-    # screenshot thumbnails' `screenshot_ts`).
-    logo_url = f"/static/dashboard_logos/{dashboard_id}{ext}?v={int(time.time())}"
+    # One asset per dashboard, keyed by its id, so a replacement overwrites the
+    # previous bytes.
+    logo_url = store_logo_asset(dashboard_logo_key(dashboard_id), content, file.content_type)
     theme = BrandTheme(**(dashboard.get("brand_theme") or {}))
     theme.logo_url = logo_url
     # An upload is an unambiguous "use this logo", so it also lifts a prior
@@ -802,8 +796,27 @@ async def upload_dashboard_logo(
         {"dashboard_id": dashboard_id},
         {"$set": {"brand_theme": theme.model_dump(exclude_none=True)}},
     )
-    logger.info(f"Dashboard {dashboard_id} logo updated ({len(content)} bytes, {ext})")
+    logger.info(f"Dashboard {dashboard_id} logo updated ({len(content)} bytes)")
     return {"logo_url": logo_url}
+
+
+@dashboards_endpoint_router.get("/logo/{dashboard_id}")
+async def get_dashboard_logo(dashboard_id: PyObjectId):
+    """Serve a dashboard's stored logo.
+
+    Unauthenticated, matching what `/static/dashboard_logos` served before the
+    bytes moved into MongoDB: the image is one an editor deliberately put on a
+    dashboard, and gating it would break the public/demo viewer.
+    """
+    asset = read_logo_asset(dashboard_logo_key(dashboard_id))
+    if asset is None:
+        raise HTTPException(status_code=404, detail="No logo stored for this dashboard.")
+    content, content_type = asset
+    return Response(
+        content=content,
+        media_type=content_type,
+        headers={"Cache-Control": LOGO_CACHE_CONTROL},
+    )
 
 
 @dashboards_endpoint_router.delete("/delete/{dashboard_id}")
@@ -848,6 +861,9 @@ async def delete_dashboard(
     result = dashboards_collection.delete_one({"dashboard_id": dashboard_id})
 
     if result.deleted_count > 0:
+        # The dashboard's uploaded logo has no other referent, so it goes with
+        # it rather than sitting in `branding_assets` forever.
+        delete_logo_asset(dashboard_logo_key(dashboard_id))
         message = f"Dashboard with ID '{str(dashboard_id)}' deleted successfully."
         if child_tabs_deleted > 0:
             message += f" Also deleted {child_tabs_deleted} child tabs."

--- a/depictio/api/v1/endpoints/user_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/user_endpoints/routes.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 
 from beanie import PydanticObjectId
 from bson import ObjectId
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
 
@@ -174,6 +174,17 @@ async def login(
             raise HTTPException(status_code=500, detail="Failed to create session token")
         token.logged_in = True
         return token
+
+    # Instances that source every account from one identity provider can close
+    # this door (`DEPICTIO_AUTH_PASSWORD_LOGIN_DISABLED`). Checked after the
+    # single-user branch above, which has no password to refuse, and read
+    # through the computed property so it only bites when Google OAuth is
+    # actually configured.
+    if settings.auth.is_password_login_disabled:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password sign-in is disabled on this instance. Use Google sign-in.",
+        )
 
     password_valid = await _check_password(login_request.username, login_request.password)
     if not password_valid:
@@ -650,6 +661,13 @@ async def get_current_user_info_optional(
         "is_single_user_mode": settings.auth.is_single_user_mode,
         "is_demo_mode": getattr(settings.auth, "is_demo_mode", False),
         "registration_disabled": getattr(settings.auth, "registration_disabled", False),
+        # Effective, not the raw flag: the SPA must not hide the password form
+        # on an instance where Google OAuth was never configured.
+        "password_login_disabled": getattr(settings.auth, "is_password_login_disabled", False),
+        # Whether public mode asks for the shared code — never the code itself.
+        "public_access_code_required": getattr(
+            settings.auth, "is_public_access_code_required", False
+        ),
         "is_dev_mode": is_dev_mode,
         "walkthrough_disabled": walkthrough_disabled,
         "unauthenticated_mode": getattr(settings.auth, "unauthenticated_mode", False),
@@ -789,12 +807,18 @@ async def cleanup_expired_temporary_users_endpoint(
 
 
 @auth_endpoint_router.post("/public/create_temporary_user", include_in_schema=True)
-async def create_temporary_user_public(request: Request) -> dict:
+async def create_temporary_user_public(request: Request, body: dict | None = Body(None)) -> dict:
     """Create a temporary user for the React /auth SPA in public mode.
 
     Public-facing variant of ``/create_temporary_user`` (no API key). Disabled
     outside public mode and rate-limited per IP. Expiry is taken from settings
     so the SPA doesn't need to (and shouldn't be able to) override it.
+
+    When ``DEPICTIO_AUTH_PUBLIC_ACCESS_CODE`` is set, the request must carry it
+    as ``access_code``. That is what separates a link-shareable deployment from
+    a world-open one: without it, public mode hands a session to anyone who
+    loads the page. The check is server-side because the SPA hiding a form
+    would stop nobody from calling this endpoint directly.
     """
     if not settings.auth.is_public_mode:
         raise HTTPException(
@@ -802,7 +826,13 @@ async def create_temporary_user_public(request: Request) -> dict:
             detail="Temporary users only available in public mode",
         )
 
+    # Rate-limited before the code check so the shared secret cannot be
+    # brute-forced any faster than any other credential on this endpoint.
     enforce_rate_limit(request, "public/create_temporary_user")
+
+    if not settings.auth.verify_public_access_code((body or {}).get("access_code")):
+        logger.warning("Public access code rejected for temporary-user request")
+        raise HTTPException(status_code=403, detail="Invalid access code.")
 
     temp_user = await _create_temporary_user(
         expiry_hours=settings.auth.temporary_user_expiry_hours,

--- a/depictio/api/v1/endpoints/utils_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/utils_endpoints/routes.py
@@ -1,10 +1,17 @@
 import asyncio
-import time
 from datetime import datetime
-from pathlib import Path
 from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, Header, HTTPException, UploadFile
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    Header,
+    HTTPException,
+    Response,
+    UploadFile,
+)
 
 from depictio.api.v1.configs.config import settings
 from depictio.api.v1.configs.logging_init import logger
@@ -149,9 +156,6 @@ async def public_config():
 # rule is enforced by the model's own validators (FastAPI turns their
 # ValueErrors into 422s) rather than by a hand-written mirror that can drift.
 
-# Uploaded branding logos; served by the /static/branding mount (api/main.py).
-_BRANDING_LOGOS_DIR = Path(__file__).resolve().parents[3] / "static" / "branding"
-
 
 def _require_admin(current_user) -> None:
     if not getattr(current_user, "is_admin", False):
@@ -250,22 +254,26 @@ async def upload_branding_logo(
     file: UploadFile = File(...),
     current_user=Depends(get_current_user),
 ):
-    """Store an instance logo (light or dark variant) and point the override at it."""
+    """Store an instance logo (light or dark variant) and point the override at it.
+
+    The bytes go to MongoDB, not to the container's filesystem: the theme
+    document survives a rebuild and its logo has to survive with it.
+    """
     _require_admin(current_user)
-    from depictio.api.v1.services.branding import patch_brand_theme_overrides, validate_logo_upload
+    from depictio.api.v1.services.branding import (
+        instance_logo_key,
+        patch_brand_theme_overrides,
+        store_logo_asset,
+        validate_logo_upload,
+    )
 
     content = await file.read()
     try:
-        ext = validate_logo_upload(file.content_type, content)
+        validate_logo_upload(file.content_type, content)
     except ValueError as exc:
         raise HTTPException(status_code=415, detail=str(exc))
 
-    _BRANDING_LOGOS_DIR.mkdir(parents=True, exist_ok=True)
-    for old in _BRANDING_LOGOS_DIR.glob(f"logo_{variant}.*"):
-        old.unlink(missing_ok=True)
-    (_BRANDING_LOGOS_DIR / f"logo_{variant}{ext}").write_bytes(content)
-
-    logo_url = f"/static/branding/logo_{variant}{ext}?v={int(time.time())}"
+    logo_url = store_logo_asset(instance_logo_key(variant), content, file.content_type)
     patch = {"logo_url" if variant == "light" else "logo_url_dark": logo_url}
     # An upload is an unambiguous "use this logo", so it also lifts a prior
     # "no logo" choice rather than silently storing an unused URL.
@@ -274,6 +282,31 @@ async def upload_branding_logo(
     patch_brand_theme_overrides(patch)
     logger.info(f"Branding logo ({variant}) updated by {getattr(current_user, 'email', '?')}")
     return _branding_admin_view()
+
+
+@utils_endpoint_router.get("/branding/logo/{variant}")
+async def get_branding_logo(variant: Literal["light", "dark"]):
+    """Serve a stored instance logo.
+
+    Deliberately unauthenticated: the login card renders the deployment's logo
+    before anyone has signed in, and this is the same image `/static/branding`
+    served to everyone before the bytes moved into MongoDB.
+    """
+    from depictio.api.v1.services.branding import (
+        LOGO_CACHE_CONTROL,
+        instance_logo_key,
+        read_logo_asset,
+    )
+
+    asset = read_logo_asset(instance_logo_key(variant))
+    if asset is None:
+        raise HTTPException(status_code=404, detail="No logo stored for this variant.")
+    content, content_type = asset
+    return Response(
+        content=content,
+        media_type=content_type,
+        headers={"Cache-Control": LOGO_CACHE_CONTROL},
+    )
 
 
 @utils_endpoint_router.get("/telemetry/preview")

--- a/depictio/api/v1/services/branding.py
+++ b/depictio/api/v1/services/branding.py
@@ -226,8 +226,9 @@ def validate_logo_upload(content_type: str | None, content: bytes) -> str:
 branding_assets_collection: Any = None
 
 _API_PREFIX = f"/depictio/api/{get_api_version()}"
-#: Only reached by a document stored without one — every upload path goes
-#: through `validate_logo_upload`, which admits nothing but the LOGO_TYPES.
+
+#: Only reached by a document stored without a content type — every upload path
+#: goes through `validate_logo_upload`, which admits nothing but the LOGO_TYPES.
 _FALLBACK_CONTENT_TYPE = "application/octet-stream"
 
 

--- a/depictio/api/v1/services/branding.py
+++ b/depictio/api/v1/services/branding.py
@@ -28,7 +28,9 @@ in-process (other processes catch up within the TTL).
 
 from __future__ import annotations
 
+import base64
 import time
+from pathlib import Path
 from typing import Any, Optional
 
 import pymongo
@@ -42,6 +44,7 @@ from depictio.models.models.branding import (
     merge_brand_themes,
     resolve_brand_theme,
 )
+from depictio.version import get_api_version
 
 _DOC_ID = "branding"
 
@@ -52,14 +55,24 @@ _DOC_ID = "branding"
 # not stall every render for half a minute. Tests inject a fake here.
 instance_settings_collection: Any = None
 
+_client: Optional[pymongo.MongoClient] = None
+
+
+def _get_client() -> pymongo.MongoClient:
+    global _client
+    if _client is None:
+        _client = pymongo.MongoClient(
+            MONGODB_URL, serverSelectionTimeoutMS=2000, connectTimeoutMS=2000
+        )
+    return _client
+
 
 def _get_collection() -> Any:
     global instance_settings_collection
     if instance_settings_collection is None:
-        client: pymongo.MongoClient = pymongo.MongoClient(
-            MONGODB_URL, serverSelectionTimeoutMS=2000, connectTimeoutMS=2000
-        )
-        instance_settings_collection = client[settings.mongodb.db_name]["instance_settings"]
+        instance_settings_collection = _get_client()[settings.mongodb.db_name][
+            settings.mongodb.collections.instance_settings_collection
+        ]
     return instance_settings_collection
 
 
@@ -199,11 +212,216 @@ def validate_logo_upload(content_type: str | None, content: bytes) -> str:
     return ext
 
 
+# ── Uploaded logo storage ─────────────────────────────────────────────────────
+# Logos live in MongoDB, not on the API container's filesystem. A theme document
+# only ever holds a URL, and that URL used to point into
+# `depictio/api/static/branding/` (or `.../dashboard_logos/`): gitignored, with
+# no compose volume and no Helm PVC behind it, so a rebuild or a redeploy left
+# the document claiming a logo whose bytes were gone. `validate_logo_upload`
+# caps an upload at LOGO_MAX_BYTES, so an asset sits far under Mongo's 16MB
+# limit.
+
+#: Same dedicated-client rationale as `instance_settings_collection` above, and
+#: the same injection point for tests.
+branding_assets_collection: Any = None
+
+_API_PREFIX = f"/depictio/api/{get_api_version()}"
+#: Only reached by a document stored without one — every upload path goes
+#: through `validate_logo_upload`, which admits nothing but the LOGO_TYPES.
+_FALLBACK_CONTENT_TYPE = "application/octet-stream"
+
+
+def _get_assets_collection() -> Any:
+    global branding_assets_collection
+    if branding_assets_collection is None:
+        branding_assets_collection = _get_client()[settings.mongodb.db_name][
+            settings.mongodb.collections.branding_assets_collection
+        ]
+    return branding_assets_collection
+
+
+def instance_logo_key(variant: str) -> str:
+    """Asset key for an instance logo variant (``light`` / ``dark``)."""
+    return f"instance-{variant}"
+
+
+def dashboard_logo_key(dashboard_id: Any) -> str:
+    """Asset key for a dashboard's own logo."""
+    return f"dashboard-{dashboard_id}"
+
+
+def logo_asset_url(key: str) -> str:
+    """The URL serving ``key``, cache-busted so a replacement shows up at once.
+
+    ``?v=`` mirrors the screenshot thumbnails' `screenshot_ts` idiom: the path
+    is stable, so without it a browser keeps the previous logo after an upload.
+    """
+    if key.startswith("instance-"):
+        endpoint = f"utils/branding/logo/{key.removeprefix('instance-')}"
+    else:
+        endpoint = f"dashboards/logo/{key.removeprefix('dashboard-')}"
+    return f"{_API_PREFIX}/{endpoint}?v={int(time.time())}"
+
+
+#: What the logo endpoints answer with. Safe because `logo_asset_url` mints a
+#: fresh ``?v=`` on every upload: the bytes behind a given URL never change.
+LOGO_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+def store_logo_asset(key: str, content: bytes, content_type: str | None) -> str:
+    """Store (or replace) a logo's bytes. Returns the URL to put on the theme.
+
+    ``content_type`` is the upload's declared type, already checked against the
+    magic bytes by `validate_logo_upload`; it is optional only because
+    ``UploadFile.content_type`` is.
+
+    Base64 rather than BSON ``Binary`` so the document is plain JSON: the
+    backup endpoint serialises with ``json.dump(..., default=str)``, which
+    would turn raw bytes into an unrestorable ``repr``. The ~33% overhead on an
+    asset capped at LOGO_MAX_BYTES is worth a brand that survives a restore.
+    """
+    _get_assets_collection().replace_one(
+        {"_id": key},
+        {
+            "content_type": content_type or _FALLBACK_CONTENT_TYPE,
+            "data_b64": base64.b64encode(content).decode("ascii"),
+            "updated_at": int(time.time()),
+        },
+        upsert=True,
+    )
+    return logo_asset_url(key)
+
+
+def read_logo_asset(key: str) -> Optional[tuple[bytes, str]]:
+    """A stored logo's ``(bytes, content_type)``, or ``None`` when absent."""
+    doc = _get_assets_collection().find_one({"_id": key})
+    if not doc or not doc.get("data_b64"):
+        return None
+    return (
+        base64.b64decode(doc["data_b64"]),
+        doc.get("content_type") or _FALLBACK_CONTENT_TYPE,
+    )
+
+
+def delete_logo_asset(key: str) -> None:
+    """Drop a stored logo. Used when the thing it belonged to is deleted."""
+    _get_assets_collection().delete_one({"_id": key})
+
+
+def content_type_for_extension(ext: str) -> Optional[str]:
+    """Reverse of `LOGO_TYPES`, for importing files written before the rework."""
+    for content_type, (known_ext, _) in LOGO_TYPES.items():
+        if known_ext == ext.lower():
+            return content_type
+    return None
+
+
+# ── Migration off the filesystem ──────────────────────────────────────────────
+
+#: Where uploads landed before the bytes moved into MongoDB. Kept as a read
+#: source only. Derived from ``__file__`` so the path holds both in Docker
+#: (/app/depictio/...) and in a local run.
+_LEGACY_STATIC_DIR = Path(__file__).resolve().parents[2] / "static"
+_LEGACY_INSTANCE_URL_PREFIX = "/static/branding/"
+_LEGACY_DASHBOARD_URL_PREFIX = "/static/dashboard_logos/"
+
+
+def _import_legacy_file(key: str, path: Path) -> Optional[str]:
+    """Import one on-disk logo, returning its new URL (``None`` if unusable)."""
+    content_type = content_type_for_extension(path.suffix)
+    if content_type is None:
+        logger.warning(f"Skipping legacy logo with unsupported extension: {path.name}")
+        return None
+    return store_logo_asset(key, path.read_bytes(), content_type)
+
+
+def _migrate_instance_logos() -> int:
+    """Import the instance's own logo files. Returns how many moved."""
+    overrides = get_brand_theme_overrides()
+    migrated = 0
+    for variant, field in (("light", "logo_url"), ("dark", "logo_url_dark")):
+        current = getattr(overrides, field, None)
+        if not current or not current.startswith(_LEGACY_INSTANCE_URL_PREFIX):
+            continue
+        matches = sorted(_LEGACY_STATIC_DIR.glob(f"branding/logo_{variant}.*"))
+        if not matches:
+            logger.warning(
+                f"Instance {variant} logo points at {current} but the file is gone; "
+                "the brand keeps its other settings and the logo needs re-uploading."
+            )
+            continue
+        new_url = _import_legacy_file(instance_logo_key(variant), matches[0])
+        if new_url:
+            patch_brand_theme_overrides({field: new_url})
+            migrated += 1
+    return migrated
+
+
+def _migrate_dashboard_logos() -> int:
+    """Import per-dashboard logo files. Returns how many moved."""
+    from depictio.api.v1.db import dashboards_collection
+
+    migrated = 0
+    for doc in dashboards_collection.find(
+        {"brand_theme.logo_url": {"$regex": f"^{_LEGACY_DASHBOARD_URL_PREFIX}"}},
+        {"dashboard_id": 1, "brand_theme": 1},
+    ):
+        dashboard_id = doc["dashboard_id"]
+        matches = sorted(_LEGACY_STATIC_DIR.glob(f"dashboard_logos/{dashboard_id}.*"))
+        if not matches:
+            continue
+        new_url = _import_legacy_file(dashboard_logo_key(dashboard_id), matches[0])
+        if new_url:
+            dashboards_collection.update_one(
+                {"dashboard_id": dashboard_id},
+                {"$set": {"brand_theme.logo_url": new_url}},
+            )
+            migrated += 1
+    return migrated
+
+
+def migrate_legacy_logo_files() -> int:
+    """Move logos left on the container filesystem into MongoDB.
+
+    Picks up the documents still holding a ``/static/...`` URL from before the
+    move described above, and rewrites them to the new endpoints.
+
+    Runs on every boot and is a no-op once the directories are empty, which is
+    the steady state after the first migrated start. Never raises, and the two
+    halves are independent: a deployment must still come up if a logo cannot be
+    moved, and a dashboard that trips over something must not cost the instance
+    its own logo.
+    """
+    migrated = 0
+    for step, migrate in (
+        ("instance", _migrate_instance_logos),
+        ("dashboard", _migrate_dashboard_logos),
+    ):
+        try:
+            migrated += migrate()
+        except Exception as exc:
+            logger.warning(f"Migration of {step} logos to MongoDB skipped: {exc}")
+
+    if migrated:
+        logger.info(f"Migrated {migrated} uploaded logo(s) from the filesystem into MongoDB")
+    return migrated
+
+
 __all__ = [
     "HEX_COLOR_RE",
+    "LOGO_CACHE_CONTROL",
     "LOGO_MAX_BYTES",
     "LOGO_TYPES",
     "PALETTE_NAME_RE",
+    "branding_assets_collection",
+    "content_type_for_extension",
+    "dashboard_logo_key",
+    "delete_logo_asset",
+    "instance_logo_key",
+    "logo_asset_url",
+    "migrate_legacy_logo_files",
+    "read_logo_asset",
+    "store_logo_asset",
     "env_brand_theme",
     "get_brand_theme_overrides",
     "get_effective_brand_theme",

--- a/depictio/api/v1/services/lifespan.py
+++ b/depictio/api/v1/services/lifespan.py
@@ -20,6 +20,7 @@ from depictio.api.v1.configs.config import MONGODB_URL, settings
 from depictio.api.v1.configs.logging_init import logger
 from depictio.api.v1.initialization import run_initialization
 from depictio.api.v1.services.background_tasks import delayed_process_data_collections
+from depictio.api.v1.services.branding import migrate_legacy_logo_files
 from depictio.api.v1.services.events import event_service
 from depictio.api.v1.services.initialization import (
     check_and_set_initialization,
@@ -338,6 +339,10 @@ async def lifespan(_app: FastAPI):
     # Startup
     await init_motor_beanie()
     should_initialize = await handle_initialization()
+    # Deliberately outside the `should_initialize` branch: an already-initialised
+    # deployment never re-runs initialization, and it is exactly the deployment
+    # whose logos are still on the filesystem. No-op once they have moved.
+    migrate_legacy_logo_files()
     background_task = start_background_services(should_initialize)
     start_yaml_services(should_initialize)
     await start_event_services(should_initialize)

--- a/depictio/tests/api/v1/test_security_pr1.py
+++ b/depictio/tests/api/v1/test_security_pr1.py
@@ -369,6 +369,95 @@ async def test_register_blocked_when_registration_disabled():
 
 
 @pytest.mark.asyncio
+async def test_login_blocked_when_password_login_disabled():
+    """With DEPICTIO_AUTH_PASSWORD_LOGIN_DISABLED set (and Google OAuth
+    configured), /login must 403 before checking any credential, so the
+    password door is closed rather than merely hidden in the UI."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from fastapi import HTTPException
+
+    from depictio.api.v1.endpoints.user_endpoints import routes as user_routes
+
+    mock_settings = MagicMock()
+    mock_settings.auth.is_single_user_mode = False
+    mock_settings.auth.is_password_login_disabled = True
+
+    login_request = MagicMock(username="someone@example.com", password="hunter2hunter2")
+    check_password = AsyncMock(return_value=True)
+    with (
+        patch.object(user_routes, "settings", mock_settings),
+        patch.object(user_routes, "enforce_rate_limit"),
+        patch.object(user_routes, "_check_password", check_password),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await user_routes.login(MagicMock(), login_request)
+
+    assert exc_info.value.status_code == 403  # type: ignore[unresolved-attribute]
+    # Refused before the credential is even looked at — a valid password must
+    # not be a way around the setting.
+    check_password.assert_not_awaited()
+
+
+def test_password_login_disabled_is_ignored_without_oauth():
+    """The flag alone would leave a deployment with no way in, so the computed
+    property only reports it as disabled once Google OAuth is configured."""
+    from depictio.api.v1.configs.settings_models import AuthConfig
+
+    assert AuthConfig(password_login_disabled=True).is_password_login_disabled is False
+    assert (
+        AuthConfig(
+            password_login_disabled=True, google_oauth_enabled=True
+        ).is_password_login_disabled
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_temporary_user_requires_the_access_code():
+    """A protected public deployment must refuse a session to a caller that
+    does not present the shared code, whatever the SPA chose to render."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from fastapi import HTTPException
+
+    from depictio.api.v1.endpoints.user_endpoints import routes as user_routes
+
+    mock_settings = MagicMock()
+    mock_settings.auth.is_public_mode = True
+    mock_settings.auth.verify_public_access_code.return_value = False
+
+    create_temp = AsyncMock()
+    with (
+        patch.object(user_routes, "settings", mock_settings),
+        patch.object(user_routes, "enforce_rate_limit"),
+        patch.object(user_routes, "_create_temporary_user", create_temp),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await user_routes.create_temporary_user_public(MagicMock(), {"access_code": "wrong"})
+
+    assert exc_info.value.status_code == 403  # type: ignore[unresolved-attribute]
+    create_temp.assert_not_awaited()
+
+
+def test_public_access_code_gates_only_public_mode():
+    """The code is meaningless outside public mode, and an open public
+    deployment must keep working with no code at all."""
+    from depictio.api.v1.configs.settings_models import AuthConfig
+
+    gated = AuthConfig(public_mode=True, public_access_code="s3cret")
+    assert gated.is_public_access_code_required is True
+    assert gated.verify_public_access_code("s3cret") is True
+    assert gated.verify_public_access_code("nope") is False
+    assert gated.verify_public_access_code(None) is False
+
+    # Not public: the code gates nothing, so it must not report as required.
+    assert AuthConfig(public_access_code="s3cret").is_public_access_code_required is False
+    # Public with no code: unchanged, anyone gets a session.
+    assert AuthConfig(public_mode=True).verify_public_access_code(None) is True
+
+
+@pytest.mark.asyncio
 async def test_oauth_create_or_get_user_blocks_unknown_when_create_disallowed():
     """With registration disabled, OAuth must not provision a new account for
     an unknown email — create_or_get_user(allow_create=False) returns

--- a/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
@@ -118,4 +118,35 @@ test.describe("Instance brand theme", () => {
     await page.locator("[data-testid='branding-reset']").click();
     await expect.poll(() => cssVar(page, "--mantine-color-blue-6")).not.toBe(TREC_PRIMARY);
   });
+
+  test("the attribution appears only once the depictio logo is gone", async ({
+    loginAsAdmin,
+    page,
+    request,
+  }) => {
+    const { access_token } = await loginAsTestUser(page, request, "adminUser");
+    const headers = { Authorization: `Bearer ${access_token}` };
+    const url = `${API_URL}${API_PREFIX}/utils/branding`;
+    const attribution = page.locator("[data-testid='powered-by']");
+
+    await loginAsAdmin();
+
+    // Stock instance: the depictio wordmark is already in the rail, so a badge
+    // repeating it would be noise.
+    await request.delete(url, { headers });
+    await page.goto("/dashboards");
+    const rail = page.locator("[data-testid='app-sidebar']");
+    await expect(rail).toBeVisible({ timeout: 15_000 });
+    // The rail is what carries the attribution, so its own theme toggle being
+    // painted means the footer stack rendered and a count of 0 is a real
+    // absence rather than a not-yet.
+    await expect(rail.locator("[data-testid='theme-toggle']")).toBeVisible();
+    await expect(attribution).toHaveCount(0);
+
+    // `logo_mode: "none"` takes the wordmark off the screen, which is exactly
+    // when the attribution has to carry it instead.
+    await request.put(url, { headers, data: { logo_mode: "none" } });
+    await page.reload();
+    await expect(attribution).toHaveCount(1);
+  });
 });

--- a/depictio/tests/unit/test_branding_service.py
+++ b/depictio/tests/unit/test_branding_service.py
@@ -1,5 +1,7 @@
 """Instance brand theme service: env/DB merge, derivation, cache, upload rules."""
 
+import json
+
 import pytest
 
 from depictio.api.v1.services import branding as branding_svc
@@ -167,3 +169,164 @@ class TestLogoUploadValidation:
         big = PNG + b"0" * branding_svc.LOGO_MAX_BYTES
         with pytest.raises(ValueError, match="too large"):
             branding_svc.validate_logo_upload("image/png", big)
+
+
+@pytest.fixture()
+def fake_assets(monkeypatch):
+    fake = FakeCollection()
+    monkeypatch.setattr(branding_svc, "branding_assets_collection", fake)
+    return fake
+
+
+class TestLogoAssetStore:
+    """Uploaded logos live in MongoDB, so a rebuild cannot orphan the theme."""
+
+    def test_round_trip_preserves_bytes_and_type(self, fake_assets):
+        branding_svc.store_logo_asset("instance-light", PNG, "image/png")
+        assert branding_svc.read_logo_asset("instance-light") == (PNG, "image/png")
+
+    def test_missing_asset_reads_as_none(self, fake_assets):
+        assert branding_svc.read_logo_asset("instance-dark") is None
+
+    def test_replacing_keeps_one_document_per_key(self, fake_assets):
+        branding_svc.store_logo_asset("instance-light", PNG, "image/png")
+        branding_svc.store_logo_asset("instance-light", JPEG, "image/jpeg")
+        assert branding_svc.read_logo_asset("instance-light") == (JPEG, "image/jpeg")
+        assert len(fake_assets.docs) == 1
+
+    def test_delete_removes_the_asset(self, fake_assets):
+        branding_svc.store_logo_asset("dashboard-abc", PNG, "image/png")
+        branding_svc.delete_logo_asset("dashboard-abc")
+        assert branding_svc.read_logo_asset("dashboard-abc") is None
+
+    def test_stored_document_is_json_serialisable(self, fake_assets):
+        """The backup endpoint dumps with `json.dump(..., default=str)`, which
+        turns raw bytes into an unrestorable repr. Base64 is what keeps a
+        backed-up brand restorable."""
+        branding_svc.store_logo_asset("instance-light", PNG, "image/png")
+        doc = fake_assets.docs["instance-light"]
+        assert isinstance(doc["data_b64"], str)
+        assert json.loads(json.dumps(doc)) == doc
+
+    def test_urls_point_at_the_serving_endpoints(self, fake_assets):
+        instance_url = branding_svc.store_logo_asset("instance-dark", PNG, "image/png")
+        dashboard_url = branding_svc.store_logo_asset("dashboard-42", PNG, "image/png")
+        assert instance_url.startswith("/depictio/api/")
+        assert "/utils/branding/logo/dark?v=" in instance_url
+        assert "/dashboards/logo/42?v=" in dashboard_url
+
+    def test_keys_are_scoped_by_owner(self):
+        assert branding_svc.instance_logo_key("light") == "instance-light"
+        assert branding_svc.dashboard_logo_key("abc123") == "dashboard-abc123"
+
+    def test_content_type_lookup_is_the_inverse_of_validation(self):
+        assert branding_svc.content_type_for_extension(".png") == "image/png"
+        assert branding_svc.content_type_for_extension(".JPG") == "image/jpeg"
+        assert branding_svc.content_type_for_extension(".svg") is None
+
+
+class FakeDashboards:
+    """Minimal `find` / `update_one` over a list, for the migration pass."""
+
+    def __init__(self, docs):
+        self.docs = docs
+
+    def find(self, query, _projection=None):
+        prefix = query["brand_theme.logo_url"]["$regex"].lstrip("^")
+        return [
+            d
+            for d in self.docs
+            if (d.get("brand_theme") or {}).get("logo_url", "").startswith(prefix)
+        ]
+
+    def update_one(self, query, update):
+        for doc in self.docs:
+            if doc["dashboard_id"] == query["dashboard_id"]:
+                for key, value in update["$set"].items():
+                    parent, _, child = key.partition(".")
+                    doc.setdefault(parent, {})[child] = value
+
+
+class TestLegacyLogoMigration:
+    """Logos left on the container filesystem move into MongoDB on boot."""
+
+    @pytest.fixture()
+    def legacy_dir(self, tmp_path, monkeypatch):
+        (tmp_path / "branding").mkdir()
+        (tmp_path / "dashboard_logos").mkdir()
+        monkeypatch.setattr(branding_svc, "_LEGACY_STATIC_DIR", tmp_path)
+        return tmp_path
+
+    @pytest.fixture()
+    def fake_dashboards(self, monkeypatch):
+        """Patched by default so no test reaches for a real Mongo connection."""
+        fake = FakeDashboards([])
+        monkeypatch.setattr("depictio.api.v1.db.dashboards_collection", fake)
+        return fake
+
+    def test_instance_logo_moves_and_url_is_rewritten(
+        self, fake_store, fake_assets, fake_dashboards, legacy_dir
+    ):
+        (legacy_dir / "branding" / "logo_light.png").write_bytes(PNG)
+        branding_svc.set_brand_theme_overrides(
+            BrandTheme(logo_url="/static/branding/logo_light.png?v=1", logo_mode="custom")
+        )
+
+        assert branding_svc.migrate_legacy_logo_files() == 1
+
+        overrides = branding_svc.get_brand_theme_overrides()
+        assert "/utils/branding/logo/light" in overrides.logo_url
+        # The rest of the brand is untouched by the rewrite.
+        assert overrides.logo_mode == "custom"
+        assert branding_svc.read_logo_asset("instance-light") == (PNG, "image/png")
+
+    def test_already_migrated_instance_is_left_alone(
+        self, fake_store, fake_assets, fake_dashboards, legacy_dir
+    ):
+        (legacy_dir / "branding" / "logo_light.png").write_bytes(PNG)
+        branding_svc.set_brand_theme_overrides(
+            BrandTheme(logo_url="/depictio/api/v1/utils/branding/logo/light?v=1")
+        )
+        assert branding_svc.migrate_legacy_logo_files() == 0
+        assert fake_assets.docs == {}
+
+    def test_missing_file_leaves_the_rest_of_the_brand_intact(
+        self, fake_store, fake_assets, fake_dashboards, legacy_dir
+    ):
+        """The orphaned case: the URL survived, the file did not."""
+        branding_svc.set_brand_theme_overrides(
+            BrandTheme(logo_url="/static/branding/logo_light.png", app_name="Core Facility")
+        )
+        assert branding_svc.migrate_legacy_logo_files() == 0
+        assert branding_svc.get_brand_theme_overrides().app_name == "Core Facility"
+
+    def test_dashboard_logo_moves_and_url_is_rewritten(
+        self, fake_store, fake_assets, fake_dashboards, legacy_dir
+    ):
+        (legacy_dir / "dashboard_logos" / "abc123.png").write_bytes(PNG)
+        fake_dashboards.docs = [
+            {
+                "dashboard_id": "abc123",
+                "brand_theme": {
+                    "logo_url": "/static/dashboard_logos/abc123.png",
+                    "logo_mode": "custom",
+                },
+            },
+            {"dashboard_id": "untouched", "brand_theme": {"primary": "#123456"}},
+        ]
+
+        assert branding_svc.migrate_legacy_logo_files() == 1
+        assert "/dashboards/logo/abc123" in fake_dashboards.docs[0]["brand_theme"]["logo_url"]
+        assert fake_dashboards.docs[1]["brand_theme"] == {"primary": "#123456"}
+        assert branding_svc.read_logo_asset("dashboard-abc123") == (PNG, "image/png")
+
+    def test_one_half_failing_neither_raises_nor_stops_the_other(self, monkeypatch):
+        """A deployment must still boot, and a dashboard tripping over
+        something must not cost the instance its own logo."""
+
+        def boom():
+            raise RuntimeError("mongo down")
+
+        monkeypatch.setattr(branding_svc, "_migrate_instance_logos", boom)
+        monkeypatch.setattr(branding_svc, "_migrate_dashboard_logos", lambda: 1)
+        assert branding_svc.migrate_legacy_logo_files() == 1

--- a/depictio/viewer/src/admin/AdminBrandingPanel.tsx
+++ b/depictio/viewer/src/admin/AdminBrandingPanel.tsx
@@ -41,6 +41,19 @@ function applyEffective(state: AdminBrandingState) {
   setBranding(state.effective);
 }
 
+/** The logo fields of the current draft, carried across a palette-shaped
+ *  change: a preset and an imported theme file are both a palette, not an
+ *  identity, so neither drops an uploaded logo unless it names one itself. */
+function carriedLogos(
+  draft: BrandTheme | null,
+): Pick<BrandTheme, 'logo_mode' | 'logo_url' | 'logo_url_dark'> {
+  return {
+    logo_mode: draft?.logo_mode,
+    logo_url: draft?.logo_url,
+    logo_url_dark: draft?.logo_url_dark,
+  };
+}
+
 const LogoField: React.FC<{
   label: string;
   hint: string;
@@ -191,12 +204,10 @@ const AdminBrandingPanel: React.FC = () => {
   };
 
   /** A preset seeds the form; it is not applied until Save, like every other
-   *  edit here. Logos are left alone — a palette is not an identity. */
+   *  edit here. Logos and the instance name are left alone. */
   const applyPreset = (preset: BrandPreset) =>
     setForm((prev) => ({
-      logo_mode: prev?.logo_mode,
-      logo_url: prev?.logo_url,
-      logo_url_dark: prev?.logo_url_dark,
+      ...carriedLogos(prev),
       app_name: prev?.app_name,
       ...preset.theme,
     }));
@@ -220,7 +231,10 @@ const AdminBrandingPanel: React.FC = () => {
       }
       // Seeded into the form, not saved: the admin still sees it in the
       // preview and decides. Unknown keys are rejected server-side on Save.
-      setForm(parsed as BrandTheme);
+      // Carrying the logos matters here because Save replaces the whole
+      // document: without it an import dropped `logo_url` and left the
+      // uploaded image behind, orphaned.
+      setForm((prev) => ({ ...carriedLogos(prev), ...(parsed as BrandTheme) }));
       notifications.show({ message: 'Theme imported — review the preview, then Save.' });
     } catch (err) {
       notifications.show({

--- a/depictio/viewer/src/auth/AuthApp.tsx
+++ b/depictio/viewer/src/auth/AuthApp.tsx
@@ -7,6 +7,7 @@ import AuthCard from './components/AuthCard';
 import GoogleOAuthCallback from './components/GoogleOAuthCallback';
 import MagicLinkCallback from './components/MagicLinkCallback';
 import LoginForm from './components/LoginForm';
+import PublicAccessGate from './components/PublicAccessGate';
 import RegisterForm from './components/RegisterForm';
 import { useAuthMode } from './hooks/useAuthMode';
 import './styles/auth.css';
@@ -38,7 +39,9 @@ export default function AuthApp() {
   //    owner.
   // 2. Public/demo mode — mint a fresh temporary user (no anonymous
   //    intermediate) and persist before navigating. Mirrors single-user
-  //    behavior so visitors land directly in /dashboards.
+  //    behavior so visitors land directly in /dashboards. Unless the
+  //    deployment sets a shared access code, in which case nothing is minted
+  //    here and PublicAccessGate asks for it first.
   // 3. Standard mode with an already-resolved session — bounce straight
   //    through without touching localStorage.
   useEffect(() => {
@@ -53,6 +56,9 @@ export default function AuthApp() {
           if (cancelled) return;
           persistSession(session);
         } else if (status.is_public_mode) {
+          // A protected public deployment asks for its shared code first, so
+          // the session is minted by the gate rather than on page load.
+          if (status.public_access_code_required) return;
           const session = await createTemporaryUser();
           if (cancelled) return;
           persistSession(session);
@@ -94,6 +100,10 @@ export default function AuthApp() {
           <AuthCard heading="Welcome to Depictio :">
             <Text c="red" ta="center">{error}</Text>
           </AuthCard>
+        ) : status?.is_public_mode && status?.public_access_code_required ? (
+          <AuthCard heading="Welcome to Depictio :">
+            <PublicAccessGate onSuccess={handleSuccess} />
+          </AuthCard>
         ) : status?.is_single_user_mode || status?.is_public_mode ? (
           <AuthCard heading="Welcome to Depictio :">
             <Stack align="center" gap="md">
@@ -122,6 +132,7 @@ export default function AuthApp() {
           <AuthCard heading="Welcome to Depictio :">
             <LoginForm
               googleEnabled={status?.google_oauth_enabled ?? false}
+              passwordLoginDisabled={status?.password_login_disabled ?? false}
               onSwitchToRegister={
                 status?.registration_disabled ? undefined : () => setView('register')
               }

--- a/depictio/viewer/src/auth/components/AuthCard.tsx
+++ b/depictio/viewer/src/auth/components/AuthCard.tsx
@@ -1,6 +1,8 @@
 import { Center, Paper, Stack, Title } from '@mantine/core';
 
 import BrandLogo from '../../chrome/BrandLogo';
+import PoweredBy from '../../chrome/PoweredBy';
+import { useBrandLogoMode } from '../../chrome/useBrandLogoMode';
 import { useBranding } from '../../branding';
 
 interface Props {
@@ -21,6 +23,7 @@ interface Props {
  */
 export default function AuthCard({ heading, children }: Props) {
   const branding = useBranding();
+  const logoMode = useBrandLogoMode();
   const resolvedHeading = branding?.app_name
     ? heading.replace('Depictio', branding.app_name)
     : heading;
@@ -34,9 +37,16 @@ export default function AuthCard({ heading, children }: Props) {
       style={{ width: 480, maxWidth: '90vw' }}
     >
       <Stack gap="md">
-        <Center>
-          <BrandLogo height={60} />
-        </Center>
+        {/* A custom mark gets the room the depictio wordmark does not need: the
+            wordmark is a wide lockup that reads fine at 60, a custom logo is as
+            often a square badge that looks incidental at that height. Width
+            stays capped by BrandLogo's `maxWidth: 100%`. The attribution sits
+            under the mark it qualifies, and renders itself only once that mark
+            is no longer the depictio one (see PoweredBy). */}
+        <Stack gap={6} align="center">
+          <BrandLogo height={logoMode === 'custom' ? 110 : 60} />
+          <PoweredBy />
+        </Stack>
         <Center>
           <Title
             order={2}

--- a/depictio/viewer/src/auth/components/LoginForm.tsx
+++ b/depictio/viewer/src/auth/components/LoginForm.tsx
@@ -6,6 +6,10 @@ const EMAIL_RE = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 
 interface Props {
   googleEnabled: boolean;
+  /** Email + password sign-in is disabled on this instance, leaving Google as
+   *  the only door in. The credentials form is hidden rather than shown and
+   *  rejected, since /auth/login answers 403 to every attempt. */
+  passwordLoginDisabled?: boolean;
   /** Switch to the register view. Omit to hide the Register button entirely
    *  (e.g. when registration is disabled on this instance). */
   onSwitchToRegister?: () => void;
@@ -13,7 +17,12 @@ interface Props {
   onSuccess: () => void;
 }
 
-export default function LoginForm({ googleEnabled, onSwitchToRegister, onSuccess }: Props) {
+export default function LoginForm({
+  googleEnabled,
+  passwordLoginDisabled = false,
+  onSwitchToRegister,
+  onSuccess,
+}: Props) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -21,6 +30,10 @@ export default function LoginForm({ googleEnabled, onSwitchToRegister, onSuccess
 
   const emailValid = EMAIL_RE.test(email);
   const canSubmit = emailValid && password.length > 0 && !submitting;
+  // Mirrors the server-side guard: hiding the credentials form is only safe
+  // while there is another way in, so a deployment that sets the flag without
+  // configuring OAuth keeps its password form instead of a dead card.
+  const showCredentials = !passwordLoginDisabled || !googleEnabled;
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -52,59 +65,73 @@ export default function LoginForm({ googleEnabled, onSwitchToRegister, onSuccess
 
   return (
     <Stack gap="md">
-      <TextInput
-        label="Email:"
-        placeholder="Enter your email"
-        value={email}
-        onChange={(e) => setEmail(e.currentTarget.value)}
-        error={email.length > 0 && !emailValid ? 'Invalid email' : null}
-        autoComplete="email"
-        data-autofocus
-        data-testid="login-email"
-      />
-      <PasswordInput
-        label="Password:"
-        placeholder="Enter your password"
-        value={password}
-        onChange={(e) => setPassword(e.currentTarget.value)}
-        onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit(); }}
-        autoComplete="current-password"
-        data-testid="login-password"
-      />
+      {showCredentials && (
+        <>
+          <TextInput
+            label="Email:"
+            placeholder="Enter your email"
+            value={email}
+            onChange={(e) => setEmail(e.currentTarget.value)}
+            error={email.length > 0 && !emailValid ? 'Invalid email' : null}
+            autoComplete="email"
+            data-autofocus
+            data-testid="login-email"
+          />
+          <PasswordInput
+            label="Password:"
+            placeholder="Enter your password"
+            value={password}
+            onChange={(e) => setPassword(e.currentTarget.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit(); }}
+            autoComplete="current-password"
+            data-testid="login-password"
+          />
+        </>
+      )}
       {error && (
         <Text c="red" size="sm" ta="center" data-testid="user-feedback-message-login">
           {error}
         </Text>
       )}
-      <Group justify="center" gap="sm" mt="sm">
-        <Button
-          radius="md"
-          color="blue"
-          loading={submitting}
-          disabled={!canSubmit}
-          onClick={handleSubmit}
-          style={{ width: 120 }}
-          data-testid="login-button"
-        >
-          Login
-        </Button>
-        {onSwitchToRegister && (
-          <Anchor
-            component="button"
-            type="button"
-            onClick={onSwitchToRegister}
-            underline="never"
-            data-testid="open-register-form"
+      {showCredentials && (
+        <Group justify="center" gap="sm" mt="sm">
+          <Button
+            radius="md"
+            color="blue"
+            loading={submitting}
+            disabled={!canSubmit}
+            onClick={handleSubmit}
+            style={{ width: 120 }}
+            data-testid="login-button"
           >
-            <Button radius="md" variant="outline" color="blue" style={{ width: 120 }}>
-              Register
-            </Button>
-          </Anchor>
-        )}
-      </Group>
+            Login
+          </Button>
+          {onSwitchToRegister && (
+            <Anchor
+              component="button"
+              type="button"
+              onClick={onSwitchToRegister}
+              underline="never"
+              data-testid="open-register-form"
+            >
+              <Button radius="md" variant="outline" color="blue" style={{ width: 120 }}>
+                Register
+              </Button>
+            </Anchor>
+          )}
+        </Group>
+      )}
       {googleEnabled && (
         <Stack gap="xs">
-          <Divider label="Or" labelPosition="center" />
+          {/* The divider separates two alternatives. With the credentials form
+              hidden there is only one, so it would divide nothing. */}
+          {showCredentials ? (
+            <Divider label="Or" labelPosition="center" />
+          ) : (
+            <Text size="sm" c="dimmed" ta="center">
+              This instance signs in with Google.
+            </Text>
+          )}
           <Button
             id="google-oauth-button"
             variant="outline"

--- a/depictio/viewer/src/auth/components/PublicAccessGate.tsx
+++ b/depictio/viewer/src/auth/components/PublicAccessGate.tsx
@@ -1,0 +1,79 @@
+import { Button, PasswordInput, Stack, Text } from '@mantine/core';
+import { useState } from 'react';
+import { createTemporaryUser, persistSession } from 'depictio-react-core';
+
+interface Props {
+  /** Called after the code is accepted and the session is persisted. */
+  onSuccess: () => void;
+}
+
+/**
+ * Access-code gate for a protected public deployment
+ * (`DEPICTIO_AUTH_PUBLIC_ACCESS_CODE`).
+ *
+ * Public mode's whole point is that a visitor needs no account: they get a
+ * throwaway user and land on the dashboards. That also means an open
+ * deployment hands a session to anyone who loads the page. The code turns it
+ * into "shareable with the people who have the link and the code" without
+ * reintroducing accounts — everyone who passes still gets their own temporary
+ * user, and the code is one shared secret rather than a credential per person.
+ *
+ * The gate is a courtesy, not the enforcement: `/auth/public/create_temporary_user`
+ * refuses a wrong or missing code on its own, so skipping this form buys
+ * nothing.
+ */
+export default function PublicAccessGate({ onSuccess }: Props) {
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    if (!code || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      persistSession(await createTemporaryUser(code));
+      onSuccess();
+    } catch {
+      // The server answers 403 for a wrong code and never says more than
+      // that; there is no account here to enumerate, so one message covers it.
+      setError('That access code was not accepted.');
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" c="dimmed" ta="center">
+        This instance is open to anyone with the access code. Enter it to
+        continue as a guest — no account needed.
+      </Text>
+      <PasswordInput
+        label="Access code:"
+        placeholder="Enter the access code"
+        value={code}
+        onChange={(e) => setCode(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleSubmit();
+        }}
+        autoComplete="one-time-code"
+        data-autofocus
+        data-testid="public-access-code"
+      />
+      {error && (
+        <Text c="red" size="sm" ta="center" data-testid="public-access-error">
+          {error}
+        </Text>
+      )}
+      <Button
+        radius="md"
+        loading={submitting}
+        disabled={!code || submitting}
+        onClick={handleSubmit}
+        data-testid="public-access-submit"
+      >
+        Continue
+      </Button>
+    </Stack>
+  );
+}

--- a/depictio/viewer/src/chrome/AppSidebar.tsx
+++ b/depictio/viewer/src/chrome/AppSidebar.tsx
@@ -91,7 +91,7 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ active }) => {
   );
 
   return (
-    <Stack gap="sm" h="100%" justify="space-between">
+    <Stack gap="sm" h="100%" justify="space-between" data-testid="app-sidebar">
       <Stack gap="sm" align="stretch">
         <Center pt="md">
           <Anchor href="/" underline="never">
@@ -127,10 +127,10 @@ const AppSidebar: React.FC<AppSidebarProps> = ({ active }) => {
       </ScrollArea>
 
       <Stack gap="xs" align="center">
-        {/* Attribution, below the operator's own logo at the top of the rail.
-            On a branded instance that top slot is the operator's, so without a
-            slot of its own the depictio wordmark disappears from the app
-            entirely. */}
+        {/* Attribution, below the logo at the top of the rail. It renders only
+            once that top slot stops showing the depictio wordmark (see
+            PoweredBy): on a branded instance it is the operator's, and without
+            this the wordmark would disappear from the app entirely. */}
         <PoweredBy />
         <Divider w="100%" />
         <ThemeToggle />

--- a/depictio/viewer/src/chrome/PoweredBy.tsx
+++ b/depictio/viewer/src/chrome/PoweredBy.tsx
@@ -1,25 +1,34 @@
 import React from 'react';
-import { Anchor, Group, Text } from '@mantine/core';
+import { Anchor, Group, Text, useComputedColorScheme } from '@mantine/core';
 
-import { useColorScheme } from '../hooks/useColorScheme';
+import { useBrandLogoMode } from './useBrandLogoMode';
 
 /**
  * "Powered by Depictio" badge — themed Depictio logo + label, linking to docs.
- * Visual parity with `_create_powered_by_section()` in
- * `depictio/dash/layouts/header.py`.
+ *
+ * Shown only when the depictio wordmark is no longer on screen, i.e. when the
+ * brand in scope resolves to a logo of its own (`custom`) or to no logo at all
+ * (`none`). On a stock deployment the wordmark is already in the app rail and
+ * on the login card, so a badge repeating it is noise; once an operator puts
+ * their own mark there, the attribution is the only thing left saying what the
+ * app is.
+ *
+ * The rule is decided here rather than at each mount site so every surface
+ * inherits it. Inside a dashboard `BrandScope` provides the dashboard theme
+ * merged over the instance one, so a dashboard with its own logo counts too.
  */
 interface PoweredByProps {
-  /** When true, renders the right-border + right-padding seen in the Dash header. */
+  /** When true, renders the right-border + right-padding seen in the header. */
   withRightBorder?: boolean;
 }
 
 const PoweredBy: React.FC<PoweredByProps> = ({ withRightBorder = false }) => {
-  const { colorScheme } = useColorScheme();
+  const logoMode = useBrandLogoMode();
+  const isDark = useComputedColorScheme('light') === 'dark';
 
-  // Both `logo_black.svg` and `logo_white.svg` are byte-identical (a base64-
-  // embedded PNG inside an SVG wrapper), so swapping `src` does nothing.
-  // Apply a CSS filter on dark mode to invert the embedded raster while
-  // preserving brand hues — the standard treatment for single-asset wordmarks.
+  // `'inherit'` is exactly when BrandLogo shows the depictio wordmark.
+  if (logoMode === 'inherit') return null;
+
   const groupStyle: React.CSSProperties = withRightBorder
     ? {
         marginRight: 15,
@@ -34,12 +43,17 @@ const PoweredBy: React.FC<PoweredByProps> = ({ withRightBorder = false }) => {
       target="_blank"
       rel="noopener noreferrer"
       underline="never"
+      data-testid="powered-by"
       style={{ color: 'inherit' }}
     >
       <Group gap={5} align="center" wrap="nowrap" style={groupStyle}>
         <Text size="xs" c="dimmed" fw={700}>
           Powered by
         </Text>
+        {/* `logo_black.svg` and `logo_white.svg` are byte-identical (a base64-
+            embedded PNG inside an SVG wrapper), so swapping `src` does nothing.
+            Dark mode inverts the embedded raster with a CSS filter instead,
+            preserving brand hues — same trick as `BrandLogo`. */}
         <img
           src="/dashboard/logos/logo_black.svg"
           alt="Depictio"
@@ -47,7 +61,7 @@ const PoweredBy: React.FC<PoweredByProps> = ({ withRightBorder = false }) => {
             height: 20,
             width: 'auto',
             display: 'block',
-            filter: colorScheme === 'dark' ? 'invert(1) hue-rotate(180deg)' : undefined,
+            filter: isDark ? 'invert(1) hue-rotate(180deg)' : undefined,
           }}
         />
       </Group>

--- a/depictio/viewer/src/chrome/Sidebar.tsx
+++ b/depictio/viewer/src/chrome/Sidebar.tsx
@@ -18,7 +18,6 @@ import { Icon } from '@iconify/react';
 import { brandAccent, useBranding } from 'depictio-react-core';
 import type { BrandTheme, DashboardSummary } from 'depictio-react-core';
 import BrandLogo from './BrandLogo';
-import PoweredBy from './PoweredBy';
 import ThemeToggle from './ThemeToggle';
 import ServerStatusBadge from './ServerStatusBadge';
 import ProfileBadge from './ProfileBadge';
@@ -438,11 +437,8 @@ const Sidebar: React.FC<SidebarProps> = ({
           testId="dashboard-logo"
           style={{ maxWidth: '92%', maxHeight: 130, margin: '0 auto' }}
         />
-        {/* Attribution, below the brand's own mark. On a branded instance the
-            logo above belongs to the operator, so the depictio wordmark needs
-            a slot of its own or it disappears from the dashboard entirely —
-            the app sidebar that normally carries it is collapsed here. */}
-        <PoweredBy />
+        {/* No attribution here — the dashboard's single slot for it is the
+            header, and carrying it in both places showed it twice. */}
         <Divider w="100%" />
         <ThemeToggle />
         <ServerStatusBadge />

--- a/depictio/viewer/src/chrome/index.ts
+++ b/depictio/viewer/src/chrome/index.ts
@@ -10,6 +10,7 @@ export { default as ServerStatusBadge } from './ServerStatusBadge';
 export { default as ProfileBadge } from './ProfileBadge';
 export { default as AuthModeBadge } from './AuthModeBadge';
 export { default as PoweredBy } from './PoweredBy';
+export { useBrandLogoMode } from './useBrandLogoMode';
 export { default as SettingsDrawer } from './SettingsDrawer';
 export { default as TabModal } from './TabModal';
 export type { TabModalSubmitPayload } from './TabModal';

--- a/depictio/viewer/src/chrome/useBrandLogoMode.ts
+++ b/depictio/viewer/src/chrome/useBrandLogoMode.ts
@@ -1,0 +1,22 @@
+import { useComputedColorScheme } from '@mantine/core';
+
+import { resolveBrandLogo, type LogoMode } from 'depictio-react-core';
+
+import { useBranding } from '../branding';
+
+/**
+ * Which logo the brand in scope actually resolves to, for the surfaces that
+ * need to react to it rather than just render it:
+ *
+ * - `'custom'` — the operator's (or the dashboard's) own mark is on screen.
+ * - `'none'`   — the brand asks for no logo at all.
+ * - `'inherit'` — nothing was supplied, so `BrandLogo` falls back to the
+ *   depictio wordmark. Also what a `logo_mode: 'custom'` with an empty URL
+ *   collapses to, which is why callers must read the resolved mode rather
+ *   than `theme.logo_mode`.
+ */
+export function useBrandLogoMode(): LogoMode {
+  const brand = useBranding();
+  const isDark = useComputedColorScheme('light') === 'dark';
+  return resolveBrandLogo(brand, isDark).mode;
+}

--- a/depictio/viewer/src/main.tsx
+++ b/depictio/viewer/src/main.tsx
@@ -261,6 +261,13 @@ async function bootstrapSession(): Promise<void> {
       return;
     }
     if (status.is_public_mode) {
+      // A protected public instance has no session to hand out until the
+      // visitor has passed the shared code, so go to the gate rather than
+      // spend a round-trip on a mint the backend is going to refuse.
+      if (status.public_access_code_required) {
+        window.location.replace('/auth');
+        return;
+      }
       const session = await createTemporaryUser();
       persistSession(session);
       return;

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -94,7 +94,38 @@ everything it fills in stays editable, and the flat env vars override it field
 by field.
 
 **Export** writes the current theme as JSON and **Import** reads one back, so a
-brand can be reviewed, version-controlled and moved between deployments.
+brand can be reviewed, version-controlled and moved between deployments. An
+imported file keeps the instance's uploaded logos unless it names logos of its
+own, on the same reasoning as a preset: a theme file is a palette, not an
+identity.
+
+## Where the logos live
+
+Uploaded logos are stored in MongoDB, in a `branding_assets` collection, and
+served from the API (`/utils/branding/logo/{variant}` for the instance,
+`/dashboards/logo/{id}` for a dashboard). Nothing is written to the container's
+filesystem, so a rebuild or a pod redeploy cannot leave a theme pointing at an
+image that no longer exists, and no volume or PVC has to be provisioned for
+them. They are capped at 2 MB each (PNG, JPEG or WebP; SVG is refused because
+it can carry scripts and would be served same-origin).
+
+Both `branding_assets` and the overrides document in `instance_settings` are
+part of the backup set, so a restore brings back the instance identity that
+every dashboard's own theme inherits from.
+
+Deployments branded before this moved keep working: logos still on disk are
+imported into the database at startup and their stored URLs rewritten, once.
+
+## The "Powered by Depictio" attribution
+
+The badge is not always shown. It appears exactly when the Depictio wordmark
+does not: on a stock deployment the wordmark is already in the app rail and on
+the login card, so a badge repeating it would be noise, and on a branded one it
+is the only thing left saying what the app is built on.
+
+Concretely, it renders when the logo in scope resolves to `custom` or `none`,
+and it appears once per surface: on the login card under the logo, in the app
+rail outside dashboards, and in the header of a dashboard.
 
 ## A dashboard override
 

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -2449,6 +2449,15 @@ export interface AuthStatusResponse {
    *  allow pre-provisioned accounts to log in. Older backends omit this —
    *  treat absent as `false`. */
   registration_disabled?: boolean;
+  /** Email + password sign-in is disabled — hide the credentials form and
+   *  leave Google OAuth as the only way in. Already accounts for whether
+   *  Google OAuth is actually configured. Older backends omit this — treat
+   *  absent as `false`. */
+  password_login_disabled?: boolean;
+  /** Public mode is gated by a shared access code — do not auto-mint a
+   *  temporary session, ask for the code first. Older backends omit this —
+   *  treat absent as `false`. */
+  public_access_code_required?: boolean;
   google_oauth_enabled: boolean;
   /** Development mode (DEPICTIO_DEV_MODE). Suppresses the walkthrough. */
   is_dev_mode?: boolean;
@@ -2590,11 +2599,17 @@ export async function registerUser(email: string, password: string): Promise<Reg
   return { success: Boolean(body.success), message: body.message };
 }
 
-/** Public-mode "Continue as temporary user" — the React modal calls this. */
-export async function createTemporaryUser(): Promise<SessionPayload> {
+/** Public-mode "Continue as temporary user" — the React modal calls this.
+ *
+ *  `accessCode` is the shared secret a protected public deployment asks for
+ *  (`DEPICTIO_AUTH_PUBLIC_ACCESS_CODE`). Omit it on an open one; the server
+ *  rejects a missing or wrong code with 403 either way, so this is a
+ *  convenience for the form rather than the check itself. */
+export async function createTemporaryUser(accessCode?: string): Promise<SessionPayload> {
   const res = await fetch(`${API_BASE}/auth/public/create_temporary_user`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(accessCode ? { access_code: accessCode } : {}),
   });
   if (!res.ok) await throwHttpError(res, 'Failed to create temporary user');
   return (await res.json()) as SessionPayload;


### PR DESCRIPTION
Stacked on `feat/brand-theme-engine`. Four changes, all found while using the brand-theme engine.

## The attribution appeared where it meant nothing

`PoweredBy` rendered unconditionally in three places, so a dashboard showed it twice (header *and* sidebar) and a stock deployment showed it under a Depictio wordmark that already said the same thing.

It now renders exactly when the wordmark does not, i.e. when the logo in scope resolves to `custom` or `none`. The rule is decided once inside `PoweredBy` (via the existing `resolveBrandLogo`, through a small `useBrandLogoMode` hook) so every mount site inherits it, and `BrandScope` means a dashboard with its own logo counts too.

| Surface | Stock | Custom or hidden logo |
| --- | --- | --- |
| `/auth` login card | no badge | badge under the logo (new) |
| App rail | no badge | badge |
| Dashboard header | no badge | badge, once |
| Dashboard sidebar | no badge | removed |

A custom logo also renders at 110px on the login card instead of 60px: the Depictio wordmark is a wide lockup that reads fine small, a custom mark is as often a square badge that looks incidental at that height.

## Brand logos did not survive a rebuild

Uploads went to `depictio/api/static/{branding,dashboard_logos}/` while only the URL reached MongoDB. Both directories are gitignored, neither has a compose volume or a Helm PVC, so a rebuild or a pod redeploy left the theme pointing at bytes that were gone. On the dev instance this showed up as a `logo_light.png` sitting on disk with no reference left in `instance_settings`.

Logos now live in a `branding_assets` collection, served by `GET /utils/branding/logo/{variant}` and `GET /dashboards/logo/{id}` (both public: the login card renders before anyone signs in). Stored base64 rather than as BSON `Binary`, because the backup endpoint serialises with `json.dump(..., default=str)`, which would turn raw bytes into an unrestorable `repr`.

`instance_settings` and `branding_assets` are now in the backup set. A restore that brought back every dashboard's `brand_theme` but not the instance identity those themes inherit from was worse than one that brought back neither.

Existing deployments keep their logo: files still on disk are imported and their URLs rewritten once at startup, deliberately outside the `should_initialize` branch since an already-initialised deployment is exactly the one with files to move.

It also fixes what orphaned the logo to begin with. `handleImport` replaced the whole draft, so the next save (a whole-document replace) dropped `logo_url` while the image stayed behind. Import now carries the logo fields forward, as applying a preset already did.

## Sign-in: two doors that could not be closed

Both opt-in, both default to today's behaviour.

**`DEPICTIO_AUTH_PASSWORD_LOGIN_DISABLED`** leaves Google OAuth as the only way in. `/auth/login` refuses before looking at any credential, so a valid password is not a way around it, and the SPA hides the form rather than showing one that always fails. Ignored unless Google OAuth is configured: the flag alone would leave a deployment with no door at all. The admin bootstrap follows, since demanding a password whose only job is to be unusable is friction. The email alone is enough, and because OAuth resolves accounts by email, setting `DEPICTIO_BOOTSTRAP_ADMIN_EMAIL` to your own Google address is what makes you the admin, with no seeded local account.

**`DEPICTIO_AUTH_PUBLIC_ACCESS_CODE`** gates public mode. Public mode hands a temporary session to anyone who loads the page, which is public with no qualifier; with a code set, a visitor enters it first and still gets their own throwaway user. The check runs in `/auth/public/create_temporary_user` after the rate limiter, so the shared secret is no more brute-forceable than any other credential there. The SPA gate is a courtesy, not the enforcement.

## Testing

- 28 unit tests in `test_branding_service.py` (asset round-trip, JSON-serialisability of a stored asset, the migration's two halves failing independently, orphaned-file case).
- 4 new tests in `test_security_pr1.py` for both sign-in gates, including that each is inert without its prerequisite.
- `brand-theme.spec.ts` extended: attribution absent on a stock instance, present once `logo_mode: "none"` is saved.
- `ruff`, `ty` on `depictio/models/`, and `tsc` on the viewer are clean. `pre-commit` passes except shellcheck, which fails on scripts this branch does not touch.
