### PR TITLE
fix(tool-studio): give the footer the full width of the bar

### DIFF
--- a/packages/tool-studio/src/App.tsx
+++ b/packages/tool-studio/src/App.tsx
@@ -62,7 +62,7 @@ export default function App() {
     // Header and footer are both AppShell slots, so both stay pinned while only
     // the wizard scrolls between them. AppShell reserves padding for each on the
     // main column, so no step can end up hidden underneath either bar.
-    <AppShell header={{ height: 56 }} footer={{ height: 52 }} padding={0}>
+    <AppShell header={{ height: 56 }} footer={{ height: 44 }} padding={0}>
       <AppShell.Header>
         <AppHeader />
       </AppShell.Header>

--- a/packages/tool-studio/src/App.tsx
+++ b/packages/tool-studio/src/App.tsx
@@ -62,7 +62,7 @@ export default function App() {
     // Header and footer are both AppShell slots, so both stay pinned while only
     // the wizard scrolls between them. AppShell reserves padding for each on the
     // main column, so no step can end up hidden underneath either bar.
-    <AppShell header={{ height: 56 }} footer={{ height: 44 }} padding={0}>
+    <AppShell header={{ height: 56 }} footer={{ height: 52 }} padding={0}>
       <AppShell.Header>
         <AppHeader />
       </AppShell.Header>

--- a/packages/tool-studio/src/components/AppFooter.tsx
+++ b/packages/tool-studio/src/components/AppFooter.tsx
@@ -1,5 +1,11 @@
-import { Anchor, Badge, Box, Container, Group, Text } from '@mantine/core';
+import { Anchor, Badge, Box, Group, Stack, Text } from '@mantine/core';
 import { Icon } from '@iconify/react';
+
+const LINKS = [
+  { label: 'Docs', href: 'https://depictio.github.io/depictio-docs/stable/catalog/' },
+  { label: 'Catalog', href: 'https://github.com/depictio/depictio/tree/main/depictio/catalog' },
+  { label: 'Report an issue', href: 'https://github.com/depictio/depictio/issues/new' },
+];
 
 /**
  * Footer bar. Rendered inside `AppShell.Footer`, so it is pinned to the bottom
@@ -7,18 +13,22 @@ import { Icon } from '@iconify/react';
  * header. AppShell reserves the matching padding on the main column, so nothing
  * ever hides behind it.
  *
- * That pinning is also why everything here is one non-wrapping row of `xs` text
- * sized to the shell's declared height: a second line would overflow the bar
- * rather than push the page. The privacy note is the part that goes when the
- * viewport is too narrow to hold both halves.
+ * Full-bleed on the header's own `px="lg"` gutter rather than inside a
+ * `Container`: a centred container is narrower than the bar it sits in, and the
+ * width it gave away is what squeezed the beta badge out of view and wrapped
+ * "Report an issue" onto a second line. So everything on the right is `nowrap`
+ * and unshrinkable, and the privacy note on the left is the single flexible
+ * part — it truncates, then drops entirely below `md`.
  *
  * A static site published from a build has no other way to say *which* build
  * you are looking at, so the bar carries both versions: Tool Studio's own
  * (packages/tool-studio/package.json, bumped with `pnpm --filter tool-studio run
  * bump <patch|minor|major>`) and the depictio release it was cut from
  * (.bumpversion.cfg), which pins the catalog schema the export has to satisfy.
- * The deploy commit is added when the Pages workflow provides GITHUB_SHA. All
- * three are injected at build time, see vite.config.ts.
+ * The deploy commit sits on a second line under the two, which read as one pair
+ * rather than a three-part run-on; it appears only when the Pages workflow
+ * provides GITHUB_SHA. All three are injected at build time, see vite.config.ts.
+ * Those two lines are what the shell's footer height is sized to.
  *
  * The beta badge sits with those versions rather than in the header: it qualifies
  * this build, and the reader who wants to know how finished the app is looks in
@@ -27,56 +37,46 @@ import { Icon } from '@iconify/react';
 export default function AppFooter() {
   const sha = __BUILD_SHA__;
   return (
-    <Box component="footer" h="100%" style={{ display: 'flex', alignItems: 'center' }}>
-      <Container size="lg" w="100%">
-        <Group justify="space-between" align="center" gap="md" wrap="nowrap">
-          <Group gap={6} wrap="nowrap" visibleFrom="md">
-            <Icon icon="mdi:shield-lock-outline" width={15} />
-            <Text size="xs" c="dimmed" lineClamp={1}>
-              Runs entirely in your browser. Your file is parsed locally and only ever leaves this
-              page if you open a pull request.
-            </Text>
-          </Group>
-          <Group gap="md" wrap="nowrap" ml="auto">
-            <Group gap={8} wrap="nowrap">
-              <Badge size="xs" variant="light" color="brand" radius="sm">
-                beta
-              </Badge>
-              <Text size="xs" c="dimmed">
-                Studio v{__STUDIO_VERSION__} · depictio v{__DEPICTIO_VERSION__}
-                {sha ? ` · ${sha}` : ''}
-              </Text>
-            </Group>
-            <Anchor
-              size="xs"
-              c="dimmed"
-              href="https://depictio.github.io/depictio-docs/stable/catalog/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Docs
-            </Anchor>
-            <Anchor
-              size="xs"
-              c="dimmed"
-              href="https://github.com/depictio/depictio/tree/main/depictio/catalog"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Catalog
-            </Anchor>
-            <Anchor
-              size="xs"
-              c="dimmed"
-              href="https://github.com/depictio/depictio/issues/new"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Report an issue
-            </Anchor>
-          </Group>
+    <Box component="footer" h="100%" px="lg" style={{ display: 'flex', alignItems: 'center' }}>
+      <Group justify="space-between" align="center" gap="md" wrap="nowrap" w="100%">
+        <Group gap={6} wrap="nowrap" visibleFrom="md" style={{ minWidth: 0 }}>
+          <Icon icon="mdi:shield-lock-outline" width={15} style={{ flexShrink: 0 }} />
+          <Text size="xs" c="dimmed" lineClamp={1}>
+            Runs entirely in your browser. Your file is parsed locally and only ever leaves this
+            page if you open a pull request.
+          </Text>
         </Group>
-      </Container>
+        <Group gap="md" wrap="nowrap" ml="auto" style={{ flexShrink: 0 }}>
+          <Group gap={8} wrap="nowrap" align="center">
+            <Badge size="xs" variant="light" color="brand" radius="sm" style={{ flexShrink: 0 }}>
+              beta
+            </Badge>
+            <Stack gap={0}>
+              <Text size="xs" c="dimmed" lh={1.35} style={{ whiteSpace: 'nowrap' }}>
+                Studio v{__STUDIO_VERSION__} · depictio v{__DEPICTIO_VERSION__}
+              </Text>
+              {sha && (
+                <Text size="xs" c="dimmed" lh={1.35} style={{ whiteSpace: 'nowrap' }}>
+                  {sha}
+                </Text>
+              )}
+            </Stack>
+          </Group>
+          {LINKS.map(({ label, href }) => (
+            <Anchor
+              key={href}
+              size="xs"
+              c="dimmed"
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              style={{ whiteSpace: 'nowrap' }}
+            >
+              {label}
+            </Anchor>
+          ))}
+        </Group>
+      </Group>
     </Box>
   );
 }

--- a/packages/tool-studio/src/components/AppFooter.tsx
+++ b/packages/tool-studio/src/components/AppFooter.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { Anchor, Badge, Box, Group, Text } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
 const LINKS = [
@@ -18,17 +18,18 @@ const LINKS = [
  * width it gave away is what squeezed the beta badge out of view and wrapped
  * "Report an issue" onto a second line. So everything on the right is `nowrap`
  * and unshrinkable, and the privacy note on the left is the single flexible
- * part — it truncates, then drops entirely below `md`.
+ * part: it truncates, then drops entirely below `md`.
  *
  * A static site published from a build has no other way to say *which* build
  * you are looking at, so the bar carries both versions: Tool Studio's own
  * (packages/tool-studio/package.json, bumped with `pnpm --filter tool-studio run
  * bump <patch|minor|major>`) and the depictio release it was cut from
  * (.bumpversion.cfg), which pins the catalog schema the export has to satisfy.
- * The deploy commit sits on a second line under the two, which read as one pair
- * rather than a three-part run-on; it appears only when the Pages workflow
- * provides GITHUB_SHA. All three are injected at build time, see vite.config.ts.
- * Those two lines are what the shell's footer height is sized to.
+ * The deploy commit follows them in parentheses on the same line, so the two
+ * versions read as one pair and the sha as their qualifier rather than a third
+ * peer; it appears only when the Pages workflow provides GITHUB_SHA. All three
+ * are injected at build time, see vite.config.ts. That single line is what the
+ * shell's footer height is sized to.
  *
  * The beta badge sits with those versions rather than in the header: it qualifies
  * this build, and the reader who wants to know how finished the app is looks in
@@ -51,16 +52,10 @@ export default function AppFooter() {
             <Badge size="xs" variant="light" color="brand" radius="sm" style={{ flexShrink: 0 }}>
               beta
             </Badge>
-            <Stack gap={0}>
-              <Text size="xs" c="dimmed" lh={1.35} style={{ whiteSpace: 'nowrap' }}>
-                Studio v{__STUDIO_VERSION__} · depictio v{__DEPICTIO_VERSION__}
-              </Text>
-              {sha && (
-                <Text size="xs" c="dimmed" lh={1.35} style={{ whiteSpace: 'nowrap' }}>
-                  {sha}
-                </Text>
-              )}
-            </Stack>
+            <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+              Studio v{__STUDIO_VERSION__} · depictio v{__DEPICTIO_VERSION__}
+              {sha ? ` (${sha})` : ''}
+            </Text>
           </Group>
           {LINKS.map(({ label, href }) => (
             <Anchor


### PR DESCRIPTION
Four things were wrong with the Tool Studio footer, and three of them had one cause.

## The cause

The footer sat in a centred `Container size="lg"`, so its content was confined to 1140px inside a bar the header spans end to end on a plain `px="lg"` gutter. The width it gave away is what squeezed the `beta` badge out of view and wrapped "Report an issue" onto a second line.

## What changed

All of it in `AppFooter.tsx`; the shell is untouched.

- Full-bleed on the header's own `px="lg"` gutter, no `Container`.
- `flexShrink: 0` on the badge, on the whole right-hand group and on the lock icon; `white-space: nowrap` on the three links. The privacy note on the left stays the single elastic part: it truncates with `lineClamp={1}`, then drops entirely below `md`.
- The deploy commit follows the two versions in parentheses on the same line, so it reads as a qualifier on the pair rather than a third peer of the same rank.
- The three links become a `LINKS` array, so the `nowrap` lives in one place instead of being recopied.
- The header comment claimed the bar was one line because a second would overflow it, which said nothing about why the bar was narrow in the first place. It now describes the full-bleed layout and what the height is sized to.

## After

<img width="1568" alt="Tool Studio footer: full-bleed bar, beta badge visible, versions with the deploy commit in parentheses, links on one line" src="https://github.com/user-attachments/assets/30c31676-f760-41a8-ac41-8a8e4ab1f3f1" />

## Verification

`pnpm --filter tool-studio run typecheck` passes; pre-commit passes on the file.

Checked in the browser against the dev server with `GITHUB_SHA` set so the commit renders:

- the footer measures 0 -> 1800px, the same width as the bar
- `document.documentElement.scrollWidth <= window.innerWidth`, so nothing overflows
- the right-hand block ends exactly on the 20px gutter
- the whole bar reads `Runs entirely in your browser... | BETA | Studio v0.2.0 · depictio v1.9.0 (233113f) | Docs | Catalog | Report an issue`, one line each

Not verified: the `md` breakpoint where the privacy note drops. `resize_window` reported success but `innerWidth` did not change on this display, so that behaviour rests on the unchanged `visibleFrom="md"` and on the width arithmetic rather than on an observation.