### PR TITLE
feat(models,cli): recognise which pipeline produced a run directory

### DIFF
--- a/depictio/cli/cli/commands/run.py
+++ b/depictio/cli/cli/commands/run.py
@@ -446,6 +446,40 @@ def register_run_command(app: typer.Typer):
                 "success",
             )
 
+        # Read the run's own provenance whenever there is a directory to look at,
+        # deliberately independent of how the template was chosen. The dominant
+        # trigger path forwards --nextflow-manifest, which already resolved a
+        # template above, but the engine version and the tool list exist nowhere
+        # except the run directory. Gating this on "no template yet" left every
+        # pipeline-triggered project with empty provenance.
+        detected_info = None
+        if data_root and Path(data_root).is_dir():
+            from depictio.models.models.run_info import read_run_info
+
+            detected_info = read_run_info(data_root)
+            if detected_info is not None:
+                version = (
+                    f" {detected_info.pipeline_version}" if detected_info.pipeline_version else ""
+                )
+                rich_print_checked_statement(
+                    f"Detected {detected_info.pipeline_name or 'an unidentified pipeline'}"
+                    f"{version} ({detected_info.engine or 'unknown engine'}, "
+                    f"{len(detected_info.tools_executed)} tool(s))",
+                    "info",
+                )
+
+        # Step 0-: nothing was specified at all, so let the run directory pick the
+        # template too. This is the fallback for a pipeline whose manifest the
+        # trigger could not forward (an older Nextflow, a hand-run CLI, a
+        # non-Nextflow engine).
+        if detected_info is not None and not template and not project_config_path:
+            from depictio.cli.cli.utils.templates import select_template_for_run
+
+            detected_template = select_template_for_run(detected_info)
+            if detected_template:
+                template = detected_template
+                rich_print_checked_statement(f"Auto-selected template: {template}", "success")
+
         # Validate template/project-config-path mutual exclusivity
         if template and project_config_path:
             rich_print_checked_statement(
@@ -595,6 +629,25 @@ def register_run_command(app: typer.Typer):
                     "success",
                     f"template '{template_metadata.template_id}' loaded",
                 )
+
+                # Stamp the run's own provenance onto each workflow config when we
+                # read it from the run directory. It lives on the run-scoped
+                # WorkflowConfig so one workflow can aggregate runs produced by
+                # different pipeline versions without them conflicting.
+                if detected_info is not None:
+                    provenance = {
+                        "engine_name": detected_info.engine,
+                        "pipeline_version": detected_info.pipeline_version,
+                        "nextflow_version": (
+                            detected_info.engine_version
+                            if detected_info.engine == "nextflow"
+                            else None
+                        ),
+                        "tools_executed": sorted(detected_info.tools_executed),
+                    }
+                    provenance = {k: v for k, v in provenance.items() if v}
+                    for wf in resolved_config.get("workflows", []):
+                        wf.setdefault("config", {}).update(provenance)
 
                 template_resolved_config = resolved_config
 

--- a/depictio/cli/cli/utils/templates.py
+++ b/depictio/cli/cli/utils/templates.py
@@ -37,24 +37,32 @@ _TEMPLATE_VAR_RE = re.compile(r"\{([A-Z0-9_]+)\}")
 _VERSION_DIR_RE = re.compile(r"^\d+(\.\d+)*$")
 
 
-def latest_template_version(pipeline_dir: Path) -> str | None:
-    """Highest numeric version subdirectory of ``pipeline_dir`` holding a template YAML.
+def _version_key(version: str) -> tuple[int, ...]:
+    """Order version strings numerically, so 2.9.0 sorts below 2.16.0."""
+    return tuple(int(part) for part in version.split("."))
 
-    Returns e.g. ``"2.16.0"`` for ``depictio/projects/nf-core/ampliseq/``, or None
-    when the directory has no versioned template subdirectories.
-    """
+
+def _template_versions(pipeline_dir: Path) -> list[str]:
+    """Numeric version subdirectories of ``pipeline_dir`` that ship a template YAML."""
     if not pipeline_dir.is_dir():
-        return None
-    versions = [
+        return []
+    return [
         d.name
         for d in pipeline_dir.iterdir()
         if d.is_dir()
         and _VERSION_DIR_RE.match(d.name)
         and any((d / f).is_file() for f in ("template.yaml", "project.yaml"))
     ]
-    if not versions:
-        return None
-    return max(versions, key=lambda v: tuple(int(p) for p in v.split(".")))
+
+
+def latest_template_version(pipeline_dir: Path) -> str | None:
+    """Highest numeric version subdirectory of ``pipeline_dir`` holding a template YAML.
+
+    Returns e.g. ``"2.16.0"`` for ``depictio/projects/nf-core/ampliseq/``, or None
+    when the directory has no versioned template subdirectories.
+    """
+    versions = _template_versions(pipeline_dir)
+    return max(versions, key=_version_key) if versions else None
 
 
 def _resolve_template_id_in(projects_dir: Path, template_id: str) -> str:
@@ -77,6 +85,21 @@ def _resolve_template_id_in(projects_dir: Path, template_id: str) -> str:
         if version:
             return "/".join([*parts, version])
     return template_id
+
+
+def _projects_roots() -> list[Path]:
+    """Candidate ``projects/`` roots a bundled template may live under.
+
+    The source checkout (``depictio/projects``) first, then the flattened layout
+    an installed package gets (``depictio/cli/projects``). Both template lookup
+    and version discovery go through here so they can never disagree about
+    where templates live.
+    """
+    here = Path(__file__).resolve()
+    return [
+        here.parents[4] / "depictio" / "projects",  # cli/cli/utils/ -> repo root
+        here.parents[3] / "projects",  # cli/cli/utils/ -> cli/
+    ]
 
 
 def _load_yaml(path: str) -> dict:
@@ -109,44 +132,122 @@ def locate_template(template_id: str) -> Path:
     Raises:
         FileNotFoundError: If no template YAML exists.
     """
-    # Resolve relative to depictio package root
-    package_root = Path(__file__).resolve().parents[4]  # cli/cli/utils/ -> depictio/
-    projects_dir = package_root / "depictio" / "projects"
-    template_dir = projects_dir / _resolve_template_id_in(projects_dir, template_id)
+    roots = _projects_roots()
+    searched: list[Path] = []
+    for projects_dir in roots:
+        template_dir = projects_dir / _resolve_template_id_in(projects_dir, template_id)
+        searched.append(template_dir)
+        # Prefer template.yaml (dedicated template file) over project.yaml (fixture)
+        for filename in ("template.yaml", "project.yaml"):
+            candidate = template_dir / filename
+            if candidate.is_file():
+                return candidate
 
-    # Prefer template.yaml (dedicated template file) over project.yaml (fixture)
-    for filename in ("template.yaml", "project.yaml"):
-        candidate = template_dir / filename
-        if candidate.is_file():
-            return candidate
-
-    # Also try without the package nesting (for installed packages)
-    alt_root = Path(__file__).resolve().parents[3]  # cli/cli/utils/ -> cli/
-    alt_projects_dir = alt_root / "projects"
-    alt_dir = alt_projects_dir / _resolve_template_id_in(alt_projects_dir, template_id)
-    for filename in ("template.yaml", "project.yaml"):
-        candidate = alt_dir / filename
-        if candidate.is_file():
-            return candidate
-
-    available = _list_available_templates(package_root)
+    available = _list_available_templates(roots[0])
     available_str = ", ".join(available) if available else "none found"
     raise FileNotFoundError(
-        f"Template '{template_id}' not found at {template_dir}. "
-        f"Available templates: {available_str}"
+        f"Template '{template_id}' not found at {searched[0]}. Available templates: {available_str}"
     )
 
 
-def _list_available_templates(package_root: Path) -> list[str]:
-    """List available template IDs by scanning the projects directory.
+def detect_template_from_run_dir(run_dir: str | Path) -> tuple[str | None, Any]:
+    """Identify the pipeline that produced ``run_dir`` and pick a bundled template.
+
+    Powers ``depictio-cli run --data-root <dir>`` with no ``--template``: the
+    results directory itself says which pipeline and release made it, so the
+    user should not have to.
+
+    Resolution, in order:
+
+    1. Read the run's provenance (engine-agnostic; see
+       ``depictio.models.models.run_info``). No engine recognised the directory,
+       or it named no pipeline → nothing to select against.
+    2. Exact match: each candidate template id the run suggests (normalised
+       version first, then the raw version string) through ``locate_template``.
+    3. Closest shipped version of the *same* pipeline: the highest available
+       version that is **not newer** than the run. Only when the run predates
+       every shipped template does the lowest one win — never the highest. A
+       newer template describes outputs the older run does not have, so
+       defaulting to "latest" produces a project whose data collections point at
+       files that were never written.
+
+    Returns:
+        ``(template_id, run_info)``. ``template_id`` is None when no template
+        can be selected; ``run_info`` is None only when no engine recognised the
+        directory at all, and is returned either way so callers can report what
+        was found.
+    """
+    from depictio.models.models.run_info import read_run_info
+
+    info = read_run_info(run_dir)
+    if info is None:
+        logger.info(f"No workflow run provenance recognised in {run_dir}")
+        return None, None
+    return select_template_for_run(info), info
+
+
+def select_template_for_run(info: Any) -> str | None:
+    """Pick the bundled template that best fits an already-read ``WorkflowRunInfo``.
+
+    Split out from ``detect_template_from_run_dir`` because the two halves are
+    wanted independently: the Nextflow trigger resolves its template from the
+    forwarded manifest, yet still needs the run's provenance, so ``run.py`` reads
+    the info once and calls this only when no template was chosen for it.
+
+    See ``detect_template_from_run_dir`` for the resolution order.
+    """
+    if not info.pipeline_name:
+        logger.info(
+            f"Run recognised as {info.engine or 'unknown engine'} but names no pipeline; "
+            "cannot auto-select a template"
+        )
+        return None
+
+    for template_id in info.template_ids():
+        try:
+            locate_template(template_id)
+        except FileNotFoundError:
+            continue
+        logger.info(f"Detected template '{template_id}' from run provenance")
+        return template_id
+
+    # Fallback: any shipped version of this pipeline, compared as int tuples the
+    # same way ``latest_template_version`` orders them.
+    available: set[str] = set()
+    for projects_dir in _projects_roots():
+        available.update(_template_versions(projects_dir / info.pipeline_name))
+    if not available:
+        logger.warning(f"No bundled template ships for pipeline '{info.pipeline_name}'")
+        return None
+
+    ordered = sorted(available, key=_version_key)
+    run_version = info.pipeline_version
+    if run_version and _VERSION_DIR_RE.match(run_version):
+        run_key = _version_key(run_version)
+        not_newer = [v for v in ordered if _version_key(v) <= run_key]
+        chosen = not_newer[-1] if not_newer else ordered[0]
+    else:
+        # No comparable version at all: latest is the only defensible guess.
+        chosen = ordered[-1]
+        run_version = run_version or "unknown"
+
+    logger.warning(
+        f"No bundled template for {info.pipeline_name} {run_version}; "
+        f"falling back to the closest shipped version {chosen} "
+        f"(available: {', '.join(ordered)})"
+    )
+    return f"{info.pipeline_name}/{chosen}"
+
+
+def _list_available_templates(projects_dir: Path) -> list[str]:
+    """List available template IDs by scanning a projects directory.
 
     Args:
-        package_root: Root of the depictio package.
+        projects_dir: A ``projects/`` root (see ``_projects_roots``).
 
     Returns:
         List of template ID strings.
     """
-    projects_dir = package_root / "depictio" / "projects"
     templates: list[str] = []
 
     if not projects_dir.is_dir():

--- a/depictio/models/models/nextflow.py
+++ b/depictio/models/models/nextflow.py
@@ -1,0 +1,262 @@
+"""Nextflow / nf-core connector for the run-provenance registry.
+
+Reads a results directory's ``pipeline_info/`` — the folder every nf-core
+pipeline writes — and answers which pipeline, which release, which Nextflow and
+which tools produced it. Falls back to a pipeline checkout's ``nextflow.config``
+manifest when pointed at a source tree rather than a results directory.
+
+Registered at import with ``priority = 100`` so a directory carrying several
+engines' footprints resolves to Nextflow first.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from depictio.models.logging import logger
+from depictio.models.models.run_info import WorkflowRunInfo, register_run_info_reader
+
+ENGINE = "nextflow"
+
+# nf-core writes the run's versions YAML under pipeline_info/ under one of three
+# names depending on the pipeline's template generation. All three carry the same
+# `Workflow:` identity section, so all three are searched, most specific first.
+_VERSIONS_GLOBS: tuple[str, ...] = (
+    "nf_core_*_software_mqc_versions.yml",
+    "*_software_mqc_versions.yml",
+    "software_versions.yml",
+)
+
+# `-params-file` runs write nf-params.json; nf-core's own launcher writes
+# params_<timestamp>.json (one per resume, so the newest name wins).
+_PARAMS_GLOBS: tuple[str, ...] = ("params*.json", "nf-params.json", "nf_params.json")
+
+_REPORT_GLOB = "execution_report*.html"
+_TRACE_GLOB = "execution_trace*.txt"
+_DAG_GLOB = "pipeline_dag*"
+
+# The key inside the versions YAML that holds the run's identity rather than a
+# process's tool versions.
+_WORKFLOW_SECTION = "Workflow"
+
+# A git-describe suffix appended by Nextflow when the pipeline was run from a
+# checkout: `v2.16.0-g3d5c7e5`, `v2.13.0dev-ge7bcfda`.
+_GIT_DESCRIBE_RE = re.compile(r"-g[0-9a-fA-F]+$")
+
+# `manifest { ... }` block of a pipeline's nextflow.config.
+_MANIFEST_BLOCK_RE = re.compile(r"manifest\s*\{(.*?)\n\}", re.DOTALL)
+
+
+def normalize_pipeline_version(raw: str | None) -> str | None:
+    """Reduce an engine-reported version string to a comparable release number.
+
+    Nextflow reports whatever git-describe produced for the checkout it ran, so
+    the same 2.16.0 release shows up as ``2.16.0``, ``v2.16.0`` or
+    ``v2.16.0-g3d5c7e5``, and a pre-release as ``v2.13.0dev-ge7bcfda``. Bundled
+    templates are named after the plain release, so strip, in order: a leading
+    ``v``, a trailing git-describe ``-g<sha>``, and a trailing ``dev``.
+
+        v2.16.0-g3d5c7e5     -> 2.16.0
+        v2.13.0dev-ge7bcfda  -> 2.13.0
+        v2.13.0dev           -> 2.13.0
+        2.8.0                -> 2.8.0
+
+    The raw string is never discarded — callers keep it in
+    ``WorkflowRunInfo.extra["pipeline_version_raw"]`` so the exact provenance
+    survives normalisation.
+    """
+    if not raw:
+        return None
+    version = str(raw).strip()
+    if version.startswith("v"):
+        version = version[1:]
+    version = _GIT_DESCRIBE_RE.sub("", version)
+    if version.endswith("dev"):
+        version = version[: -len("dev")]
+    return version or None
+
+
+def _newest(directory: Path, pattern: str) -> Path | None:
+    """Last match of ``pattern`` in name order — nf-core names these by timestamp."""
+    matches = sorted(p for p in directory.glob(pattern) if p.is_file())
+    return matches[-1] if matches else None
+
+
+def _newest_matching(directory: Path, patterns: tuple[str, ...]) -> Path | None:
+    """First ``_newest`` hit across ``patterns``, in order (most specific first)."""
+    for pattern in patterns:
+        match = _newest(directory, pattern)
+        if match is not None:
+            return match
+    return None
+
+
+def _parse_versions_yaml(path: Path) -> tuple[dict[str, Any], set[str]]:
+    """Split a versions YAML into its ``Workflow:`` identity and the executed tools.
+
+    nf-core writes ``{PROCESS: {tool: version}}`` plus one ``Workflow:`` section
+    holding ``nf-core/<pipeline>: <version>`` and ``Nextflow: <version>``. The
+    section is indented two spaces by some template generations and four by
+    others, which is why this parses YAML rather than matching lines.
+    """
+    try:
+        data = yaml.safe_load(path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning(f"Nextflow run-info: could not parse {path}: {exc}")
+        return {}, set()
+    if not isinstance(data, dict):
+        return {}, set()
+
+    workflow: dict[str, Any] = {}
+    tools: set[str] = set()
+    for section, values in data.items():
+        if not isinstance(values, dict):
+            continue
+        if str(section) == _WORKFLOW_SECTION:
+            workflow = values
+            continue
+        tools.update(str(tool).lower() for tool in values)
+    return workflow, tools
+
+
+def _identity_from_workflow_section(
+    workflow: dict[str, Any],
+) -> tuple[str | None, str | None, str | None]:
+    """``(pipeline_name, raw_version, engine_version)`` from a ``Workflow:`` section."""
+    pipeline_name: str | None = None
+    raw_version: str | None = None
+    engine_version: str | None = None
+    for key, value in workflow.items():
+        if str(key).lower() == "nextflow":
+            engine_version = str(value)
+        elif pipeline_name is None:
+            pipeline_name = str(key)
+            raw_version = str(value)
+    return pipeline_name, raw_version, engine_version
+
+
+def _manifest_entry(block: str, key: str) -> str | None:
+    match = re.search(rf"^\s*{key}\s*=\s*['\"]([^'\"]+)['\"]", block, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def _identity_from_nextflow_config(
+    run_dir: Path,
+) -> tuple[str | None, str | None, str | None]:
+    """``(name, version, homepage)`` from a pipeline checkout's ``manifest {}`` block.
+
+    Only present when pointed at a pipeline source tree rather than a results
+    directory. ``nextflowVersion`` is deliberately ignored: it is a *constraint*
+    (``!>=25.04.3``), not the version that actually ran.
+    """
+    config = run_dir / "nextflow.config"
+    if not config.is_file():
+        return None, None, None
+    try:
+        text = config.read_text()
+    except OSError as exc:
+        logger.warning(f"Nextflow run-info: could not read {config}: {exc}")
+        return None, None, None
+    block_match = _MANIFEST_BLOCK_RE.search(text)
+    if block_match is None:
+        return None, None, None
+    block = block_match.group(1)
+    return (
+        _manifest_entry(block, "name"),
+        _manifest_entry(block, "version"),
+        _manifest_entry(block, "homePage"),
+    )
+
+
+def _read_params(path: Path | None) -> dict:
+    if path is None:
+        return {}
+    try:
+        loaded = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        logger.warning(f"Nextflow run-info: could not parse {path}: {exc}")
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+class NextflowRunInfoReader:
+    """Recognise a Nextflow/nf-core results directory."""
+
+    name = ENGINE
+    priority = 100
+
+    def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+        run_dir = Path(run_dir)
+        if not run_dir.is_dir():
+            return None
+
+        pipeline_info = run_dir / "pipeline_info"
+        versions_path: Path | None = None
+        params_path: Path | None = None
+        report_path: Path | None = None
+        trace_path: Path | None = None
+        dag_path: Path | None = None
+        workflow: dict[str, Any] = {}
+        tools: set[str] = set()
+
+        if pipeline_info.is_dir():
+            versions_path = _newest_matching(pipeline_info, _VERSIONS_GLOBS)
+            params_path = _newest_matching(pipeline_info, _PARAMS_GLOBS)
+            report_path = _newest(pipeline_info, _REPORT_GLOB)
+            trace_path = _newest(pipeline_info, _TRACE_GLOB)
+            dag_path = _newest(pipeline_info, _DAG_GLOB)
+            if versions_path is not None:
+                workflow, tools = _parse_versions_yaml(versions_path)
+
+        pipeline_name, raw_version, engine_version = _identity_from_workflow_section(workflow)
+        homepage: str | None = None
+
+        # Fallback identity: a pipeline checkout's manifest block.
+        if pipeline_name is None:
+            manifest_name, manifest_version, homepage = _identity_from_nextflow_config(run_dir)
+            if manifest_name:
+                pipeline_name = manifest_name
+                raw_version = manifest_version
+
+        # A run directory with none of these is not a Nextflow run as far as we
+        # can tell — say so rather than returning a hollow, misleading answer.
+        if not any((pipeline_name, versions_path, params_path, report_path, trace_path, dag_path)):
+            return None
+
+        # Only when the run wrote no versions YAML we recognise: catalog's reader
+        # searches the whole tree for a legacy `software_versions.yml`.
+        if not tools:
+            from depictio.models.components.advanced_viz.catalog import read_software_versions
+
+            tools = read_software_versions(run_dir)
+
+        params = _read_params(params_path)
+        extra: dict[str, Any] = {}
+        if raw_version:
+            extra["pipeline_version_raw"] = raw_version
+
+        run_name = params.get("run_name")
+        return WorkflowRunInfo(
+            engine=ENGINE,
+            pipeline_name=pipeline_name,
+            pipeline_version=normalize_pipeline_version(raw_version),
+            engine_version=engine_version,
+            run_name=str(run_name) if run_name else None,
+            homepage=homepage,
+            params=params,
+            tools_executed=tools,
+            software_versions_path=str(versions_path) if versions_path else None,
+            params_json_path=str(params_path) if params_path else None,
+            execution_report_path=str(report_path) if report_path else None,
+            execution_trace_path=str(trace_path) if trace_path else None,
+            pipeline_dag_path=str(dag_path) if dag_path else None,
+            extra=extra,
+        )
+
+
+register_run_info_reader(NextflowRunInfoReader())

--- a/depictio/models/models/run_info.py
+++ b/depictio/models/models/run_info.py
@@ -1,0 +1,178 @@
+"""Engine-agnostic workflow-run provenance.
+
+A results directory produced by a workflow engine carries enough breadcrumbs to
+say *what produced it*: which engine, which pipeline, which version, which tools
+ran. This module defines the neutral shape of that answer (``WorkflowRunInfo``),
+a reader protocol so each engine gets its own connector, and a tiny registry
+that dispatches a directory to the highest-priority connector that recognises
+it.
+
+The split matters because the consumers are engine-agnostic: the CLI uses the
+result to auto-select a bundled template for ``depictio-cli run --data-root``,
+and nothing in that path should know about Nextflow specifically. Adding
+Snakemake, WDL or CWL support is then a new connector module plus one entry in
+``_CONNECTOR_MODULES`` — no change here and no change in the CLI.
+
+This module stays pure and offline: it reads no files itself, performs no
+network access, and imports no recipe/catalog machinery. The connectors are
+imported lazily, on first use, so importing the models package does not pull
+their (heavier) dependencies in.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from depictio.models.logging import logger
+
+
+class WorkflowRunInfo(BaseModel):
+    """What a workflow engine's output directory says about the run that made it.
+
+    Every field is optional: connectors are best-effort readers of whatever the
+    engine happened to write, and a partially-identified run is far more useful
+    than no answer at all. ``extra`` is the escape hatch for engine-specific
+    details that do not deserve a first-class field (e.g. the raw, un-normalised
+    version string).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    engine: str | None = None
+    """Workflow engine that produced the directory, e.g. ``"nextflow"``."""
+
+    pipeline_name: str | None = None
+    """Fully-qualified pipeline id, e.g. ``"nf-core/ampliseq"``."""
+
+    pipeline_version: str | None = None
+    """Normalised, comparable release, e.g. ``"2.16.0"`` (see connectors)."""
+
+    engine_version: str | None = None
+    """Engine runtime version, e.g. Nextflow ``"25.10.0"``."""
+
+    run_name: str | None = None
+    homepage: str | None = None
+
+    params: dict = Field(default_factory=dict)
+    """The run's parameters, as the engine recorded them."""
+
+    tools_executed: set[str] = Field(default_factory=set)
+    """Lowercased names of the tools the run actually executed."""
+
+    software_versions_path: str | None = None
+    params_json_path: str | None = None
+    execution_report_path: str | None = None
+    execution_trace_path: str | None = None
+    pipeline_dag_path: str | None = None
+
+    extra: dict = Field(default_factory=dict)
+
+    @property
+    def short_name(self) -> str | None:
+        """Pipeline name without its namespace: ``nf-core/ampliseq`` -> ``ampliseq``."""
+        if not self.pipeline_name:
+            return None
+        return self.pipeline_name.rsplit("/", 1)[-1]
+
+    def template_ids(self) -> list[str]:
+        """Candidate bundled-template ids for this run, most specific first.
+
+        The normalised version comes first (``nf-core/ampliseq/2.16.0``), then
+        the raw string the engine actually wrote if it differs
+        (``nf-core/ampliseq/v2.16.0-g3d5c7e5``) — a template directory could in
+        principle be named either way.
+
+        Deliberately never yields the version-less ``nf-core/ampliseq``: that id
+        resolves to the *latest* shipped template, which is exactly the wrong
+        answer for an old run. Choosing a substitute when no version matches is
+        the caller's decision, not this list's.
+        """
+        if not self.pipeline_name:
+            return []
+        raw = self.extra.get("pipeline_version_raw")
+        ids: list[str] = []
+        for version in (self.pipeline_version, raw):
+            if not version:
+                continue
+            candidate = f"{self.pipeline_name}/{version}"
+            if candidate not in ids:
+                ids.append(candidate)
+        return ids
+
+
+@runtime_checkable
+class RunInfoReader(Protocol):
+    """One engine's reader: recognise a run directory and describe it.
+
+    ``priority`` orders connectors when a directory carries more than one
+    engine's footprint (a Nextflow run staged inside a Snakemake project, say).
+    Higher wins.
+    """
+
+    name: str
+    priority: int
+
+    def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+        """Return the run's provenance, or None if this engine doesn't recognise it."""
+        ...
+
+
+# Connector modules imported lazily on first dispatch; importing one registers
+# its reader as a side effect. Adding an engine is a new module plus one line.
+_CONNECTOR_MODULES: tuple[str, ...] = (
+    "depictio.models.models.nextflow",
+    "depictio.models.models.snakemake",
+)
+
+_READERS: list[RunInfoReader] = []
+
+
+def register_run_info_reader(reader: RunInfoReader) -> None:
+    """Register (or replace) a reader, keeping the list sorted by descending priority.
+
+    Idempotent by ``reader.name`` so a module re-imported under a different path
+    — or a test registering a stub twice — cannot install duplicates.
+    """
+    global _READERS
+    _READERS = [r for r in _READERS if r.name != reader.name]
+    _READERS.append(reader)
+    _READERS.sort(key=lambda r: (-r.priority, r.name))
+
+
+def _load_connectors() -> None:
+    """Import the bundled connectors so they self-register. Best-effort."""
+    for module in _CONNECTOR_MODULES:
+        try:
+            importlib.import_module(module)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"Run-info connector {module!r} failed to import: {exc}")
+
+
+def registered_readers() -> list[RunInfoReader]:
+    """Every registered reader, highest priority first."""
+    _load_connectors()
+    return list(_READERS)
+
+
+def read_run_info(run_dir: str | Path) -> WorkflowRunInfo | None:
+    """Identify the workflow run that produced ``run_dir``.
+
+    Tries each registered connector by descending priority and returns the first
+    non-None answer. A connector that raises is logged and skipped so one broken
+    engine reader cannot mask the others.
+    """
+    path = Path(run_dir)
+    for reader in registered_readers():
+        try:
+            info = reader.read(path)
+        except Exception as exc:
+            logger.warning(f"Run-info reader {reader.name!r} failed on {path}: {exc}")
+            continue
+        if info is not None:
+            logger.debug(f"Run-info reader {reader.name!r} recognised {path}")
+            return info
+    return None

--- a/depictio/models/models/snakemake.py
+++ b/depictio/models/models/snakemake.py
@@ -1,0 +1,144 @@
+"""Snakemake connector for the run-provenance registry.
+
+Snakemake has no equivalent of nf-core's ``pipeline_info/``: there is no
+standard file that names the pipeline and its release. So this connector is
+deliberately weaker than the Nextflow one — it recognises the workflow's
+footprint (``.snakemake/`` metadata, a ``Snakefile``) and then reads what
+identity it can from the project's config file, falling back to the directory
+name.
+
+Registered at import with ``priority = 50``, below Nextflow: a Nextflow run
+staged inside a Snakemake project should still resolve as Nextflow, which has
+the stronger, unambiguous signal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from depictio.models.logging import logger
+from depictio.models.models.run_info import WorkflowRunInfo, register_run_info_reader
+
+ENGINE = "snakemake"
+
+_METADATA_DIR = ".snakemake"
+
+# Both the flat layout and the recommended `workflow/` layout.
+_SNAKEFILES: tuple[str, ...] = ("Snakefile", "workflow/Snakefile")
+
+_CONFIG_FILES: tuple[str, ...] = (
+    "config.yaml",
+    "config.yml",
+    "config/config.yaml",
+    "config/config.yml",
+)
+
+# Keys a project might use to name itself, most explicit first.
+_NAME_KEYS: tuple[str, ...] = ("pipeline", "name", "workflow")
+
+# Per-rule conda environments Snakemake materialises under .snakemake/conda/.
+_CONDA_ENV_GLOBS: tuple[str, ...] = ("conda/*.yaml", "conda/*.yml")
+
+
+def _first_existing(run_dir: Path, relatives: tuple[str, ...]) -> Path | None:
+    for relative in relatives:
+        candidate = run_dir / relative
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_config(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    try:
+        loaded = yaml.safe_load(path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning(f"Snakemake run-info: could not parse {path}: {exc}")
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _tools_from_conda_envs(metadata_dir: Path) -> set[str]:
+    """Tool names from the ``dependencies:`` of every materialised conda env.
+
+    Entries look like ``bioconda::fastqc=0.12.1`` or ``samtools=1.19``; the
+    channel prefix and the version pin are both dropped, leaving the tool name.
+    A nested ``pip:`` mapping is skipped — it lists Python distributions, not
+    the workflow's tools.
+    """
+    tools: set[str] = set()
+    for pattern in _CONDA_ENV_GLOBS:
+        for env_path in sorted(metadata_dir.glob(pattern)):
+            try:
+                env = yaml.safe_load(env_path.read_text()) or {}
+            except (OSError, yaml.YAMLError) as exc:
+                logger.warning(f"Snakemake run-info: could not parse {env_path}: {exc}")
+                continue
+            if not isinstance(env, dict):
+                continue
+            for dependency in env.get("dependencies") or []:
+                if not isinstance(dependency, str):
+                    continue  # e.g. {"pip": [...]}
+                spec = dependency.split("::", 1)[-1]
+                name = spec.split("=", 1)[0].strip().lower()
+                if name:
+                    tools.add(name)
+    return tools
+
+
+class SnakemakeRunInfoReader:
+    """Recognise a Snakemake workflow directory."""
+
+    name = ENGINE
+    priority = 50
+
+    def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+        run_dir = Path(run_dir)
+        if not run_dir.is_dir():
+            return None
+
+        metadata_dir = run_dir / _METADATA_DIR
+        snakefile = _first_existing(run_dir, _SNAKEFILES)
+        # Recognition rests on the two signals unique to Snakemake. A bare
+        # `config.yaml` is far too common to identify an engine on its own, so
+        # it contributes identity but never recognition.
+        if not metadata_dir.is_dir() and snakefile is None:
+            return None
+
+        config_path = _first_existing(run_dir, _CONFIG_FILES)
+        config = _load_config(config_path)
+
+        pipeline_name: str | None = None
+        for key in _NAME_KEYS:
+            value = config.get(key)
+            if isinstance(value, str) and value.strip():
+                pipeline_name = value.strip()
+                break
+        if pipeline_name is None:
+            pipeline_name = run_dir.resolve().name or None
+
+        version = config.get("version")
+        pipeline_version = str(version).strip() if version not in (None, "") else None
+
+        tools = _tools_from_conda_envs(metadata_dir) if metadata_dir.is_dir() else set()
+
+        extra: dict[str, Any] = {}
+        if config_path is not None:
+            extra["config_path"] = str(config_path)
+        if snakefile is not None:
+            extra["snakefile_path"] = str(snakefile)
+
+        return WorkflowRunInfo(
+            engine=ENGINE,
+            pipeline_name=pipeline_name,
+            pipeline_version=pipeline_version,
+            tools_executed=tools,
+            extra=extra,
+        )
+
+
+register_run_info_reader(SnakemakeRunInfoReader())

--- a/depictio/models/models/workflows.py
+++ b/depictio/models/models/workflows.py
@@ -71,6 +71,15 @@ class WorkflowConfig(MongoModel):
     version: str | None = None
     workflow_parameters: dict | None = None
 
+    # Per-run provenance, filled from `depictio.models.models.run_info` when the
+    # ingested directory identifies the engine that produced it. All optional and
+    # defaulted: configs written before provenance existed still validate, and a
+    # run whose engine left no breadcrumbs simply leaves them unset.
+    engine_name: str | None = None
+    pipeline_version: str | None = None
+    nextflow_version: str | None = None
+    tools_executed: list[str] | None = None
+
 
 class WorkflowRunScan(BaseModel):
     stats: dict[str, int]

--- a/depictio/tests/cli/commands/test_run_attach_flow.py
+++ b/depictio/tests/cli/commands/test_run_attach_flow.py
@@ -45,6 +45,22 @@ def data_root(tmp_path):
     return root
 
 
+@pytest.fixture
+def nextflow_run_dir(tmp_path):
+    """A run directory carrying the provenance nf-core writes on completion."""
+    root = tmp_path / "run_nf"
+    info = root / "pipeline_info"
+    info.mkdir(parents=True)
+    (info / "software_versions.yml").write_text(
+        "FASTQC:\n  fastqc: 0.12.1\n"
+        "CUTADAPT_BASIC:\n  cutadapt: 5.2\n"
+        "Workflow:\n"
+        "    nf-core/ampliseq: v2.16.0-g3d5c7e5\n"
+        "    Nextflow: 25.10.2\n"
+    )
+    return root
+
+
 def _project(locations: list[str]) -> Project:
     return Project.model_validate(
         {
@@ -112,7 +128,7 @@ class _Harness:
     def patches(self):
         template_meta = MagicMock()
         template_meta.template_id = "nf-core/ampliseq/2.16.0"
-        resolve = MagicMock(
+        resolve = getattr(self, "resolve", None) or MagicMock(
             return_value=({"name": self.project.name, "workflows": []}, template_meta, {}, [], {})
         )
         validate = MagicMock(
@@ -211,3 +227,67 @@ class TestAttachRunFlags:
         assert "--update-config" in normalized
         assert "--attach-run" in normalized
         harness.scan.assert_not_called()
+
+
+class TestProvenanceStamping:
+    """The run's provenance must be read from the directory however the template
+    was chosen. It lives only there: no manifest string carries the engine
+    version or the tool list."""
+
+    def _resolved_workflow(self, app, runner, harness, root, flags):
+        with_patches = harness.patches()
+        for patch_ctx in with_patches:
+            patch_ctx.start()
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "--data-root",
+                    str(root),
+                    "--skip-server-check",
+                    "--skip-s3-check",
+                    *flags,
+                ],
+            )
+        finally:
+            for patch_ctx in with_patches:
+                patch_ctx.stop()
+        return result
+
+    @pytest.fixture
+    def harness(self, nextflow_run_dir):
+        harness = _Harness(nextflow_run_dir, remote_locations=[])
+        template_meta = MagicMock()
+        template_meta.template_id = "nf-core/ampliseq/2.16.0"
+        # A single workflow dict, so the stamping has somewhere to land.
+        harness.resolved_config = {
+            "name": harness.project.name,
+            "workflows": [{"name": "ampliseq", "config": {}}],
+        }
+        harness.resolve = MagicMock(
+            return_value=(harness.resolved_config, template_meta, {}, [], {})
+        )
+        return harness
+
+    @pytest.mark.parametrize(
+        "flags",
+        [
+            pytest.param(["--template", "nf-core/ampliseq/2.16.0"], id="explicit-template"),
+            pytest.param(
+                ["--nextflow-manifest", "nf-core/ampliseq/2.16.0"], id="nextflow-manifest"
+            ),
+            pytest.param([], id="auto-detected"),
+        ],
+    )
+    def test_provenance_is_stamped_however_the_template_was_chosen(
+        self, app, runner, harness, nextflow_run_dir, flags
+    ):
+        result = self._resolved_workflow(app, runner, harness, nextflow_run_dir, flags)
+        assert result.exit_code == 0, result.output
+
+        config = harness.resolved_config["workflows"][0]["config"]
+        assert config["engine_name"] == "nextflow"
+        # `v2.16.0-g3d5c7e5` normalised, git-describe suffix dropped.
+        assert config["pipeline_version"] == "2.16.0"
+        assert config["nextflow_version"] == "25.10.2"
+        assert config["tools_executed"] == ["cutadapt", "fastqc"]

--- a/depictio/tests/cli/utils/test_template_detection.py
+++ b/depictio/tests/cli/utils/test_template_detection.py
@@ -1,0 +1,184 @@
+"""Auto-selecting a bundled template from a results directory.
+
+Most tests point ``_projects_roots`` at a synthetic ``projects/`` tree so the
+version-fallback policy is asserted against a fixed set of shipped versions
+rather than whatever the repo happens to ship today. One test deliberately runs
+against the real bundled reference directory.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from depictio.cli.cli.utils import templates as templates_module
+from depictio.cli.cli.utils.templates import detect_template_from_run_dir
+
+# Versions the synthetic projects tree ships. 2.15.0 sits between two of them
+# and 2.8.0 is older than all of them, which is what the fallback policy turns on.
+SHIPPED_VERSIONS = ("2.14.0", "2.16.0", "2.18.0")
+
+REPO_REFERENCE_DIR = (
+    Path(__file__).resolve().parents[4] / "depictio" / "projects" / "nf-core" / "ampliseq"
+)
+
+
+def _versions_yaml(raw_version: str, pipeline: str = "nf-core/ampliseq") -> str:
+    # 4-space `Workflow:` indent, as real nf-core output uses.
+    return f"FASTQC:\n  fastqc: 0.12.1\nWorkflow:\n    {pipeline}: {raw_version}\n    Nextflow: 25.10.0\n"
+
+
+@pytest.fixture
+def shipped_templates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A synthetic ``projects/`` root shipping nf-core/ampliseq 2.14.0/2.16.0/2.18.0."""
+    projects = tmp_path / "projects"
+    for version in SHIPPED_VERSIONS:
+        version_dir = projects / "nf-core" / "ampliseq" / version
+        version_dir.mkdir(parents=True)
+        (version_dir / "template.yaml").write_text(
+            f"template:\n  template_id: nf-core/ampliseq/{version}\n  version: '{version}'\n"
+        )
+    monkeypatch.setattr(templates_module, "_projects_roots", lambda: [projects])
+    return projects
+
+
+def _nextflow_run(root: Path, raw_version: str, pipeline: str = "nf-core/ampliseq") -> Path:
+    pipeline_info = root / "pipeline_info"
+    pipeline_info.mkdir(parents=True)
+    (pipeline_info / "software_versions.yml").write_text(_versions_yaml(raw_version, pipeline))
+    (pipeline_info / "params.json").write_text('{"input": "samplesheet.csv"}')
+    return root
+
+
+class TestExactMatch:
+    def test_exact_version_selects_that_template(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        run = _nextflow_run(tmp_path / "run", "v2.16.0-g3d5c7e5")
+        template_id, info = detect_template_from_run_dir(run)
+        assert template_id == "nf-core/ampliseq/2.16.0"
+        assert info is not None
+        assert info.pipeline_name == "nf-core/ampliseq"
+        assert info.pipeline_version == "2.16.0"
+        assert info.extra["pipeline_version_raw"] == "v2.16.0-g3d5c7e5"
+
+    def test_plain_version_string_matches_too(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        run = _nextflow_run(tmp_path / "run", "2.18.0")
+        template_id, _ = detect_template_from_run_dir(run)
+        assert template_id == "nf-core/ampliseq/2.18.0"
+
+
+class TestVersionFallback:
+    def test_picks_highest_version_not_newer_than_the_run(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        """A 2.15.0 run falls back to 2.14.0, not to 2.16.0."""
+        run = _nextflow_run(tmp_path / "run", "v2.15.0-gabc1234")
+        template_id, info = detect_template_from_run_dir(run)
+        assert template_id == "nf-core/ampliseq/2.14.0"
+        assert info is not None
+        assert info.pipeline_version == "2.15.0"
+
+    def test_run_older_than_every_template_picks_the_lowest(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        """The #811 regression: an old run must NOT be handed the newest template.
+
+        A newer template describes outputs the older run never produced, so the
+        lowest shipped version is the only defensible substitute.
+        """
+        run = _nextflow_run(tmp_path / "run", "2.8.0")
+        template_id, _ = detect_template_from_run_dir(run)
+        assert template_id == "nf-core/ampliseq/2.14.0"
+        assert template_id != "nf-core/ampliseq/2.18.0"
+
+    def test_run_newer_than_every_template_picks_the_highest(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        run = _nextflow_run(tmp_path / "run", "v2.20.0-gdeadbee")
+        template_id, _ = detect_template_from_run_dir(run)
+        assert template_id == "nf-core/ampliseq/2.18.0"
+
+    def test_dev_suffix_normalises_before_comparison(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        run = _nextflow_run(tmp_path / "run", "v2.13.0dev-ge7bcfda")
+        template_id, info = detect_template_from_run_dir(run)
+        assert info is not None
+        assert info.pipeline_version == "2.13.0"
+        assert template_id == "nf-core/ampliseq/2.14.0"  # lowest: run predates them all
+
+
+class TestNoSelection:
+    def test_unknown_pipeline_returns_none_with_info(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        run = _nextflow_run(tmp_path / "run", "1.2.3", pipeline="nf-core/nowhere")
+        template_id, info = detect_template_from_run_dir(run)
+        assert template_id is None
+        assert info is not None
+        assert info.pipeline_name == "nf-core/nowhere"
+        assert info.engine == "nextflow"
+
+    def test_empty_directory_returns_none_none(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert detect_template_from_run_dir(empty) == (None, None)
+
+    def test_recognised_run_without_pipeline_identity(
+        self, tmp_path: Path, shipped_templates: Path
+    ) -> None:
+        run = tmp_path / "legacy"
+        pipeline_info = run / "pipeline_info"
+        pipeline_info.mkdir(parents=True)
+        (pipeline_info / "software_versions.yml").write_text("FASTQC:\n  fastqc: 0.12.1\n")
+        template_id, info = detect_template_from_run_dir(run)
+        assert template_id is None
+        assert info is not None
+        assert info.pipeline_name is None
+        assert info.tools_executed == {"fastqc"}
+
+
+class TestBundledReferenceDirectory:
+    """Against the real reference run shipped in the repo, not a fixture."""
+
+    @staticmethod
+    def _reference_run() -> Path:
+        from depictio.cli.cli.utils.templates import latest_template_version
+
+        version = latest_template_version(REPO_REFERENCE_DIR)
+        if version is None:
+            pytest.skip(f"No bundled ampliseq template under {REPO_REFERENCE_DIR}")
+        run_dir = REPO_REFERENCE_DIR / version
+        if not (run_dir / "pipeline_info").is_dir():
+            pytest.skip(f"Bundled reference run has no pipeline_info/: {run_dir}")
+        return run_dir
+
+    def test_detection_on_the_bundled_reference_run(self) -> None:
+        run_dir = self._reference_run()
+        template_id, info = detect_template_from_run_dir(run_dir)
+
+        # Whatever the reference ships, detection must never raise and must
+        # never invent a template that is not on disk.
+        assert info is not None
+        assert info.engine == "nextflow"
+        if info.pipeline_name is None:
+            # Degrades cleanly when the bundled versions YAML carries no
+            # `Workflow:` identity section.
+            assert template_id is None
+            return
+
+        assert info.pipeline_name == "nf-core/ampliseq"
+        assert template_id is not None
+        from depictio.cli.cli.utils.templates import locate_template
+
+        assert locate_template(template_id).is_file()
+
+    def test_bundled_reference_run_reports_tools(self) -> None:
+        run_dir = self._reference_run()
+        _, info = detect_template_from_run_dir(run_dir)
+        assert info is not None
+        assert info.tools_executed, "reference software_versions.yml should list tools"

--- a/depictio/tests/models/test_nextflow_run_info.py
+++ b/depictio/tests/models/test_nextflow_run_info.py
@@ -1,0 +1,251 @@
+"""Nextflow/nf-core run-provenance connector.
+
+The fixtures reproduce, byte-for-byte where it matters, shapes observed in real
+nf-core output on disk: the 4-space-indented ``Workflow:`` section some template
+generations emit, the plain ``software_versions.yml`` filename, and the four
+distinct version strings the same pipeline reports depending on how it was
+checked out.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from depictio.models.models.nextflow import NextflowRunInfoReader, normalize_pipeline_version
+
+# Real shape: `Workflow:` indented 4 spaces, plain `software_versions.yml`.
+# (~/Data/ampliseq/megatest-full/pipeline_info/software_versions.yml)
+VERSIONS_YAML_4_SPACE = """\
+BARRNAP:
+  barrnap: 0.9
+CUTADAPT_BASIC:
+  cutadapt: 4.6
+DADA2_DENOISING:
+  R: 4.3.2
+  dada2: 1.30.0
+Workflow:
+    nf-core/ampliseq: v2.13.0dev-ge7bcfda
+    Nextflow: 24.04.2
+"""
+
+# Real shape: `Workflow:` indented 2 spaces, Nextflow listed first.
+# (~/Data/ampliseq/testdata/nf-core-ampliseq-202411281303/pipeline_info/software_versions.yml)
+VERSIONS_YAML_2_SPACE = """\
+FASTQC:
+  fastqc: 0.12.1
+Workflow:
+  Nextflow: 23.10.1
+  nf-core/ampliseq: 2.8.0
+"""
+
+# Legacy shape: process sections only, no identity at all.
+VERSIONS_YAML_NO_WORKFLOW = """\
+FASTQC:
+  fastqc: 0.12.1
+MULTIQC:
+  multiqc: 1.21
+"""
+
+NEXTFLOW_CONFIG = """\
+manifest {
+    name            = 'nf-core/ampliseq'
+    author          = 'Someone'
+    homePage        = 'https://github.com/nf-core/ampliseq'
+    description     = 'Amplicon sequencing analysis workflow'
+    mainScript      = 'main.nf'
+    nextflowVersion = '!>=25.04.3'
+    version         = '2.16.0'
+}
+"""
+
+
+def _reader() -> NextflowRunInfoReader:
+    return NextflowRunInfoReader()
+
+
+def _pipeline_info(root: Path) -> Path:
+    pipeline_info = root / "pipeline_info"
+    pipeline_info.mkdir(parents=True, exist_ok=True)
+    return pipeline_info
+
+
+class TestNormalizePipelineVersion:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # Every one of these was read off a real run directory.
+            ("v2.16.0-g3d5c7e5", "2.16.0"),
+            ("v2.13.0dev-ge7bcfda", "2.13.0"),
+            ("v2.13.0dev", "2.13.0"),
+            ("2.8.0", "2.8.0"),
+            # Shapes the same rules must not mangle.
+            ("v3.0.0", "3.0.0"),
+            ("2.16.0", "2.16.0"),
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_normalises_to_a_comparable_release(
+        self, raw: str | None, expected: str | None
+    ) -> None:
+        assert normalize_pipeline_version(raw) == expected
+
+    def test_non_hex_suffix_is_not_a_git_sha(self) -> None:
+        """`-g<sha>` stripping must not eat a legitimate pre-release suffix."""
+        assert normalize_pipeline_version("v3.0.0-gamma") == "3.0.0-gamma"
+
+
+class TestFullPipelineInfoParse:
+    def test_reads_identity_tools_and_artefact_paths(self, tmp_path: Path) -> None:
+        run = tmp_path / "run_16s_pe"
+        pipeline_info = _pipeline_info(run)
+        (pipeline_info / "software_versions.yml").write_text(VERSIONS_YAML_4_SPACE)
+        (pipeline_info / "params_2026-06-11_16-37-38.json").write_text('{"skip_qiime": false}')
+        (pipeline_info / "params_2026-06-12_07-20-45.json").write_text(
+            '{"skip_qiime": true, "run_name": "grave_curie"}'
+        )
+        (pipeline_info / "execution_report_2026-06-12_07-20-35.html").write_text("<html/>")
+        (pipeline_info / "execution_trace_2026-06-12_07-20-35.txt").write_text("task_id\n")
+        (pipeline_info / "pipeline_dag_2026-06-12_07-20-35.html").write_text("<html/>")
+
+        info = _reader().read(run)
+        assert info is not None
+        assert info.engine == "nextflow"
+        assert info.pipeline_name == "nf-core/ampliseq"
+        assert info.short_name == "ampliseq"
+        assert info.pipeline_version == "2.13.0"
+        assert info.extra["pipeline_version_raw"] == "v2.13.0dev-ge7bcfda"
+        assert info.engine_version == "24.04.2"
+        assert info.tools_executed == {"barrnap", "cutadapt", "r", "dada2"}
+        # Newest params file by name wins (nf-core writes one per resume).
+        assert info.params["skip_qiime"] is True
+        assert info.run_name == "grave_curie"
+        assert info.params_json_path is not None
+        assert info.params_json_path.endswith("params_2026-06-12_07-20-45.json")
+        assert info.software_versions_path is not None
+        assert info.execution_report_path is not None
+        assert info.execution_trace_path is not None
+        assert info.pipeline_dag_path is not None
+        assert info.template_ids()[0] == "nf-core/ampliseq/2.13.0"
+
+
+class TestVersionsFileNameShapes:
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "software_versions.yml",
+            "nf_core_ampliseq_software_mqc_versions.yml",
+            "ampliseq_software_mqc_versions.yml",
+        ],
+    )
+    def test_identity_read_from_every_shipped_filename(self, tmp_path: Path, filename: str) -> None:
+        run = tmp_path / "run"
+        (_pipeline_info(run) / filename).write_text(VERSIONS_YAML_4_SPACE)
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name == "nf-core/ampliseq"
+        assert info.pipeline_version == "2.13.0"
+
+    def test_plain_software_versions_with_four_space_indent(self, tmp_path: Path) -> None:
+        """The exact real-world combination a regex-based parser would miss."""
+        run = tmp_path / "megatest-full"
+        (_pipeline_info(run) / "software_versions.yml").write_text(VERSIONS_YAML_4_SPACE)
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name == "nf-core/ampliseq"
+        assert info.engine_version == "24.04.2"
+
+    def test_two_space_indent_with_nextflow_listed_first(self, tmp_path: Path) -> None:
+        run = tmp_path / "testdata-run"
+        (_pipeline_info(run) / "software_versions.yml").write_text(VERSIONS_YAML_2_SPACE)
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name == "nf-core/ampliseq"
+        assert info.pipeline_version == "2.8.0"
+        assert info.engine_version == "23.10.1"
+
+
+class TestParamsFileShapes:
+    @pytest.mark.parametrize("filename", ["params.json", "nf-params.json", "nf_params.json"])
+    def test_reads_every_params_filename(self, tmp_path: Path, filename: str) -> None:
+        run = tmp_path / "run"
+        pipeline_info = _pipeline_info(run)
+        (pipeline_info / "software_versions.yml").write_text(VERSIONS_YAML_2_SPACE)
+        (pipeline_info / filename).write_text('{"input": "samplesheet.csv"}')
+        info = _reader().read(run)
+        assert info is not None
+        assert info.params == {"input": "samplesheet.csv"}
+
+    def test_unparseable_params_do_not_abort_detection(self, tmp_path: Path) -> None:
+        run = tmp_path / "run"
+        pipeline_info = _pipeline_info(run)
+        (pipeline_info / "software_versions.yml").write_text(VERSIONS_YAML_2_SPACE)
+        (pipeline_info / "params.json").write_text("{not json")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.params == {}
+        assert info.pipeline_name == "nf-core/ampliseq"
+
+
+class TestTolerance:
+    def test_empty_directory_returns_none(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert _reader().read(empty) is None
+
+    def test_empty_pipeline_info_returns_none(self, tmp_path: Path) -> None:
+        run = tmp_path / "run"
+        _pipeline_info(run)
+        assert _reader().read(run) is None
+
+    def test_nonexistent_path_returns_none(self, tmp_path: Path) -> None:
+        assert _reader().read(tmp_path / "does-not-exist") is None
+
+    def test_legacy_versions_without_workflow_section_yields_tools_only(
+        self, tmp_path: Path
+    ) -> None:
+        run = tmp_path / "legacy"
+        (_pipeline_info(run) / "software_versions.yml").write_text(VERSIONS_YAML_NO_WORKFLOW)
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name is None
+        assert info.pipeline_version is None
+        assert info.tools_executed == {"fastqc", "multiqc"}
+        assert info.template_ids() == []
+
+    def test_malformed_versions_yaml_does_not_raise(self, tmp_path: Path) -> None:
+        run = tmp_path / "broken"
+        pipeline_info = _pipeline_info(run)
+        (pipeline_info / "software_versions.yml").write_text("::: not: [valid: yaml")
+        (pipeline_info / "params.json").write_text("{}")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name is None
+
+
+class TestNextflowConfigFallback:
+    def test_manifest_supplies_identity_when_no_versions_file(self, tmp_path: Path) -> None:
+        checkout = tmp_path / "ampliseq-checkout"
+        checkout.mkdir()
+        (checkout / "nextflow.config").write_text(NEXTFLOW_CONFIG)
+        info = _reader().read(checkout)
+        assert info is not None
+        assert info.pipeline_name == "nf-core/ampliseq"
+        assert info.pipeline_version == "2.16.0"
+        assert info.homepage == "https://github.com/nf-core/ampliseq"
+        # `nextflowVersion` is a constraint (`!>=25.04.3`), never a runtime version.
+        assert info.engine_version is None
+
+    def test_versions_file_wins_over_the_manifest(self, tmp_path: Path) -> None:
+        run = tmp_path / "run"
+        (_pipeline_info(run) / "software_versions.yml").write_text(VERSIONS_YAML_2_SPACE)
+        (run / "nextflow.config").write_text(NEXTFLOW_CONFIG)
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_version == "2.8.0"
+
+    def test_config_without_manifest_block_is_not_a_signal(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        (plain / "nextflow.config").write_text("process {\n    cpus = 2\n}\n")
+        assert _reader().read(plain) is None

--- a/depictio/tests/models/test_run_info_dispatch.py
+++ b/depictio/tests/models/test_run_info_dispatch.py
@@ -1,0 +1,157 @@
+"""Registry/dispatch tests for the engine-agnostic run-provenance layer.
+
+Covers the part that is engine-independent: which connectors are registered,
+which one a given directory dispatches to, and that registration is idempotent.
+Engine-specific parsing lives in ``test_nextflow_run_info.py`` /
+``test_snakemake_run_info.py``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from depictio.models.models.run_info import (
+    WorkflowRunInfo,
+    read_run_info,
+    register_run_info_reader,
+    registered_readers,
+)
+
+# A minimal but realistic nf-core versions YAML: process sections plus the
+# `Workflow:` identity section.
+NEXTFLOW_VERSIONS_YAML = """\
+FASTQC:
+  fastqc: 0.12.1
+Workflow:
+    nf-core/ampliseq: v2.16.0-g3d5c7e5
+    Nextflow: 25.10.0
+"""
+
+
+def _make_nextflow_run(root: Path) -> Path:
+    pipeline_info = root / "pipeline_info"
+    pipeline_info.mkdir(parents=True)
+    (pipeline_info / "software_versions.yml").write_text(NEXTFLOW_VERSIONS_YAML)
+    return root
+
+
+def _make_snakemake_run(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "Snakefile").write_text('rule all:\n    input: "done.txt"\n')
+    (root / ".snakemake").mkdir()
+    return root
+
+
+class TestRegistry:
+    def test_both_bundled_connectors_are_registered(self) -> None:
+        names = [reader.name for reader in registered_readers()]
+        assert "nextflow" in names
+        assert "snakemake" in names
+
+    def test_readers_are_ordered_by_descending_priority(self) -> None:
+        priorities = [reader.priority for reader in registered_readers()]
+        assert priorities == sorted(priorities, reverse=True)
+
+    def test_registration_is_idempotent_by_name(self) -> None:
+        before = len(registered_readers())
+
+        class _Stub:
+            name = "stub-engine"
+            priority = 1
+
+            def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+                return None
+
+        register_run_info_reader(_Stub())
+        register_run_info_reader(_Stub())
+        names = [reader.name for reader in registered_readers()]
+        assert names.count("stub-engine") == 1
+        assert len(names) == before + 1
+
+
+class TestDispatch:
+    def test_dispatches_to_nextflow(self, tmp_path: Path) -> None:
+        info = read_run_info(_make_nextflow_run(tmp_path / "run"))
+        assert info is not None
+        assert info.engine == "nextflow"
+        assert info.pipeline_name == "nf-core/ampliseq"
+
+    def test_dispatches_to_snakemake(self, tmp_path: Path) -> None:
+        info = read_run_info(_make_snakemake_run(tmp_path / "my_pipeline"))
+        assert info is not None
+        assert info.engine == "snakemake"
+
+    def test_nextflow_wins_when_both_footprints_present(self, tmp_path: Path) -> None:
+        """Higher priority resolves a directory carrying two engines' footprints."""
+        run = tmp_path / "mixed"
+        _make_snakemake_run(run)
+        _make_nextflow_run(run)
+        info = read_run_info(run)
+        assert info is not None
+        assert info.engine == "nextflow"
+
+    def test_unknown_directory_returns_none(self, tmp_path: Path) -> None:
+        plain = tmp_path / "just-results"
+        plain.mkdir()
+        (plain / "results.csv").write_text("a,b\n1,2\n")
+        assert read_run_info(plain) is None
+
+    def test_failing_reader_does_not_break_the_others(self, tmp_path: Path) -> None:
+        class _Exploding:
+            name = "exploding-engine"
+            priority = 1000  # ahead of every bundled connector
+
+            def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+                raise RuntimeError("boom")
+
+        register_run_info_reader(_Exploding())
+        try:
+            info = read_run_info(_make_nextflow_run(tmp_path / "run"))
+            assert info is not None
+            assert info.engine == "nextflow"
+        finally:
+            # Restore the registry for the rest of the session.
+            class _Inert:
+                name = "exploding-engine"
+                priority = -1
+
+                def read(self, run_dir: Path) -> WorkflowRunInfo | None:
+                    return None
+
+            register_run_info_reader(_Inert())
+
+
+class TestWorkflowRunInfo:
+    def test_short_name_strips_the_namespace(self) -> None:
+        assert WorkflowRunInfo(pipeline_name="nf-core/ampliseq").short_name == "ampliseq"
+        assert WorkflowRunInfo(pipeline_name="ampliseq").short_name == "ampliseq"
+        assert WorkflowRunInfo().short_name is None
+
+    def test_template_ids_normalised_then_raw(self) -> None:
+        info = WorkflowRunInfo(
+            pipeline_name="nf-core/ampliseq",
+            pipeline_version="2.16.0",
+            extra={"pipeline_version_raw": "v2.16.0-g3d5c7e5"},
+        )
+        assert info.template_ids() == [
+            "nf-core/ampliseq/2.16.0",
+            "nf-core/ampliseq/v2.16.0-g3d5c7e5",
+        ]
+
+    def test_template_ids_deduplicates_identical_raw(self) -> None:
+        info = WorkflowRunInfo(
+            pipeline_name="nf-core/ampliseq",
+            pipeline_version="2.8.0",
+            extra={"pipeline_version_raw": "2.8.0"},
+        )
+        assert info.template_ids() == ["nf-core/ampliseq/2.8.0"]
+
+    def test_template_ids_empty_without_identity(self) -> None:
+        assert WorkflowRunInfo().template_ids() == []
+        # A pipeline with no version yields no id: the version-less id would
+        # resolve to the latest template, which is never a safe default.
+        assert WorkflowRunInfo(pipeline_name="nf-core/ampliseq").template_ids() == []
+
+    def test_model_forbids_extra_fields(self) -> None:
+        with pytest.raises(Exception):
+            WorkflowRunInfo(unexpected_field="x")  # type: ignore[call-arg]

--- a/depictio/tests/models/test_snakemake_run_info.py
+++ b/depictio/tests/models/test_snakemake_run_info.py
@@ -1,0 +1,137 @@
+"""Snakemake run-provenance connector."""
+
+from pathlib import Path
+
+from depictio.models.models.snakemake import SnakemakeRunInfoReader
+
+CONDA_ENV_YAML = """\
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fastqc=0.12.1
+  - samtools=1.19
+  - python
+  - pip:
+      - some-python-package==1.0
+"""
+
+
+def _reader() -> SnakemakeRunInfoReader:
+    return SnakemakeRunInfoReader()
+
+
+def _snakemake_project(root: Path, *, snakefile: str = "Snakefile") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / snakefile
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('rule all:\n    input: "done.txt"\n')
+    return root
+
+
+class TestIdentity:
+    def test_config_pipeline_key_names_the_workflow(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "results")
+        (run / "config.yaml").write_text("pipeline: my-lab/rnaseq\nversion: 1.4.2\n")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.engine == "snakemake"
+        assert info.pipeline_name == "my-lab/rnaseq"
+        assert info.short_name == "rnaseq"
+        assert info.pipeline_version == "1.4.2"
+        assert info.template_ids() == ["my-lab/rnaseq/1.4.2"]
+        assert info.extra["config_path"].endswith("config.yaml")
+
+    def test_name_and_workflow_keys_are_accepted(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "by-name")
+        (run / "config.yml").write_text("name: assembly\n")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name == "assembly"
+
+        other = _snakemake_project(tmp_path / "by-workflow")
+        (other / "config" / "config.yaml").parent.mkdir(parents=True, exist_ok=True)
+        (other / "config" / "config.yaml").write_text("workflow: variant-calling\n")
+        info = _reader().read(other)
+        assert info is not None
+        assert info.pipeline_name == "variant-calling"
+
+    def test_directory_name_is_the_fallback_identity(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "chipseq-analysis")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name == "chipseq-analysis"
+        assert info.pipeline_version is None
+        # Without a version there is no template id to offer.
+        assert info.template_ids() == []
+
+
+class TestRecognition:
+    def test_snakefile_only_is_recognised(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "flat")
+        assert _reader().read(run) is not None
+
+    def test_workflow_snakefile_layout_is_recognised(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "nested", snakefile="workflow/Snakefile")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.extra["snakefile_path"].endswith("workflow/Snakefile")
+
+    def test_metadata_dir_alone_is_recognised(self, tmp_path: Path) -> None:
+        run = tmp_path / "results-only"
+        (run / ".snakemake").mkdir(parents=True)
+        assert _reader().read(run) is not None
+
+    def test_non_snakemake_directory_returns_none(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        (plain / "results.csv").write_text("a,b\n1,2\n")
+        assert _reader().read(plain) is None
+
+    def test_config_alone_is_not_enough(self, tmp_path: Path) -> None:
+        """A bare config.yaml is far too common to identify an engine."""
+        plain = tmp_path / "some-project"
+        plain.mkdir()
+        (plain / "config.yaml").write_text("pipeline: not-snakemake\n")
+        assert _reader().read(plain) is None
+
+    def test_nonexistent_path_returns_none(self, tmp_path: Path) -> None:
+        assert _reader().read(tmp_path / "missing") is None
+
+
+class TestCondaTools:
+    def test_tools_extracted_from_materialised_conda_envs(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "with-conda")
+        conda = run / ".snakemake" / "conda"
+        conda.mkdir(parents=True)
+        (conda / "a1b2c3.yaml").write_text(CONDA_ENV_YAML)
+        (conda / "d4e5f6.yaml").write_text("dependencies:\n  - bioconda::MultiQC=1.21\n")
+        info = _reader().read(run)
+        assert info is not None
+        # Channel prefixes and version pins stripped, names lowercased; the
+        # nested `pip:` mapping is skipped.
+        assert info.tools_executed == {"fastqc", "samtools", "python", "multiqc"}
+
+    def test_no_conda_envs_yields_no_tools(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "no-conda")
+        (run / ".snakemake").mkdir()
+        info = _reader().read(run)
+        assert info is not None
+        assert info.tools_executed == set()
+
+    def test_unparseable_conda_env_is_skipped(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "broken-conda")
+        conda = run / ".snakemake" / "conda"
+        conda.mkdir(parents=True)
+        (conda / "broken.yaml").write_text("::: [not: yaml")
+        (conda / "ok.yaml").write_text("dependencies:\n  - bwa=0.7.17\n")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.tools_executed == {"bwa"}
+
+    def test_unparseable_config_does_not_abort(self, tmp_path: Path) -> None:
+        run = _snakemake_project(tmp_path / "broken-config")
+        (run / "config.yaml").write_text("::: [not: yaml")
+        info = _reader().read(run)
+        assert info is not None
+        assert info.pipeline_name == "broken-config"


### PR DESCRIPTION
## Why

A pipeline that triggers Depictio itself should not have to be told what it is. Its output directory already carries the answer: nf-core writes `pipeline_info/` with `software_versions.yml`, and the equivalent exists for other engines.

This adds an engine-agnostic layer that reads a run directory and reports which pipeline produced it, so `depictio-cli run --data-root <dir>` with no other flag can resolve a bundled template on its own. It is the fallback for the trigger's `--nextflow-manifest` (renamed `--pipeline-id` in #1037, since the value is engine-neutral) when the manifest cannot be forwarded: an older Nextflow, a hand-run CLI, or an engine that is not Nextflow at all.

## What is in here

`depictio/models/models/run_info.py` defines `WorkflowRunInfo` (engine, pipeline name and version, engine version, params, tools executed, artefact paths) and a `RunInfoReader` protocol with a priority-ordered registry. `read_run_info` dispatches to the highest-priority reader that recognises the directory, importing connectors lazily.

Two connectors ship: `nextflow.py` (priority 100) and `snakemake.py` (priority 50). Snakemake is the reference shape for adding Galaxy or CWL later; the point of the registry is that a new engine is a new file, not a change to the dispatcher.

`detect_template_from_run_dir` in `templates.py` maps the detected identity onto a bundled template, reusing the existing `latest_template_version` and `_resolve_template_id_in` rather than reimplementing version resolution.

`WorkflowConfig` gains optional `engine_name`, `pipeline_version`, `nextflow_version` and `tools_executed`, and `run.py` stamps them, so a project records the provenance of what was ingested.

## Version handling

Real run directories do not carry clean versions, so the matching is deliberate about three cases:

- Real versions look like `v2.16.0-g3d5c7e5` and `v2.13.0dev-ge7bcfda`. Stripping the leading `v` alone leaves the git sha's digits polluting the sort key, so the trailing `-g<sha>` and `dev` are removed before comparing.
- A run older than every shipped template (ampliseq `2.8.0` against 2.14.0 / 2.16.0 / 2.18.0) takes the **lowest** shipped template, not the highest.
- Otherwise the highest shipped template less than or equal to the run's version.

The `Workflow:` section is parsed from `software_versions.yml` as well as from `nf_core_*_software_mqc_versions.yml`. Reading only the latter loses the pipeline's identity on real megatest output.

## Provenance is read independently of template selection

Worth calling out because a review pass caught it here: reading the run directory and *choosing a template from it* are two jobs, and folding them together broke the main path. The trigger forwards `--nextflow-manifest`, which resolves a template before the directory is ever read, so gating the read on "no template chosen yet" left every pipeline-triggered project with empty provenance. The engine version and the tool list exist nowhere but the run directory, so the read now happens whenever there is a directory, and only the template *selection* is gated. `select_template_for_run` is split out of `detect_template_from_run_dir` for that.

The regression test is parameterised over all three ways a template gets chosen (explicit `--template`, `--nextflow-manifest`, auto-detection); the first two fail without the fix.

## Verification

Unit tests in `test_run_info_dispatch.py`, `test_nextflow_run_info.py`, `test_snakemake_run_info.py` and `test_template_detection.py`, with a case per row above.

Run against six real ampliseq output directories, five of them outside the repo:

| Directory | Detected | Template chosen |
| --- | --- | --- |
| `depictio-nfcore/ampliseq/2.16.0/run_16s_pe` | 2.16.0, nextflow 25.10.0, 14 tools | `nf-core/ampliseq/2.16.0` |
| `ampliseq/megatest-full` | 2.13.0 (from `v2.13.0dev-ge7bcfda`), nextflow 24.04.2 | `nf-core/ampliseq/2.14.0` |
| `depictio-nfcore/ampliseq/2.16.0/run_16s_multi` | 2.16.0, 4 tools (partial run) | `nf-core/ampliseq/2.16.0` |
| `ampliseq/testdata/nf-core-ampliseq-202411281303` | 2.8.0, nextflow 23.10.1 | `nf-core/ampliseq/2.14.0`, the lowest shipped |
| `ampliseq/TREC/ampliseq-results` | 2.13.0, nextflow 24.10.4 | `nf-core/ampliseq/2.14.0` |
| `depictio/projects/nf-core/ampliseq/2.16.0` | 2.16.0, nextflow 25.10.2 | `nf-core/ampliseq/2.16.0` |

`uv run ty check depictio/models/` passes with zero errors; the three new files are inside the gated directory.

## A note on checks

`depictio-ci.yaml` triggers on `pull_request: branches: [main]`, so a PR based on another branch shows no checks. This one gets them once the PR below it merges and its base becomes `main`. In the meantime the stack tip was validated by a `workflow_dispatch` run of the same workflow: https://github.com/depictio/depictio/actions/runs/33919930280

## Stack

Linked as a GitHub stack (#1046). Each layer needs the one below it and nothing above it:

![the three-PR stack](https://raw.githubusercontent.com/depictio/depictio/364931f77b5a9817f3f5e6eda074ae86d09c8f5b/docs/images/v1.4/nextflow/schema_stack.png)

1. #1035 CLI auth, robustness and `--attach-run`
2. #1036 recognising which pipeline produced a run directory  <- this PR
3. #1037 the Nextflow `workflow.onComplete` trigger

This is the connector-registry part of #811, ported rather than rebased. Everything else that PR carried (`latest` resolution, params introspection, provenance collection) is already on main in a richer form, and its `compose.py` is out of scope here.



