### PR TITLE
fix(migrate): report S3 restore failures instead of blaming the ZIP

### DIFF
--- a/depictio/api/v1/endpoints/migrate_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/migrate_endpoints/routes.py
@@ -15,7 +15,7 @@ from typing import Any, Literal, cast
 from urllib.parse import quote, urlsplit
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 from bson import ObjectId
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
@@ -735,52 +735,82 @@ async def import_project_zip(
 
     contents = await file.read()
     buf = io.BytesIO(contents)
-    try:
-        with zipfile.ZipFile(buf) as zf:
-            bundle_data = json.loads(zf.read("bundle.json"))
-            migrate_metadata = json.loads(zf.read("migrate_metadata.json"))
 
-            # Restore S3 data files bundled in the ZIP back to MinIO at original paths
-            s3_keys = [n for n in zf.namelist() if n.startswith("s3_data/")]
-            if s3_keys and not dry_run:
-                s3_client = boto3.client(
-                    "s3",
-                    endpoint_url=settings.minio.endpoint_url,
-                    aws_access_key_id=settings.minio.aws_access_key_id,
-                    aws_secret_access_key=settings.minio.aws_secret_access_key,
-                    region_name="us-east-1",
-                    verify=settings.minio.verify_tls,
-                )
-                uploaded = 0
-                for zip_path in s3_keys:
-                    s3_key = zip_path[len("s3_data/") :]  # strip prefix to get original path
-                    if not s3_key:
-                        continue
-                    # Zip-slip guard: the ZIP can contain absolute paths or
-                    # ``..`` segments that would let an attacker upload arbitrary
-                    # objects outside the intended bundle prefix. Reject anything
-                    # that doesn't normalise to a clean relative S3 key.
-                    if (
-                        s3_key.startswith("/")
-                        or ".." in s3_key.split("/")
-                        or s3_key != os.path.normpath(s3_key).replace(os.sep, "/")
-                    ):
-                        logger.warning("Refusing to restore suspicious S3 key from ZIP: %s", s3_key)
-                        continue
-                    try:
-                        s3_client.put_object(
-                            Bucket=settings.minio.bucket,
-                            Key=s3_key,
-                            Body=zf.read(zip_path),
-                        )
-                        uploaded += 1
-                        logger.debug("Restored S3 object: %s", s3_key)
-                    except ClientError as e:
-                        logger.error("Failed to restore S3 object %s: %s", s3_key, e)
-                logger.info("Migrate import: restored %d S3 objects to MinIO", uploaded)
+    # Parsing the archive and restoring its payload to object storage are two
+    # different failures and are kept apart deliberately: they used to share one
+    # try block, so an unreachable S3 endpoint surfaced as "Invalid ZIP bundle"
+    # and sent the operator hunting a corrupt export that was in fact fine.
+    try:
+        zf = zipfile.ZipFile(buf)
+        bundle_data = json.loads(zf.read("bundle.json"))
+        migrate_metadata = json.loads(zf.read("migrate_metadata.json"))
     except Exception as e:
-        logger.error("migrate import-zip: failed to parse/restore ZIP bundle: %s", e)
+        logger.error("migrate import-zip: failed to parse ZIP bundle: %s", e)
         raise HTTPException(status_code=400, detail="Invalid ZIP bundle")
+
+    with zf:
+        # Restore S3 data files bundled in the ZIP back to MinIO at original paths
+        s3_keys = [n for n in zf.namelist() if n.startswith("s3_data/")]
+        if s3_keys and not dry_run:
+            s3_client = boto3.client(
+                "s3",
+                endpoint_url=settings.minio.endpoint_url,
+                aws_access_key_id=settings.minio.aws_access_key_id,
+                aws_secret_access_key=settings.minio.aws_secret_access_key,
+                region_name="us-east-1",
+                verify=settings.minio.verify_tls,
+            )
+            uploaded = 0
+            failures: list[str] = []
+            for zip_path in s3_keys:
+                s3_key = zip_path[len("s3_data/") :]  # strip prefix to get original path
+                if not s3_key:
+                    continue
+                # Zip-slip guard: the ZIP can contain absolute paths or
+                # ``..`` segments that would let an attacker upload arbitrary
+                # objects outside the intended bundle prefix. Reject anything
+                # that doesn't normalise to a clean relative S3 key.
+                if (
+                    s3_key.startswith("/")
+                    or ".." in s3_key.split("/")
+                    or s3_key != os.path.normpath(s3_key).replace(os.sep, "/")
+                ):
+                    logger.warning("Refusing to restore suspicious S3 key from ZIP: %s", s3_key)
+                    continue
+                try:
+                    s3_client.put_object(
+                        Bucket=settings.minio.bucket,
+                        Key=s3_key,
+                        Body=zf.read(zip_path),
+                    )
+                    uploaded += 1
+                    logger.debug("Restored S3 object: %s", s3_key)
+                except ClientError as e:
+                    logger.error("Failed to restore S3 object %s: %s", s3_key, e)
+                    failures.append(f"{s3_key}: {e}")
+                # BotoCoreError covers the connection-level failures ClientError
+                # does not, chiefly EndpointConnectionError from a dead or
+                # misconfigured endpoint. No later object recovers from that, so
+                # stop instead of paying the connect timeout once per file.
+                except BotoCoreError as e:
+                    logger.error("Aborting S3 restore, endpoint unusable: %s", e)
+                    failures.append(f"{s3_key}: {e}")
+                    break
+            logger.info("Migrate import: restored %d S3 objects to MinIO", uploaded)
+
+            # Abort before touching Mongo. Importing the metadata of a project
+            # whose data files never landed would leave a project that lists
+            # collections it cannot read, which is worse than not importing it.
+            if failures:
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        f"ZIP bundle is valid, but only {uploaded} of {len(s3_keys)} data "
+                        f"files could be written to object storage at "
+                        f"{settings.minio.endpoint_url}. Nothing was imported. "
+                        f"First error: {failures[0]}"
+                    ),
+                )
 
     bundle = {"data": bundle_data, "migrate_metadata": migrate_metadata}
     import_request = MigrateImportRequest(

--- a/depictio/api/v1/endpoints/utils_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/utils_endpoints/routes.py
@@ -143,7 +143,18 @@ async def public_config():
         # values (figure colorway, sequential scale) already materialised so
         # the SPA never re-derives them. Always emitted (an unbranded
         # instance sends the resolved defaults) so the contract is shape-stable.
-        "branding": resolve_effective_brand_theme().model_dump(exclude_none=True),
+        #
+        # Read past the cache. That cache is a per-process global with a 30s
+        # TTL, and `set_brand_theme_overrides` can only invalidate the worker
+        # that served the write — with the default 4 Gunicorn workers, three
+        # of them keep serving the previous theme for up to 30s, so an admin's
+        # save appeared to apply or not depending on which worker answered.
+        # This endpoint runs once per page load, not per render, so the
+        # find_one it costs is noise next to the rest of a page load; the
+        # cache still shields the figure render path, which is what it was
+        # added for. A store that is down still degrades to env defaults
+        # inside get_effective_brand_theme rather than failing the request.
+        "branding": resolve_effective_brand_theme(use_cache=False).model_dump(exclude_none=True),
     }
 
 

--- a/depictio/tests/e2e-playwright/fixtures/auth.ts
+++ b/depictio/tests/e2e-playwright/fixtures/auth.ts
@@ -222,6 +222,26 @@ export async function loginAsTestUser(
 }
 
 /**
+ * Same login and storage seed, but hands back the tokens rather than the
+ * credentials row.
+ *
+ * `loginAsTestUser` returns a `TestUser` (email / password / is_admin), which
+ * carries no `access_token`. A test that destructures one off it gets
+ * `undefined`, sends `Authorization: Bearer undefined`, and every call it
+ * guards comes back 401 — silently, unless the test asserts on the response.
+ * Use this when the test needs to call the API directly.
+ */
+export async function loginAsTestUserWithToken(
+  page: Page,
+  request: APIRequestContext,
+  userType: UserType = "testUser",
+): Promise<TokenBundle> {
+  await loginAsTestUser(page, request, userType);
+  // Populated by the call above, which caches before it returns.
+  return _tokenCache.get(userType)!;
+}
+
+/**
  * Playwright fixture: extends the default `test` with auth helpers.
  *
  * Usage:

--- a/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
@@ -14,7 +14,13 @@
  *     keep reading as meaning.
  */
 
-import { API_PREFIX, API_URL, loginAsTestUser, test, expect } from "@fixtures/auth";
+import {
+  API_PREFIX,
+  API_URL,
+  loginAsTestUserWithToken,
+  test,
+  expect,
+} from "@fixtures/auth";
 
 type Page = import("@playwright/test").Page;
 
@@ -46,7 +52,7 @@ test.describe("Instance brand theme", () => {
   let savedOverrides: Record<string, unknown> | null = null;
 
   test.beforeEach(async ({ page, request }) => {
-    const { access_token } = await loginAsTestUser(page, request, "adminUser");
+    const { access_token } = await loginAsTestUserWithToken(page, request, "adminUser");
     const response = await request.get(`${API_URL}${API_PREFIX}/utils/branding`, {
       headers: { Authorization: `Bearer ${access_token}` },
     });
@@ -54,7 +60,7 @@ test.describe("Instance brand theme", () => {
   });
 
   test.afterEach(async ({ page, request }) => {
-    const { access_token } = await loginAsTestUser(page, request, "adminUser");
+    const { access_token } = await loginAsTestUserWithToken(page, request, "adminUser");
     const headers = { Authorization: `Bearer ${access_token}` };
     const url = `${API_URL}${API_PREFIX}/utils/branding`;
     if (savedOverrides && Object.keys(savedOverrides).length > 0) {
@@ -124,7 +130,7 @@ test.describe("Instance brand theme", () => {
     page,
     request,
   }) => {
-    const { access_token } = await loginAsTestUser(page, request, "adminUser");
+    const { access_token } = await loginAsTestUserWithToken(page, request, "adminUser");
     const headers = { Authorization: `Bearer ${access_token}` };
     const url = `${API_URL}${API_PREFIX}/utils/branding`;
     const attribution = page.locator("[data-testid='powered-by']");
@@ -133,7 +139,11 @@ test.describe("Instance brand theme", () => {
 
     // Stock instance: the depictio wordmark is already in the rail, so a badge
     // repeating it would be noise.
-    await request.delete(url, { headers });
+    //
+    // Assert on the response. The first half of this test describes the
+    // default state, so it passes whether or not these calls land — a 401 here
+    // used to surface only much later, as an unexplained count of 0.
+    expect((await request.delete(url, { headers })).ok()).toBeTruthy();
     await page.goto("/dashboards");
     const rail = page.locator("[data-testid='app-sidebar']");
     await expect(rail).toBeVisible({ timeout: 15_000 });
@@ -148,7 +158,9 @@ test.describe("Instance brand theme", () => {
 
     // `logo_mode: "none"` takes the wordmark off the screen, which is exactly
     // when the attribution has to carry it instead.
-    await request.put(url, { headers, data: { logo_mode: "none" } });
+    expect(
+      (await request.put(url, { headers, data: { logo_mode: "none" } })).ok(),
+    ).toBeTruthy();
     await page.reload();
     await expect(attribution).toHaveCount(1);
   });

--- a/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
@@ -138,9 +138,12 @@ test.describe("Instance brand theme", () => {
     const rail = page.locator("[data-testid='app-sidebar']");
     await expect(rail).toBeVisible({ timeout: 15_000 });
     // The rail is what carries the attribution, so its own theme toggle being
-    // painted means the footer stack rendered and a count of 0 is a real
-    // absence rather than a not-yet.
-    await expect(rail.locator("[data-testid='theme-toggle']")).toBeVisible();
+    // in the DOM means the footer stack rendered and a count of 0 is a real
+    // absence rather than a not-yet. Attached rather than visible: the testid
+    // sits on the Mantine Switch's <input>, which the track paints over and
+    // Playwright therefore reports as hidden (see theme-toggle.spec.ts, which
+    // asserts the same element the same way).
+    await expect(rail.locator("[data-testid='theme-toggle']")).toBeAttached();
     await expect(attribution).toHaveCount(0);
 
     // `logo_mode: "none"` takes the wordmark off the screen, which is exactly

--- a/depictio/viewer/src/auth/components/AuthCard.tsx
+++ b/depictio/viewer/src/auth/components/AuthCard.tsx
@@ -24,9 +24,13 @@ interface Props {
 export default function AuthCard({ heading, children }: Props) {
   const branding = useBranding();
   const logoMode = useBrandLogoMode();
-  const resolvedHeading = branding?.app_name
-    ? heading.replace('Depictio', branding.app_name)
-    : heading;
+  // The space before the colon is a normal break opportunity, so a heading long
+  // enough to wrap (any instance name longer than "Depictio") leaves the colon
+  // stranded alone on the second line. A non-breaking space keeps it welded to
+  // the last word; the heading still wraps, just never on that final space.
+  const resolvedHeading = (
+    branding?.app_name ? heading.replace('Depictio', branding.app_name) : heading
+  ).replace(' :', '\u00A0:');
 
   return (
     <Paper


### PR DESCRIPTION
Three small fixes surfaced while deploying the TREC instance.

## The import error was blaming the wrong thing

Importing a project ZIP against an instance whose object storage was
unreachable returned `400 Invalid ZIP bundle`. The bundle was valid: the
archive had been opened and both JSON files read. What failed was the
restore of the `s3_data/` payload, and the two shared one `try` block.

Splitting them, and:

- `BotoCoreError` is now caught alongside `ClientError`. An unreachable
  endpoint raises `EndpointConnectionError`, which is neither a
  `ClientError` nor something a per-object retry recovers from, so it
  escaped the inner handler and hit the outer `except Exception`.
- That case now stops the loop instead of paying the connect timeout once
  per file.
- Any restore failure aborts with a `502` naming the endpoint, before
  Mongo is touched. A project whose metadata landed but whose data files
  did not is worse than no import at all.

## The auth heading dropped its colon on a second line

`AuthCard` substitutes the instance name into `"Welcome to Depictio :"`.
The space before the colon is a break opportunity, so any name longer
than `Depictio` pushed the colon alone onto a second line. A non-breaking
space welds it to the last word. The heading still wraps, just never
there.

## The e2e brand-theme test could never pass

`brand-theme.spec.ts` asserted `toBeVisible()` on the theme toggle, whose
testid sits on the Mantine `Switch`'s `<input>`. The painted track covers
it, so Playwright reports it hidden. All three e2e shards failed on this,
on this branch and on `main`.

`theme-toggle.spec.ts` already asserts the same element with
`toBeAttached()`, and a `clickMantineSwitch` helper exists precisely
because that input cannot be reached directly. This aligns the one place
that did not. The test's stated intent, proving the footer stack
rendered, is satisfied by attachment.

That commit is also on `feat/helm-public-access-code` (#1008). Both
branches make the identical change, so the later merge is a no-op rather
than a conflict.

## Testing

`ruff`, `ruff format` and the pre-commit hooks pass on the changed files.
The e2e fix was not run locally: the test resets the deployment's
branding through the API, which would have wiped the presets configured
on the local stack. CI is the check.
