### PR TITLE
fix(e2e): stop the SPA refresh from revoking the token specs call the API with

### DIFF
--- a/depictio/tests/e2e-playwright/fixtures/auth.ts
+++ b/depictio/tests/e2e-playwright/fixtures/auth.ts
@@ -40,6 +40,10 @@ export interface TokenBundle {
   access_token: string;
   refresh_token: string;
   user_id: string;
+  /** Access-token expiry as the API serialises it ("YYYY-MM-DD HH:MM:SS", UTC,
+   *  no offset). Returned by /auth/login and required by seedTokenInStorage —
+   *  see the comment there for why leaving it out breaks the caller's token. */
+  expire_datetime?: string;
   /** Populated by loginAsTestUser from the credentials table — not returned by
    *  the login endpoint but required by the viewer's local-store session shape
    *  so the ownership check (isOwner) works correctly. */
@@ -147,11 +151,34 @@ export async function seedTokenInStorage(
     }, tokens);
   } else {
     await page.addInitScript((t) => {
+      // Keep a session the SPA has already refreshed for itself. This script
+      // re-runs on every navigation, and an unconditional write would restore
+      // `t.access_token` — which /auth/refresh revokes when it rotates the
+      // token document (the API resolves a caller by looking the access token
+      // up in the store, so the previous one stops authenticating). A caller
+      // still holding the original bundle would then start getting 401s.
+      // Matching on refresh_token — stable across refreshes, distinct per
+      // login — keeps the switch-user case (loginAsUser then loginAsAdmin on
+      // the same page) working.
+      let keepStored = false;
+      try {
+        const raw = window.localStorage.getItem("local-store");
+        keepStored = !!raw && JSON.parse(raw).refresh_token === t.refresh_token;
+      } catch {
+        keepStored = false;
+      }
+      if (keepStored) return;
       window.localStorage.setItem(
         "local-store",
         JSON.stringify({
           access_token: t.access_token,
           refresh_token: t.refresh_token,
+          // Without a parseable expiry the SPA treats the session as already
+          // stale and calls /auth/refresh on the first authenticated request
+          // of every page load (see ensureFreshAccessToken in
+          // depictio-react-core), rotating the token document each time. Seed
+          // the real one so a freshly minted token is simply used as-is.
+          ...(t.expire_datetime ? { expire_datetime: t.expire_datetime } : {}),
           logged_in: true,
           user_id: t.user_id,
           email: t.email ?? "",
@@ -229,7 +256,10 @@ export async function loginAsTestUser(
  * carries no `access_token`. A test that destructures one off it gets
  * `undefined`, sends `Authorization: Bearer undefined`, and every call it
  * guards comes back 401 — silently, unless the test asserts on the response.
- * Use this when the test needs to call the API directly.
+ * Use this when the test needs both a browser session and its tokens.
+ *
+ * For API calls alone, prefer `apiOnlyToken`: the bundle returned here is also
+ * seeded into the page, and the SPA rotates it on refresh — see the note there.
  */
 export async function loginAsTestUserWithToken(
   page: Page,
@@ -239,6 +269,35 @@ export async function loginAsTestUserWithToken(
   await loginAsTestUser(page, request, userType);
   // Populated by the call above, which caches before it returns.
   return _tokenCache.get(userType)!;
+}
+
+/**
+ * Tokens minted for direct API calls only — never seeded into a browser.
+ *
+ * `loginAsTestUserWithToken` hands back the same bundle `seedTokenInStorage`
+ * puts in the page's localStorage, so the browser and the API caller share one
+ * token document. The SPA refreshes that document when the access token nears
+ * expiry, and /auth/refresh rotates the stored access token, which revokes the
+ * copy the API caller is still sending — a 401 with no obvious cause. A token
+ * that never reaches a page cannot be rotated out from under its holder.
+ *
+ * Cached per worker like `_tokenCache`, so this costs one extra /auth/login per
+ * worker rather than one per call (the login endpoint is rate-limited per IP).
+ */
+const _apiTokenCache = new Map<UserType, TokenBundle>();
+
+export async function apiOnlyToken(
+  request: APIRequestContext,
+  userType: UserType = "adminUser",
+): Promise<TokenBundle> {
+  let tokens = _apiTokenCache.get(userType);
+  if (!tokens) {
+    const user = credentials[userType];
+    tokens = await apiLogin(request, user.email, user.password);
+    tokens.email = user.email;
+    _apiTokenCache.set(userType, tokens);
+  }
+  return tokens;
 }
 
 /**

--- a/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/ui/brand-theme.spec.ts
@@ -17,7 +17,7 @@
 import {
   API_PREFIX,
   API_URL,
-  loginAsTestUserWithToken,
+  apiOnlyToken,
   test,
   expect,
 } from "@fixtures/auth";
@@ -51,16 +51,16 @@ test.describe("Instance brand theme", () => {
   // put them back, whatever the test did in between.
   let savedOverrides: Record<string, unknown> | null = null;
 
-  test.beforeEach(async ({ page, request }) => {
-    const { access_token } = await loginAsTestUserWithToken(page, request, "adminUser");
+  test.beforeEach(async ({ request }) => {
+    const { access_token } = await apiOnlyToken(request, "adminUser");
     const response = await request.get(`${API_URL}${API_PREFIX}/utils/branding`, {
       headers: { Authorization: `Bearer ${access_token}` },
     });
     savedOverrides = response.ok() ? ((await response.json()).overrides ?? null) : null;
   });
 
-  test.afterEach(async ({ page, request }) => {
-    const { access_token } = await loginAsTestUserWithToken(page, request, "adminUser");
+  test.afterEach(async ({ request }) => {
+    const { access_token } = await apiOnlyToken(request, "adminUser");
     const headers = { Authorization: `Bearer ${access_token}` };
     const url = `${API_URL}${API_PREFIX}/utils/branding`;
     if (savedOverrides && Object.keys(savedOverrides).length > 0) {
@@ -130,7 +130,12 @@ test.describe("Instance brand theme", () => {
     page,
     request,
   }) => {
-    const { access_token } = await loginAsTestUserWithToken(page, request, "adminUser");
+    // A token of its own, not the one seeded into the page: the SPA refreshes
+    // its stored session on expiry and /auth/refresh rotates the token
+    // document, which revokes the access token any other holder is still
+    // sending. Sharing one bundle between the browser and these calls is what
+    // turned the PUT below into an unexplained 401.
+    const { access_token } = await apiOnlyToken(request, "adminUser");
     const headers = { Authorization: `Bearer ${access_token}` };
     const url = `${API_URL}${API_PREFIX}/utils/branding`;
     const attribution = page.locator("[data-testid='powered-by']");


### PR DESCRIPTION
## Summary

`e2e-playwright (single-user)` has been the only red job on `main` since 2026-08-28 (merge of #1007), always on the same test:

```
tests/ui/brand-theme.spec.ts:128 › Instance brand theme ›
  the attribution appears only once the depictio logo is gone
```

The service log uploaded by the failing job says what the assertion could not:

```
GET    /depictio/api/v1/utils/branding  200 OK
DELETE /depictio/api/v1/utils/branding  200 OK
PUT    /depictio/api/v1/utils/branding  401 Unauthorized   ← same token
```

### Root cause

Two things combine to revoke the token the spec is holding.

1. **The fixture seeded a session with no expiry.** `seedTokenInStorage` wrote `local-store` with `access_token / refresh_token / logged_in / user_id / email` but no `expire_datetime`. In the SPA, `ensureFreshAccessToken` (`packages/depictio-react-core/src/api.ts`) computes `NaN`, so the "still fresh, return as-is" early return never fires and it calls `/auth/refresh` on the first authenticated request of **every page load**. `addInitScript` re-runs on every navigation and restored the original bundle, so it repeated on each `page.goto` — **444 refreshes for 46 logins** in the failing job.
2. **`/auth/refresh` revokes the previous access token.** `refresh_token_browser` mutates the document in place (`token_doc.access_token = new_access_token`) and `_async_fetch_user_from_token` resolves a caller with `TokenBeanie.find_one({"access_token": token})`.

The spec shared one bundle between the browser and its API calls (`loginAsTestUserWithToken` returns the cached entry that `seedTokenInStorage` also puts in the page's `localStorage`), so the page's own refresh killed the credential the spec was still sending.

Not actually single-user-specific: on the `standard` leg of the same run this test failed on its first attempt and only passed on retry — it is reported as `flaky`, not as a pass. The JWT payload carries no `iat`/`jti`, so a refresh landing in the same wall-clock second as the login re-encodes a byte-identical token and revokes nothing; that race is what decides it. Single-user lost it 3/3.

### Changes (tests only — no product code touched)

- `TokenBundle` carries `expire_datetime`, and `seedTokenInStorage` seeds it. `/auth/login` already returns it, serialized as `"YYYY-MM-DD HH:MM:SS"` — exactly the offset-less shape `parseBackendTimestamp` handles. With a real expiry ~1 h out the SPA uses the stored token as-is, so nothing rotates. This also removes ~440 spurious refreshes per e2e run.
- The init script no longer clobbers a session the SPA has refreshed for itself. The guard matches on `refresh_token` (stable across refreshes, distinct per login), so a refreshed access token survives a navigation while switching users mid-page still works.
- New `apiOnlyToken(request, userType)`: a per-worker token that is never seeded into a browser, for tests that call the API directly. `brand-theme.spec.ts` now uses it in `beforeEach`, `afterEach` and the failing test; `loginAsAdmin()` still drives the browser session.

The `expect(...ok()).toBeTruthy()` assertions added in 751daa6 stay — they are what surfaced this, and they should keep guarding it.

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactor / code style
- [x] Build / CI / deps
- [ ] Documentation

## Related issue

None — reported from the red `main` CI run [33562490765](https://github.com/depictio/depictio/actions/runs/33562490765).

## How was this tested?

- `npx tsc --noEmit` in `depictio/tests/e2e-playwright` — clean.
- `pre-commit run` on the two changed files — passing.
- The e2e suite itself was **not** run locally (no stack available in the authoring environment); CI on this branch is the verification. What to check on the run: all three `e2e-playwright` legs green, and `standard` no longer reporting this test as flaky.

## Checklist
- [x] Code follows project style (`ruff`, `ty`, pre-commit pass)
- [x] Tests added/updated and passing
- [ ] Docs updated if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkekN41wrSzbymmC1QzHr5

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkekN41wrSzbymmC1QzHr5)_