### PR TITLE
fix(docker): ship the catalog-preview bundle in the API image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,10 @@
 # Dockerfile_depictio_uv.dockerfile. Excluding it from the docker context
 # prevents a stale host bundle from clobbering the freshly-built one.
 depictio/viewer/dist/
+# Same for the single-file catalog-preview bundle: Dockerfile.api builds it in
+# its catalog-preview-builder stage, so a host build must not ride along in the
+# `COPY depictio ./depictio/` layer.
+depictio/viewer/dist-catalog-preview/
 
 # -----------------------------
 # Exclude Legacy Directories

--- a/docker-images/Dockerfile.api
+++ b/docker-images/Dockerfile.api
@@ -2,9 +2,41 @@
 # Depictio API image (FastAPI only)
 # -----------------------------
 # Carries only what `depictio.api.main:app` needs at runtime: Python +
-# uv-installed deps. No Playwright (worker owns screenshots), no Node,
-# no Dash assets.
+# uv-installed deps. No Playwright (worker owns screenshots), no Dash assets.
+# The one Node artefact it needs is the single-file catalog-preview bundle
+# served by GET /catalog/output/{id}/preview-html, built in the stage below
+# and copied in — the runtime layer itself still carries no Node.
 # -----------------------------
+
+# -----------------------------
+# catalog-preview bundle stage
+# -----------------------------
+# `depictio/catalog/payload.py` injects the computed payload into a prebuilt
+# single-file HTML (`pnpm run build:catalog-preview`). It is gitignored build
+# output, so without this stage the released image ships without it and every
+# preview request 422s with "catalog-preview bundle not built".
+# Node/pnpm pins mirror docker-images/Dockerfile.viewer.
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS catalog-preview-builder
+WORKDIR /build
+
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+# ---- Dependency layer (cached across viewer source changes) ----
+COPY pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY packages/depictio-components/package.json ./packages/depictio-components/
+COPY packages/depictio-react-core/package.json ./packages/depictio-react-core/
+COPY depictio/viewer/package.json ./depictio/viewer/
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+# ---- Source + build ----
+COPY packages ./packages/
+COPY depictio/viewer ./depictio/viewer/
+
+# Same memory caps as the viewer build: sourcemaps off, heap capped at 4 GB
+# to leave cgroup headroom for native + worker stacks.
+RUN VITE_NO_SOURCEMAP=true NODE_OPTIONS="--max-old-space-size=4096" \
+    pnpm --filter depictio-viewer build:catalog-preview
 
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 AS base
 
@@ -49,6 +81,13 @@ COPY --chown=depictio:depictio VERSION ./
 COPY --chown=depictio:depictio depictio ./depictio/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev || uv sync --no-dev
+
+# Prebuilt catalog-preview bundle (one self-contained ~7 MB HTML). Copied after
+# the source layer so it lands on top of depictio/viewer/, and last-but-one so a
+# viewer edit does not invalidate the Python layers above.
+COPY --from=catalog-preview-builder --chown=depictio:depictio \
+    /build/depictio/viewer/dist-catalog-preview/catalog-preview.html \
+    /app/depictio/viewer/dist-catalog-preview/catalog-preview.html
 
 COPY --chown=depictio:depictio docker-images/run_fastapi.sh /app/run_fastapi.sh
 RUN chmod +x /app/run_fastapi.sh


### PR DESCRIPTION
## Problem

`GET /catalog/output/{id}/preview-html` returns 422 on every deployment:

```
{"detail":"catalog-preview bundle not built: /app/depictio/viewer/dist-catalog-preview/catalog-preview.html is missing — run `cd depictio/viewer && rtk pnpm run build:catalog-preview`"}
```

Reported on dev.depictio.embl.org and demo.depictio.embl.org.

`depictio/viewer/dist-catalog-preview/` is gitignored build output (`.gitignore:423`), and nothing ever built it outside a dev checkout: `Dockerfile.api` carried no Node, and no CI job runs `build:catalog-preview`. `depictio/catalog/payload.py` reads that file at runtime to inject the computed payload, so the released `depictio-api` image could never serve a catalog preview. Not a regression in 1.9.2-b1: the endpoint has only ever worked locally.

## Fix

- `docker-images/Dockerfile.api` gains a `catalog-preview-builder` stage (node:20-slim + pnpm 10, same pins and memory caps as `Dockerfile.viewer`) running `pnpm --filter depictio-viewer build:catalog-preview`, then copies only the self-contained HTML into the image. The runtime layer still carries no Node.
- The `COPY --from` lands after the source layer, so a viewer edit does not invalidate the Python dependency layers above it.
- `.dockerignore` excludes `depictio/viewer/dist-catalog-preview/` so a host build cannot ride along in `COPY depictio ./depictio/` (same rationale as the existing `dist/` entry).

## Validation

- `pnpm --filter depictio-viewer build:catalog-preview` from the repo root (the exact command the stage runs) produces `catalog-preview.html`, 7.1 MB, in 2m37.
- `pre-commit run --all-files`: only the pre-existing shellcheck and `ty` failures, untouched by this diff.
- No local `docker build` (project rule); the image build is exercised by the `build-images` workflow on this PR.

Takes effect on the next tag: dev receives every tag, demo only stable ones.

## Adjacent finding, not fixed here

The viewer image has the same class of gap: `scripts/generate-icon-subset.mjs` scans `depictio/projects` and `advanced_viz_endpoints/routes.py`, but `Dockerfile.viewer`'s builder stage copies only `packages/` and `depictio/viewer/`, and absent paths are silently skipped. 19 icon ids declared only in dashboard data (`mdi:penguin`, `mdi:flower-outline`, `mdi:chart-sankey`, ...) are missing from the built subset, and the CSP blocks the Iconify API, so they render blank in prod. Two `COPY` lines would fix it.