### PR TITLE
feat(viewer): let any project manage its data collections from the UI

### DIFF
--- a/depictio/tests/api/v1/endpoints/datacollections_endpoints/test_edit_permission_ignores_project_type.py
+++ b/depictio/tests/api/v1/endpoints/datacollections_endpoints/test_edit_permission_ignores_project_type.py
@@ -1,0 +1,67 @@
+"""Adding data to a project is an editing right, not a project-type privilege.
+
+The viewer used to refuse the create-data-collection form outright for
+`project_type: "advanced"`, telling the user to go and run depictio-cli. The
+backend never agreed: the three creation helpers gate on
+`_user_can_edit_project` and nothing else. Removing that client-side refusal
+makes the two surfaces consistent, and these tests pin the backend half so the
+UI cannot silently break if someone later adds a project-type check here.
+"""
+
+import pytest
+from bson import ObjectId
+
+from depictio.api.v1.endpoints.datacollections_endpoints.utils import _user_can_edit_project
+
+PROJECT_TYPES = ["basic", "advanced"]
+
+
+def _project(project_type: str, *, owners=(), editors=(), viewers=()) -> dict:
+    return {
+        "_id": ObjectId(),
+        "name": "demo",
+        "project_type": project_type,
+        "permissions": {
+            "owners": [{"_id": oid} for oid in owners],
+            "editors": [{"_id": oid} for oid in editors],
+            "viewers": [{"_id": oid} for oid in viewers],
+        },
+    }
+
+
+@pytest.mark.parametrize("project_type", PROJECT_TYPES)
+class TestEditPermissionIgnoresProjectType:
+    def test_an_owner_may_edit(self, project_type):
+        user_id = ObjectId()
+
+        assert _user_can_edit_project(_project(project_type, owners=[user_id]), user_id, False)
+
+    def test_an_editor_may_edit(self, project_type):
+        user_id = ObjectId()
+
+        assert _user_can_edit_project(_project(project_type, editors=[user_id]), user_id, False)
+
+    def test_a_viewer_may_not(self, project_type):
+        user_id = ObjectId()
+
+        assert not _user_can_edit_project(_project(project_type, viewers=[user_id]), user_id, False)
+
+    def test_a_stranger_may_not(self, project_type):
+        assert not _user_can_edit_project(_project(project_type), ObjectId(), False)
+
+    def test_an_admin_may_edit(self, project_type):
+        assert _user_can_edit_project(_project(project_type), ObjectId(), True)
+
+
+def test_the_two_project_types_are_treated_identically():
+    """The point of the whole change, stated once as a single assertion."""
+    user_id = ObjectId()
+
+    decisions = {
+        project_type: _user_can_edit_project(
+            _project(project_type, owners=[user_id]), user_id, False
+        )
+        for project_type in PROJECT_TYPES
+    }
+
+    assert len(set(decisions.values())) == 1, decisions

--- a/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
+++ b/depictio/viewer/src/projects/detail/ProjectDetailApp.tsx
@@ -615,7 +615,6 @@ const ProjectDetailApp: React.FC = () => {
 
       <CreateDataCollectionModal
         opened={createDcOpened}
-        projectType={projectType}
         projectId={projectId}
         onClose={() => setCreateDcOpened(false)}
         onSuccess={() => {
@@ -1068,11 +1067,10 @@ const CoordColumnPickers: React.FC<{
 
 const CreateDataCollectionModal: React.FC<{
   opened: boolean;
-  projectType: 'basic' | 'advanced';
   projectId: string | null;
   onClose: () => void;
   onSuccess: () => void;
-}> = ({ opened, projectType, projectId, onClose, onSuccess }) => {
+}> = ({ opened, projectId, onClose, onSuccess }) => {
   const accent = useBrandAccents();
   const [dcType, setDcType] = useState<'table' | 'multiqc'>('table');
   const [file, setFile] = useState<File | null>(null);
@@ -1268,45 +1266,6 @@ const CreateDataCollectionModal: React.FC<{
         : common[common.length - 1];
     setName(deepest || 'multiqc_reports');
   }, [dcType, multiqcDropzone.files, name]);
-
-  if (projectType === 'advanced') {
-    return (
-      <Modal
-        opened={opened}
-        onClose={onClose}
-        title="Create data collection"
-        centered
-        size="md"
-      >
-        <Stack gap="md">
-          <Group gap="xs">
-            <Icon
-              icon="mdi:database-plus-outline"
-              width={28}
-              color="var(--mantine-color-orange-6)"
-            />
-            <Text fw={500}>Advanced project — use depictio-CLI</Text>
-          </Group>
-          <Alert
-            color="yellow"
-            variant="light"
-            icon={<Icon icon="mdi:information-outline" width={18} />}
-          >
-            <Text size="sm">
-              For advanced (CLI-driven) projects, data collections are added by
-              running <code>depictio-cli</code> against your workflow output —
-              not from this UI.
-            </Text>
-          </Alert>
-          <Group justify="flex-end">
-            <Button variant="default" onClick={onClose}>
-              Got it
-            </Button>
-          </Group>
-        </Stack>
-      </Modal>
-    );
-  }
 
   const handleCheckUniformity = async () => {
     if (multiqcDropzone.files.length < 2) return;


### PR DESCRIPTION
Stacked on #1038. Review that one first.

## The wall was policy, and only in React

Create a project with the CLI and it is stamped `project_type: advanced`. Open it in the
browser and the Create Data Collection modal refuses:

> Advanced project. Use depictio-CLI to manage data collections, not from this UI.

That refusal lives entirely in the frontend, as an early return inside
`CreateDataCollectionModal`. The backend never agreed with it:

- `grep project_type depictio/api/v1/endpoints/datacollections_endpoints/utils.py`
  returns nothing.
- The three creation helpers (`_create_dc_from_upload`, `_create_dc_from_url`,
  `_create_multiqc_dc_from_uploads`) check `_user_can_edit_project` and nothing else.
- `project_type` has exactly one consequence anywhere in the backend,
  `validate_yaml_config_path`, and that validator is dead code: `yaml_config_path` is
  declared before `project_type`, so a pydantic v2 field validator never sees
  `project_type` in `info.data`. It always reads `"basic"` and returns early.

So the API would have accepted a browser upload into a CLI-created project all along.

## The change

Delete the early return, the now-unused `projectType` prop, its destructuring and its
call site. The normal Create-DC flow then renders for every project type.

Nothing else was needed, because the modal already had the machinery: `tableDropzone` and
`multiqcDropzone` are both `useFolderDropzone`, so dropping a run folder worked the whole
time. It was only hidden behind the wall.

`StepData.tsx`'s workflow-scoped data collection picker stays. That fork is real UX for a
project with several workflows, not a block.

## Why this is worth doing

Getting data into Depictio means the CLI: write or pick a `project.yaml`, run
`depictio run`, debug when the scan matches nothing. The browser could not help, because
every CLI-created project was off limits. After this, the CLI creates the project once and
the UI can keep filling it.

That only becomes safe once #1038 lands, because until then the next
`depictio run --update-config` deletes whatever the browser added.

## Tests

`depictio/tests/api/v1/endpoints/datacollections_endpoints/test_edit_permission_ignores_project_type.py`
(11 tests, parametrised over both project types) pins the invariant the React wall was
standing in for: permission decides, project type does not. tsc, prettier and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168MH2GPtdWxqJGwbXzTJVj
