### PR TITLE
fix(helm): stop the demo wipe hook from racing the upgrade

### DIFF
--- a/helm-charts/depictio/templates/wipe-job.yaml
+++ b/helm-charts/depictio/templates/wipe-job.yaml
@@ -31,9 +31,12 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments/scale"]
   verbs: ["get", "patch", "update"]
+# `watch` is what makes `kubectl delete --wait` actually block. Without it
+# the delete still succeeds but the wait degrades to a "cannot watch"
+# reflector error, which is the opposite of what this hook needs.
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
-  verbs: ["delete", "list", "get"]
+  verbs: ["delete", "list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list", "get", "delete"]

--- a/helm-charts/depictio/templates/wipe-job.yaml
+++ b/helm-charts/depictio/templates/wipe-job.yaml
@@ -25,6 +25,12 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments", "statefulsets"]
   verbs: ["get", "patch", "list"]
+# `kubectl scale` patches the scale subresource, not the deployment itself.
+# Without this the scale-down below fails, and it fails silently because the
+# job used to swallow the error.
+- apiGroups: ["apps"]
+  resources: ["deployments/scale"]
+  verbs: ["get", "patch", "update"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["delete", "list", "get"]
@@ -101,28 +107,57 @@ spec:
             set -e
             echo "🗑️ Demo auto-wipe: Cleaning data before upgrade..."
 
-            # Scale down services
-            echo "📉 Scaling down services..."
-            kubectl scale statefulset/{{ .Release.Name }}-mongo -n {{ .Release.Namespace }} --replicas=0 || true
-            kubectl scale statefulset/{{ .Release.Name }}-redis -n {{ .Release.Namespace }} --replicas=0 || true
-            kubectl scale deployment/{{ .Release.Name }}-depictio-backend -n {{ .Release.Namespace }} --replicas=0 || true
-            kubectl scale deployment/{{ .Release.Name }}-depictio-viewer -n {{ .Release.Namespace }} --replicas=0 || true
+            NS={{ .Release.Namespace }}
+            REL={{ .Release.Name }}
 
-            # Wait for pods to terminate
-            echo "⏳ Waiting for pods to terminate..."
-            sleep 15
+            # Blocks until no pod matches the selector. The hook also runs
+            # pre-install, where nothing exists yet, so "none left" has to be
+            # the success case rather than an error.
+            wait_gone() {
+              local sel="$1"
+              local deadline=$((SECONDS + 180))
+              while [ "$(kubectl get pods -n ${NS} -l "${sel}" --no-headers 2>/dev/null | wc -l)" -ne 0 ]; do
+                if [ ${SECONDS} -ge ${deadline} ]; then
+                  echo "❌ Timed out waiting for pods matching ${sel} to terminate"
+                  exit 1
+                fi
+                sleep 3
+              done
+            }
 
-            # Delete MongoDB PVC
-            echo "🗑️ Deleting MongoDB PVC..."
-            kubectl delete pvc mongo-storage-{{ .Release.Name }}-mongo-0 -n {{ .Release.Namespace }} --wait=false || echo "MongoDB PVC not found or already deleted"
+            # The keys and config PVCs are mounted by the backend *and* the
+            # celery worker. A PVC stays in Terminating for as long as any pod
+            # still mounts it (kubernetes.io/pvc-protection), so both have to
+            # go before the delete can complete. Scaling only the backend left
+            # celery holding the claims, so the delete hung and Helm went on to
+            # patch a PVC that was on its way out, failing the upgrade with
+            # `persistentvolumeclaims "<release>-depictio-keys-pvc" not found`.
+            echo "📉 Scaling down the workloads that mount the PVCs..."
+            for DEP in ${REL}-depictio-backend ${REL}-celery-worker; do
+              if kubectl get deployment/${DEP} -n ${NS} >/dev/null 2>&1; then
+                kubectl scale deployment/${DEP} -n ${NS} --replicas=0
+              else
+                echo "  ${DEP} is not deployed yet, nothing to scale down"
+              fi
+            done
 
-            # Delete config PVC
-            echo "🗑️ Deleting config PVC (.depictio)..."
-            kubectl delete pvc {{ .Release.Name }}-depictio-config-pvc -n {{ .Release.Namespace }} --wait=false || echo "Config PVC not found or already deleted"
+            echo "⏳ Waiting for those pods to terminate..."
+            wait_gone "release=${REL},app=depictio-backend"
+            wait_gone "release=${REL},app=celery-worker"
 
-            # Delete keys PVC
-            echo "🗑️ Deleting keys PVC..."
-            kubectl delete pvc {{ .Release.Name }}-depictio-keys-pvc -n {{ .Release.Namespace }} --wait=false || echo "Keys PVC not found or already deleted"
+            # MongoDB is not wiped here: the demo values set
+            # DEPICTIO_MONGODB_WIPE=true, so the backend drops the database on
+            # startup. The delete this job used to attempt named
+            # `mongo-storage-<release>-mongo-0`, which the replica-set
+            # migration renamed to `mongod-data-<release>-mongo-rs0-N`, so it
+            # had been a silent no-op.
+            for PVC in ${REL}-depictio-config-pvc ${REL}-depictio-keys-pvc; do
+              echo "🗑️ Deleting ${PVC}..."
+              # Blocking delete: Helm patches these same PVCs as soon as the
+              # hook returns, so the job must not hand back until they are
+              # really gone.
+              kubectl delete pvc ${PVC} -n ${NS} --ignore-not-found --wait=true --timeout=180s
+            done
 
             echo "✅ Demo auto-wipe complete! Fresh PVCs will be created on upgrade."
             echo "Note: S3 will be wiped by backend initialization (wipe: true)"


### PR DESCRIPTION
## What broke

Upgrading `devdemo` to 1.9.2-b2 failed:

```
Error: UPGRADE FAILED: persistentvolumeclaims "devdemo-depictio-keys-pvc" not found
```

The release went to `failed` at revision 2 and the backend pods were left unschedulable:

```
Warning FailedScheduling  0/53 nodes are available:
  persistentvolumeclaim "devdemo-depictio-keys-pvc" is being deleted.
```

Re-running the same command recovered it, because by then the PVCs had finished disappearing and Helm created them instead of patching them. So this is a race, not a deterministic failure, and it can bite any environment with `demo.autoWipeOnUpgrade: true`. That is both `values-embl-demo-dev.yaml` and `values-embl-demo.yaml`, so the public demo is exposed to it too.

## Why

The `pre-upgrade` hook deleted the keys and config PVCs with `--wait=false` and returned immediately. Helm then patched those same PVCs as part of the upgrade, and they were still `Terminating`.

Two things kept the deletion pending:

1. The hook scaled down only the backend. `<release>-celery-worker` mounts the same `keys-pvc` and `config-pvc`, so the `kubernetes.io/pvc-protection` finalizer held both claims for as long as its pods were running.
2. Nothing waited for the objects to actually be gone. `sleep 15` then `--wait=false` is not a wait.

## What changed

- Scale down both workloads that mount the claims, not just the backend.
- Block until their pods are actually gone, then delete the PVCs with a blocking delete, so the hook cannot hand back to Helm early.
- Grant `deployments/scale` in the Role. `kubectl scale` patches the scale subresource, which the Role did not cover, so the scale-down could only ever have failed. It failed silently because the old script swallowed every error with `|| true`.
- Drop the MongoDB lines. They named `mongo-storage-<release>-mongo-0` and `statefulset/<release>-mongo`, both renamed by the replica-set migration to `mongod-data-<release>-mongo-rs0-N` and `<release>-mongo-rs0`. They had been silent no-ops ever since. MongoDB is wiped by the backend at startup through `DEPICTIO_MONGODB_WIPE`, which the demo values already set to `"true"`, so nothing is lost by removing them.

Both waits treat "nothing matches" as success, so the hook stays valid on `pre-install` where none of these objects exist yet.

## Checks

- `helm template` renders clean against `values.yaml` + `values-embl-demo-base.yaml` + `values-embl-demo-dev.yaml` + the EMBL secrets file.
- The rendered hook script passes `bash -n`.
- `pre-commit run --all-files`: `check yaml` and `Helm Lint` pass. `ty check models` and `shellcheck` fail on files this branch does not touch (`depictio/models/`, `scripts/upload.sh` SC2006), same as on `main`.

Not yet exercised against a live upgrade. The next `autoWipeOnUpgrade` deploy is the real test.