### PR TITLE
fix(ampliseq): make the phylogeny and taxonomy tiles work on a full-size run

### DIFF
--- a/depictio/catalog/qiime2/stacked_taxonomy_canonical.py
+++ b/depictio/catalog/qiime2/stacked_taxonomy_canonical.py
@@ -21,11 +21,36 @@ import polars as pl
 from depictio.models.models.transforms import RecipeSource
 
 SOURCES: list[RecipeSource] = [
-    RecipeSource(ref="phylum", dc_ref="rel_abundance_phylum"),
-    RecipeSource(ref="class_", dc_ref="rel_abundance_class"),
-    RecipeSource(ref="order", dc_ref="rel_abundance_order"),
-    RecipeSource(ref="family", dc_ref="rel_abundance_family"),
-    RecipeSource(ref="genus", dc_ref="rel_abundance_genus"),
+    RecipeSource(
+        ref="phylum",
+        path="qiime2/rel_abundance_tables/rel-table-2.tsv",
+        format="TSV",
+        read_kwargs={"skip_rows": 1},
+    ),
+    RecipeSource(
+        ref="class_",
+        path="qiime2/rel_abundance_tables/rel-table-3.tsv",
+        format="TSV",
+        read_kwargs={"skip_rows": 1},
+    ),
+    RecipeSource(
+        ref="order",
+        path="qiime2/rel_abundance_tables/rel-table-4.tsv",
+        format="TSV",
+        read_kwargs={"skip_rows": 1},
+    ),
+    RecipeSource(
+        ref="family",
+        path="qiime2/rel_abundance_tables/rel-table-5.tsv",
+        format="TSV",
+        read_kwargs={"skip_rows": 1},
+    ),
+    RecipeSource(
+        ref="genus",
+        path="qiime2/rel_abundance_tables/rel-table-6.tsv",
+        format="TSV",
+        read_kwargs={"skip_rows": 1},
+    ),
     RecipeSource(ref="metadata", dc_ref="metadata", optional=True),
 ]
 

--- a/depictio/catalog/qiime2/stacked_taxonomy_canonical.py
+++ b/depictio/catalog/qiime2/stacked_taxonomy_canonical.py
@@ -113,9 +113,11 @@ def transform(sources: dict[str, pl.DataFrame]) -> pl.DataFrame:
     """Combine 5 rank-level rel-tables + a derived Kingdom level."""
     pieces: list[pl.DataFrame] = []
 
-    # Map source ref → (rank, level). We tolerate missing levels (e.g. if the
-    # pipeline didn't emit a deeper collapse) by skipping them rather than
-    # failing the whole recipe.
+    # Map source ref → (rank, level). QIIME2 writes the five collapse levels
+    # together, and the engine rejects a required source that is missing or
+    # empty, so in practice all five arrive. The skip below is what keeps a
+    # level that was repointed at a glob matching nothing from poisoning the
+    # concat rather than a route the pipeline actually takes.
     level_specs = (
         ("phylum", "Phylum"),
         ("class_", "Class"),

--- a/depictio/cli/cli/utils/templates.py
+++ b/depictio/cli/cli/utils/templates.py
@@ -20,6 +20,7 @@ import yaml
 
 from depictio.cli.cli_logging import logger
 from depictio.models.models.templates import (
+    DCOverride,
     ExpectedDataCollection,
     ProvenanceEntry,
     ProvenanceGroupRule,
@@ -434,6 +435,7 @@ def _apply_conditionals(
     conditionals: list[TemplateConditional],
     provided_vars: set[str],
     template_dir: Path,
+    variables: dict[str, str] | None = None,
 ) -> tuple[dict[str, Any], list[str], dict[str, str]]:
     """Apply conditional rules based on which optional variables were provided.
 
@@ -448,6 +450,10 @@ def _apply_conditionals(
         conditionals: List of conditional rules from template metadata.
         provided_vars: Set of variable names actually provided by the user.
         template_dir: Template directory for resolving dashboard paths.
+        variables: Variable map, for the placeholders an override may carry.
+            Conditionals run *after* the config-wide substitution pass, so an
+            override written as `scan_filename: "{TREE_FILE}"` would otherwise
+            reach the DC verbatim and read as a path that does not exist.
 
     Returns:
         Tuple of (modified_config, active_dashboard_rel_paths, removal_reasons),
@@ -478,8 +484,13 @@ def _apply_conditionals(
             removal_reasons.setdefault(tag, reason)
             logger.info(f"Conditional rule: removing DC tag '{tag}'")
 
-        # Collect DC source-binding overrides (last-write-wins per tag)
+        # Collect DC source-binding overrides (last-write-wins per tag).
+        # Resolved through the variable map first: the rule fires on a variable
+        # being present, so pointing the DC at that variable's value is the
+        # natural thing to write, and every override field can hold a path.
         for ov in rule.override_dcs:
+            if variables:
+                ov = DCOverride(**substitute_template_variables(ov.model_dump(), variables))
             overrides_by_tag[ov.data_collection_tag] = ov
             logger.info(f"Conditional rule: overriding DC source '{ov.data_collection_tag}'")
 
@@ -1176,6 +1187,7 @@ def resolve_template(
         template_metadata.conditional,
         provided_vars,
         template_dir,
+        variables,
     )
     removal_reasons.update(conditional_reasons)
 

--- a/depictio/projects/nf-core/ampliseq/2.16.0/template.yaml
+++ b/depictio/projects/nf-core/ampliseq/2.16.0/template.yaml
@@ -24,6 +24,9 @@ template:
     - name: "SAMPLESHEET_FILE"
       description: "Path to the ampliseq samplesheet. Auto-detected from {DATA_ROOT}/input/ (CSV or TSV) when omitted."
       required: false
+    - name: "TREE_FILE"
+      description: "Path to the Newick tree to serve. Defaults to {DATA_ROOT}/qiime2/phylogenetic_tree/tree.nwk. A run with far more ASVs than a tree renders readably should point this at the output of scripts/prune_newick.py, which cuts the tree to the same taxa the tip-metadata recipe keeps."
+      required: false
     - name: "METADATA_FILE"
       description: "Path to sample metadata TSV (--metadata in ampliseq run). Optional. All non-ID columns become annotations."
       required: false
@@ -192,6 +195,12 @@ template:
     - if_var_present: "SKIP_ANCOM"
       remove_dc_tags: ["ancombc_results", "ma_canonical"]
       dashboards: ["dashboards/base.yaml"]
+    # A cohort large enough to need a pruned tree supplies its own Newick; the
+    # DC's default path stays the pipeline's, which is never written to.
+    - if_var_present: "TREE_FILE"
+      override_dcs:
+        - data_collection_tag: "phylogenetic_tree_canonical"
+          scan_filename: "{TREE_FILE}"
 
 # ============================================================================
 # PROJECT CONFIGURATION
@@ -583,6 +592,10 @@ workflows:
       - data_collection_tag: "phylogenetic_tree_canonical"
         optional: true  # tree.nwk absent for ITS / IonTorrent / multi-region / skip_qiime runs
         description: "QIIME2 phylogenetic tree (Newick) — tips are ASV identifiers"
+        # Serves the pipeline's tree as-is. Runs whose ASV count outgrows the
+        # renderer prune it with scripts/prune_newick.py and pass --var
+        # TREE_FILE=<pruned>; the tip-metadata recipe caps itself to the same
+        # taxa, so the two never disagree about which tips exist.
         config:
           type: "phylogeny"
           metatype: "Aggregate"

--- a/depictio/projects/nf-core/ampliseq/recipes/sankey_canonical.py
+++ b/depictio/projects/nf-core/ampliseq/recipes/sankey_canonical.py
@@ -29,7 +29,12 @@ import polars as pl
 from depictio.models.models.transforms import RecipeSource
 
 SOURCES: list[RecipeSource] = [
-    RecipeSource(ref="genus", dc_ref="rel_abundance_genus"),
+    RecipeSource(
+        ref="genus",
+        path="qiime2/rel_abundance_tables/rel-table-6.tsv",
+        format="TSV",
+        read_kwargs={"skip_rows": 1},
+    ),
     RecipeSource(ref="metadata", dc_ref="metadata", optional=True),
 ]
 

--- a/depictio/projects/nf-core/ampliseq/recipes/sunburst_canonical.py
+++ b/depictio/projects/nf-core/ampliseq/recipes/sunburst_canonical.py
@@ -14,7 +14,12 @@ import polars as pl
 from depictio.models.models.transforms import RecipeSource
 
 SOURCES: list[RecipeSource] = [
-    RecipeSource(ref="genus", dc_ref="rel_abundance_genus"),
+    RecipeSource(
+        ref="genus",
+        path="qiime2/rel_abundance_tables/rel-table-6.tsv",
+        format="TSV",
+        read_kwargs={"skip_rows": 1},
+    ),
     RecipeSource(ref="metadata", dc_ref="metadata", optional=True),
 ]
 

--- a/depictio/projects/nf-core/ampliseq/recipes/tree_metadata_canonical.py
+++ b/depictio/projects/nf-core/ampliseq/recipes/tree_metadata_canonical.py
@@ -1,21 +1,35 @@
 """Tip metadata for the ampliseq phylogenetic tree.
 
-Parses the QIIME2 taxonomy.tsv (Feature ID / Taxon / Confidence) into a
-joinable tip-metadata table where ``taxon`` matches the ASV-hash tip labels
-in tree.nwk and the taxonomy string is split into per-rank columns the
+Builds a joinable tip-metadata table whose ``taxon`` matches the ASV-hash tip
+labels in tree.nwk, with the taxonomy split into per-rank columns the
 phylogenetic renderer can use for tip colouring / labelling.
+
+Reads whichever taxonomy artefact the run actually produced. ampliseq emits
+different ones depending on the classifier and whether taxonomy was supplied as
+input rather than assigned, and a recipe bound to only one of them leaves the
+Phylogeny tab empty on every other route:
+
+* ``rel-table-ASV_with-DADA2-tax.tsv`` — preferred. Ranks are already split into
+  columns, confidence is a column, and the per-sample abundances sit in the same
+  frame, so the dominant-group call needs no second source.
+* ``qiime2/taxonomy/taxonomy.tsv`` — the classifier's own table, a ``Taxon``
+  lineage string to parse. Both dialects are handled: Greengenes-style
+  ``k__Bacteria; p__…`` prefixes, and prefix-less SILVA-style ``Bacteria;…``.
+  ``Confidence`` may be a column, a trailing field of the lineage string, or
+  absent entirely.
+
+A run can carry far more ASVs than a tree is readable at: this one has
+127,845 tips against the reference dataset's 2,683. Where the abundances are
+available the table is capped to the ``MAX_TIPS`` most abundant ASVs, and
+``prune_newick.py`` cuts tree.nwk to the same set at ingestion so tips and
+metadata stay in step.
 
 Output schema:
     taxon : Utf8 — ASV hash (matches tree.nwk tip names)
-    Kingdom : Utf8
-    Phylum : Utf8
-    Class : Utf8
-    Order : Utf8
-    Family : Utf8
-    Genus : Utf8
-    Species : Utf8
+    Kingdom … Species : Utf8
     confidence : Float64
     label : Utf8 — short display label (Phylum if known, else taxon[:8])
+    dominant_habitat : Utf8 — group carrying most of the ASV's abundance
 """
 
 import polars as pl
@@ -23,8 +37,25 @@ import polars as pl
 from depictio.models.models.transforms import RecipeSource
 
 SOURCES: list[RecipeSource] = [
-    RecipeSource(ref="taxonomy", dc_ref="qiime2_taxonomy"),
-    RecipeSource(ref="asv_abundance", dc_ref="rel_abundance_asv", optional=True),
+    RecipeSource(
+        ref="asv_tax",
+        path="qiime2/rel_abundance_tables/rel-table-ASV_with-DADA2-tax.tsv",
+        format="TSV",
+        # Read every column as text and cast at the point of use. A sample
+        # column whose first few thousand ASVs are all absent looks like an
+        # integer column until a relative abundance in scientific notation
+        # turns up 40,000 rows later, and schema inference over a 90 MB table
+        # never sees it. Nothing here needs an inferred numeric type: the ranks
+        # are strings, and every numeric read below casts explicitly.
+        read_kwargs={"infer_schema_length": 0},
+        optional=True,
+    ),
+    RecipeSource(
+        ref="taxonomy",
+        path="qiime2/taxonomy/taxonomy.tsv",
+        format="TSV",
+        optional=True,
+    ),
     RecipeSource(ref="metadata", dc_ref="metadata", optional=True),
 ]
 
@@ -54,6 +85,13 @@ _DOMINANCE_THRESHOLD = 0.6
 # labelled "Rare" — they're statistically unstable for any habitat call.
 _RARE_TOTAL_ABUNDANCE = 0.0001  # = 0.01% of the cohort-wide summed abundance
 
+# Cap on the number of tips carried into the tree metadata. Ranking is by
+# summed cohort abundance, so what survives is the community the run actually
+# measured rather than an arbitrary slice. 3000 sits just above the reference
+# dataset (2,683 tips), which therefore passes through untouched, and holds
+# ~93% of the summed abundance on a 127k-ASV run. None disables the cap.
+MAX_TIPS: int | None = 3000
+
 _METADATA_ID_COL = "sample"
 
 _RANK_PREFIXES = (
@@ -67,27 +105,151 @@ _RANK_PREFIXES = (
 )
 
 
+# Columns of the ASV table that are not per-sample abundances.
+_ASV_META_COLS = (
+    "ID",
+    "Kingdom",
+    "Phylum",
+    "Class",
+    "Order",
+    "Family",
+    "Genus",
+    "Species",
+    "confidence",
+    "sequence",
+)
+
+_RANKS = ("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")
+
+
+def _blank_to_null(col: str) -> pl.Expr:
+    """ampliseq writes unassigned ranks as empty strings, not nulls."""
+    return pl.when(pl.col(col).str.strip_chars() == "").then(None).otherwise(pl.col(col)).alias(col)
+
+
+def top_taxa(asv_tax: pl.DataFrame, max_tips: int) -> list[str]:
+    """The `max_tips` ASV ids carrying the most abundance across the cohort.
+
+    Shared with ``scripts/prune_newick.py``, which prunes tree.nwk to exactly
+    this set. Two implementations of the same rule would drift, and a tree
+    holding tips the metadata has dropped renders them unannotated.
+
+    Ties break on the ASV id so the selection is reproducible across runs.
+    """
+    sample_cols = [c for c in asv_tax.columns if c not in _ASV_META_COLS]
+    if not sample_cols:
+        return asv_tax["ID"].to_list()
+    ranked = (
+        asv_tax.select(
+            pl.col("ID"),
+            pl.sum_horizontal(
+                [pl.col(c).cast(pl.Float64, strict=False) for c in sample_cols]
+            ).alias("total_abundance"),
+        )
+        .sort(["total_abundance", "ID"], descending=[True, False])
+        .head(max_tips)
+    )
+    return ranked["ID"].to_list()
+
+
+def _from_asv_table(asv: pl.DataFrame) -> pl.DataFrame:
+    """Ranks are already columns here — only naming and blanks need work."""
+    df = asv.rename({"ID": "taxon"})
+    present = [r for r in _RANKS if r in df.columns]
+    df = df.with_columns([_blank_to_null(r) for r in present])
+    if "confidence" in df.columns:
+        df = df.with_columns(pl.col("confidence").cast(pl.Float64, strict=False))
+    return df.select(["taxon", *present, *(["confidence"] if "confidence" in df.columns else [])])
+
+
+def _from_taxonomy_table(tax: pl.DataFrame) -> pl.DataFrame:
+    """Parse a lineage string, in either dialect, into per-rank columns."""
+    id_col = next((c for c in ("Feature ID", "feature_id", "taxon") if c in tax.columns), None)
+    tax_col = next((c for c in ("Taxon", "taxon_string", "Taxonomy") if c in tax.columns), None)
+    if id_col is None or tax_col is None:
+        raise ValueError(f"taxonomy table needs an id and a lineage column; got {tax.columns}")
+    df = tax.rename({id_col: "taxon", tax_col: "taxonomy_string"})
+
+    prefixed = bool(df.select(pl.col("taxonomy_string").str.contains("k__").any()).item())
+    if prefixed:
+        rank_exprs = [
+            pl.col("taxonomy_string")
+            .str.extract(rf"{prefix}([^;]+)", 1)
+            .str.strip_chars()
+            .alias(rank)
+            for rank, prefix in zip(
+                _RANKS, ("k__", "p__", "c__", "o__", "f__", "g__", "s__"), strict=True
+            )
+        ]
+    else:
+        # Prefix-less: ranks are positional, semicolon-separated.
+        parts = pl.col("taxonomy_string").str.split(";")
+        rank_exprs = [
+            parts.list.get(i, null_on_oob=True).str.strip_chars().alias(rank)
+            for i, rank in enumerate(_RANKS)
+        ]
+    df = df.with_columns(rank_exprs).with_columns([_blank_to_null(r) for r in _RANKS])
+
+    if "Confidence" in df.columns:
+        conf = pl.col("Confidence").cast(pl.Float64, strict=False)
+    else:
+        # Some exports append confidence as a trailing field of the lineage
+        # ("Bacteria;…;;1"). Non-numeric trailing fields cast to null, which is
+        # the same answer as "no confidence recorded".
+        conf = (
+            pl.col("taxonomy_string")
+            .str.split(";")
+            .list.last()
+            .str.strip_chars()
+            .cast(pl.Float64, strict=False)
+        )
+    return df.with_columns(conf.alias("confidence")).select(["taxon", *_RANKS, "confidence"])
+
+
+def _group_column(metadata: pl.DataFrame) -> str | None:
+    """The metadata column samples are grouped by.
+
+    `habitat` when the run has one, else the template's own convention: the
+    first column is the sample id and the second is the grouping factor. Reading
+    it positionally is what lets this work on a run whose factor is `locality`,
+    `site` or anything else, instead of only on the reference dataset.
+    """
+    if "habitat" in metadata.columns:
+        return "habitat"
+    candidates = [c for c in metadata.columns if not c.startswith("depictio_")]
+    return candidates[1] if len(candidates) > 1 else None
+
+
 def transform(sources: dict[str, pl.DataFrame]) -> pl.DataFrame:
-    """Parse QIIME2 'k__X; p__Y; ...' Taxon string into per-rank columns."""
-    df = sources["taxonomy"].rename({"Feature ID": "taxon", "Taxon": "taxonomy_string"})
+    """Build tip metadata from whichever taxonomy artefact the run produced."""
+    asv_tax = sources.get("asv_tax")
+    taxonomy = sources.get("taxonomy")
 
-    rank_exprs = [
-        pl.col("taxonomy_string")
-        .str.extract(rf"{prefix}([^;]+)", 1)
-        .str.strip_chars()
-        .alias(rank_name)
-        for rank_name, prefix in _RANK_PREFIXES
-    ]
-
-    df = df.with_columns(rank_exprs).drop("taxonomy_string")
+    if asv_tax is not None:
+        df = _from_asv_table(asv_tax)
+    elif taxonomy is not None:
+        df = _from_taxonomy_table(taxonomy)
+    else:
+        raise ValueError(
+            "no taxonomy source found: expected either "
+            "qiime2/rel_abundance_tables/rel-table-ASV_with-DADA2-tax.tsv or "
+            "qiime2/taxonomy/taxonomy.tsv under the run directory"
+        )
 
     df = df.with_columns(
-        pl.col("Confidence").cast(pl.Float64, strict=False).alias("confidence"),
         pl.when(pl.col("Phylum").is_not_null() & (pl.col("Phylum") != ""))
         .then(pl.col("Phylum"))
         .otherwise(pl.col("taxon").str.slice(0, 8))
-        .alias("label"),
-    ).drop("Confidence")
+        .alias("label")
+    )
+
+    # The ASV table carries its own per-sample abundances; the classifier table
+    # does not, so dominance is only available on the first route.
+    asv_abundance = None
+    if asv_tax is not None:
+        sample_cols = [c for c in asv_tax.columns if c not in _ASV_META_COLS]
+        if sample_cols:
+            asv_abundance = asv_tax.select(["ID", *sample_cols])
 
     # Dominant-habitat derivation. When ASV abundance + sample metadata are
     # both available, compute per-ASV summed abundance by habitat and assign:
@@ -97,24 +259,24 @@ def transform(sources: dict[str, pl.DataFrame]) -> pl.DataFrame:
     # ASVs that don't appear in the abundance table at all get
     # 'No abundance' (~75 % of the metadata DC for this run — they're
     # taxonomy-classified rep-seqs that dropped out before the OTU table).
-    asv_abundance = sources.get("asv_abundance")
     metadata = sources.get("metadata")
-    if asv_abundance is not None and metadata is not None and "habitat" in metadata.columns:
+    group_col = _group_column(metadata) if metadata is not None else None
+    if asv_abundance is not None and metadata is not None and group_col is not None:
         sample_col = next(
             (c for c in (_METADATA_ID_COL, "ID", "sample_id") if c in metadata.columns),
-            None,
+            metadata.columns[0] if metadata.columns else None,
         )
-        if sample_col is not None:
+        if sample_col is not None and sample_col != group_col:
             sample_to_habitat = (
-                metadata.select(sample_col, "habitat")
+                metadata.select(sample_col, group_col)
                 .unique(subset=[sample_col])
-                .rename({sample_col: "sample_id"})
+                .rename({sample_col: "sample_id", group_col: "habitat"})
             )
 
             # Unpivot the ASV × sample wide table to long form, then join the
             # habitat mapping. The lineage column is whatever name the source
             # CSV used (typically '#OTU ID' from the QIIME2 biom export).
-            lineage_col = asv_abundance.columns[0]
+            lineage_col = asv_abundance.columns[0]  # "ID"
             value_cols = [c for c in asv_abundance.columns if c != lineage_col]
             long_abund = (
                 asv_abundance.unpivot(
@@ -168,6 +330,12 @@ def transform(sources: dict[str, pl.DataFrame]) -> pl.DataFrame:
             df = df.join(top_habitat, on="taxon", how="left").with_columns(
                 pl.col("dominant_habitat").fill_null("No abundance")
             )
+
+    # Cap last, so the dominance call still sees the whole cohort: an ASV's
+    # share of its habitat is a property of all the abundance recorded, not of
+    # the subset that survives the cut.
+    if asv_tax is not None and MAX_TIPS is not None and df.height > MAX_TIPS:
+        df = df.filter(pl.col("taxon").is_in(top_taxa(asv_tax, MAX_TIPS)))
 
     keep = [
         "taxon",

--- a/depictio/projects/nf-core/ampliseq/scripts/prune_newick.py
+++ b/depictio/projects/nf-core/ampliseq/scripts/prune_newick.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Cut an ampliseq tree.nwk down to the ASVs worth drawing.
+
+A full ampliseq run classifies every ASV it sees, and on a large cohort that is
+two orders of magnitude more tips than a tree renders usefully: 127,845 on the
+TREC Advanced Mobile Lab run against 2,683 in the bundled reference dataset. The
+7.8 MB Newick alone stalls the browser before Phylocanvas draws anything.
+
+The kept set comes from ``tree_metadata_canonical.top_taxa`` — the same ranking
+the tip-metadata recipe applies to itself — so the pruned tree and the metadata
+DC hold exactly the same taxa. Point the ingest at the result with
+``--var TREE_FILE=<output>``; the pipeline's own tree.nwk is never written to.
+
+Usage:
+    python depictio/projects/nf-core/ampliseq/scripts/prune_newick.py \
+        --data-root /path/to/ampliseq/results \
+        --out /path/to/ampliseq/results/qiime2/phylogenetic_tree/tree.pruned.nwk
+
+No phylogeny library is needed (or installed): the parser below is the whole of
+Newick that QIIME2 emits — nested clades, labels, branch lengths, comments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_RECIPE = _HERE.parent / "recipes" / "tree_metadata_canonical.py"
+
+# Relative to --data-root; both are ampliseq's own fixed output layout.
+_TREE_REL = "qiime2/phylogenetic_tree/tree.nwk"
+_ASV_REL = "qiime2/rel_abundance_tables/rel-table-ASV_with-DADA2-tax.tsv"
+
+
+def _load_recipe():
+    """Import the recipe module by path — ``recipes/`` is not a package."""
+    spec = importlib.util.spec_from_file_location("tree_metadata_canonical", _RECIPE)
+    if spec is None or spec.loader is None:  # pragma: no cover - unreachable in-tree
+        raise RuntimeError(f"cannot load {_RECIPE}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Tree:
+    """A Newick forest flattened into parallel arrays.
+
+    Arrays rather than objects, and every traversal below is iterative: a
+    ladderised bacterial tree is deep enough that a recursive walk overflows
+    the interpreter's stack well before it runs out of memory.
+    """
+
+    __slots__ = ("parent", "name", "length", "children")
+
+    def __init__(self) -> None:
+        self.parent: list[int] = []
+        self.name: list[str] = []
+        self.length: list[float] = []
+        self.children: list[list[int]] = []
+
+    def add(self, parent: int) -> int:
+        idx = len(self.parent)
+        self.parent.append(parent)
+        self.name.append("")
+        self.length.append(0.0)
+        self.children.append([])
+        if parent >= 0:
+            self.children[parent].append(idx)
+        return idx
+
+
+def parse_newick(text: str) -> tuple[Tree, int]:
+    """Parse one Newick string; returns the tree and its root index."""
+    tree = Tree()
+    root = tree.add(-1)
+    cur = root
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "(":
+            cur = tree.add(cur)
+            i += 1
+        elif c == ",":
+            cur = tree.add(tree.parent[cur])
+            i += 1
+        elif c == ")":
+            cur = tree.parent[cur]
+            i += 1
+        elif c == ";":
+            break
+        elif c == ":":
+            j = i + 1
+            while j < n and text[j] not in ",);":
+                j += 1
+            try:
+                tree.length[cur] = float(text[i + 1 : j].strip())
+            except ValueError:
+                tree.length[cur] = 0.0
+            i = j
+        elif c == "[":  # comment / NHX annotation
+            j = text.find("]", i)
+            i = n if j < 0 else j + 1
+        elif c in " \t\r\n":
+            i += 1
+        else:
+            j = i
+            while j < n and text[j] not in "(),:;[":
+                j += 1
+            tree.name[cur] = text[i:j].strip().strip("'\"")
+            i = j
+    return tree, root
+
+
+def _fmt(x: float) -> str:
+    """Newick branch length, short but lossless enough for QIIME2's precision."""
+    return f"{x:.10g}"
+
+
+def prune(tree: Tree, root: int, wanted: set[str]) -> str:
+    """Render the subtree spanning `wanted`, collapsing what is left over.
+
+    A node with a single surviving child carries no topology, so it is dropped
+    and its branch length folded into that child's. Skipping this leaves long
+    chains of degree-two nodes that every renderer has to walk through.
+    """
+    keep = [False] * len(tree.parent)
+    for idx, children in enumerate(tree.children):
+        if not children and tree.name[idx] in wanted:
+            keep[idx] = True
+    # Walk kept tips up to the root. `keep` doubles as the visited set, so each
+    # edge is climbed once no matter how many tips share the ancestor.
+    for idx in [i for i, k in enumerate(keep) if k]:
+        p = tree.parent[idx]
+        while p >= 0 and not keep[p]:
+            keep[p] = True
+            p = tree.parent[p]
+
+    if not keep[root]:
+        raise SystemExit("no requested tip found in the tree — wrong tree or wrong ids?")
+
+    rendered: dict[int, tuple[str, float]] = {}
+    stack: list[tuple[int, bool]] = [(root, False)]
+    while stack:
+        node, expanded = stack.pop()
+        kids = [c for c in tree.children[node] if keep[c]]
+        if not expanded:
+            stack.append((node, True))
+            stack.extend((c, False) for c in kids)
+            continue
+        if not kids:
+            rendered[node] = (tree.name[node], tree.length[node])
+        elif len(kids) == 1:
+            text, edge = rendered.pop(kids[0])
+            rendered[node] = (text, edge + tree.length[node])
+        else:
+            body = ",".join(f"{t}:{_fmt(e)}" for t, e in (rendered.pop(c) for c in kids))
+            rendered[node] = (f"({body}){tree.name[node]}", tree.length[node])
+    return rendered[root][0] + ";"
+
+
+def count_tips(tree: Tree) -> int:
+    return sum(1 for c in tree.children if not c)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--data-root", type=Path, required=True, help="ampliseq results directory")
+    ap.add_argument("--tree", type=Path, help=f"Newick to prune (default: <data-root>/{_TREE_REL})")
+    ap.add_argument("--abundance", type=Path, help=f"ASV table (default: <data-root>/{_ASV_REL})")
+    ap.add_argument("--out", type=Path, required=True, help="where to write the pruned Newick")
+    ap.add_argument(
+        "--max-tips",
+        type=int,
+        default=None,
+        help="tips to keep (default: the recipe's own MAX_TIPS, so the two agree)",
+    )
+    args = ap.parse_args(argv)
+
+    import polars as pl
+
+    recipe = _load_recipe()
+    max_tips = args.max_tips if args.max_tips is not None else recipe.MAX_TIPS
+    if max_tips is None:
+        print("MAX_TIPS is None and --max-tips was not given: nothing to prune", file=sys.stderr)
+        return 2
+
+    tree_path = args.tree or args.data_root / _TREE_REL
+    asv_path = args.abundance or args.data_root / _ASV_REL
+    for path in (tree_path, asv_path):
+        if not path.exists():
+            print(f"not found: {path}", file=sys.stderr)
+            return 2
+
+    # Text-only, like the recipe reads it: a sample column can stay all-zero
+    # for tens of thousands of ASVs before a scientific-notation abundance
+    # appears, and top_taxa casts what it needs anyway.
+    asv = pl.read_csv(asv_path, separator="\t", infer_schema_length=0)
+    wanted = set(recipe.top_taxa(asv, max_tips))
+
+    tree, root = parse_newick(tree_path.read_text())
+    before = count_tips(tree)
+    newick = prune(tree, root, wanted)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(newick + "\n")
+
+    after, _ = parse_newick(newick)
+    print(
+        f"{tree_path}: {before} tips ({tree_path.stat().st_size / 1e6:.1f} MB)\n"
+        f"{args.out}: {count_tips(after)} tips ({args.out.stat().st_size / 1e6:.1f} MB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/depictio/recipes/__init__.py
+++ b/depictio/recipes/__init__.py
@@ -207,6 +207,14 @@ def resolve_sources(
 
         file_path = data_dir / rel_path
         if not file_path.exists():
+            # `optional` has always meant "pass None to transform() when this
+            # source cannot be resolved"; until now only dc_ref sources honoured
+            # it, so an optional *file* source still hard-failed the whole recipe.
+            # A recipe that can read either of two pipeline outputs (they vary by
+            # classifier / route) has no way to express that otherwise.
+            if source.optional:
+                sources[source.ref] = None  # type: ignore[assignment]
+                continue
             raise RecipeError(f"Source '{source.ref}': file not found: {file_path}")
 
         df = _read_source_file(file_path, source)

--- a/depictio/tests/recipes/test_advanced_viz_recipes.py
+++ b/depictio/tests/recipes/test_advanced_viz_recipes.py
@@ -40,34 +40,55 @@ def _polars_schema_name(df: pl.DataFrame) -> dict[str, str]:
 
 def test_ampliseq_stacked_taxonomy_canonical(tmp_path: Path) -> None:
     # The recipe fans in QIIME2 rel-table-{2..6}.tsv (one wide table per rank,
-    # taxa × samples) via dc_ref sources — injected here as `extra_sources`.
-    # Only the Phylum level (rel-table-2) is supplied; the recipe tolerates the
-    # deeper levels being absent and derives a Kingdom level from the Phylum rows.
-    phylum = pl.DataFrame(
-        {
-            "#OTU ID": ["k__Bacteria;p__Firmicutes", "k__Bacteria;p__Bacteroidetes"],
-            "S1": [0.55, 0.30],
-            "S2": [0.40, 0.50],
-        }
-    )
-    empty = pl.DataFrame()
+    # taxa × samples), read from the run directory. Each carries the
+    # "# Constructed from biom file" banner QIIME2's biom export writes, which is
+    # why the sources skip a row.
+    #
+    # All five levels are written because the recipe engine rejects a required
+    # source that is missing *or* that loads zero rows, so a run cannot present
+    # QIIME2's collapse levels one at a time. Kingdom is not among them: the
+    # recipe derives it by summing the Phylum rows.
+    tables = tmp_path / "qiime2" / "rel_abundance_tables"
+    tables.mkdir(parents=True)
+    lineages = {
+        2: ("k__Bacteria;p__Firmicutes", "k__Bacteria;p__Bacteroidetes"),
+        3: ("k__Bacteria;p__Firmicutes;c__Bacilli", "k__Bacteria;p__Bacteroidetes;c__Bacteroidia"),
+        4: (
+            "k__Bacteria;p__Firmicutes;c__Bacilli;o__Lactobacillales",
+            "k__Bacteria;p__Bacteroidetes;c__Bacteroidia;o__Bacteroidales",
+        ),
+        5: (
+            "k__Bacteria;p__Firmicutes;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae",
+            "k__Bacteria;p__Bacteroidetes;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae",
+        ),
+        6: (
+            "k__Bacteria;p__Firmicutes;c__Bacilli;o__Lactobacillales;f__Lactobacillaceae;"
+            "g__Lactobacillus",
+            "k__Bacteria;p__Bacteroidetes;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;"
+            "g__Bacteroides",
+        ),
+    }
+    for level, (first, second) in lineages.items():
+        (tables / f"rel-table-{level}.tsv").write_text(
+            "# Constructed from biom file\n"
+            "#OTU ID\tS1\tS2\n"
+            f"{first}\t0.55\t0.40\n"
+            f"{second}\t0.30\t0.50\n"
+        )
 
-    result = execute_recipe(
-        "qiime2/stacked_taxonomy_canonical.py",
-        tmp_path,
-        extra_sources={
-            "phylum": phylum,
-            "class_": empty,
-            "order": empty,
-            "family": empty,
-            "genus": empty,
-        },
-    )
+    result = execute_recipe("qiime2/stacked_taxonomy_canonical.py", tmp_path)
 
     assert not result.is_empty()
     assert set(["sample_id", "taxon", "rank", "abundance"]).issubset(result.columns)
-    # Phylum rows plus a Kingdom level the recipe derives by summing Phylum.
-    assert set(result["rank"].unique().to_list()) == {"Kingdom", "Phylum"}
+    # Every collapse level, plus the Kingdom the recipe derives by summing Phylum.
+    assert set(result["rank"].unique().to_list()) == {
+        "Kingdom",
+        "Phylum",
+        "Class",
+        "Order",
+        "Family",
+        "Genus",
+    }
 
     cfg = StackedTaxonomyConfig(
         sample_id_col="sample_id",


### PR DESCRIPTION
## What

Four ampliseq recipes never materialised a Delta table on a plain CLI ingest, so every tile bound to them answered 404. Traced from a 127,845-ASV run (TREC Advanced Mobile Lab 2024), fixed generically.

## Why the tiles were empty

Eight recipe sources pointed at `dc_ref`s that no template defines: `rel_abundance_genus` and `rel_abundance_{phylum,class,order,family,genus}`. Nothing resolved them, so `sunburst_canonical`, `sankey_canonical`, `stacked_taxonomy_canonical` and `tree_metadata_canonical` failed at ingest. They now read the QIIME2 `rel_abundance_tables/rel-table-*.tsv` files those refs were standing in for.

## Generalising the tip-metadata recipe

`tree_metadata_canonical` was bound to one artefact and one column name. It now:

- takes either `rel-table-ASV_with-DADA2-tax.tsv` or the classifier's own `taxonomy/taxonomy.tsv`
- parses both lineage dialects: Greengenes-prefixed (`k__Bacteria; p__...`) and prefix-less SILVA (`Bacteria;Bacillota;...`)
- reads `Confidence` as a column, as a trailing lineage field, or not at all
- picks the grouping column positionally, following the template's own convention (column 1 is the sample id, column 2 is the factor), so a run grouped by `locality` behaves like the reference run grouped by `habitat`
- reads the ASV table as text and casts at the point of use, because a sample column can stay all-zero for tens of thousands of rows before a scientific-notation abundance appears, which schema inference over a 90 MB table never sees

## Tree size

A cohort can carry far more ASVs than a tree renders readably: 127,845 tips and 7.8 MB of Newick here, against 2,683 in the bundled reference. Two halves of one decision:

- the recipe caps its output at `MAX_TIPS` (3000) by summed cohort abundance
- `scripts/prune_newick.py` cuts `tree.nwk` to exactly the set `top_taxa()` keeps

Sharing the selection function is what stops the tree and its tip metadata disagreeing about which tips exist. The pruner is self-contained (no phylogeny library is installed); it writes a new file and never touches the pipeline's own output. Point an ingest at the result with the new optional `TREE_FILE` template variable.

On the run this was traced from: 127,845 tips / 7.8 MB to 3,000 tips / 0.2 MB in 1.5 s, holding ~93% of the summed abundance.

## Two supporting fixes

- `RecipeSource(optional=True)` was only honoured for `dc_ref` sources, so a missing optional *file* source still failed the whole recipe.
- Conditional `override_dcs` values never went through variable substitution. Conditionals run after the config-wide pass, so an override written as `scan_filename: "{TREE_FILE}"` reached the DC verbatim, read as a path that does not exist, and then had the optional DC silently pruned for a missing source file.

## Seeded reference datasets are untouched

2.16.0 ships a `{dc_tag}.tsv` seed for all four recipes, and the boot resolver short-circuits a seeded recipe DC into a file scan with `transform.materialized = true`, so none of them runs at init. `reference.vars` supplies no `TREE_FILE`, so the new conditional never fires and the tree DC keeps the pipeline path.

Note for whoever regenerates seeds: the reference tip-metadata seed holds 11,994 rows (classified rep-seqs that never entered the 2,683-tip tree). Regenerating it from the ASV table would now apply the cap.

## Verification

- End to end on the traced run: 21 of 23 DCs processed, the 2 skipped are the SIDLE optionals whose sources that run does not produce.
- `/advanced_viz/phylogeny/{dc}/newick` 404 to 200, 182 KB, 3,000 tips.
- `POST /advanced_viz/data` for the tip metadata 404 to 200, 3,000 rows.
- Tree tips and metadata taxa verified equal as sets.
- Both recipe routes exercised against real data: the ASV table (127,845 rows) and the classifier taxonomy (135,717 rows).
- `depictio/tests/cli/utils/test_templates.py`: 38 passed.
- `pre-commit run --all-files` clean (the shellcheck failures are pre-existing, on files this PR does not touch).