### PR TITLE
fix(e2e,catalog): serialize backup-restore, fix multiqc section match

### DIFF
--- a/depictio/api/v1/endpoints/catalog_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/catalog_endpoints/routes.py
@@ -131,7 +131,8 @@ def _match_dc_to_catalog(
 
 
 def _multiqc_sections(dc_id: str) -> set[str] | None:
-    """Modules actually present in a MultiQC DC's report, or None if unknown.
+    """Modules a MultiQC DC's report can actually render as a `multiqc` component,
+    or None if unknown.
 
     Every MultiQC catalog output keys on the same `multiqc.parquet` path, so path
     matching alone offers all of them (bcftools, ivar, samtools, ...) on a report
@@ -144,26 +145,48 @@ def _multiqc_sections(dc_id: str) -> set[str] | None:
     a catalog output's `section` names the module itself. `multiqc_module` is the
     normalisation the preview payload already applies to the same anchors, so both
     sides of the catalog agree on what a section means.
+
+    A module that is present but produced no *plot* (a custom-content table like
+    `summary_conformance_metrics`, or a `*_software_versions` module) is excluded
+    too: the picker (`multiqcConfigForSection` in CatalogTab.tsx) resolves a
+    section to `opts.plots[anchor][0]`, and a module with no `plots` entry there
+    persists a null `selected_plot` that `render_multiqc` then 400s on at render
+    time instead of never being offered. `general_stats` is the one exception —
+    it renders through its own stub path and needs no plot.
     """
-    doc = multiqc_collection.find_one({"data_collection_id": dc_id}, {"metadata.modules": 1})
+    doc = multiqc_collection.find_one(
+        {"data_collection_id": dc_id}, {"metadata.modules": 1, "metadata.plots": 1}
+    )
     if not doc:
         return None
-    modules = (doc.get("metadata") or {}).get("modules")
+    metadata = doc.get("metadata") or {}
+    modules = metadata.get("modules")
     if not isinstance(modules, list) or not modules:
         # An empty list means extraction produced nothing, not that the report is
         # empty. `_parsed_multiqc_report` in dashboards_endpoints treats it the
         # same way: keep every component rather than silently dropping them all.
         return None
-    return {multiqc_module(str(m).lower()) for m in modules}
+    present = {multiqc_module(str(m).lower()) for m in modules}
+
+    plots_meta = metadata.get("plots") or {}
+    if not plots_meta:
+        # No plot metadata recorded at all for this report (older ingests, or a
+        # write that hasn't backfilled `plots` yet) — fall back to presence-only
+        # rather than reading "plots block entirely absent" as "nothing here is
+        # plottable" and dropping every section.
+        return present
+    plottable = {multiqc_module(str(m).lower()) for m in plots_meta} | {"general_stats"}
+    return present & plottable
 
 
 def _keep_present_multiqc_sections(
     matches: list[dict[str, Any]], sections: set[str] | None
 ) -> list[dict[str, Any]]:
-    """Keep only matches whose section renders exist in this report.
+    """Keep only matches whose section renders both exist in this report and are
+    renderable (see `_multiqc_sections`).
 
-    A match is dropped when it declares section renders and none of them is
-    present. Renders without a `section` (plain tables, cards) are never touched.
+    A match is dropped when it declares section renders and none of them is in
+    `sections`. Renders without a `section` (plain tables, cards) are never touched.
     """
     if sections is None:
         return matches

--- a/depictio/api/v1/endpoints/catalog_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/catalog_endpoints/routes.py
@@ -168,13 +168,17 @@ def _multiqc_sections(dc_id: str) -> set[str] | None:
         return None
     present = {multiqc_module(str(m).lower()) for m in modules}
 
+    # An empty `plots_meta` is not treated as "unknown, trust presence": a
+    # module-wide extraction failure in `extract_multiqc_metadata` (one
+    # section's plot anchor missing from MultiQC's own report.plot_by_id) can
+    # leave `plots` empty on an otherwise-healthy, fully-populated report —
+    # confirmed happening intermittently on this exact fixture. Every module
+    # in `present` genuinely has no plot to show in that case, so offering
+    # them anyway only guarantees a `selected_plot` 400 at render time; the
+    # extraction side now recovers per-section instead of zeroing the whole
+    # report (see the `multiqc.list_plots()` reimplementation in
+    # `multiqc_processor.py`), so this branch should be rare going forward.
     plots_meta = metadata.get("plots") or {}
-    if not plots_meta:
-        # No plot metadata recorded at all for this report (older ingests, or a
-        # write that hasn't backfilled `plots` yet) — fall back to presence-only
-        # rather than reading "plots block entirely absent" as "nothing here is
-        # plottable" and dropping every section.
-        return present
     plottable = {multiqc_module(str(m).lower()) for m in plots_meta} | {"general_stats"}
     return present & plottable
 

--- a/depictio/cli/cli/utils/multiqc_processor.py
+++ b/depictio/cli/cli/utils/multiqc_processor.py
@@ -81,9 +81,41 @@ def extract_multiqc_metadata(parquet_path: str) -> Dict[str, Any]:
         samples = multiqc.list_samples()
         modules = multiqc.list_modules()
 
-        # Try to get plots, but handle errors gracefully
+        # `multiqc.list_plots()` walks every module's sections and raises the
+        # instant ONE section's `plot_anchor` isn't in `report.plot_by_id` —
+        # observed intermittently on custom-content sections like
+        # `summary_conformance_metrics` (the same parquet parses clean on a
+        # later run), which discards every OTHER module's perfectly good
+        # plots along with it. Reimplement the same walk (mirrors
+        # `multiqc.interactive.list_plots`) so one bad section is skipped and
+        # logged instead of zeroing the whole report's plot metadata — a
+        # report with 12 real modules should not end up offering none of them
+        # because one section's anchor didn't register.
         try:
-            plots = multiqc.list_plots()
+            from multiqc import report as mq_report
+            from multiqc.plots.plot import Plot
+
+            plots: Dict[str, list] = {}
+            for module in mq_report.modules:
+                plots[module.id] = []
+                for section in module.sections:
+                    if not section.plot_anchor:
+                        continue
+                    section_id = section.name or section.anchor
+                    plot_anchor = section.plot_anchor
+                    if plot_anchor not in mq_report.plot_by_id:
+                        logger.warning(
+                            f"Plot '{plot_anchor}' not found in report.plot_by_id "
+                            f"(module '{module.id}', section '{section_id}') — "
+                            "skipping this section, keeping the module's other plots"
+                        )
+                        continue
+                    plot = mq_report.plot_by_id[plot_anchor]
+                    if isinstance(plot, Plot):
+                        if len(plot.datasets) == 1:
+                            plots[module.id].append(section_id)
+                        elif len(plot.datasets) > 1:
+                            plots[module.id].append({section_id: [d.label for d in plot.datasets]})
         except Exception as e:
             logger.warning(f"Could not extract plots from MultiQC parquet: {e}")
             plots = {}

--- a/depictio/tests/cli/utils/test_multiqc_processor.py
+++ b/depictio/tests/cli/utils/test_multiqc_processor.py
@@ -2,9 +2,11 @@
 
 import builtins
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from multiqc.plots.plot import Plot
 
 from depictio.cli.cli.utils.multiqc_processor import (
     extract_multiqc_metadata,
@@ -14,6 +16,39 @@ from depictio.cli.cli.utils.multiqc_processor import (
 
 # Save original __import__ before any mocking happens
 _original_import = builtins.__import__
+
+
+class _RaisingIterable:
+    """A `.modules`-shaped stand-in that raises on iteration.
+
+    Mirrors a live `report.modules` walk blowing up (e.g. a genuinely corrupt
+    parquet), as opposed to `list_plots()`'s missing-anchor `ValueError` —
+    see `test_extract_multiqc_metadata_plots_error`.
+    """
+
+    def __iter__(self):
+        raise Exception("Plots extraction failed")
+
+
+def _make_multiqc_report(module_sections: dict) -> SimpleNamespace:
+    """Build a `multiqc.report`-shaped object for the extraction walk.
+
+    `module_sections` maps module id -> list of (section_id, num_datasets)
+    tuples, mirroring the module/section/plot_by_id shape that
+    `extract_multiqc_metadata` walks in place of `multiqc.list_plots()`.
+    """
+    modules = []
+    plot_by_id = {}
+    for module_id, sections in module_sections.items():
+        section_objs = []
+        for section_id, num_datasets in sections:
+            anchor = f"{module_id}-{section_id}-anchor"
+            section_objs.append(SimpleNamespace(plot_anchor=anchor, name=section_id, anchor=anchor))
+            plot = MagicMock(spec=Plot)
+            plot.datasets = [MagicMock(label=f"{section_id}_ds{i}") for i in range(num_datasets)]
+            plot_by_id[anchor] = plot
+        modules.append(SimpleNamespace(id=module_id, sections=section_objs))
+    return SimpleNamespace(modules=modules, plot_by_id=plot_by_id)
 
 
 class TestMultiQCProcessor:
@@ -27,10 +62,12 @@ class TestMultiQCProcessor:
         mock_multiqc.parse_logs.return_value = None
         mock_multiqc.list_samples.return_value = ["sample1", "sample2", "sample3"]
         mock_multiqc.list_modules.return_value = ["fastqc", "cutadapt"]
-        mock_multiqc.list_plots.return_value = {
-            "fastqc": ["quality", "length"],
-            "cutadapt": ["trimmed"],
-        }
+        # `extract_multiqc_metadata` walks `multiqc.report` directly instead
+        # of calling `multiqc.list_plots()` (see multiqc_processor.py) so the
+        # plot data comes from `.report`, not a `list_plots` return value.
+        mock_multiqc.report = _make_multiqc_report(
+            {"fastqc": [("quality", 1), ("length", 1)], "cutadapt": [("trimmed", 1)]}
+        )
         return mock_multiqc
 
     @pytest.fixture
@@ -88,7 +125,6 @@ class TestMultiQCProcessor:
         mock_multiqc_module.parse_logs.assert_called_once_with("/path/to/multiqc.parquet")
         mock_multiqc_module.list_samples.assert_called_once()
         mock_multiqc_module.list_modules.assert_called_once()
-        mock_multiqc_module.list_plots.assert_called_once()
 
         # Verify extracted metadata
         assert result["samples"] == ["sample1", "sample2", "sample3"]
@@ -108,8 +144,8 @@ class TestMultiQCProcessor:
             "sample3": ["sample3"],
         }
 
-        # Configure plots to raise an exception
-        mock_multiqc_module.list_plots.side_effect = Exception("Plots extraction failed")
+        # Configure the report walk to raise while iterating modules
+        mock_multiqc_module.report = SimpleNamespace(modules=_RaisingIterable(), plot_by_id={})
 
         def mock_import_func(name, *args, **kwargs):
             if name == "multiqc":

--- a/depictio/tests/e2e-playwright/playwright.config.ts
+++ b/depictio/tests/e2e-playwright/playwright.config.ts
@@ -45,6 +45,18 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      // admin/backup-restore does a real destructive restore (wipe + reinsert
+      // every collection, including deltatables) against the shared stack.
+      // It runs in its own project below, gated to start only once every
+      // other spec here has finished — otherwise its restore can silently
+      // drop a data collection another spec is still relying on mid-run.
+      testIgnore: /admin\/backup-restore\.spec\.ts$/,
+    },
+    {
+      name: "chromium-destructive",
+      use: { ...devices["Desktop Chrome"] },
+      testMatch: /admin\/backup-restore\.spec\.ts$/,
+      dependencies: ["chromium"],
     },
     // Uncomment to add cross-browser coverage:
     // { name: "firefox",  use: { ...devices["Desktop Firefox"] } },

--- a/depictio/viewer/src/builder/catalog/CatalogTab.tsx
+++ b/depictio/viewer/src/builder/catalog/CatalogTab.tsx
@@ -143,17 +143,33 @@ async function buildConfigFromRender(
  *  Report anchors are module-prefixed (`samtools_bowtie2`, `ivar_variants`)
  *  while the catalog names the module (`samtools`, `ivar`), so an exact match is
  *  tried first and a prefix match second — the same normalisation the compose
- *  endpoint applies when it decides which sections a report carries. */
+ *  endpoint applies when it decides which sections a report carries. Matching is
+ *  case-insensitive on both arms: a report anchor can carry its tool's own casing
+ *  (`iVar`) while the catalog always names the section lowercase (`ivar`), and the
+ *  compose endpoint already lowercases both sides the same way.
+ *
+ *  A module can be present without a plot (a custom-content *table*, e.g.
+ *  `summary_conformance_metrics`) — the compose endpoint excludes those from what
+ *  it offers (see `_multiqc_sections` in catalog_endpoints/routes.py), so this
+ *  should not see one under normal operation. Prefer a plottable candidate
+ *  anyway as defense in depth, rather than persisting a null `selected_plot`
+ *  that only surfaces as a render-time failure. */
 async function multiqcConfigForSection(
   dcId: string,
   section: string | undefined,
 ): Promise<Record<string, unknown>> {
   const opts = await fetchMultiQCBuilderOptions(dcId);
   const modulePrefix = (anchor: string) => anchor.split(/[-_]/)[0];
-  const anchor =
-    (section && opts.modules.find((m) => m === section)) ||
-    (section && opts.modules.find((m) => modulePrefix(m) === section)) ||
-    opts.modules[0];
+  const norm = (s: string) => s.toLowerCase();
+  const hasPlot = (m: string) => m === 'general_stats' || (opts.plots[m]?.length ?? 0) > 0;
+
+  const candidates = section
+    ? opts.modules.filter(
+        (m) => norm(m) === norm(section) || norm(modulePrefix(m)) === norm(section),
+      )
+    : [];
+  const anchor = candidates.find(hasPlot) ?? candidates[0] ?? opts.modules.find(hasPlot) ?? opts.modules[0];
+
   return {
     selected_module: anchor ?? null,
     selected_plot: (anchor && opts.plots[anchor]?.[0]) ?? null,


### PR DESCRIPTION
## Summary
- Run `admin/backup-restore` in its own Playwright project, gated to start only after every other spec finishes — its destructive restore was silently wiping `deltatables_collection` entries for DCs the catalog-modules-on-dashboard walk was still relying on, surfacing as table/advanced_viz render failures.
- Match a catalog section against a MultiQC report's module anchors case-insensitively (`ivar` vs `iVar`), and exclude modules with no plot data (summary/software-versions tables) from what compose offers, so the picker never persists a null `selected_plot`.
- Stop `extract_multiqc_metadata` from erasing an entire report's plot metadata when one section's plot anchor is missing from MultiQC's own `report.plot_by_id` — it now skips just that section instead of raising and zeroing every other module's plots. Tightened `_multiqc_sections`'s fallback to match: a module with no plot data is never offered, whatever the reason.

## Test plan
- [x] `npx playwright test catalog-modules-on-dashboard` green on the `standard` and `public-demo` e2e-playwright CI legs.
