### PR TITLE
test(remote-data): coverage for template export, scan wrappers, create_from_url, and the manifest e2e in CI

### DIFF
--- a/.github/workflows/depictio-ci.yaml
+++ b/.github/workflows/depictio-ci.yaml
@@ -2722,6 +2722,18 @@ jobs:
           sed -i 's/^DEPICTIO_AUTH_PUBLIC_MODE=.*/DEPICTIO_AUTH_PUBLIC_MODE=${{ matrix.public_mode }}/' docker-compose/.env
           sed -i 's/^DEPICTIO_AUTH_DEMO_MODE=.*/DEPICTIO_AUTH_DEMO_MODE=${{ matrix.demo_mode }}/' docker-compose/.env
           sed -i 's/^#* *DEPICTIO_DEV_MODE=.*/DEPICTIO_DEV_MODE=true/' docker-compose/.env
+          # Standard leg only: the create-from-manifest spec fetches a Data
+          # Manifest the runner serves at http://host.docker.internal:8099 (see
+          # the step below). That name maps to the docker bridge gateway, a
+          # private address the SSRF gateway rejects unless the host is
+          # allowlisted. DEPICTIO_REMOTE_ALLOW_HTTP=true is already the committed
+          # dev default in docker-compose/.env and the sed edits above leave it
+          # alone. The allowlist is exclusive while set; no other spec fetches
+          # a remote URL, and the storage panel's own-endpoint exemption is
+          # checked before it.
+          if [ "${{ matrix.auth_mode }}" = "standard" ]; then
+            echo "DEPICTIO_REMOTE_URL_ALLOWLIST=host.docker.internal" >> docker-compose/.env
+          fi
           # Seed the catalog conformance project on top of the default set. It is
           # opt-in because it is a test fixture, and the catalog coverage spec is
           # the only thing that needs it.
@@ -2743,7 +2755,13 @@ jobs:
           docker pull "${DEPICTIO_VIEWER_VERSION}" &
           wait
           export DEPICTIO_FASTAPI_WORKERS=1  # Single worker to avoid boot race conditions
-          docker compose -f docker-compose.dev.yaml --env-file docker-compose/.env --profile ci up -d mongo redis minio depictio-backend depictio-celery-worker depictio-viewer
+          COMPOSE_FILES="-f docker-compose.dev.yaml"
+          if [ "${{ matrix.auth_mode }}" = "standard" ]; then
+            # host.docker.internal for the backend + worker (Linux docker does
+            # not provide it): lets them reach the manifest server on the runner.
+            COMPOSE_FILES="$COMPOSE_FILES -f docker-compose/docker-compose.e2e-manifest.yaml"
+          fi
+          docker compose $COMPOSE_FILES --env-file docker-compose/.env --profile ci up -d mongo redis minio depictio-backend depictio-celery-worker depictio-viewer
 
       # Node + Playwright setup runs while the docker stack boots; the
       # explicit health gate below is the only wait.
@@ -2807,10 +2825,34 @@ jobs:
           echo "🔍 Auth mode reported by API:"
           curl -s http://localhost:8058/depictio/api/v1/auth/me/optional || true
 
+      # Standard leg only: generate the demo Data Manifest kit on the runner
+      # and serve it over plain HTTP so the create-from-manifest spec runs
+      # end to end (it self-skips without MANIFEST_E2E_URL). The entry URLs
+      # are absolute and must be the address the *backend* resolves, hence
+      # host.docker.internal (mapped by the compose overlay above).
+      - name: Serve a Data Manifest for the create-from-manifest flow
+        if: matrix.auth_mode == 'standard'
+        run: |
+          MANIFEST_DIR="${RUNNER_TEMP}/demo-manifest-data"
+          python3 depictio/dev_scripts/demo_manifest/generate.py \
+            --base-url http://host.docker.internal:8099 \
+            --output-dir "$MANIFEST_DIR"
+          (cd "$MANIFEST_DIR" && nohup python3 -m http.server 8099 --bind 0.0.0.0 > "${RUNNER_TEMP}/manifest-server.log" 2>&1 &)
+          for i in {1..15}; do
+            curl -fs http://localhost:8099/manifest.json > /dev/null && break
+            [ "$i" = "15" ] && { echo "❌ Manifest server never came up"; cat "${RUNNER_TEMP}/manifest-server.log"; exit 1; }
+            sleep 1
+          done
+          # Prove the backend can reach it through the overlay's host mapping
+          # and the allowlist (curl is not in the image; python is).
+          docker compose -f docker-compose.dev.yaml -f docker-compose/docker-compose.e2e-manifest.yaml --env-file docker-compose/.env exec -T depictio-backend \
+            python -c "import urllib.request; print('manifest reachable from backend:', urllib.request.urlopen('http://host.docker.internal:8099/manifest.json', timeout=10).status)"
+
       - name: Run Playwright tests (${{ matrix.auth_mode }})
         run: |
           cd depictio/tests/e2e-playwright
           CATALOG_CONFORMANCE_REQUIRED=1 \
+          MANIFEST_E2E_URL="${{ matrix.auth_mode == 'standard' && 'http://host.docker.internal:8099/manifest.json' || '' }}" \
           PLAYWRIGHT_BASE_URL=http://localhost:5080 \
           PLAYWRIGHT_API_URL=http://localhost:8058 \
           npx playwright test
@@ -2835,6 +2877,9 @@ jobs:
         if: failure()
         run: |
           docker compose -f docker-compose.dev.yaml --env-file docker-compose/.env logs > e2e-${{ matrix.auth_mode }}-services.log 2>&1 || true
+          if [ -f "${RUNNER_TEMP}/manifest-server.log" ]; then
+            { echo "===== manifest server (runner) ====="; cat "${RUNNER_TEMP}/manifest-server.log"; } >> e2e-${{ matrix.auth_mode }}-services.log
+          fi
 
       - name: Upload service logs on failure
         uses: actions/upload-artifact@v7

--- a/depictio/tests/api/v1/endpoints/datacollections_endpoints/test_create_from_url.py
+++ b/depictio/tests/api/v1/endpoints/datacollections_endpoints/test_create_from_url.py
@@ -24,11 +24,11 @@ STORAGE = "depictio.api.v1.endpoints.projects_endpoints.storage_config"
 CLI_HELPER = "depictio.cli.cli.utils.helpers.process_data_collection_helper"
 
 
-def _call(url: str, project_id: str = str(ObjectId()), user=None):
+def _call(url: str, project_id: str = str(ObjectId()), user=None, name: str = "remote-dc"):
     user = user or _user()
     return dc_utils._create_dc_from_url(
         project_id=project_id,
-        name="remote-dc",
+        name=name,
         description="",
         data_type="table",
         file_format="csv",
@@ -190,4 +190,124 @@ def test_unusable_project_storage_is_a_clean_http_error_before_any_write(mock_db
     assert "/app/depictio/keys" not in exc.value.detail  # sanitized: no server paths
     helper.assert_not_called()
     # Resolved before the workflow $push: nothing to roll back, nothing left behind.
+    assert mock_db["projects"].find_one({"_id": project_id})["workflows"] == []
+
+
+# ── Happy path ──────────────────────────────────────────────────────────────
+
+
+def _ingest_recorder(outcomes: dict[str, dict] | None = None):
+    """Fake CLI helper that records each stage and answers per ``outcomes``."""
+    seen: list[dict] = []
+    outcomes = outcomes or {}
+
+    def _fake_helper(CLI_config, wf, dc_id, mode, command_parameters=None):
+        seen.append(
+            {
+                "mode": mode,
+                "dc_id": dc_id,
+                "workflow_id": str(wf.id),
+                "command_parameters": command_parameters,
+                "cli_config": CLI_config,
+            }
+        )
+        return outcomes.get(mode, {"result": "success"})
+
+    return seen, _fake_helper
+
+
+def test_https_url_becomes_a_url_scan_workflow_that_is_ingested(mock_db):
+    url = "https://example.org/run42/data.csv"
+    user = _user()
+    project_id = _owned_project_with_token(mock_db, user)
+    seen, fake_helper = _ingest_recorder()
+
+    with (
+        patch(f"{STORAGE}.storage_options_for_project", return_value=None),
+        patch(CLI_HELPER, side_effect=fake_helper),
+    ):
+        result = _call(url, project_id=str(project_id), user=user, name="  remote-dc  ")
+
+    assert result["success"] is True
+    assert "remote-dc" in result["message"]
+
+    # Scan, then process (overwriting), both against the same new DC.
+    assert [s["mode"] for s in seen] == ["scan", "process"]
+    assert {s["dc_id"] for s in seen} == {result["data_collection_id"]}
+    assert {s["workflow_id"] for s in seen} == {result["workflow_id"]}
+    assert seen[1]["command_parameters"] == {"overwrite": True}
+    cli_config = seen[0]["cli_config"]
+    assert str(cli_config.user.id) == str(user.id)
+    assert cli_config.remote_storage_options is None  # no project storage: instance creds
+
+    # The workflow the ingest ran on is the one persisted on the project.
+    (workflow,) = mock_db["projects"].find_one({"_id": project_id})["workflows"]
+    assert str(workflow["_id"]) == result["workflow_id"]
+    assert workflow["data_location"]["locations"] == [url]
+    (dc,) = workflow["data_collections"]
+    assert str(dc["_id"]) == result["data_collection_id"]
+    assert dc["data_collection_tag"] == "remote-dc"  # whitespace trimmed
+    scan = dc["config"]["scan"]
+    assert str(scan["mode"]).lower() == "url"
+    assert scan["scan_parameters"] == {"url": url}
+    table = dc["config"]["dc_specific_properties"]
+    assert table["format"] == "csv"
+    assert table["polars_kwargs"]["separator"] == ","
+    assert table["polars_kwargs"]["has_header"] is True
+    assert "lat_column" not in table
+
+
+def test_coordinate_columns_select_the_coordinates_table_config(mock_db):
+    user = _user()
+    project_id = _owned_project_with_token(mock_db, user)
+    _, fake_helper = _ingest_recorder()
+
+    with (
+        patch(f"{STORAGE}.storage_options_for_project", return_value=None),
+        patch(CLI_HELPER, side_effect=fake_helper),
+    ):
+        result = dc_utils._create_dc_from_url(
+            project_id=str(project_id),
+            name="sites",
+            description="Sampling sites",
+            data_type="table",
+            file_format="tsv",
+            separator="\t",
+            custom_separator=None,
+            compression="none",
+            has_header=True,
+            url="https://example.org/sites.tsv",
+            current_user=user,
+            lat_column="lat",
+            lon_column="lon",
+        )
+
+    assert result["success"] is True
+    (workflow,) = mock_db["projects"].find_one({"_id": project_id})["workflows"]
+    (dc,) = workflow["data_collections"]
+    assert dc["description"] == "Sampling sites"
+    table = dc["config"]["dc_specific_properties"]
+    assert table["format"] == "tsv"
+    assert table["polars_kwargs"]["separator"] == "\t"
+    assert (table["lat_column"], table["lon_column"]) == ("lat", "lon")
+
+
+def test_failed_processing_is_a_500_and_rolls_the_workflow_back(mock_db):
+    user = _user()
+    project_id = _owned_project_with_token(mock_db, user)
+    seen, fake_helper = _ingest_recorder(
+        {"process": {"result": "error", "message": "remote read failed"}}
+    )
+
+    with (
+        patch(f"{STORAGE}.storage_options_for_project", return_value=None),
+        patch(CLI_HELPER, side_effect=fake_helper),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _call("https://example.org/run42/data.csv", project_id=str(project_id), user=user)
+
+    assert exc.value.status_code == 500
+    assert "remote read failed" in exc.value.detail
+    assert [s["mode"] for s in seen] == ["scan", "process"]
+    # No ghost workflow without a delta table behind it.
     assert mock_db["projects"].find_one({"_id": project_id})["workflows"] == []

--- a/depictio/tests/api/v1/endpoints/projects_endpoints/test_export_template.py
+++ b/depictio/tests/api/v1/endpoints/projects_endpoints/test_export_template.py
@@ -7,6 +7,8 @@ parameterization ({MANIFEST_URL}, {DATA_ROOT}), the tag-based dashboard
 export, and the actual round-trip against the real resolver.
 """
 
+import io
+import zipfile
 from unittest.mock import patch
 
 import mongomock
@@ -339,3 +341,58 @@ def test_round_trip_through_resolve_template(mock_db, tmp_path):
     assert scan["scan_parameters"]["manifest_url"] == "https://mirror.example.org/manifest.json"
     assert [p.name for p in dashboard_paths] == ["run42_overview.yaml"]
     assert variables["MANIFEST_URL"] == "https://mirror.example.org/manifest.json"
+
+
+# ── bundle_to_zip: the bytes the route actually sends ───────────────────────
+
+
+def test_bundle_to_zip_round_trips_every_member():
+    bundle = {
+        "template.yaml": "name: Run42's project\n",
+        "dashboards/run42_overview.yaml": "title: Run42 Overview\n",
+    }
+
+    data = export_template.bundle_to_zip(bundle)
+
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        assert archive.testzip() is None
+        assert archive.namelist() == list(bundle)  # bundle order is archive order
+        assert {name: archive.read(name).decode("utf-8") for name in bundle} == bundle
+        assert {info.compress_type for info in archive.infolist()} == {zipfile.ZIP_DEFLATED}
+
+
+def test_bundle_to_zip_keeps_non_ascii_text():
+    text = "description: Café résumé 中文\n"
+
+    data = export_template.bundle_to_zip({"template.yaml": text})
+
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        assert archive.read("template.yaml").decode("utf-8") == text
+
+
+def test_zipped_bundle_is_what_the_cli_unpacks(mock_db, tmp_path):
+    """Route body to CLI: the archive built from a real bundle passes the CLI's
+    zip-slip guard and unpacks into the template directory layout."""
+    from depictio.cli.cli.commands.template import _members_within
+
+    user = _user()
+    doc = _manifest_project_doc(user.id)
+    mock_db["projects"].insert_one(doc)
+    wf = doc["workflows"][0]
+    mock_db["dashboards"].insert_one(
+        _dashboard_doc(doc["_id"], wf["_id"], wf["data_collections"][0]["_id"])
+    )
+    bundle = _build(str(doc["_id"]), user)
+
+    data = export_template.bundle_to_zip(bundle)
+
+    target = tmp_path / "test-lab" / "exported" / "1"
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        assert sorted(_members_within(archive, target)) == sorted(bundle)
+        target.mkdir(parents=True)
+        archive.extractall(target)
+    template = yaml.safe_load((target / "template.yaml").read_text())
+    assert template["template"]["template_id"] == "test-lab/exported/1"
+    assert (target / "dashboards" / "run42_overview.yaml").read_text() == (
+        bundle["dashboards/run42_overview.yaml"]
+    )

--- a/depictio/tests/api/v1/endpoints/projects_endpoints/test_manifest_tables_template.py
+++ b/depictio/tests/api/v1/endpoints/projects_endpoints/test_manifest_tables_template.py
@@ -1,0 +1,176 @@
+"""The shipped ``generic/manifest-tables/1`` reference template, parsed through
+the models the server uses when it instantiates a template.
+
+``template.yaml`` must validate as ``TemplateMetadata`` and, once the manifest
+variable is substituted, as ``Project`` (what ``POST /projects/from_manifest``
+does). ``dashboards/base.yaml`` must parse as ``DashboardDataLite``, the format
+``import_dashboard_yaml_content`` accepts, and every tile must bind to a
+workflow and data collection the template actually declares. No database is
+involved: the point is catching a template edit that would only fail once
+someone instantiates it.
+"""
+
+import json
+
+import pytest
+import yaml
+from bson import ObjectId
+
+from depictio.cli.cli.utils.templates import locate_template, substitute_template_variables
+from depictio.models.models.dashboards import DashboardDataLite
+from depictio.models.models.projects import Project
+from depictio.models.models.templates import TemplateMetadata
+
+TEMPLATE_ID = "generic/manifest-tables/1"
+MANIFEST_VAR = "MANIFEST_URL"
+MANIFEST_URL = "https://data.example.org/run42/manifest.json"
+# The only column the manifest contract guarantees on every ingested table.
+JOIN_COLUMN = "depictio_manifest_id"
+
+
+@pytest.fixture(scope="module")
+def template_dir():
+    return locate_template(TEMPLATE_ID).parent
+
+
+@pytest.fixture(scope="module")
+def template_cfg(template_dir) -> dict:
+    return yaml.safe_load((template_dir / "template.yaml").read_text())
+
+
+@pytest.fixture(scope="module")
+def meta(template_cfg) -> TemplateMetadata:
+    return TemplateMetadata(**template_cfg["template"])
+
+
+@pytest.fixture(scope="module")
+def project(template_cfg) -> Project:
+    """The config as the from_manifest endpoint validates it."""
+    cfg = {key: value for key, value in template_cfg.items() if key != "template"}
+    cfg = substitute_template_variables(cfg, {MANIFEST_VAR: MANIFEST_URL})
+    cfg["permissions"] = {"owners": [{"_id": ObjectId(), "email": "owner@example.com"}]}
+    return Project(**cfg)
+
+
+@pytest.fixture(scope="module")
+def dashboards(template_dir, meta) -> dict[str, DashboardDataLite]:
+    return {
+        rel_path: DashboardDataLite.from_yaml((template_dir / rel_path).read_text())
+        for rel_path in meta.dashboards
+    }
+
+
+def _components(dashboard: DashboardDataLite) -> list[dict]:
+    """Components as plain dicts, whether they parsed as typed Lite models or
+    fell through to the dict fallback."""
+    return [c if isinstance(c, dict) else c.model_dump() for c in dashboard.components]
+
+
+def test_metadata_binds_one_required_manifest_variable_and_no_data_root(meta):
+    assert meta.template_id == TEMPLATE_ID
+    assert meta.get_required_variable_names() == [MANIFEST_VAR]
+    # Manifest-driven: no local layout to declare and nothing conditional.
+    assert meta.structure is None
+    assert meta.runs_regex is None
+    assert meta.conditional == []
+
+
+def test_declared_dashboards_match_the_files_on_disk(template_dir, meta):
+    declared = set(meta.dashboards)
+    on_disk = {
+        str(path.relative_to(template_dir)) for path in (template_dir / "dashboards").glob("*.yaml")
+    }
+    assert declared
+    assert declared == on_disk
+
+
+def test_config_instantiates_as_a_manifest_driven_project(project):
+    assert len(project.workflows) == 1
+    workflow = project.workflows[0]
+    assert workflow.data_location.locations == [MANIFEST_URL]
+    for dc in workflow.data_collections:
+        scan = dc.config.scan
+        assert str(scan.mode).lower() == "manifest"
+        assert scan.scan_parameters.manifest_url == MANIFEST_URL
+        # The manifest `type` a row carries is the DC tag it lands in.
+        assert scan.scan_parameters.manifest_type == dc.data_collection_tag
+    # Substitution left no placeholder behind anywhere in the document.
+    assert "{" + MANIFEST_VAR + "}" not in json.dumps(project.model_dump(), default=str)
+
+
+def test_base_dashboard_parses_and_targets_the_template_project(dashboards, template_cfg):
+    base = dashboards["dashboards/base.yaml"]
+    assert base.project_tag == template_cfg["name"]
+    assert base.is_main_tab
+    assert base.title
+    components = _components(base)
+    assert components
+    assert len({c["tag"] for c in components}) == len(components), "component tags must be unique"
+
+
+def test_components_bind_only_to_declared_workflow_and_collections(dashboards, project):
+    """Mirrors ``_resolve_workflow_tags`` in the dashboards routes: a component
+    tag is ``[engine/]name``; the name part must match a workflow's ``name``
+    or ``workflow_tag``, and an engine prefix must be that workflow's engine
+    (the ``engine/name`` form the exporter writes back)."""
+    workflows = {wf.name: wf for wf in project.workflows}
+    by_tag = {wf.workflow_tag: wf for wf in project.workflows}
+    dc_tags = {dc.data_collection_tag for wf in project.workflows for dc in wf.data_collections}
+    bound = [c for d in dashboards.values() for c in _components(d) if c.get("data_collection_tag")]
+    assert bound
+    resolved: set[str] = set()
+    for comp in bound:
+        engine, _, name = comp["workflow_tag"].rpartition("/")
+        workflow = workflows.get(name) or by_tag.get(name)
+        assert workflow is not None, (
+            f"{comp['tag']} binds unknown workflow {comp['workflow_tag']!r}"
+        )
+        if engine:
+            assert engine == workflow.engine.name, f"{comp['tag']} names the wrong engine"
+        resolved.add(workflow.name)
+    assert resolved == set(workflows)
+    # Every collection the template declares gets at least one tile.
+    assert {c["data_collection_tag"] for c in bound} == dc_tags
+
+
+def test_column_bound_components_use_only_the_injected_join_column(dashboards):
+    """The template is schema-agnostic: nothing but the injected id column may
+    be referenced, since it is the only column every manifest table carries."""
+    columns = {
+        c["column_name"]
+        for d in dashboards.values()
+        for c in _components(d)
+        if c.get("column_name")
+    }
+    assert columns == {JOIN_COLUMN}
+
+
+def test_component_sections_are_declared_in_the_matching_panel(dashboards):
+    for dashboard in dashboards.values():
+        filter_names = {s.name for s in dashboard.filter_sections}
+        grid_names = {s.name for s in dashboard.grid_sections}
+        for comp in _components(dashboard):
+            section = comp.get("section")
+            if not section:
+                continue
+            declared = filter_names if comp["component_type"] == "interactive" else grid_names
+            assert section in declared, f"{comp['tag']} names undeclared section {section!r}"
+
+
+def test_filters_only_bind_to_required_collections(dashboards, project):
+    """A filter on an optional collection would vanish with it when the
+    self-adapting import drops empty optional DCs, taking the panel with it."""
+    required = {
+        dc.data_collection_tag
+        for wf in project.workflows
+        for dc in wf.data_collections
+        if not getattr(dc, "optional", False)
+    }
+    filters = [
+        c
+        for d in dashboards.values()
+        for c in _components(d)
+        if c["component_type"] == "interactive"
+    ]
+    assert filters
+    assert {c["data_collection_tag"] for c in filters} <= required

--- a/depictio/tests/api/v1/monitoring/test_store.py
+++ b/depictio/tests/api/v1/monitoring/test_store.py
@@ -1,0 +1,131 @@
+"""Tests for the monitoring ledger's ingestion-run step writers.
+
+``set_ingestion_step`` is the concurrent-safe writer (one positional update,
+no read-modify-write) used when several workers report on different steps of
+the same run. Its contract is narrower than ``upsert_ingestion_step``: the
+step must have been seeded at run creation, so an unknown name is refused
+rather than appended. Backed by mongomock, no live database.
+
+mongomock 4.3 applies a positional ``steps.$`` assignment but drops the plain
+sibling field set in the same ``$set`` (``current_step``); MongoDB applies
+both. ``current_step`` is therefore only asserted where nothing should have
+changed.
+"""
+
+import mongomock
+import pytest
+
+from depictio.api.v1.monitoring import store
+from depictio.models.models.monitoring import IngestionRun, IngestionStep
+
+
+@pytest.fixture()
+def runs(monkeypatch):
+    collection = mongomock.MongoClient()["depictio_test"]["ingestion_runs"]
+    monkeypatch.setattr(store, "ingestion_runs_collection", collection)
+    return collection
+
+
+def _seed_run(run_id: str = "run-1", steps: tuple[str, ...] = ("counts", "annotations")) -> None:
+    store.create_ingestion_run(
+        IngestionRun(
+            run_id=run_id,
+            steps=[IngestionStep(name=name, status="pending") for name in steps],
+        )
+    )
+
+
+def _steps(runs, run_id: str = "run-1") -> dict[str, dict]:
+    doc = runs.find_one({"run_id": run_id})
+    return {step["name"]: step for step in doc["steps"]}
+
+
+def test_set_ingestion_step_replaces_only_the_named_step(runs):
+    _seed_run()
+
+    assert (
+        store.set_ingestion_step(
+            "run-1",
+            step={"name": "counts", "status": "success", "detail": "3 entries"},
+            current_step="annotations",
+        )
+        is True
+    )
+
+    steps = _steps(runs)
+    assert steps["counts"] == {"name": "counts", "status": "success", "detail": "3 entries"}
+    # The sibling step is untouched, and the order of the seeded list is kept.
+    assert steps["annotations"]["status"] == "pending"
+    assert [s["name"] for s in runs.find_one({"run_id": "run-1"})["steps"]] == [
+        "counts",
+        "annotations",
+    ]
+
+
+def test_set_ingestion_step_is_a_single_positional_update(runs):
+    """No read-modify-write: one update_one with a positional filter, which is
+    what lets concurrent workers report on different steps of one run."""
+    _seed_run()
+    calls: list[tuple[dict, dict]] = []
+    original = runs.update_one
+
+    def _spy(filter_doc, update_doc, **kwargs):
+        calls.append((filter_doc, update_doc))
+        return original(filter_doc, update_doc, **kwargs)
+
+    runs.update_one = _spy  # type: ignore[method-assign]
+
+    store.set_ingestion_step(
+        "run-1", step={"name": "counts", "status": "success"}, current_step="annotations"
+    )
+
+    assert calls == [
+        (
+            {"run_id": "run-1", "steps.name": "counts"},
+            {
+                "$set": {
+                    "steps.$": {"name": "counts", "status": "success"},
+                    "current_step": "annotations",
+                }
+            },
+        )
+    ]
+
+
+def test_set_ingestion_step_unknown_step_returns_false_and_never_appends(runs):
+    _seed_run()
+
+    assert (
+        store.set_ingestion_step(
+            "run-1", step={"name": "ghost", "status": "success"}, current_step="ghost"
+        )
+        is False
+    )
+
+    doc = runs.find_one({"run_id": "run-1"})
+    assert [s["name"] for s in doc["steps"]] == ["counts", "annotations"]
+    assert all(s["status"] == "pending" for s in doc["steps"])
+    # A refused write changes nothing else on the run either.
+    assert doc["current_step"] is None
+
+
+def test_set_ingestion_step_unknown_run_returns_false_without_creating_it(runs):
+    _seed_run()
+
+    assert store.set_ingestion_step("nope", step={"name": "counts", "status": "success"}) is False
+
+    assert runs.count_documents({}) == 1
+    assert _steps(runs)["counts"]["status"] == "pending"
+
+
+def test_upsert_ingestion_step_appends_what_set_refuses(runs):
+    """The read-modify-write sibling is the one that grows the step list; the
+    contrast pins down which writer a caller needs."""
+    _seed_run()
+
+    assert store.upsert_ingestion_step("run-1", step={"name": "ghost", "status": "running"}) is True
+    assert store.upsert_ingestion_step("run-1", step={"name": "ghost", "status": "success"}) is True
+
+    steps = _steps(runs)
+    assert list(steps) == ["counts", "annotations", "ghost"]
+    assert steps["ghost"]["status"] == "success"  # replaced in place, not duplicated

--- a/depictio/tests/cli/commands/test_template_export.py
+++ b/depictio/tests/cli/commands/test_template_export.py
@@ -12,13 +12,36 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
 from depictio.cli.cli.commands import template as template_cmd
-from depictio.cli.depictio_cli import app
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _cli_context(monkeypatch):
+    """Keep the CLI's process-wide context flip out of the other tests.
+
+    Importing ``depictio.cli.depictio_cli`` sets ``DEPICTIO_CONTEXT=CLI`` on
+    the process, and ``depictio.models.config`` caches whatever the context
+    is at its first import (CLI context makes data-location validators
+    check that directories exist). Import the models config first so its
+    cache holds the session default, then scope the CLI value to this test:
+    the app is imported lazily by the helpers below, and monkeypatch puts
+    the variable back afterwards.
+    """
+    import depictio.models.config  # noqa: F401
+
+    monkeypatch.setenv("DEPICTIO_CONTEXT", "CLI")
+
+
+def _cli_app():
+    from depictio.cli.depictio_cli import app
+
+    return app
 
 
 def _zip_bytes(members: dict[str, str]) -> bytes:
@@ -55,7 +78,7 @@ def _export(output_dir: Path, bundle: bytes):
         patch.object(template_cmd.httpx, "Client", return_value=_FakeClient(bundle)),
     ):
         return runner.invoke(
-            app,
+            _cli_app(),
             [
                 "template",
                 "export",
@@ -118,3 +141,174 @@ def test_corrupt_bundle_is_reported_not_traced(tmp_path):
     assert result.exit_code == 1
     assert "not a valid zip" in result.output
     assert list(tmp_path.iterdir()) == []
+
+
+# ── Request shape and failure paths ─────────────────────────────────────────
+
+PROJECT_ID = "6824cb3b89d2b72169309737"
+BASE_ARGS = ["-t", "lab/tool/1", "-c", "cfg.yaml"]
+
+
+class _RecordingClient(_FakeClient):
+    """httpx.Client stand-in that records the POST it receives.
+
+    ``error`` shapes the failure: an ``httpx.RequestError`` is raised by the
+    call itself (transport failure), any other exception is raised by
+    ``raise_for_status()`` on the returned response (HTTP error status).
+    """
+
+    def __init__(self, content: bytes = b"", error: Exception | None = None):
+        super().__init__(content)
+        self.error = error
+        self.calls: list[dict] = []
+
+    def post(self, url, headers=None, json=None):
+        self.calls.append({"url": url, "headers": headers, "json": json})
+        if isinstance(self.error, httpx.RequestError):
+            raise self.error
+
+        def _raise_for_status():
+            if self.error is not None:
+                raise self.error
+
+        return SimpleNamespace(content=self._content, raise_for_status=_raise_for_status)
+
+
+def _http_error(status: int, text: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://api.test/export")
+    response = httpx.Response(status, text=text, request=request)
+    return httpx.HTTPStatusError("status error", request=request, response=response)
+
+
+def _invoke(args: list[str], client, config_error: Exception | None = None):
+    """Run ``template export`` with the CLI config and HTTP client stubbed.
+
+    The stubbed config reports ``api_base_url=http://from-config:9999`` so a
+    test can tell whether the command used ``--api`` or fell back to it.
+    """
+    with (
+        patch(
+            "depictio.cli.cli.utils.common.load_depictio_config",
+            return_value=SimpleNamespace(api_base_url="http://from-config:9999"),
+            side_effect=config_error,
+        ),
+        patch(
+            "depictio.cli.cli.utils.common.generate_api_headers",
+            return_value={"Authorization": "Bearer t0k"},
+        ),
+        patch.object(template_cmd.httpx, "Client", return_value=client),
+    ):
+        return runner.invoke(_cli_app(), ["template", "export", PROJECT_ID, *args])
+
+
+def test_request_carries_every_option_to_the_export_endpoint(tmp_path):
+    client = _RecordingClient(_zip_bytes({"template.yaml": "name: x\n"}))
+
+    result = _invoke(
+        [
+            *BASE_ARGS,
+            "-o",
+            str(tmp_path),
+            "--api",
+            "http://api.test",
+            "--version",
+            "2.1.0",
+            "--description",
+            "Exported for review",
+            "--data-root",
+            "/data/run42",
+        ],
+        client,
+    )
+
+    assert result.exit_code == 0, result.output
+    # An explicit --api wins over the CLI config's api_base_url.
+    assert client.calls == [
+        {
+            "url": f"http://api.test/depictio/api/v1/projects/{PROJECT_ID}/export_template",
+            "headers": {"Authorization": "Bearer t0k"},
+            "json": {
+                "template_id": "lab/tool/1",
+                "version": "2.1.0",
+                "description": "Exported for review",
+                "data_root": "/data/run42",
+            },
+        }
+    ]
+
+
+def test_optional_fields_default_to_none_and_version_to_1_0_0(tmp_path):
+    client = _RecordingClient(_zip_bytes({"template.yaml": "name: x\n"}))
+
+    result = _invoke([*BASE_ARGS, "-o", str(tmp_path), "--api", "http://api.test"], client)
+
+    assert result.exit_code == 0, result.output
+    assert client.calls[0]["json"] == {
+        "template_id": "lab/tool/1",
+        "version": "1.0.0",
+        "description": None,
+        "data_root": None,
+    }
+
+
+def test_api_url_falls_back_to_the_cli_config(tmp_path):
+    """Without --api the command targets the API the CLI config was made for."""
+    client = _RecordingClient(_zip_bytes({"template.yaml": "name: x\n"}))
+
+    result = _invoke([*BASE_ARGS, "-o", str(tmp_path)], client)
+
+    assert result.exit_code == 0, result.output
+    assert client.calls[0]["url"] == (
+        f"http://from-config:9999/depictio/api/v1/projects/{PROJECT_ID}/export_template"
+    )
+
+
+def test_config_error_exits_with_a_hint_before_any_request(tmp_path):
+    client = _RecordingClient()
+
+    result = _invoke(
+        [*BASE_ARGS, "-o", str(tmp_path)], client, config_error=FileNotFoundError("cfg.yaml")
+    )
+
+    assert result.exit_code == 1
+    assert "Error loading CLI config" in result.output
+    assert "depictio config" in result.output
+    assert client.calls == []
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_http_error_reports_status_and_server_detail(tmp_path):
+    client = _RecordingClient(
+        error=_http_error(422, '{"detail":"template_id must be slash-separated"}')
+    )
+
+    result = _invoke([*BASE_ARGS, "-o", str(tmp_path)], client)
+
+    assert result.exit_code == 1
+    assert "HTTP 422" in result.output
+    assert "slash-separated" in result.output
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_transport_error_is_reported_not_traced(tmp_path):
+    client = _RecordingClient(error=httpx.ConnectError("connection refused"))
+
+    result = _invoke([*BASE_ARGS, "-o", str(tmp_path)], client)
+
+    assert result.exit_code == 1
+    assert "connection refused" in result.output
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_success_lists_the_unpacked_members(tmp_path):
+    client = _RecordingClient(
+        _zip_bytes({"template.yaml": "name: x\n", "dashboards/base.yaml": "title: t\n"})
+    )
+
+    result = _invoke([*BASE_ARGS, "-o", str(tmp_path)], client)
+
+    assert result.exit_code == 0, result.output
+    assert "Template bundle written to" in result.output
+    assert "template.yaml" in result.output
+    assert "dashboards/base.yaml" in result.output
+    assert (tmp_path / "lab" / "tool" / "1" / "dashboards" / "base.yaml").exists()

--- a/depictio/tests/cli/test_remote_read.py
+++ b/depictio/tests/cli/test_remote_read.py
@@ -562,3 +562,203 @@ def test_manifest_id_column_injected(http_fixture_server):
     df = read_single_file_lazy(file_info, "csv", {}).collect()
     assert df["depictio_manifest_id"].to_list() == ["S1", "S1"]
     assert set(df["depictio_run_id"].to_list()) == {"remote-run"}
+
+
+class TestUrlScan:
+    """scan mode "url": one synthesized File per DC, keyed by the remote URL."""
+
+    @staticmethod
+    def _dc_and_workflow(url: str):
+        from depictio.models.models.data_collections import (
+            DataCollection,
+            DataCollectionConfig,
+            Scan,
+            ScanURL,
+        )
+        from depictio.models.models.workflows import (
+            Workflow,
+            WorkflowConfig,
+            WorkflowDataLocation,
+            WorkflowEngine,
+        )
+
+        dc = DataCollection(
+            data_collection_tag="remote",
+            config=DataCollectionConfig(
+                type="table",
+                metatype="aggregate",
+                scan=Scan(mode="url", scan_parameters=ScanURL(url=url)),
+                dc_specific_properties={"format": "csv"},
+            ),
+        )
+        workflow = Workflow(
+            name="wf",
+            workflow_tag="wf",
+            engine=WorkflowEngine(name="python"),
+            config=WorkflowConfig(),
+            data_location=WorkflowDataLocation(structure="flat", locations=[url]),
+            data_collections=[dc],
+        )
+        return dc, workflow
+
+    @pytest.fixture()
+    def api(self, monkeypatch):
+        """Stub the API round-trips the scan makes.
+
+        ``existing`` and ``status`` shape the existing-files lookup;
+        ``created`` records ``(files, update)`` per registration call and
+        ``deleted`` the ids of stale records the scan removed.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from depictio.cli.cli.utils import scan as scan_mod
+
+        recorder = SimpleNamespace(existing=[], status=200, created=[], deleted=[])
+
+        def _lookup(**_):
+            response = MagicMock(status_code=recorder.status)
+            response.json.return_value = recorder.existing
+            return response
+
+        monkeypatch.setattr(scan_mod, "api_get_files_by_dc_id", _lookup)
+        monkeypatch.setattr(
+            scan_mod,
+            "api_create_files",
+            lambda files, CLI_config, update: recorder.created.append((list(files), update)),
+        )
+        monkeypatch.setattr(
+            scan_mod,
+            "api_delete_file",
+            lambda file_id, CLI_config: recorder.deleted.append(file_id),
+        )
+        return recorder
+
+    def _scan(self, url: str, update_files: bool = False):
+        from unittest.mock import MagicMock
+
+        from depictio.cli.cli.utils.scan import scan_url_for_data_collection
+
+        dc, workflow = self._dc_and_workflow(url)
+        owner = UserBase(id=PyObjectId(), email="o@example.com", is_admin=False)
+        result = scan_url_for_data_collection(
+            workflow=workflow,
+            data_collection=dc,
+            CLI_config=MagicMock(),
+            permissions=Permission(owners=[owner]),
+            update_files=update_files,
+        )
+        return result, dc
+
+    @staticmethod
+    def _identity_hash(url: str, etag: str = "") -> str:
+        import hashlib
+
+        return hashlib.sha256(f"{url}|{etag}".encode()).hexdigest()
+
+    @staticmethod
+    def _existing(url: str, file_hash: str) -> dict:
+        from bson import ObjectId
+
+        return {"_id": str(ObjectId()), "file_location": url, "file_hash": file_hash}
+
+    def test_registers_the_url_as_one_file(self, api, http_fixture_server):
+        url = f"{http_fixture_server}/table.csv"
+
+        result, dc = self._scan(url)
+
+        assert result == {"result": "success"}
+        ((files, update),) = api.created
+        assert update is False
+        (file,) = files
+        assert file.file_location == url
+        assert file.filename == "table.csv"
+        assert file.filesize == len("sample,value\nS1,1\nS2,2\n")  # from the HEAD probe
+        # The fixture server sends no ETag: the identity hash is url + "".
+        assert file.file_hash == self._identity_hash(url)
+        assert file.data_collection_id == dc.id
+        assert file.run_tag == "remote-url-scan"
+        assert api.deleted == []
+
+    def test_unchanged_url_is_skipped(self, api, http_fixture_server):
+        url = f"{http_fixture_server}/table.csv"
+        api.existing = [self._existing(url, self._identity_hash(url))]
+
+        result, _ = self._scan(url)
+
+        assert result == {"result": "success"}
+        assert api.created == []
+        assert api.deleted == []
+
+    def test_update_files_re_registers_an_unchanged_url_under_its_existing_id(
+        self, api, http_fixture_server
+    ):
+        url = f"{http_fixture_server}/table.csv"
+        known = self._existing(url, self._identity_hash(url))
+        api.existing = [known]
+
+        self._scan(url, update_files=True)
+
+        ((files, update),) = api.created
+        assert update is True
+        assert str(files[0].id) == known["_id"]
+
+    def test_changed_remote_content_is_registered_as_an_update(self, api, http_fixture_server):
+        url = f"{http_fixture_server}/table.csv"
+        known = self._existing(url, "0" * 64)  # hash recorded before the content changed
+        api.existing = [known]
+
+        self._scan(url)
+
+        ((files, update),) = api.created
+        assert update is True
+        assert str(files[0].id) == known["_id"]
+        assert files[0].file_hash == self._identity_hash(url)
+
+    def test_repointed_dc_drops_the_stale_record(self, api, http_fixture_server):
+        old_url = f"{http_fixture_server}/table.tsv"
+        new_url = f"{http_fixture_server}/table.csv"
+        stale = self._existing(old_url, self._identity_hash(old_url))
+        api.existing = [stale]
+
+        self._scan(new_url)
+
+        assert api.deleted == [stale["_id"]]
+        ((files, update),) = api.created
+        assert update is False
+        assert files[0].file_location == new_url
+
+    def test_unreachable_url_is_registered_with_the_size_fallback_hash(self, api, caplog):
+        import hashlib
+
+        url = "http://127.0.0.1:1/data.csv"
+
+        with caplog.at_level(logging.WARNING, logger="depictio-cli"):
+            result, _ = self._scan(url)
+
+        assert result == {"result": "success"}
+        ((files, _),) = api.created
+        assert files[0].filesize == -1
+        # Failed probe: the weaker url + size hash, and it says so.
+        assert files[0].file_hash == hashlib.sha256(f"{url}|size=-1".encode()).hexdigest()
+        assert any("Could not probe" in rec.message for rec in caplog.records)
+        assert any("falls back to URL + size" in rec.message for rec in caplog.records)
+
+    def test_lookup_failure_warns_and_still_registers(self, api, http_fixture_server, caplog):
+        url = f"{http_fixture_server}/table.csv"
+        api.status = 500
+
+        with caplog.at_level(logging.WARNING, logger="depictio-cli"):
+            result, _ = self._scan(url)
+
+        assert result == {"result": "success"}
+        assert any("Failed to retrieve existing files" in rec.message for rec in caplog.records)
+        ((files, update),) = api.created
+        assert update is False
+        assert files[0].file_location == url
+
+    def test_url_without_a_basename_gets_a_placeholder_filename(self, api, http_fixture_server):
+        self._scan(f"{http_fixture_server}/")
+
+        ((files, _),) = api.created
+        assert files[0].filename == "remote-file"

--- a/depictio/tests/cli/utils/test_s3_prefix_scan.py
+++ b/depictio/tests/cli/utils/test_s3_prefix_scan.py
@@ -4,10 +4,28 @@ Listing is exercised against a stubbed boto3 paginator: the S3 wire protocol is
 not what can break here, the key filtering and pagination handling are.
 """
 
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
+from bson import ObjectId
 
 from depictio.cli.cli.utils import scan as scan_module
-from depictio.models.models.data_collections import Scan, ScanS3Prefix
+from depictio.models.models.base import PyObjectId
+from depictio.models.models.data_collections import (
+    DataCollection,
+    DataCollectionConfig,
+    Scan,
+    ScanS3Prefix,
+)
+from depictio.models.models.users import Permission, UserBase
+from depictio.models.models.workflows import (
+    Workflow,
+    WorkflowConfig,
+    WorkflowDataLocation,
+    WorkflowEngine,
+)
 
 
 class _StubPaginator:
@@ -253,3 +271,198 @@ class TestListS3PrefixKeyBudget:
         found = scan_module.list_s3_prefix("s3://b/run42/", "*.csv", 5, None)
         assert [o["relative"] for o in found] == ["late.csv"]
         assert messages == []
+
+
+# ── scan_s3_prefix_for_data_collection: listing to File records ─────────────
+
+PREFIX = "s3://b/run42/"
+SAMPLE_ID_REGEX = r"(sample_[A-Z])\.samples\.csv"
+
+
+def _s3_prefix_dc(pattern: str = "*.samples.csv", id_regex: str | None = SAMPLE_ID_REGEX):
+    return DataCollection(
+        data_collection_tag="samples",
+        config=DataCollectionConfig(
+            type="table",
+            metatype="aggregate",
+            scan=Scan(
+                mode="s3_prefix",
+                scan_parameters=ScanS3Prefix(prefix=PREFIX, pattern=pattern, id_regex=id_regex),
+            ),
+            dc_specific_properties={"format": "csv"},
+        ),
+    )
+
+
+def _workflow(dc: DataCollection) -> Workflow:
+    return Workflow(
+        name="wf",
+        workflow_tag="wf",
+        engine=WorkflowEngine(name="python"),
+        config=WorkflowConfig(),
+        data_location=WorkflowDataLocation(structure="flat", locations=[PREFIX]),
+        data_collections=[dc],
+    )
+
+
+def _object_hash(key: str) -> str:
+    """Identity hash of a stubbed object: url + the ETag the stub derives from its key."""
+    return hashlib.sha256(f"s3://b/{key}|{key}-etag".encode()).hexdigest()
+
+
+def _existing(key: str, file_hash: str) -> dict:
+    return {"_id": str(ObjectId()), "file_location": f"s3://b/{key}", "file_hash": file_hash}
+
+
+@pytest.fixture
+def api(monkeypatch):
+    """Stub the API round-trips the scan makes; see TestUrlScan in
+    tests/cli/test_remote_read.py for the same shape."""
+    recorder = SimpleNamespace(existing=[], status=200, created=[], deleted=[])
+
+    def _lookup(**_):
+        response = MagicMock(status_code=recorder.status)
+        response.json.return_value = recorder.existing
+        return response
+
+    monkeypatch.setattr(scan_module, "api_get_files_by_dc_id", _lookup)
+    monkeypatch.setattr(
+        scan_module,
+        "api_create_files",
+        lambda files, CLI_config, update: recorder.created.append((list(files), update)),
+    )
+    monkeypatch.setattr(
+        scan_module, "api_delete_file", lambda file_id, CLI_config: recorder.deleted.append(file_id)
+    )
+    return recorder
+
+
+@pytest.fixture
+def messages(monkeypatch):
+    captured: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        scan_module,
+        "rich_print_checked_statement",
+        lambda msg, level="info": captured.append((level, msg)),
+    )
+    return captured
+
+
+class TestScanS3PrefixForDataCollection:
+    @staticmethod
+    def _scan(dc: DataCollection, update_files: bool = False) -> dict:
+        owner = UserBase(id=PyObjectId(), email="o@example.com", is_admin=False)
+        return scan_module.scan_s3_prefix_for_data_collection(
+            workflow=_workflow(dc),
+            data_collection=dc,
+            CLI_config=MagicMock(),
+            permissions=Permission(owners=[owner]),
+            update_files=update_files,
+        )
+
+    def test_registers_every_matching_object_with_a_join_id(self, stub_s3, api):
+        stub_s3(KEYS)
+        dc = _s3_prefix_dc()
+
+        assert self._scan(dc) == {"result": "success", "added": 3, "updated": 0}
+
+        ((files, update),) = api.created
+        assert update is False
+        by_id = {f.manifest_id: f for f in files}
+        # id_regex captured the entity id from nested keys too.
+        assert set(by_id) == {"sample_A", "sample_B", "sample_D"}
+        nested = by_id["sample_D"]
+        assert nested.file_location == "s3://b/run42/nested/sample_D.samples.csv"
+        assert nested.filename == "sample_D.samples.csv"
+        assert nested.file_hash == _object_hash("run42/nested/sample_D.samples.csv")
+        assert nested.filesize == 10
+        assert nested.run_tag == "remote"
+        assert {f.data_collection_id for f in files} == {dc.id}
+        assert api.deleted == []
+
+    def test_no_match_is_an_error_not_an_empty_success(self, stub_s3, api):
+        stub_s3(KEYS)
+
+        result = self._scan(_s3_prefix_dc(pattern="*.parquet"))
+
+        assert result["result"] == "error"
+        assert PREFIX in result["message"]
+        assert "*.parquet" in result["message"]
+        assert "samples" in result["message"]
+        assert api.created == []
+
+    def test_listing_failure_is_reported_as_a_scan_error(self, monkeypatch, api):
+        def _no_client(_cfg):
+            raise RuntimeError("no credentials")
+
+        monkeypatch.setattr(scan_module, "_s3_read_client", _no_client)
+
+        result = self._scan(_s3_prefix_dc())
+
+        assert result["result"] == "error"
+        assert "S3 prefix listing failed" in result["message"]
+        assert "no credentials" in result["message"]
+        assert api.created == []
+
+    def test_unchanged_objects_are_skipped_and_stale_records_removed(self, stub_s3, api):
+        stub_s3(KEYS)
+        stale = _existing("run42/gone.samples.csv", "x" * 64)
+        api.existing = [
+            _existing("run42/sample_A.samples.csv", _object_hash("run42/sample_A.samples.csv")),
+            stale,
+        ]
+
+        assert self._scan(_s3_prefix_dc()) == {"result": "success", "added": 2, "updated": 0}
+
+        assert api.deleted == [stale["_id"]]
+        ((files, update),) = api.created
+        assert update is False
+        assert {f.manifest_id for f in files} == {"sample_B", "sample_D"}
+
+    def test_re_uploaded_object_is_an_update_that_keeps_its_id(self, stub_s3, api):
+        stub_s3(KEYS)
+        known = _existing("run42/sample_A.samples.csv", "0" * 64)  # ETag has since changed
+        api.existing = [known]
+
+        assert self._scan(_s3_prefix_dc()) == {"result": "success", "added": 2, "updated": 1}
+
+        ((files, _),) = [(files, update) for files, update in api.created if update]
+        assert [str(f.id) for f in files] == [known["_id"]]
+        assert files[0].file_hash == _object_hash("run42/sample_A.samples.csv")
+
+    def test_update_files_forces_reregistration_of_unchanged_objects(self, stub_s3, api):
+        stub_s3(KEYS)
+        api.existing = [
+            _existing("run42/sample_A.samples.csv", _object_hash("run42/sample_A.samples.csv"))
+        ]
+
+        result = self._scan(_s3_prefix_dc(), update_files=True)
+
+        assert result == {"result": "success", "added": 2, "updated": 1}
+
+    def test_lookup_failure_still_registers_everything(self, stub_s3, api):
+        stub_s3(KEYS)
+        api.status = 500
+
+        assert self._scan(_s3_prefix_dc()) == {"result": "success", "added": 3, "updated": 0}
+
+    def test_unmatched_id_regex_warns_and_leaves_no_join_id(self, stub_s3, api, messages):
+        stub_s3(KEYS)
+
+        result = self._scan(_s3_prefix_dc(id_regex=r"^(run\d+)_"))
+
+        assert result == {"result": "success", "added": 3, "updated": 0}
+        ((files, _),) = api.created
+        assert [f.manifest_id for f in files] == [None, None, None]
+        warning = next(msg for level, msg in messages if level == "warning")
+        assert "3 object(s)" in warning
+        assert "did not match id_regex" in warning
+
+    def test_without_id_regex_no_join_id_and_no_warning(self, stub_s3, api, messages):
+        stub_s3(KEYS)
+
+        self._scan(_s3_prefix_dc(id_regex=None))
+
+        ((files, _),) = api.created
+        assert [f.manifest_id for f in files] == [None, None, None]
+        assert [level for level, _ in messages] == ["info"]

--- a/depictio/tests/e2e-playwright/tests/projects/export-template.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/projects/export-template.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * "Export as template" on the project detail page (ExportTemplateModal.tsx).
+ *
+ * The modal validates the template id client-side (same rule as the backend:
+ * slash-separated `[A-Za-z0-9][A-Za-z0-9._-]*` segments) and, on success,
+ * hands the zip from POST /projects/{id}/export_template to the browser as a
+ * download. The download is captured and its central directory read here so
+ * the assertion is on the bundle's contents, not just on a file name.
+ *
+ * Runs for admins in standard AND single-user mode; skipped in public mode.
+ * Targets the seeded Iris project and skips when that seed is absent.
+ */
+
+import { readFileSync } from "node:fs";
+import { Page } from "@playwright/test";
+import { test, expect, getAuthMode } from "@fixtures/auth";
+import { IRIS_PROJECT_ID } from "@fixtures/projects";
+
+const PROJECT_URL = `/projects/${IRIS_PROJECT_ID}`;
+
+/**
+ * Entry names of a zip archive, read from its central directory (no
+ * dependency needed). Signatures: end-of-central-directory 0x06054b50,
+ * central file header 0x02014b50.
+ */
+function zipEntryNames(archive: Buffer): string[] {
+  let eocd = -1;
+  for (let i = archive.length - 22; i >= Math.max(0, archive.length - 65_557); i--) {
+    if (archive.readUInt32LE(i) === 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) throw new Error("not a zip archive: no end-of-central-directory record");
+  const entryCount = archive.readUInt16LE(eocd + 10);
+  let offset = archive.readUInt32LE(eocd + 16);
+  const names: string[] = [];
+  for (let n = 0; n < entryCount; n++) {
+    if (archive.readUInt32LE(offset) !== 0x02014b50) {
+      throw new Error(`corrupt central directory at byte ${offset}`);
+    }
+    const nameLength = archive.readUInt16LE(offset + 28);
+    const extraLength = archive.readUInt16LE(offset + 30);
+    const commentLength = archive.readUInt16LE(offset + 32);
+    names.push(archive.toString("utf8", offset + 46, offset + 46 + nameLength));
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+  return names;
+}
+
+async function openExportModal(page: Page) {
+  await page.locator("[data-testid='export-template-button']").click();
+  const idInput = page.locator("[data-testid='export-template-id-input']");
+  await expect(idInput).toBeVisible();
+  return idInput;
+}
+
+test.describe("Export project as template", () => {
+  test.beforeEach(async ({ loginAsAdmin, page }) => {
+    const { is_public_mode } = await getAuthMode();
+    test.skip(is_public_mode, "Exporting a template needs edit permission on a project.");
+
+    await loginAsAdmin();
+    await page.goto(PROJECT_URL);
+
+    // Skip (not fail) on stacks without the Iris reference seed.
+    const exportButton = page.locator("[data-testid='export-template-button']");
+    const loadError = page.getByText(/failed to load|back to projects/i);
+    await expect(exportButton.or(loadError).first()).toBeVisible({ timeout: 15_000 });
+    test.skip(
+      !(await exportButton.isVisible()),
+      "Iris reference project not seeded in this stack.",
+    );
+    await expect(exportButton).toBeEnabled({ timeout: 15_000 });
+  });
+
+  test("rejects an empty or malformed template id inline", async ({ page }) => {
+    const idInput = await openExportModal(page);
+    const submit = page.locator("[data-testid='export-template-submit']");
+    const dialog = page.getByRole("dialog");
+
+    await submit.click();
+    await expect(dialog.getByText("Template ID is required.")).toBeVisible();
+
+    // A path-escaping id never reaches the server: the client mirrors the
+    // backend's segment rule and explains it.
+    await idInput.fill("../escape");
+    await submit.click();
+    await expect(dialog.getByText(/invalid format/i)).toBeVisible();
+    await expect(dialog).toBeVisible(); // still open for correction
+
+    // Typing again clears the error.
+    await idInput.fill("e2e");
+    await expect(dialog.getByText(/invalid format/i)).toHaveCount(0);
+  });
+
+  test("downloads a zip bundle whose root holds template.yaml", async ({ page }) => {
+    const idInput = await openExportModal(page);
+    await idInput.fill("e2e/iris-export/1");
+
+    const downloadPromise = page.waitForEvent("download", { timeout: 60_000 });
+    await page.locator("[data-testid='export-template-submit']").click();
+    const download = await downloadPromise;
+
+    // File name mirrors the template id with slashes flattened.
+    expect(download.suggestedFilename()).toMatch(/\.zip$/);
+    expect(download.suggestedFilename()).toBe("e2e_iris-export_1.zip");
+
+    const archivePath = await download.path();
+    expect(archivePath).toBeTruthy();
+    const names = zipEntryNames(readFileSync(archivePath!));
+    expect(names).toContain("template.yaml");
+    // The seeded project has dashboards, exported as tag-based YAML.
+    expect(names.some((name) => /^dashboards\/[^/]+\.yaml$/.test(name))).toBeTruthy();
+
+    await expect(page.getByText("Template exported")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+});

--- a/depictio/tests/e2e-playwright/tests/projects/storage-panel.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/projects/storage-panel.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Project storage panel (StoragePanel.tsx on /projects/{id}).
+ *
+ * Per-project S3 credentials for remote data collections. The secret is
+ * write-only end to end: the backend stores it encrypted and only reports
+ * `has_secret`, so the panel shows a "Secret set" badge and an edit that
+ * leaves the secret field empty keeps the stored value.
+ *
+ * The endpoint used is the instance's own MinIO: the API exempts it from the
+ * SSRF gate that rejects other private hosts, so this works on any stack
+ * without an allowlist. Override via env when the stack differs:
+ *   PLAYWRIGHT_STORAGE_ENDPOINT   (default http://minio:9000, as seen by the API)
+ *   PLAYWRIGHT_STORAGE_ACCESS_KEY / PLAYWRIGHT_STORAGE_SECRET_KEY
+ *                                 (default: the committed docker-compose/.env
+ *                                 MinIO root credentials)
+ *
+ * Runs for admins in standard AND single-user mode; skipped in public mode
+ * (temporary users own no project). Targets the seeded Iris project and
+ * skips when that seed is absent, like project-permissions.spec.ts.
+ */
+
+import { Page, APIRequestContext } from "@playwright/test";
+import {
+  test,
+  expect,
+  getAuthMode,
+  loginAsTestUserWithToken,
+  API_URL,
+  API_PREFIX,
+} from "@fixtures/auth";
+import { IRIS_PROJECT_ID } from "@fixtures/projects";
+
+const STORAGE_ENDPOINT = process.env.PLAYWRIGHT_STORAGE_ENDPOINT ?? "http://minio:9000";
+const STORAGE_ACCESS_KEY = process.env.PLAYWRIGHT_STORAGE_ACCESS_KEY ?? "depictio_dev";
+const STORAGE_SECRET_KEY =
+  process.env.PLAYWRIGHT_STORAGE_SECRET_KEY ?? "dev_minio_secret_x3uG7q9Wz2";
+
+const PROJECT_URL = `/projects/${IRIS_PROJECT_ID}`;
+const STORAGE_API = `${API_URL}${API_PREFIX}/projects/${IRIS_PROJECT_ID}/storage`;
+
+/** DELETE is idempotent on the backend: 200 whether or not a config exists. */
+async function clearStorage(request: APIRequestContext, token: string): Promise<void> {
+  const res = await request.delete(STORAGE_API, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  // 404 only when the project itself is missing; the seed check below skips then.
+  expect([200, 404]).toContain(res.status());
+}
+
+function panel(page: Page) {
+  return page.locator("[data-testid='storage-panel']");
+}
+
+test.describe("Project storage panel", () => {
+  let token = "";
+
+  test.beforeEach(async ({ page, request }) => {
+    const { is_public_mode } = await getAuthMode();
+    test.skip(is_public_mode, "Storage credentials need a project owner account.");
+
+    token = (await loginAsTestUserWithToken(page, request, "adminUser")).access_token;
+    await clearStorage(request, token);
+    await page.goto(PROJECT_URL);
+
+    // Skip (not fail) on stacks without the Iris reference seed.
+    const loadError = page.getByText(/failed to load|back to projects/i);
+    await expect(panel(page).or(loadError).first()).toBeVisible({ timeout: 15_000 });
+    test.skip(
+      !(await panel(page).isVisible()),
+      "Iris reference project not seeded in this stack.",
+    );
+    // Fresh state: nothing configured, the configure affordance is offered.
+    await expect(page.locator("[data-testid='storage-configure-button']")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (token) await clearStorage(request, token);
+  });
+
+  test("configures the instance endpoint, keeps the secret on edit, then removes it", async ({
+    page,
+  }) => {
+    const storagePanel = panel(page);
+
+    // Configure: endpoint + credentials.
+    await page.locator("[data-testid='storage-configure-button']").click();
+    await page.locator("[data-testid='storage-endpoint-input']").fill(STORAGE_ENDPOINT);
+    await storagePanel.getByLabel("Access key ID").fill(STORAGE_ACCESS_KEY);
+    await page.locator("[data-testid='storage-secret-input']").fill(STORAGE_SECRET_KEY);
+    await page.locator("[data-testid='storage-save-button']").click();
+
+    // Configured state: badge, summary row, and the owner actions.
+    await expect(storagePanel.getByText("Secret set")).toBeVisible({ timeout: 10_000 });
+    await expect(storagePanel.getByText(STORAGE_ENDPOINT)).toBeVisible();
+    await expect(page.locator("[data-testid='storage-test-button']")).toBeEnabled();
+
+    // Edit without retyping the secret: the field advertises "unchanged" and
+    // saving with it empty keeps the stored secret (write-only semantics).
+    await storagePanel.getByRole("button", { name: "Edit" }).click();
+    const secretInput = page.locator("[data-testid='storage-secret-input']");
+    await expect(secretInput).toHaveAttribute("placeholder", "unchanged");
+    await expect(secretInput).toHaveValue("");
+    await storagePanel.getByLabel("Bucket").fill("");
+    await page.locator("[data-testid='storage-save-button']").click();
+    await expect(storagePanel.getByText("Secret set")).toBeVisible({ timeout: 10_000 });
+    await expect(storagePanel.getByText("No secret")).toHaveCount(0);
+
+    // The stored credentials reach the instance's own object store.
+    await page.locator("[data-testid='storage-test-button']").click();
+    await expect(page.getByText("Storage connection OK")).toBeVisible({ timeout: 20_000 });
+
+    // Remove: confirm in the modal, panel returns to the unconfigured state.
+    await storagePanel.getByRole("button", { name: "Remove" }).click();
+    const confirm = page.getByRole("dialog", { name: "Remove storage configuration?" });
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole("button", { name: "Remove" }).click();
+    await expect(page.locator("[data-testid='storage-configure-button']")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(storagePanel.getByText("Secret set")).toHaveCount(0);
+    await expect(storagePanel.getByText(STORAGE_ENDPOINT)).toHaveCount(0);
+  });
+
+  test("surfaces the backend rejection of a private endpoint inline", async ({ page }) => {
+    // A private address that is not the instance's own endpoint: the API's
+    // host gating refuses it (either the private-range rule or, on stacks
+    // running with an allowlist, the allowlist rule) and the form shows why.
+    await page.locator("[data-testid='storage-configure-button']").click();
+    await page.locator("[data-testid='storage-endpoint-input']").fill("http://10.0.0.5:9000");
+    await page.locator("[data-testid='storage-save-button']").click();
+
+    await expect(panel(page).getByRole("alert")).toContainText(
+      /non-public|rejected|allowlist|not allowed/i,
+      { timeout: 10_000 },
+    );
+    // Still in the form, nothing saved.
+    await expect(page.locator("[data-testid='storage-endpoint-input']")).toBeVisible();
+    await expect(panel(page).getByText("Secret set")).toHaveCount(0);
+  });
+});

--- a/docker-compose/docker-compose.e2e-manifest.yaml
+++ b/docker-compose/docker-compose.e2e-manifest.yaml
@@ -1,0 +1,18 @@
+# CI-only overlay for the e2e-playwright `standard` leg.
+#
+# The create-from-manifest spec fetches a Data Manifest that the runner serves
+# from the docker host (python -m http.server on port 8099). The backend and
+# the celery worker reach it as http://host.docker.internal:8099; Docker on
+# Linux does not provide that name by itself, so it is mapped to the host
+# gateway here. Nothing else changes: the stack stays as declared in
+# docker-compose.dev.yaml. Layer it with a second -f:
+#
+#   docker compose -f docker-compose.dev.yaml \
+#     -f docker-compose/docker-compose.e2e-manifest.yaml --env-file docker-compose/.env up
+services:
+  depictio-backend:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  depictio-celery-worker:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Summary

Test coverage follow-up for #965 (stacked on `feat/remote-data-binding`). Nothing here changes runtime code.

- **`depictio template export`** (CLI): request shape, `--api` fallback to the CLI config, config and HTTP and transport errors, unpacked members. The module also stops leaking `DEPICTIO_CONTEXT=CLI` into sibling tests under xdist, which had made `test_export_template.py` order-dependent.
- **`bundle_to_zip`**: round trip, UTF-8, and a real bundle passing the CLI's zip-slip guard.
- **`generic/manifest-tables/1`**: `template.yaml` and `dashboards/base.yaml` are parsed with the same models the API uses, and the dashboard's bindings are checked against the template's workflow and collections (only `depictio_manifest_id` is referenced, filters sit on required collections only).
- **`scan_url_for_data_collection`** and **`scan_s3_prefix_for_data_collection`**: registration, skip and update semantics, stale record removal, probe and listing failures, `id_regex` join ids.
- **`_create_dc_from_url`** happy path (scan then process, persisted workflow shape, coordinates config, rollback on failure) next to the existing rejection tests.
- **`monitoring/store.set_ingestion_step`**: the documented "unknown step returns False and never appends" contract.
- **Playwright**: `storage-panel.spec.ts` (configure the instance's own MinIO, write-only secret, test connection, remove; private endpoint rejected) and `export-template.spec.ts` (inline errors, download, `template.yaml` present in the zip).
- **CI**: the full create-from-manifest flow now runs on the `standard` e2e leg. The job generates the demo manifest on the runner, serves it on port 8099, adds `host.docker.internal` via a small compose overlay (`docker-compose/docker-compose.e2e-manifest.yaml`) and the SSRF allowlist entry, and exports `MANIFEST_E2E_URL` to Playwright. The other legs keep the existing skip.

## How was this tested?

The seven Python test files pass under xdist (118 tests, 43 new); `ruff`, `pre-commit` (except the pre-existing shellcheck failures) and the Playwright `--list` and type check of the new specs are clean. The specs themselves and the CI wiring are exercised by this PR's own CI run.
