### PR TITLE
chore(helm): turn on public mode for the TREC internal dev instance

### DIFF
--- a/helm-charts/depictio/values-embl-internal-dev-trec.yaml
+++ b/helm-charts/depictio/values-embl-internal-dev-trec.yaml
@@ -20,6 +20,20 @@
 
 backend:
   env:
+    # Link-shareable, not world-open. Public mode alone hands a temporary
+    # session to anyone who loads the page; the shared access code that gates
+    # it lives in values-embl-internal-secrets.yaml (never committed), as
+    # secrets.publicAccessCode. Without that code set, this line ALONE would
+    # open the instance to the whole internet, so the two must move together.
+    #
+    # Consequences worth knowing before flipping this back and forth:
+    #   - PublicAccessGate replaces the login form for everyone, admins
+    #     included. Admin access becomes POST /auth/login by API, not UI.
+    #   - Visitors are throwaway users, so they only see projects flagged
+    #     public (or shared with "*"), and only ever as viewers.
+    #   - Dashboard import is refused in public mode, admin token or not.
+    DEPICTIO_AUTH_PUBLIC_MODE: "true"
+
     # No self-service accounts. /register returns 403 and the Register button
     # is hidden, AND the OAuth callback stops provisioning: the route passes
     # allow_create=not registration_disabled, so an unknown Google email gets


### PR DESCRIPTION
Recovered from a stale local stash (`Teleport auto-stash`, made on `main`); the change was never committed.

## What

`helm-charts/depictio/values-embl-internal-dev-trec.yaml` sets `backend.env.DEPICTIO_AUTH_PUBLIC_MODE: "true"`, making the TREC devinternal instance link-shareable: visitors get a throwaway viewer session instead of a login form, and only see projects flagged public (or shared with `*`).

The comment block records the consequences worth knowing before flipping it back: `PublicAccessGate` replaces the login form for admins too (admin access becomes `POST /auth/login` by API, not UI), and dashboard import is refused in public mode regardless of token.

## Blocking precondition, hence draft

`secrets.publicAccessCode` must already be set in `values-embl-internal-secrets.yaml` (never committed) on the deploy side. Without it, this flag alone opens the instance to the whole internet rather than gating it behind the shared code. The chart wiring itself is in place: `secrets.yaml:61-65` renders the secret, `deployments.yaml:516` injects `DEPICTIO_AUTH_PUBLIC_ACCESS_CODE`, and `DEPICTIO_AUTH_PUBLIC_MODE` is on the configmap key allowlist (`configmaps.yaml:45,160`), so the value is not silently dropped.

Mark ready once the access code is confirmed set.