### PR TITLE
feat(cli): trigger-ready auth, and attach a run to an existing project

### DIFF
--- a/depictio/cli/cli/commands/config.py
+++ b/depictio/cli/cli/commands/config.py
@@ -142,6 +142,15 @@ def sync(
         return
     rich_print_checked_statement("Pipeline configuration validated", "success")
     project_config = convert_model_to_dict(validation_response["project_config"])
-    api_sync_project_config_to_server(
+    sync_verdict = api_sync_project_config_to_server(
         CLI_config=CLI_config, ProjectConfig=project_config, update=update
     )
+    # The sync reports "exists" instead of raising, so this caller has to speak up:
+    # otherwise refusing to touch an existing project looks exactly like success.
+    if sync_verdict.get("action") == "exists":
+        rich_print_checked_statement(
+            f"Project '{project_config.get('name')}' already exists on this server. "
+            "Re-run with --update to refresh its configuration.",
+            "error",
+        )
+        raise typer.Exit(code=2)

--- a/depictio/cli/cli/commands/run.py
+++ b/depictio/cli/cli/commands/run.py
@@ -155,6 +155,63 @@ def _write_provisioned_cli_config(base_raw_config: dict, provision: dict) -> str
     return path
 
 
+def attach_run_to_project(project_config, remote_project: dict) -> dict:
+    """Fold this run into an existing project, in place, and report what changed.
+
+    ``data_location.locations`` is a list and the scan treats each entry as its own
+    run (``structure: flat``) or walks it for run subdirectories
+    (``sequencing-runs``), so appending this run's directory is all it takes to add
+    a run. The scan is incremental, so the runs already registered are skipped.
+
+    Two things are deliberately preserved from the server:
+
+    * the existing locations, so attaching never drops a run already ingested;
+    * the ``scan.mode: single`` bindings. Such a collection points at ONE absolute
+      path, substituted from whichever ``DATA_ROOT`` the template was resolved
+      against, which here is the *new* run. Pushing that as-is would re-point the
+      collection, and the next scan deletes files whose location no longer matches
+      the config (the stale-file cleanup in ``scan_files_for_data_collection``), so
+      the original run's samplesheet/metadata/tree would be dropped.
+
+    Returns ``{"added": {workflow_tag: [locations]}, "kept_single": [dc_tags]}``.
+    """
+    remote_locations: dict[str, list[str]] = {}
+    remote_single: dict[tuple[str, str], str] = {}
+    for wf_doc in remote_project.get("workflows", []) or []:
+        wf_tag = wf_doc.get("workflow_tag")
+        if not wf_tag:
+            continue
+        remote_locations[wf_tag] = list((wf_doc.get("data_location") or {}).get("locations") or [])
+        for dc_doc in wf_doc.get("data_collections", []) or []:
+            scan_doc = (dc_doc.get("config") or {}).get("scan") or {}
+            if str(scan_doc.get("mode", "")).lower() != "single":
+                continue
+            filename = (scan_doc.get("scan_parameters") or {}).get("filename")
+            dc_tag = dc_doc.get("data_collection_tag")
+            if filename and dc_tag:
+                remote_single[(wf_tag, dc_tag)] = filename
+
+    added: dict[str, list[str]] = {}
+    for wf in project_config.workflows:
+        known = remote_locations.get(wf.workflow_tag, [])
+        new_locations = [loc for loc in wf.data_location.locations if loc not in known]
+        # A fresh list, so the remote entry is never aliased into the model.
+        wf.data_location.locations = known + new_locations
+        added[wf.workflow_tag] = new_locations
+
+    kept_single: list[str] = []
+    for wf in project_config.workflows:
+        for dc in wf.data_collections:
+            if not (dc.config.scan and dc.config.scan.mode.lower() == "single"):
+                continue
+            previous = remote_single.get((wf.workflow_tag, dc.data_collection_tag))
+            if previous and previous != dc.config.scan.scan_parameters.filename:
+                dc.config.scan.scan_parameters.filename = previous
+                kept_single.append(dc.data_collection_tag)
+
+    return {"added": added, "kept_single": kept_single}
+
+
 def register_run_command(app: typer.Typer):
     @app.command("run")
     def run(
@@ -175,6 +232,18 @@ def register_run_command(app: typer.Typer):
                 "Mutually exclusive with --project-config-path.",
             ),
         ] = None,
+        nextflow_manifest: Annotated[
+            str | None,
+            typer.Option(
+                "--nextflow-manifest",
+                help=(
+                    "Nextflow manifest as '<name>/<version>' (e.g. 'nf-core/ampliseq/2.16.0'). "
+                    "When neither --template nor --project-config-path is given, the CLI "
+                    "auto-resolves a bundled template matching this manifest. Intended for "
+                    "automated triggering from a Nextflow pipeline's workflow.onComplete."
+                ),
+            ),
+        ] = None,
         data_root: Annotated[
             str | None,
             typer.Option(
@@ -189,6 +258,16 @@ def register_run_command(app: typer.Typer):
                 help="Custom project name (auto-generated from template if omitted).",
             ),
         ] = None,
+        attach_run: bool = typer.Option(
+            False,
+            "--attach-run",
+            help=(
+                "Add --data-root to an EXISTING project as an additional run instead of "
+                "creating a new project. The project must already exist (resolved by "
+                "--project-name, else by the template's own name). Implies --update-config, "
+                "rebuilds the delta tables from all runs, and skips dashboard import."
+            ),
+        ),
         dashboard_name: Annotated[
             str | None,
             typer.Option(
@@ -345,6 +424,28 @@ def register_run_command(app: typer.Typer):
         """
         rich_print_command_usage("run")
 
+        # Step 0-: resolve a bundled template from the Nextflow manifest. The
+        # trigger forwards `workflow.manifest` verbatim and lets the CLI decide
+        # the mode; an explicit --template / --project-config-path always wins.
+        if nextflow_manifest and not template and not project_config_path:
+            from depictio.cli.cli.utils.templates import locate_template
+
+            try:
+                locate_template(nextflow_manifest)
+            except FileNotFoundError:
+                rich_print_checked_statement(
+                    f"No bundled depictio template matches Nextflow manifest "
+                    f"'{nextflow_manifest}'. Provide --project-config-path with a depictio "
+                    f"project YAML for this pipeline (or --template for a known one).",
+                    "error",
+                )
+                raise typer.Exit(code=1)
+            template = nextflow_manifest
+            rich_print_checked_statement(
+                f"Resolved Nextflow manifest '{nextflow_manifest}' to bundled template.",
+                "success",
+            )
+
         # Validate template/project-config-path mutual exclusivity
         if template and project_config_path:
             rich_print_checked_statement(
@@ -363,7 +464,23 @@ def register_run_command(app: typer.Typer):
                 "DRY RUN MODE - No actual operations will be performed", "info"
             )
 
-        if sync_files or overwrite:
+        # `--overwrite` normally implies a full re-scan. In attach mode that would be
+        # wrong: the point is to add ONE run, and the scan is already incremental
+        # (a known run_tag is skipped). We still need overwrite for the *process*
+        # step, because write_delta_table refuses to rewrite an existing table
+        # without it, and the rebuild must include the runs already ingested.
+        if attach_run:
+            update_config = True
+            overwrite = True
+            if not skip_dashboard_import:
+                # The dashboards already exist for this project; re-importing would
+                # either 409 or overwrite edits the user made since the first run.
+                skip_dashboard_import = True
+                rich_print_checked_statement(
+                    "--attach-run: skipping dashboard import (dashboards already exist).",
+                    "info",
+                )
+        if sync_files or (overwrite and not attach_run):
             rescan_folders = True
 
         if user and not provisioning_key:
@@ -384,6 +501,9 @@ def register_run_command(app: typer.Typer):
 
         success_count = 0
         total_steps = 8 if is_template_mode else 7
+        # --attach-run adds step 3b (folding the run into the existing project).
+        if attach_run and not dry_run:
+            total_steps += 1
 
         # Server-side monitoring record for this ingestion run (best-effort).
         ingestion_run_id: str | None = None
@@ -595,6 +715,58 @@ def register_run_command(app: typer.Typer):
             if not continue_on_error:
                 raise typer.Exit(code=1)
 
+        # Step 3b (--attach-run): fold the run into an EXISTING project instead of
+        # creating a new one. `data_location.locations` is a list and the scan treats
+        # each entry as its own run (structure: flat) or walks it for run subdirs
+        # (sequencing-runs), so appending this run's directory is all it takes. The
+        # validation above already ran merge_existing_ids(), which copies the server's
+        # workflow / data-collection ids onto this config by tag, so the runs and files
+        # already ingested stay attached to the same collections.
+        if attach_run and not dry_run:
+            rich_print_section_separator("Step 3b: Attaching run to existing project")
+            try:
+                remote = api_get_project_from_name(str(project_config.name), CLI_config)
+                if remote.status_code != 200:
+                    rich_print_checked_statement(
+                        f"--attach-run: no project named '{project_config.name}' on this "
+                        f"server (HTTP {remote.status_code}). Run once without --attach-run "
+                        f"to create it, or pass --project-name to target another project.",
+                        "error",
+                    )
+                    _rec("attach_run", "failed", "target project not found")
+                    raise typer.Exit(code=2)
+
+                report = attach_run_to_project(project_config, remote.json())
+                added_locations = {tag: locs for tag, locs in report["added"].items() if locs}
+                for wf_tag, new_locations in added_locations.items():
+                    rich_print_checked_statement(
+                        f"Workflow '{wf_tag}': +{len(new_locations)} run location(s) -> "
+                        f"{', '.join(new_locations)}",
+                        "success",
+                    )
+                if not added_locations:
+                    rich_print_checked_statement(
+                        "--attach-run: no new location to add; this run is already "
+                        "registered on the project. Re-scanning it only.",
+                        "info",
+                    )
+                if report["kept_single"]:
+                    rich_print_checked_statement(
+                        f"{len(report['kept_single'])} single-file data collection(s) keep "
+                        f"the file they were first ingested from, and do not pick up this "
+                        f"run's copy: {', '.join(report['kept_single'])}",
+                        "warning",
+                    )
+
+                success_count += 1
+                _rec("attach_run", "success", f"{len(project_config.workflows)} workflow(s)")
+            except typer.Exit:
+                raise
+            except Exception as e:
+                rich_print_checked_statement(f"--attach-run failed: {e}", "error")
+                _rec("attach_run", "failed", str(e))
+                raise typer.Exit(code=1)
+
         # Open the monitoring ingestion record now that CLI_config is validated.
         # Best-effort: a monitoring outage must never affect the ingestion.
         if not dry_run:
@@ -627,11 +799,24 @@ def register_run_command(app: typer.Typer):
                     # instance — defeating the per-user separation --user is for.
                     if user:
                         project_config_dict["is_public"] = False
-                    api_sync_project_config_to_server(
+                    sync_verdict = api_sync_project_config_to_server(
                         CLI_config=CLI_config,
                         ProjectConfig=project_config_dict,
                         update=update_config,
                     )
+                    # The project is already on the server and no update was asked
+                    # for: nothing can be ingested, so say so plainly and stop with
+                    # a distinct exit code instead of pretending the run succeeded.
+                    if sync_verdict.get("action") == "exists":
+                        rich_print_checked_statement(
+                            f"Project '{project_config.name}' already exists on this server. "
+                            f"Re-run with --update-config to refresh its configuration, or "
+                            f"with --attach-run to add {data_root or project_config_path} as "
+                            f"an additional run of that project.",
+                            "error",
+                        )
+                        _rec("sync_project", "failed", "project exists, no --update-config")
+                        raise typer.Exit(code=2)
                 rich_print_checked_statement("Project configuration sync completed", "success")
 
                 # Resolve tag-based link IDs now that the server has assigned real DC IDs
@@ -693,6 +878,11 @@ def register_run_command(app: typer.Typer):
 
                 success_count += 1
                 _rec("sync_project", "success", "project synced")
+            except typer.Exit:
+                # Deliberate, already-reported exit (e.g. the "exists" verdict
+                # above). `typer.Exit` subclasses RuntimeError, so without this
+                # it would be caught below and re-reported as an empty failure.
+                raise
             except Exception as e:
                 rich_print_checked_statement(f"Project configuration sync failed: {e}", "error")
                 _rec("sync_project", "failed", str(e))

--- a/depictio/cli/cli/utils/api_calls.py
+++ b/depictio/cli/cli/utils/api_calls.py
@@ -201,12 +201,39 @@ def api_update_project(project_config: dict, CLI_config: CLIConfig):
     return response
 
 
+def _project_write_outcome(response: httpx.Response) -> tuple[bool, str | None]:
+    """Normalise a /projects/create|update response into ``(succeeded, detail)``.
+
+    ``/projects/create`` answers **HTTP 200 with a failure body** for the cases
+    that matter to an automated trigger - ``409`` when the name is taken and
+    ``403`` in public/demo mode - so the transport status alone silently reports
+    a project that was never written. Read the body when there is one.
+    """
+    if response.status_code != 200:
+        return False, response.text
+    try:
+        body = response.json()
+    except ValueError:
+        return True, None
+    if isinstance(body, dict) and body.get("success") is False:
+        return False, body.get("message") or response.text
+    return True, None
+
+
 @validate_call
 def api_sync_project_config_to_server(
     CLI_config: CLIConfig, ProjectConfig: dict, update: bool = False
-):
+) -> dict:
     """
     Sync the pipeline configuration to the server.
+
+    Returns a verdict dict ``{"action": "created" | "updated" | "exists"}``.
+    ``"exists"`` means the project is already on the server and ``update`` was not
+    requested: that is a *decision for the caller*, not an error, which is why it
+    is returned rather than raised. It used to ``raise typer.Exit(code=0)``, and
+    since ``typer.Exit`` subclasses ``RuntimeError`` the caller's ``except
+    Exception`` swallowed it and reported an empty "sync failed" with exit code 1 -
+    exactly the path a second automated trigger takes.
     """
     rich_print_checked_statement("Syncing pipeline configuration to server...", "info")
 
@@ -242,16 +269,10 @@ def api_sync_project_config_to_server(
         rich_print_checked_statement("Project configuration found on server", "info")
         logger.info(f"Project configuration found on server: {response.json()}")
 
-        # If update flag is False, exit
+        # Already on the server and no update requested: hand the decision back.
         if not update:
-            logger.error(
-                "Project configuration already exists on server, use --update flag to update."
-            )
-            rich_print_checked_statement(
-                "Project configuration already exists on server, use --update flag to update.",
-                "error",
-            )
-            raise typer.Exit(code=0)
+            logger.info("Project already exists on server and no update was requested.")
+            return {"action": "exists"}
 
         # If update flag is True, update the project on the server
         rich_print_checked_statement(
@@ -259,15 +280,14 @@ def api_sync_project_config_to_server(
         )
         logger.debug(f"Updating project configuration on server: {project_config}")
         response = api_update_project(project_config, CLI_config)
-        if response.status_code == 200:
-            rich_print_checked_statement("Project updated on server", "success")
-            logger.info(f"Project updated on server: {response.json()}")
-        else:
-            rich_print_checked_statement(
-                f"Failed to update project on server: {response.text}", "error"
-            )
-            logger.error(f"Failed to update project on server: {response.text}")
+        succeeded, detail = _project_write_outcome(response)
+        if not succeeded:
+            rich_print_checked_statement(f"Failed to update project on server: {detail}", "error")
+            logger.error(f"Failed to update project on server: {detail}")
             raise typer.Exit(code=1)
+        rich_print_checked_statement("Project updated on server", "success")
+        logger.info("Project updated on server")
+        return {"action": "updated"}
 
     elif response.status_code == 404:
         logger.info("Project configuration not found on server.")
@@ -276,15 +296,21 @@ def api_sync_project_config_to_server(
         )
         # Create the project on the server
         response = api_create_project(project_config, CLI_config)
-        if response.status_code == 200:
-            logger.info(f"Project created on server: {response.json()}")
-            rich_print_checked_statement("Project created on server", "success")
-        else:
-            logger.error(f"Failed to create project on server: {response.text}")
-            rich_print_checked_statement(
-                f"Failed to create project on server: {response.text}", "error"
-            )
+        succeeded, detail = _project_write_outcome(response)
+        if not succeeded:
+            logger.error(f"Failed to create project on server: {detail}")
+            rich_print_checked_statement(f"Failed to create project on server: {detail}", "error")
             raise typer.Exit(code=1)
+        logger.info("Project created on server")
+        rich_print_checked_statement("Project created on server", "success")
+        return {"action": "created"}
+
+    else:
+        rich_print_checked_statement(
+            f"Could not look up project on server (HTTP {response.status_code}): {response.text}",
+            "error",
+        )
+        raise typer.Exit(code=1)
 
 
 @validate_call

--- a/depictio/cli/cli/utils/common.py
+++ b/depictio/cli/cli/utils/common.py
@@ -104,14 +104,69 @@ def validate_depictio_cli_config(depictio_cli_config: dict) -> CLIConfig:
     return config
 
 
+# CLI config paths considered "default" - only these are overridden by
+# DEPICTIO_CLI_CONFIG_PATH, so an explicit --CLI-config-path is never clobbered.
+_DEFAULT_CLI_CONFIG_PATHS = ("~/.depictio/cli.yaml", "~/.depictio/CLI.yaml")
+
+
+def _apply_env_overrides(config: dict) -> dict:
+    """Apply environment-variable overrides to a loaded CLI config dict.
+
+    Lets a ``CLI.yaml`` be committed **without secrets** and have the token (and
+    optionally the API URL) injected at runtime - the mechanism that makes
+    automated triggering (e.g. from a Nextflow pipeline in CI or on a cluster)
+    practical, since the head job usually has env vars but no writable home.
+
+    Recognised variables:
+      - ``DEPICTIO_CLI_TOKEN``        -> ``user.token.access_token``
+      - ``DEPICTIO_CLI_API_BASE_URL`` -> ``api_base_url``
+
+    (``DEPICTIO_CLI_CONFIG_PATH`` is handled in :func:`load_depictio_config`
+    since it selects which file to load, before this runs.)
+    """
+    token = os.environ.get("DEPICTIO_CLI_TOKEN")
+    if token:
+        user = config.setdefault("user", {})
+        if not isinstance(user.get("token"), dict):
+            user["token"] = {}
+        user["token"]["access_token"] = token
+
+    api_base_url = os.environ.get("DEPICTIO_CLI_API_BASE_URL")
+    if api_base_url:
+        config["api_base_url"] = api_base_url
+
+    return config
+
+
 @validate_call(validate_return=True)
-def load_depictio_config(yaml_config_path: str = "~/.depictio/cli.yaml") -> CLIConfig:
+def load_depictio_config(yaml_config_path: str = "~/.depictio/CLI.yaml") -> CLIConfig:
     """
     Load the Depictio configuration file.
     """
     try:
         rich_print_checked_statement("Loading Depictio configuration...", "loading")
-        config = get_config(os.path.expanduser(yaml_config_path))
+        # DEPICTIO_CLI_CONFIG_PATH overrides the path only when the caller left it
+        # at a default - an explicit --CLI-config-path always wins.
+        env_path = os.environ.get("DEPICTIO_CLI_CONFIG_PATH")
+        from_env = bool(env_path) and yaml_config_path in _DEFAULT_CLI_CONFIG_PATHS
+        if from_env:
+            yaml_config_path = env_path  # type: ignore[assignment]
+        expanded = os.path.expanduser(yaml_config_path)
+        # `get_config` signals a missing/unsuitable file with ValueError, not
+        # FileNotFoundError, so checking here is what turns a typo into a usable
+        # message instead of a traceback. That matters most for an automated
+        # trigger, where the path usually arrives from DEPICTIO_CLI_CONFIG_PATH.
+        if not os.path.isfile(expanded):
+            source = "DEPICTIO_CLI_CONFIG_PATH" if from_env else "--CLI-config-path"
+            logger.error(f"Depictio CLI configuration file not found: {expanded} (from {source})")
+            rich_print_checked_statement(
+                f"Depictio CLI configuration file not found: {expanded} (from {source}). "
+                f"Create it, or point {source} at an existing config.",
+                "error",
+            )
+            raise typer.Exit(code=1)
+        config = get_config(expanded)
+        config = _apply_env_overrides(config)
         config = validate_depictio_cli_config(config)
         return config
     except FileNotFoundError:

--- a/depictio/cli/cli/utils/scan.py
+++ b/depictio/cli/cli/utils/scan.py
@@ -801,28 +801,29 @@ def scan_files_for_workflow(
 
                     progress.update(task_id, description="✅ Scanning completed")
 
-        # Handle missing runs if rescanning
-        if rescan_folders:
-            missing_runs_tag = set(existing_runs_reformated.keys()) - set(
-                [run.run_tag for run in all_workflow_runs if run]
-            )
-            missing_runs = [
-                str(existing_runs_reformated[run_tag].id) for run_tag in missing_runs_tag
-            ]
+    # Handle missing runs if rescanning. Runs ONCE, after every location has been
+    # walked: `all_workflow_runs` accumulates across locations, so doing this inside
+    # the loop made a multi-location workflow delete the runs of the locations not
+    # yet scanned (they were then re-created with fresh ids, losing scan_results).
+    if rescan_folders:
+        missing_runs_tag = set(existing_runs_reformated.keys()) - {
+            run.run_tag for run in all_workflow_runs if run
+        }
+        missing_runs = [str(existing_runs_reformated[run_tag].id) for run_tag in missing_runs_tag]
 
-            if missing_runs:
-                logger.info(f"Runs to remove: {missing_runs}")
-                for run_id in missing_runs:
-                    api_delete_run(run_id=run_id, CLI_config=CLI_config)
-                    # Delete related files
-                    for dc_id, files in all_existing_files.items():
-                        for file in files.values():
-                            if str(file["run_id"]) == run_id:
-                                api_delete_file(file_id=str(file["_id"]), CLI_config=CLI_config)
-                rich_print_checked_statement(
-                    f"Removed {len(missing_runs)} runs and related files from the DB : {missing_runs_tag}",
-                    "info",
-                )
+        if missing_runs:
+            logger.info(f"Runs to remove: {missing_runs}")
+            for run_id in missing_runs:
+                api_delete_run(run_id=run_id, CLI_config=CLI_config)
+                # Delete related files
+                for files in all_existing_files.values():
+                    for file in files.values():
+                        if str(file["run_id"]) == run_id:
+                            api_delete_file(file_id=str(file["_id"]), CLI_config=CLI_config)
+            rich_print_checked_statement(
+                f"Removed {len(missing_runs)} runs and related files from the DB : {missing_runs_tag}",
+                "info",
+            )
 
     # Upsert all runs at once with progress indicator
     if all_workflow_runs:

--- a/depictio/tests/cli/commands/test_attach_run.py
+++ b/depictio/tests/cli/commands/test_attach_run.py
@@ -1,0 +1,186 @@
+"""Tests for `depictio-cli run --attach-run`: folding a run into an existing project.
+
+These exercise :func:`attach_run_to_project`, the pure part of the feature: it takes
+the locally resolved project plus the project document the server already holds, and
+merges the two in place. No server or filesystem is involved.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from depictio.cli.cli.commands.run import attach_run_to_project
+from depictio.models.models.projects import Project
+
+OWNER = {"id": "507f1f77bcf86cd799439011", "email": "owner@example.org"}
+
+
+def _project(locations: list[str], single_filename: str) -> Project:
+    """A one-workflow project with a recursive and a single-file data collection."""
+    return Project.model_validate(
+        {
+            "name": "Ampliseq Microbial Community Analysis",
+            "project_type": "advanced",
+            "permissions": {"owners": [OWNER], "editors": [], "viewers": []},
+            "workflows": [
+                {
+                    "name": "ampliseq",
+                    "engine": {"name": "nextflow"},
+                    "catalog": {"name": "nf-core", "url": "https://nf-co.re"},
+                    "data_location": {"structure": "flat", "locations": list(locations)},
+                    "data_collections": [
+                        {
+                            "data_collection_tag": "asv_table",
+                            "config": {
+                                "type": "Table",
+                                "scan": {
+                                    "mode": "recursive",
+                                    "scan_parameters": {
+                                        "regex_config": {"pattern": "asv_table.tsv$"}
+                                    },
+                                },
+                                "dc_specific_properties": {
+                                    "format": "TSV",
+                                    "polars_kwargs": {"separator": "\t"},
+                                },
+                            },
+                        },
+                        {
+                            "data_collection_tag": "metadata",
+                            "config": {
+                                "type": "Table",
+                                "scan": {
+                                    "mode": "single",
+                                    "scan_parameters": {"filename": single_filename},
+                                },
+                                "dc_specific_properties": {
+                                    "format": "TSV",
+                                    "polars_kwargs": {"separator": "\t"},
+                                },
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def _remote_doc(project: Project) -> dict:
+    """The shape `GET /projects/get/from_name/{name}` returns, from a Project."""
+    wf = project.workflows[0]
+    return {
+        "name": project.name,
+        "workflows": [
+            {
+                "workflow_tag": wf.workflow_tag,
+                "data_location": {
+                    "structure": wf.data_location.structure,
+                    "locations": list(wf.data_location.locations),
+                },
+                "data_collections": [
+                    {
+                        "data_collection_tag": dc.data_collection_tag,
+                        "config": {
+                            "scan": {
+                                "mode": dc.config.scan.mode,
+                                "scan_parameters": (
+                                    {"filename": dc.config.scan.scan_parameters.filename}
+                                    if dc.config.scan.mode.lower() == "single"
+                                    else {}
+                                ),
+                            }
+                        },
+                    }
+                    for dc in wf.data_collections
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def remote() -> dict:
+    """The project as already ingested from run_a."""
+    return _remote_doc(_project(["/data/run_a"], "/data/run_a/metadata.tsv"))
+
+
+class TestLocationMerge:
+    def test_new_run_is_appended_after_the_existing_one(self, remote):
+        local = _project(["/data/run_b"], "/data/run_b/metadata.tsv")
+        report = attach_run_to_project(local, remote)
+        # The already-ingested run must survive, and order must stay stable.
+        assert local.workflows[0].data_location.locations == ["/data/run_a", "/data/run_b"]
+        assert report["added"] == {"ampliseq": ["/data/run_b"]}
+
+    def test_reattaching_the_same_run_adds_nothing(self, remote):
+        local = _project(["/data/run_a"], "/data/run_a/metadata.tsv")
+        report = attach_run_to_project(local, remote)
+        assert local.workflows[0].data_location.locations == ["/data/run_a"]
+        assert report["added"] == {"ampliseq": []}
+
+    def test_a_third_run_keeps_both_predecessors(self):
+        remote = _remote_doc(_project(["/data/run_a"], "/data/run_a/metadata.tsv"))
+        remote["workflows"][0]["data_location"]["locations"] = ["/data/run_a", "/data/run_b"]
+        local = _project(["/data/run_c"], "/data/run_c/metadata.tsv")
+        attach_run_to_project(local, remote)
+        assert local.workflows[0].data_location.locations == [
+            "/data/run_a",
+            "/data/run_b",
+            "/data/run_c",
+        ]
+
+    def test_workflow_absent_from_the_remote_keeps_its_own_locations(self, remote):
+        remote["workflows"][0]["workflow_tag"] = "some/other-workflow"
+        local = _project(["/data/run_b"], "/data/run_b/metadata.tsv")
+        report = attach_run_to_project(local, remote)
+        assert local.workflows[0].data_location.locations == ["/data/run_b"]
+        assert report["added"] == {"ampliseq": ["/data/run_b"]}
+
+    def test_empty_remote_document_is_tolerated(self):
+        local = _project(["/data/run_b"], "/data/run_b/metadata.tsv")
+        report = attach_run_to_project(local, {})
+        assert local.workflows[0].data_location.locations == ["/data/run_b"]
+        assert report["kept_single"] == []
+
+
+class TestSingleFileBindingIsPreserved:
+    """A `scan.mode: single` collection points at ONE absolute path.
+
+    The template resolved it against the NEW run, but the next scan deletes files
+    whose location no longer matches the config, so re-pointing it would silently
+    drop the file ingested from the original run. Attaching must not do that.
+    """
+
+    def test_single_file_collection_keeps_the_original_binding(self, remote):
+        local = _project(["/data/run_b"], "/data/run_b/metadata.tsv")
+        report = attach_run_to_project(local, remote)
+        metadata_dc = local.workflows[0].data_collections[1]
+        assert metadata_dc.config.scan.scan_parameters.filename == "/data/run_a/metadata.tsv"
+        assert report["kept_single"] == ["metadata"]
+
+    def test_recursive_collection_is_left_alone(self, remote):
+        local = _project(["/data/run_b"], "/data/run_b/metadata.tsv")
+        before = copy.deepcopy(local.workflows[0].data_collections[0].config.scan.model_dump())
+        attach_run_to_project(local, remote)
+        after = local.workflows[0].data_collections[0].config.scan.model_dump()
+        assert after == before
+
+    def test_unchanged_binding_is_not_reported_as_kept(self, remote):
+        local = _project(["/data/run_b"], "/data/run_a/metadata.tsv")
+        report = attach_run_to_project(local, remote)
+        assert report["kept_single"] == []
+
+    def test_collection_absent_from_the_remote_keeps_this_run_binding(self, remote):
+        remote["workflows"][0]["data_collections"] = [
+            dc
+            for dc in remote["workflows"][0]["data_collections"]
+            if dc["data_collection_tag"] != "metadata"
+        ]
+        local = _project(["/data/run_b"], "/data/run_b/metadata.tsv")
+        report = attach_run_to_project(local, remote)
+        metadata_dc = local.workflows[0].data_collections[1]
+        assert metadata_dc.config.scan.scan_parameters.filename == "/data/run_b/metadata.tsv"
+        assert report["kept_single"] == []

--- a/depictio/tests/cli/commands/test_backup.py
+++ b/depictio/tests/cli/commands/test_backup.py
@@ -336,19 +336,36 @@ class TestBackupCLI:
         assert "New collections found without backup coverage" in result.stdout
         assert "new_collection" in result.stdout
 
+    @patch("depictio.cli.cli.commands.backup.api_login")
     @patch("depictio.cli.cli.utils.backup_validation.check_backup_collections_coverage")
-    def test_check_coverage_error_handling(self, mock_detect, runner):
-        """Test coverage check error handling."""
+    def test_check_coverage_error_handling(
+        self, mock_detect, mock_api_login, runner, mock_cli_config
+    ):
+        """Test coverage check error handling.
+
+        Uses a real config file like its siblings: without one the command now
+        stops at "configuration file not found", so the test would pass on the
+        strength of the missing file rather than the reported coverage error.
+        """
+        mock_api_login.return_value = {"success": True, "is_admin": True}
         mock_detect.return_value = {
             "error": "Could not import settings",
             "valid": False,
             "errors": ["Unable to check collection coverage - settings not available"],
         }
 
-        result = runner.invoke(dev_app, ["backup", "check-coverage"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_file = os.path.join(tmp_dir, "config.yaml")
+            with open(config_file, "w") as f:
+                yaml.dump(mock_cli_config, f)
+
+            result = runner.invoke(
+                dev_app, ["backup", "check-coverage", "--CLI-config-path", config_file]
+            )
 
         assert result.exit_code == 1
         assert "Coverage check failed" in result.stdout
+        assert "Could not import settings" in result.stdout
 
 
 class TestRestoreCLI:

--- a/depictio/tests/cli/commands/test_config.py
+++ b/depictio/tests/cli/commands/test_config.py
@@ -168,3 +168,53 @@ class TestConfigCommands:
             ):
                 result = command.run("sync", cli_config=cli_config_path)
                 assert result.exit_code == 0
+
+        @pytest.fixture
+        def validated(self):
+            """Patch validation so only the sync verdict decides the outcome."""
+            return patch(
+                "depictio.cli.cli.commands.config.validate_project_config_and_check_S3_storage",
+                return_value=(
+                    MagicMock(),
+                    {"success": True, "project_config": {"name": "Existing project"}},
+                ),
+            )
+
+        def test_existing_project_without_update_is_reported(
+            self, runner, cli_config_path, validated
+        ):
+            """The sync returns a verdict rather than raising, so a caller that
+            ignored it made refusing to touch an existing project look like
+            success."""
+            with (
+                validated,
+                patch(
+                    "depictio.cli.cli.commands.config.convert_model_to_dict",
+                    return_value={"name": "Existing project"},
+                ),
+                patch(
+                    "depictio.cli.cli.commands.config.api_sync_project_config_to_server",
+                    return_value={"action": "exists"},
+                ),
+            ):
+                result = runner.invoke(app, ["sync", "--CLI-config-path", cli_config_path])
+            assert result.exit_code == 2
+            normalized = " ".join(result.output.split())
+            assert "already exists on this server" in normalized
+            assert "--update" in normalized
+
+        def test_created_project_succeeds_quietly(self, runner, cli_config_path, validated):
+            with (
+                validated,
+                patch(
+                    "depictio.cli.cli.commands.config.convert_model_to_dict",
+                    return_value={"name": "New project"},
+                ),
+                patch(
+                    "depictio.cli.cli.commands.config.api_sync_project_config_to_server",
+                    return_value={"action": "created"},
+                ),
+            ):
+                result = runner.invoke(app, ["sync", "--CLI-config-path", cli_config_path])
+            assert result.exit_code == 0
+            assert "already exists" not in result.output

--- a/depictio/tests/cli/commands/test_run.py
+++ b/depictio/tests/cli/commands/test_run.py
@@ -1,0 +1,145 @@
+"""Tests for the ``run`` command's early option-resolution branch.
+
+Only the guards that execute *before* any server, S3 or filesystem work are
+covered here: the ``--nextflow-manifest`` auto-resolution added for automated
+triggering, its precedence against ``--template`` / ``--project-config-path``,
+and the mutual-exclusivity check. That branch is pure argument handling, so
+these tests need no network and no mocking of the ingestion pipeline.
+"""
+
+import re
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from depictio.cli.cli.commands.run import register_run_command
+
+# Manifests for templates that really ship in this repository
+# (depictio/projects/nf-core/<pipeline>/<version>/template.yaml).
+SHIPPED_MANIFESTS = [
+    "nf-core/ampliseq/2.16.0",
+    "nf-core/ampliseq/2.18.0",
+    "nf-core/viralrecon/3.0.0",
+    "nf-core/variantbenchmarking/1.4.0",
+]
+
+UNKNOWN_MANIFEST = "acme/not-a-real-pipeline/9.9.9"
+
+NO_TEMPLATE_MESSAGE = "No bundled depictio template"
+
+
+def normalize(output: str) -> str:
+    """Collapse Rich's line wrapping so message assertions are stable.
+
+    Rich hard-wraps console output at the (non-TTY) default width, which can
+    split an asserted phrase across two lines.
+    """
+    return re.sub(r"\s+", " ", output)
+
+
+@pytest.fixture
+def app():
+    """A minimal Typer app exposing only the ``run`` command."""
+    app = typer.Typer()
+    register_run_command(app)
+    return app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestNextflowManifestResolution:
+    """``--nextflow-manifest`` maps a Nextflow manifest onto a bundled template."""
+
+    def test_unknown_manifest_exits_with_guidance(self, app, runner):
+        """An unmatched manifest fails loudly instead of silently doing nothing."""
+        result = runner.invoke(app, ["--nextflow-manifest", UNKNOWN_MANIFEST])
+
+        assert result.exit_code == 1
+        output = normalize(result.output)
+        assert NO_TEMPLATE_MESSAGE in output
+        assert UNKNOWN_MANIFEST in output
+        # The message must point at the manual escape hatches.
+        assert "--project-config-path" in output
+        assert "--template" in output
+
+    @pytest.mark.parametrize("manifest", SHIPPED_MANIFESTS)
+    def test_known_manifest_resolves_to_template(self, app, runner, manifest):
+        """A shipped manifest becomes template mode and falls through to the
+        next guard (``--data-root``), proving resolution succeeded."""
+        result = runner.invoke(app, ["--nextflow-manifest", manifest])
+
+        output = normalize(result.output)
+        assert NO_TEMPLATE_MESSAGE not in output
+        assert "--data-root is required when using --template" in output
+        assert result.exit_code == 1
+
+    def test_explicit_project_config_path_wins_over_manifest(self, app, runner, tmp_path):
+        """--project-config-path short-circuits manifest resolution entirely.
+
+        The manifest is deliberately bogus: if it were resolved at all, the run
+        would abort with the "no bundled template" error.
+        """
+        project_config = tmp_path / "project.yaml"
+        project_config.write_text("name: irrelevant-under-dry-run\n")
+
+        result = runner.invoke(
+            app,
+            [
+                "--nextflow-manifest",
+                UNKNOWN_MANIFEST,
+                "--project-config-path",
+                str(project_config),
+                "--dry-run",
+                "--skip-server-check",
+                "--skip-s3-check",
+            ],
+        )
+
+        output = normalize(result.output)
+        assert NO_TEMPLATE_MESSAGE not in output
+        assert result.exit_code == 0
+
+    def test_explicit_template_wins_over_manifest(self, app, runner):
+        """--template short-circuits manifest resolution too."""
+        result = runner.invoke(
+            app,
+            [
+                "--nextflow-manifest",
+                UNKNOWN_MANIFEST,
+                "--template",
+                SHIPPED_MANIFESTS[0],
+            ],
+        )
+
+        output = normalize(result.output)
+        assert NO_TEMPLATE_MESSAGE not in output
+        # Stopped at the --data-root guard, i.e. --template was used as-is.
+        assert "--data-root is required when using --template" in output
+        assert result.exit_code == 1
+
+
+class TestMutuallyExclusiveOptions:
+    """``--template`` and ``--project-config-path`` describe two different modes."""
+
+    def test_template_with_project_config_path_is_rejected(self, app, runner, tmp_path):
+        project_config = tmp_path / "project.yaml"
+        project_config.write_text("name: irrelevant\n")
+
+        result = runner.invoke(
+            app,
+            [
+                "--template",
+                SHIPPED_MANIFESTS[0],
+                "--project-config-path",
+                str(project_config),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "--template and --project-config-path are mutually exclusive" in normalize(
+            result.output
+        )

--- a/depictio/tests/cli/commands/test_run_attach_flow.py
+++ b/depictio/tests/cli/commands/test_run_attach_flow.py
@@ -1,0 +1,213 @@
+"""End-to-end flag contract for `depictio-cli run --attach-run`.
+
+Attaching a run to an existing project is a specific combination of the flags the
+pipeline already had, and getting any one of them wrong is silently destructive:
+
+* sync must UPDATE the project (otherwise nothing is written);
+* the scan must stay INCREMENTAL (a full rescan deletes runs missing from disk);
+* process must OVERWRITE (write_delta_table refuses to rewrite an existing table
+  otherwise, and the rebuild has to include the runs already ingested);
+* dashboards must NOT be re-imported over the ones the user has since edited.
+
+Every server call is mocked, so this runs offline and asserts the wiring only.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from depictio.cli.cli.commands.run import register_run_command
+from depictio.models.models.projects import Project
+
+OWNER = {"id": "507f1f77bcf86cd799439011", "email": "owner@example.org"}
+
+
+@pytest.fixture
+def app():
+    application = typer.Typer()
+    register_run_command(application)
+    return application
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def data_root(tmp_path):
+    root = tmp_path / "run_b"
+    root.mkdir()
+    return root
+
+
+def _project(locations: list[str]) -> Project:
+    return Project.model_validate(
+        {
+            "name": "Ampliseq Microbial Community Analysis",
+            "project_type": "advanced",
+            "permissions": {"owners": [OWNER], "editors": [], "viewers": []},
+            "workflows": [
+                {
+                    "name": "ampliseq",
+                    "engine": {"name": "nextflow"},
+                    "catalog": {"name": "nf-core", "url": "https://nf-co.re"},
+                    "data_location": {"structure": "flat", "locations": list(locations)},
+                    "data_collections": [
+                        {
+                            "data_collection_tag": "asv_table",
+                            "config": {
+                                "type": "Table",
+                                "scan": {
+                                    "mode": "recursive",
+                                    "scan_parameters": {
+                                        "regex_config": {"pattern": "asv_table.tsv$"}
+                                    },
+                                },
+                                "dc_specific_properties": {
+                                    "format": "TSV",
+                                    "polars_kwargs": {"separator": "\t"},
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+class _Harness:
+    """Every mock the run pipeline needs, plus the recorded call arguments."""
+
+    def __init__(self, data_root, remote_locations: list[str], project_found: bool = True):
+        self.project = _project([str(data_root)])
+        self.remote_doc = {
+            "name": self.project.name,
+            "hash": None,
+            "workflows": [
+                {
+                    "workflow_tag": self.project.workflows[0].workflow_tag,
+                    "data_location": {"structure": "flat", "locations": remote_locations},
+                    "data_collections": [],
+                }
+            ],
+        }
+        self.project_found = project_found
+        self.sync = MagicMock(return_value={"action": "updated"})
+        self.scan = MagicMock(return_value={"result": "success"})
+        self.process = MagicMock(return_value={"total_failed": 0})
+        self.import_dashboards = MagicMock(return_value=[])
+
+    def _get_project(self, *args, **kwargs):
+        response = MagicMock()
+        response.status_code = 200 if self.project_found else 404
+        response.json.return_value = self.remote_doc
+        return response
+
+    def patches(self):
+        template_meta = MagicMock()
+        template_meta.template_id = "nf-core/ampliseq/2.16.0"
+        resolve = MagicMock(
+            return_value=({"name": self.project.name, "workflows": []}, template_meta, {}, [], {})
+        )
+        validate = MagicMock(
+            return_value=(MagicMock(), {"success": True, "project_config": self.project})
+        )
+        return [
+            patch("depictio.cli.cli.utils.templates.resolve_template", resolve),
+            patch("depictio.cli.cli.utils.config.validate_template_project_config", validate),
+            patch("depictio.cli.cli.commands.run.api_get_project_from_name", self._get_project),
+            patch("depictio.cli.cli.commands.run.api_sync_project_config_to_server", self.sync),
+            patch("depictio.cli.cli.commands.run.scan_project_files", self.scan),
+            patch("depictio.cli.cli.commands.run.process_project_helper", self.process),
+            patch("depictio.cli.cli.commands.run.api_monitoring_ingestion_start", MagicMock()),
+            patch("depictio.cli.cli.commands.run.api_monitoring_ingestion_finish", MagicMock()),
+            patch("depictio.cli.cli.commands.run.generate_api_headers", MagicMock(return_value={})),
+            patch(
+                "depictio.cli.cli.utils.templates.import_dashboards_from_template",
+                self.import_dashboards,
+            ),
+        ]
+
+
+def _invoke(app, runner, harness, extra_args):
+    with_patches = harness.patches()
+    for p in with_patches:
+        p.start()
+    try:
+        return runner.invoke(
+            app,
+            [
+                "--template",
+                "nf-core/ampliseq/2.16.0",
+                "--data-root",
+                str(extra_args["data_root"]),
+                "--skip-server-check",
+                "--skip-s3-check",
+                *extra_args["flags"],
+            ],
+        )
+    finally:
+        for p in with_patches:
+            p.stop()
+
+
+class TestAttachRunFlags:
+    def test_attach_updates_scans_incrementally_and_overwrites_the_tables(
+        self, app, runner, data_root
+    ):
+        harness = _Harness(data_root, remote_locations=["/data/run_a"])
+        result = _invoke(app, runner, harness, {"data_root": data_root, "flags": ["--attach-run"]})
+        assert result.exit_code == 0, result.output
+
+        # The project is updated, not created a second time.
+        assert harness.sync.call_args.kwargs["update"] is True
+        # The scan stays incremental: a full rescan would delete runs off disk.
+        assert harness.scan.call_args.kwargs["command_parameters"]["rescan_folders"] is False
+        # The delta tables are rebuilt, including the runs already ingested.
+        assert harness.process.call_args.kwargs["command_parameters"]["overwrite"] is True
+        # The existing dashboards are left alone.
+        harness.import_dashboards.assert_not_called()
+        # And the new run really was appended after the existing one.
+        assert harness.sync.call_args.kwargs["ProjectConfig"]["workflows"][0]["data_location"][
+            "locations"
+        ] == ["/data/run_a", str(data_root)]
+
+    def test_overwrite_alone_still_implies_a_full_rescan(self, app, runner, data_root):
+        """Only attach mode decouples the two; the normal --overwrite is unchanged."""
+        harness = _Harness(data_root, remote_locations=["/data/run_a"])
+        result = _invoke(
+            app,
+            runner,
+            harness,
+            {"data_root": data_root, "flags": ["--overwrite", "--update-config"]},
+        )
+        assert result.exit_code == 0, result.output
+        assert harness.scan.call_args.kwargs["command_parameters"]["rescan_folders"] is True
+
+    def test_attach_to_a_missing_project_stops_before_writing(self, app, runner, data_root):
+        harness = _Harness(data_root, remote_locations=[], project_found=False)
+        result = _invoke(app, runner, harness, {"data_root": data_root, "flags": ["--attach-run"]})
+        assert result.exit_code == 2
+        assert "no project named" in " ".join(result.output.split())
+        harness.sync.assert_not_called()
+        harness.scan.assert_not_called()
+
+    def test_without_attach_an_existing_project_is_reported_not_silently_skipped(
+        self, app, runner, data_root
+    ):
+        """The regression: this used to exit 1 with an empty error message."""
+        harness = _Harness(data_root, remote_locations=["/data/run_a"])
+        harness.sync = MagicMock(return_value={"action": "exists"})
+        result = _invoke(app, runner, harness, {"data_root": data_root, "flags": []})
+        assert result.exit_code == 2
+        normalized = " ".join(result.output.split())
+        assert "already exists on this server" in normalized
+        assert "--update-config" in normalized
+        assert "--attach-run" in normalized
+        harness.scan.assert_not_called()

--- a/depictio/tests/cli/utils/test_common.py
+++ b/depictio/tests/cli/utils/test_common.py
@@ -1,12 +1,15 @@
+import copy
 from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+import yaml
 from pydantic import ValidationError
 from typer import Exit
 
 # Remove this line as we already import datetime later
 from depictio.cli.cli.utils.common import (
+    _apply_env_overrides,
     format_timestamp,
     generate_api_headers,
     load_depictio_config,
@@ -212,3 +215,123 @@ class TestCommon:
 
                 with pytest.raises(Exit):
                     load_depictio_config()
+
+    class TestEnvironmentOverrides:
+        """Tests for the DEPICTIO_CLI_* environment overrides.
+
+        These let a ``CLI.yaml`` be committed without secrets and have the token
+        (and optionally the API URL / the config path itself) injected at runtime,
+        which is what makes automated triggering practical: the head job of a
+        pipeline usually has env vars but no writable home directory.
+
+        Every test here works against a throwaway YAML under ``tmp_path`` — the
+        real ``~/.depictio`` is never read or written.
+        """
+
+        _ENV_VARS = (
+            "DEPICTIO_CLI_TOKEN",
+            "DEPICTIO_CLI_API_BASE_URL",
+            "DEPICTIO_CLI_CONFIG_PATH",
+        )
+
+        @pytest.fixture(autouse=True)
+        def isolated_env(self, monkeypatch):
+            """Start from a clean slate so a developer's shell can't taint results."""
+            for var in self._ENV_VARS:
+                monkeypatch.delenv(var, raising=False)
+            with patch("depictio.cli.cli.utils.common.rich_print_checked_statement"):
+                yield
+
+        def _write_config(self, tmp_path, sample_cli_config, filename, api_base_url):
+            """Write a valid CLI config YAML, tagged by its api_base_url.
+
+            The URL doubles as a marker: asserting on it tells us *which* file a
+            given call actually loaded.
+            """
+            config = copy.deepcopy(sample_cli_config)
+            config["api_base_url"] = api_base_url
+            path = tmp_path / filename
+            path.write_text(yaml.safe_dump(config))
+            return path
+
+        @pytest.fixture
+        def config_file(self, tmp_path, sample_cli_config):
+            """A throwaway CLI config file (never ``~/.depictio``)."""
+            return self._write_config(
+                tmp_path, sample_cli_config, "CLI.yaml", "https://from-env-path.example.org"
+            )
+
+        def test_token_env_var_overrides_config(self, monkeypatch, config_file):
+            """DEPICTIO_CLI_TOKEN replaces the access token from the YAML."""
+            monkeypatch.setenv("DEPICTIO_CLI_TOKEN", "env.injected.token")
+
+            config = load_depictio_config(str(config_file))
+
+            assert config.user.token.access_token == "env.injected.token"
+
+        def test_token_env_var_when_user_key_missing(self, monkeypatch):
+            """A secret-free config need not carry a ``user`` key at all."""
+            monkeypatch.setenv("DEPICTIO_CLI_TOKEN", "env.injected.token")
+
+            result = _apply_env_overrides({"api_base_url": "https://api.depictio.dev"})
+
+            assert result["user"]["token"]["access_token"] == "env.injected.token"
+
+        @pytest.mark.parametrize("token_value", [None, "not-a-dict", 42, ["list"]])
+        def test_token_env_var_when_token_is_not_a_dict(self, monkeypatch, token_value):
+            """A non-dict ``user.token`` is replaced, not indexed into."""
+            monkeypatch.setenv("DEPICTIO_CLI_TOKEN", "env.injected.token")
+
+            result = _apply_env_overrides({"user": {"email": "a@b.co", "token": token_value}})
+
+            assert result["user"]["token"] == {"access_token": "env.injected.token"}
+            # Other user fields survive the token replacement.
+            assert result["user"]["email"] == "a@b.co"
+
+        def test_api_base_url_env_var_overrides_config(self, monkeypatch, config_file):
+            """DEPICTIO_CLI_API_BASE_URL replaces the api_base_url from the YAML."""
+            monkeypatch.setenv("DEPICTIO_CLI_API_BASE_URL", "https://depictio.example.org:8058")
+
+            config = load_depictio_config(str(config_file))
+
+            assert config.api_base_url == "https://depictio.example.org:8058"
+
+        def test_no_env_vars_leaves_config_untouched(self, sample_cli_config):
+            """With neither variable set, the dict comes back unchanged."""
+            original = copy.deepcopy(sample_cli_config)
+
+            result = _apply_env_overrides(sample_cli_config)
+
+            assert result == original
+
+        def test_config_path_env_var_used_without_argument(self, monkeypatch, config_file):
+            """DEPICTIO_CLI_CONFIG_PATH selects the file when no path is passed."""
+            monkeypatch.setenv("DEPICTIO_CLI_CONFIG_PATH", str(config_file))
+
+            config = load_depictio_config()
+
+            assert config.api_base_url == "https://from-env-path.example.org"
+
+        @pytest.mark.parametrize("default_path", ["~/.depictio/cli.yaml", "~/.depictio/CLI.yaml"])
+        def test_config_path_env_var_used_for_default_spellings(
+            self, monkeypatch, config_file, default_path
+        ):
+            """Both historic default spellings are still treated as "no choice made"."""
+            monkeypatch.setenv("DEPICTIO_CLI_CONFIG_PATH", str(config_file))
+
+            config = load_depictio_config(default_path)
+
+            assert config.api_base_url == "https://from-env-path.example.org"
+
+        def test_explicit_path_beats_config_path_env_var(
+            self, monkeypatch, tmp_path, sample_cli_config, config_file
+        ):
+            """An explicit --CLI-config-path is never clobbered by the env var."""
+            explicit = self._write_config(
+                tmp_path, sample_cli_config, "explicit.yaml", "https://from-explicit.example.org"
+            )
+            monkeypatch.setenv("DEPICTIO_CLI_CONFIG_PATH", str(config_file))
+
+            config = load_depictio_config(str(explicit))
+
+            assert config.api_base_url == "https://from-explicit.example.org"

--- a/depictio/tests/cli/utils/test_common.py
+++ b/depictio/tests/cli/utils/test_common.py
@@ -1,4 +1,6 @@
 import copy
+import os
+import tempfile
 from datetime import datetime
 from unittest.mock import patch
 
@@ -194,7 +196,14 @@ class TestCommon:
                     s3_storage=mock_config["s3_storage"],
                 )
 
-                result = load_depictio_config()
+                # A real file on disk: load_depictio_config checks the path
+                # exists before reading it, and the default ~/.depictio/CLI.yaml
+                # is present on a developer machine but not on CI.
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    config_path = os.path.join(tmp_dir, "CLI.yaml")
+                    with open(config_path, "w") as handle:
+                        handle.write("placeholder: true\n")
+                    result = load_depictio_config(yaml_config_path=config_path)
 
                 # Verify that the functions were called
                 mock_get_config.assert_called_once()

--- a/depictio/tests/cli/utils/test_scan_missing_runs.py
+++ b/depictio/tests/cli/utils/test_scan_missing_runs.py
@@ -1,0 +1,235 @@
+"""Regression test: missing-run reconciliation must not fire per location.
+
+`scan_files_for_workflow` deletes runs that are registered server-side but no longer
+present on disk. That reconciliation compares the registry against
+``all_workflow_runs``, which accumulates *across* locations, so running it inside the
+``for location in locations`` loop deleted the runs of every location not yet walked
+(they were then re-created with fresh ids, losing their scan history).
+
+`--attach-run` makes multi-location workflows the normal case, so this is exercised
+directly here: two locations, `rescan_folders=True`, and nothing may be deleted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from depictio.models.models.base import PyObjectId
+from depictio.models.models.users import Permission, UserBase
+from depictio.models.models.workflows import Workflow, WorkflowRun
+
+NOW = "2026-09-03 23:00:00"
+OWNER = {"id": "507f1f77bcf86cd799439011", "email": "owner@example.org"}
+WF_CONFIG_ID = "507f1f77bcf86cd799439099"
+
+
+@pytest.fixture
+def two_run_dirs(tmp_path):
+    run_a = tmp_path / "run_a"
+    run_b = tmp_path / "run_b"
+    for d in (run_a, run_b):
+        d.mkdir()
+        (d / "table.tsv").write_text("a\tb\n1\t2\n")
+    return run_a, run_b
+
+
+@pytest.fixture
+def workflow(two_run_dirs):
+    run_a, run_b = two_run_dirs
+    return Workflow.model_validate(
+        {
+            "name": "ampliseq",
+            "engine": {"name": "nextflow"},
+            "catalog": {"name": "nf-core", "url": "https://nf-co.re"},
+            "data_location": {
+                "structure": "flat",
+                "locations": [str(run_a), str(run_b)],
+            },
+            "config": {"version": "2.16.0"},
+            "data_collections": [
+                {
+                    "data_collection_tag": "asv_table",
+                    "config": {
+                        "type": "Table",
+                        "scan": {
+                            "mode": "recursive",
+                            "scan_parameters": {"regex_config": {"pattern": "table.tsv$"}},
+                        },
+                        "dc_specific_properties": {
+                            "format": "TSV",
+                            "polars_kwargs": {"separator": "\t"},
+                        },
+                    },
+                }
+            ],
+        }
+    )
+
+
+def _existing_run(workflow_id, run_tag: str, location: str) -> dict:
+    return WorkflowRun(
+        workflow_id=workflow_id,
+        run_tag=run_tag,
+        workflow_config_id=PyObjectId(WF_CONFIG_ID),
+        run_location=location,
+        creation_time=NOW,
+        last_modification_time=NOW,
+        permissions=Permission(owners=[UserBase.model_validate(OWNER)]),
+    ).mongo()
+
+
+def _cli_config():
+    cli_config = MagicMock()
+    cli_config.user.model_dump.return_value = {**OWNER, "token": None}
+    return cli_config
+
+
+def test_rescan_over_two_locations_deletes_nothing(workflow, two_run_dirs):
+    """Both runs are on disk, so a full rescan must delete neither."""
+    run_a, run_b = two_run_dirs
+    existing = [
+        _existing_run(workflow.id, run_a.name, str(run_a)),
+        _existing_run(workflow.id, run_b.name, str(run_b)),
+    ]
+
+    files_resp = MagicMock(status_code=200)
+    files_resp.json.return_value = []
+    runs_resp = MagicMock(status_code=200)
+    runs_resp.json.return_value = existing
+
+    def fake_scan(**kwargs):
+        return WorkflowRun(
+            workflow_id=workflow.id,
+            run_tag=kwargs["run_tag"],
+            workflow_config_id=PyObjectId(WF_CONFIG_ID),
+            run_location=kwargs["run_location"],
+            creation_time=NOW,
+            last_modification_time=NOW,
+            permissions=Permission(owners=[UserBase.model_validate(OWNER)]),
+        )
+
+    with (
+        patch("depictio.cli.cli.utils.scan.api_get_files_by_dc_id", return_value=files_resp),
+        patch("depictio.cli.cli.utils.scan.api_get_runs_by_wf_id", return_value=runs_resp),
+        patch(
+            "depictio.cli.cli.utils.scan.scan_run_for_multiple_data_collections",
+            side_effect=fake_scan,
+        ),
+        patch("depictio.cli.cli.utils.scan.api_upsert_runs_batch") as upsert,
+        patch("depictio.cli.cli.utils.scan.api_delete_run") as delete_run,
+        patch("depictio.cli.cli.utils.scan.api_delete_file") as delete_file,
+    ):
+        from depictio.cli.cli.utils.scan import scan_files_for_workflow
+
+        result = scan_files_for_workflow(
+            workflow=workflow,
+            data_collections=workflow.data_collections,
+            CLI_config=_cli_config(),
+            command_parameters={"rescan_folders": True, "rich_tables": False},
+        )
+
+    assert result["result"] == "success"
+    # The regression: run_b was deleted after location 1 was walked.
+    assert delete_run.call_count == 0
+    assert delete_file.call_count == 0
+    scanned = {r.run_tag for r in upsert.call_args.args[0]}
+    assert scanned == {run_a.name, run_b.name}
+
+
+def test_run_that_vanished_from_disk_is_still_deleted(workflow, two_run_dirs):
+    """The reconciliation must keep working: a registered run with no directory goes."""
+    run_a, run_b = two_run_dirs
+    gone = _existing_run(workflow.id, "run_gone", "/nowhere/run_gone")
+    existing = [
+        _existing_run(workflow.id, run_a.name, str(run_a)),
+        _existing_run(workflow.id, run_b.name, str(run_b)),
+        gone,
+    ]
+
+    files_resp = MagicMock(status_code=200)
+    files_resp.json.return_value = []
+    runs_resp = MagicMock(status_code=200)
+    runs_resp.json.return_value = existing
+
+    def fake_scan(**kwargs):
+        return WorkflowRun(
+            workflow_id=workflow.id,
+            run_tag=kwargs["run_tag"],
+            workflow_config_id=PyObjectId(WF_CONFIG_ID),
+            run_location=kwargs["run_location"],
+            creation_time=NOW,
+            last_modification_time=NOW,
+            permissions=Permission(owners=[UserBase.model_validate(OWNER)]),
+        )
+
+    with (
+        patch("depictio.cli.cli.utils.scan.api_get_files_by_dc_id", return_value=files_resp),
+        patch("depictio.cli.cli.utils.scan.api_get_runs_by_wf_id", return_value=runs_resp),
+        patch(
+            "depictio.cli.cli.utils.scan.scan_run_for_multiple_data_collections",
+            side_effect=fake_scan,
+        ),
+        patch("depictio.cli.cli.utils.scan.api_upsert_runs_batch"),
+        patch("depictio.cli.cli.utils.scan.api_delete_run") as delete_run,
+        patch("depictio.cli.cli.utils.scan.api_delete_file"),
+    ):
+        from depictio.cli.cli.utils.scan import scan_files_for_workflow
+
+        scan_files_for_workflow(
+            workflow=workflow,
+            data_collections=workflow.data_collections,
+            CLI_config=_cli_config(),
+            command_parameters={"rescan_folders": True, "rich_tables": False},
+        )
+
+    assert delete_run.call_count == 1
+    assert delete_run.call_args.kwargs["run_id"] == str(gone["_id"])
+
+
+def test_without_rescan_nothing_is_reconciled(workflow, two_run_dirs):
+    """The incremental path (`--attach-run` uses it) never deletes."""
+    run_a, run_b = two_run_dirs
+    existing = [_existing_run(workflow.id, run_a.name, str(run_a))]
+
+    files_resp = MagicMock(status_code=200)
+    files_resp.json.return_value = []
+    runs_resp = MagicMock(status_code=200)
+    runs_resp.json.return_value = existing
+
+    def fake_scan(**kwargs):
+        return WorkflowRun(
+            workflow_id=workflow.id,
+            run_tag=kwargs["run_tag"],
+            workflow_config_id=PyObjectId(WF_CONFIG_ID),
+            run_location=kwargs["run_location"],
+            creation_time=NOW,
+            last_modification_time=NOW,
+            permissions=Permission(owners=[UserBase.model_validate(OWNER)]),
+        )
+
+    with (
+        patch("depictio.cli.cli.utils.scan.api_get_files_by_dc_id", return_value=files_resp),
+        patch("depictio.cli.cli.utils.scan.api_get_runs_by_wf_id", return_value=runs_resp),
+        patch(
+            "depictio.cli.cli.utils.scan.scan_run_for_multiple_data_collections",
+            side_effect=fake_scan,
+        ),
+        patch("depictio.cli.cli.utils.scan.api_upsert_runs_batch") as upsert,
+        patch("depictio.cli.cli.utils.scan.api_delete_run") as delete_run,
+        patch("depictio.cli.cli.utils.scan.api_delete_file"),
+    ):
+        from depictio.cli.cli.utils.scan import scan_files_for_workflow
+
+        scan_files_for_workflow(
+            workflow=workflow,
+            data_collections=workflow.data_collections,
+            CLI_config=_cli_config(),
+            command_parameters={"rescan_folders": False, "rich_tables": False},
+        )
+
+    assert delete_run.call_count == 0
+    # Only the run that was not already registered gets scanned.
+    scanned = {r.run_tag for r in upsert.call_args.args[0]}
+    assert scanned == {run_b.name}


### PR DESCRIPTION
## Why

Depictio ingestion is pull-only today: when a pipeline finishes, somebody has to remember to run `depictio-cli run`. This stack makes the pipeline push instead. This first PR is the CLI groundwork, and it fixes two failures that made repeated automated triggering impossible.

## What is in here

**Auth without a secret in the file.** `DEPICTIO_CLI_TOKEN` and `DEPICTIO_CLI_API_BASE_URL` override the loaded config, and `DEPICTIO_CLI_CONFIG_PATH` selects the file. The env path only applies when the caller left `--CLI-config-path` at its default, so an explicit flag is never clobbered. A head job on a cluster or a CI runner can now carry a committed, secret-free `CLI.yaml`.

**Two silent failures fixed.**

- `/projects/create` answers HTTP 200 with a failure body (409 name taken, 403 public mode). The CLI read the transport status only and reported "Project created on server" when nothing had been written. `_project_write_outcome` now reads the body.
- `api_sync_project_config_to_server` used to `raise typer.Exit(code=0)` when the project already existed. `typer.Exit` inherits from `RuntimeError`, so `run.py`'s `except Exception` caught it, logged `Project configuration sync failed:` with an empty message and exited **1**. That is exactly the path of a second automated trigger. It now returns a verdict (`created` / `updated` / `exists`) and `run.py` decides, with a message naming the two ways forward and an explicit exit code.

**`--attach-run`.** Registers this `--data-root` as an additional run of an existing project instead of creating one. `data_location.locations` is a list and the scan is incremental, so attaching is a union of locations; `merge_existing_ids` keeps the server-side workflow and data collection ids, so already-ingested runs and files are not orphaned.

The flag combination is the load-bearing part, and each half is silently destructive if it drifts:

| | attach | why |
| --- | --- | --- |
| sync `update` | forced on | otherwise nothing is written |
| scan `rescan_folders` | left **off** | a full rescan deletes runs whose directories are not on disk |
| process `overwrite` | forced on | `write_delta_table` refuses to rewrite an existing table, and the rebuild has to cover the runs already ingested |
| dashboard import | skipped | the dashboards exist, and a re-import would overwrite the user's edits |

`--overwrite` and `--rescan-folders` were coupled, so this decouples them. Outside attach mode the old coupling is unchanged, and a test pins that.

`attach_run_to_project` also protects `scan.mode: single` data collections. Those are bound to an absolute path substituted from the first `DATA_ROOT` (samplesheet, metadata, tree). Re-pointing them at the new run would make the next scan delete the original run's file, so the existing binding is preserved and the summary says so.

**`--nextflow-manifest "<name>/<version>"`.** Resolves a bundled template from a raw Nextflow manifest, only when neither `--template` nor `--project-config-path` was given, so an explicit choice always wins. #1037 renames it `--pipeline-id`, since the value is engine-neutral once #1036 is in; the behaviour is the one described here.

**A scan bug this exposed.** In `scan.py` the "runs that disappeared from disk" reconciliation sat *inside* the `for location in locations:` loop, but `all_workflow_runs` accumulates across locations. With more than one location and `--rescan-folders`, the first location deleted the runs of every location not yet scanned, which were then recreated with fresh ids, losing `scan_results`. The block now runs once, after every location has been walked. Multi-location is precisely what attach mode produces, so this was a prerequisite. Proven by re-indenting it temporarily: 2 of the 3 new regression tests fail.

**`config sync` says so too.** Making the sync return a verdict instead of raising meant `depictio-cli config sync` against an existing project without `--update` printed nothing and looked like success. It now reports it and exits 2, matching `run`.

## Verification

`1738 passed` in `depictio/tests/cli depictio/tests/models` at this commit. New tests: `test_attach_run.py` (9, the location union and the single-file guard), `test_scan_missing_runs.py` (3, the reconciliation regression), `test_run_attach_flow.py` (4, the flag contract end to end through `CliRunner`), 2 in `test_config.py` (the `config sync` verdict, which fails without the fix above), plus 12 in `test_common.py` and 8 in `test_run.py`.

Exercised against a live server in #1037, where the attach and update paths run end to end from a real `nextflow run`. Checks run natively on this PR since its base is `main`.

## Stack

Linked as a GitHub stack (#1046). Each layer needs the one below it and nothing above it:

![the three-PR stack](https://raw.githubusercontent.com/depictio/depictio/2e0ed5225d51b26be6f442dd87e51b53be4c99a1/docs/images/v1.4/nextflow/schema_stack.png)

1. #1035 CLI auth, robustness and `--attach-run`  <- this PR
2. #1036 recognising which pipeline produced a run directory
3. #1037 the Nextflow `workflow.onComplete` trigger

Supersedes the CLI parts of #813. Both #811 and #813 are around 740 commits behind main, and main has since absorbed much of their content, so this stack ports only what is still missing rather than rebasing them.

