### PR TITLE
fix(cli): make an empty scan and a dry run say what they actually found

### DIFF
--- a/depictio/cli/cli/commands/run.py
+++ b/depictio/cli/cli/commands/run.py
@@ -16,11 +16,16 @@ from depictio.cli.cli.utils.common import generate_api_headers, load_depictio_co
 from depictio.cli.cli.utils.config import validate_project_config_and_check_S3_storage
 from depictio.cli.cli.utils.helpers import process_project_helper
 from depictio.cli.cli.utils.rich_utils import (
+    render_records_table,
     rich_print_checked_statement,
     rich_print_command_usage,
     rich_print_section_separator,
 )
 from depictio.cli.cli.utils.scan import scan_project_files
+from depictio.cli.cli.utils.scan_utils import (
+    count_data_collection_matches,
+    resolve_run_locations,
+)
 from depictio.cli.cli_logging import logger
 from depictio.models.s3_utils import S3_storage_checks
 from depictio.models.utils import convert_model_to_dict
@@ -74,22 +79,40 @@ def _redacted_command_line() -> str | None:
         return None
 
 
-def _ingestion_data_collections(project_config) -> list[dict]:
+def _ingestion_data_collections(project_config, count_files: bool = False) -> list[dict]:
     """Per-DC summary (tag / type / format) + the local scan paths the CLI
-    resolved, walked from the validated project config. Best-effort; never raises."""
+    resolved, walked from the validated project config. Best-effort; never raises.
+
+    ``count_files`` walks the run directories to fill ``file_count`` with what a
+    scan would match. Off by default: the monitoring ledger is written after the
+    scan, which already knows the real counts, so pre-walking for it would be
+    both slower and less accurate. The dry run is the one caller with no scan to
+    learn from, so it is the one that pays for the walk.
+    """
     out: list[dict] = []
     try:
         for wf in getattr(project_config, "workflows", None) or []:
             dl = getattr(wf, "data_location", None)
             locations = [str(x) for x in (getattr(dl, "locations", None) or [])] if dl else []
-            for dc in getattr(wf, "data_collections", None) or []:
+            data_collections = getattr(wf, "data_collections", None) or []
+            # Counted for the whole workflow at once: the counter walks each run
+            # directory a single time and tests every pattern against that one
+            # listing, as the scanner does.
+            file_counts: list[int | None] = [None] * len(data_collections)
+            if count_files:
+                run_locations = resolve_run_locations(wf).locations
+                file_counts = count_data_collection_matches(data_collections, run_locations)
+            for dc, file_count in zip(data_collections, file_counts, strict=True):
                 cfg = getattr(dc, "config", None)
                 scan = getattr(cfg, "scan", None) if cfg else None
                 mode = getattr(scan, "mode", None) if scan else None
                 params = getattr(scan, "scan_parameters", None) if scan else None
-                if mode == "single":
+                # Lowercased like the scanner, which compares `scan.mode.lower()`
+                # while the model stores whatever spelling the config used.
+                normalized_mode = mode.lower() if mode else None
+                if normalized_mode == "single":
                     pattern = getattr(params, "filename", None)
-                elif mode == "recursive":
+                elif normalized_mode == "recursive":
                     rc = getattr(params, "regex_config", None)
                     pattern = getattr(rc, "pattern", None) if rc else None
                 else:
@@ -103,12 +126,79 @@ def _ingestion_data_collections(project_config) -> list[dict]:
                         "scan_mode": mode,
                         "scan_pattern": pattern,
                         "locations": locations,
-                        "file_count": None,
+                        "file_count": file_count,
                     }
                 )
     except Exception:
         return out
     return out
+
+
+def _shorten_scan_pattern(pattern: str | None, locations: list[str]) -> str:
+    """Render a scan pattern short enough to survive the preview table.
+
+    A single-file scan's pattern is an absolute path, and in a terminal-width
+    table it truncates to the data root every collection shares, hiding the one
+    part that identifies the file. Relative to the configured location it stays
+    unambiguous and readable.
+    """
+    if not pattern:
+        return "-"
+    for location in locations:
+        try:
+            return str(Path(pattern).relative_to(location))
+        except ValueError:
+            continue
+    return pattern
+
+
+def _print_dry_run_scan_preview(project_config) -> bool:
+    """Show what a real scan would match, per data collection.
+
+    Answering "is --data-root pointing at the right level?" is the whole reason
+    to run ``--dry-run``, and it could not: every step was wrapped in
+    ``if not dry_run`` and the run then printed "Data scanning completed" all
+    the same. The counts come from the scanner's own matcher, so a preview
+    cannot promise files the scan would not find.
+
+    Returns whether every data collection would find something, so the caller
+    does not follow a warning with a green "completed".
+    """
+    records = _ingestion_data_collections(project_config, count_files=True)
+    if not records:
+        rich_print_checked_statement("No data collection found in the project config.", "warning")
+        return False
+
+    # Reported before the table: a location that resolved no run at all explains
+    # every zero below it, and naming the directory level is what turns "0 files"
+    # into a fix.
+    for workflow in getattr(project_config, "workflows", None) or []:
+        for warning in resolve_run_locations(workflow).warnings:
+            rich_print_checked_statement(warning, "warning")
+
+    rows = []
+    for record in records:
+        file_count = record["file_count"]
+        rows.append(
+            {
+                "data collection": record["tag"],
+                "scan mode": record["scan_mode"] or "-",
+                "pattern": _shorten_scan_pattern(record["scan_pattern"], record["locations"]),
+                # A collection with no scan config (a derived one) has no files
+                # to count, which is not the same as counting zero.
+                "files": "n/a (no scan)" if file_count is None else str(file_count),
+            }
+        )
+    render_records_table(rows, title="Dry run: files each data collection would match")
+
+    empty = [record["tag"] for record in records if record["file_count"] == 0]
+    if empty:
+        rich_print_checked_statement(
+            f"{len(empty)} data collection(s) would match no file: {', '.join(empty)}. "
+            "Check --data-root and the scan patterns before running for real.",
+            "warning",
+        )
+    return not empty
 
 
 def _write_provisioned_cli_config(base_raw_config: dict, provision: dict) -> str:
@@ -566,26 +656,36 @@ def register_run_command(app: typer.Typer):
             _rec("s3_check", "skipped")
 
         # Step 3: Validate project configuration
+        # Stays None when validation fails under --continue-on-error. Every later
+        # step has to check it: reading it unbound surfaced the validation failure
+        # as "Data scanning failed: cannot access local variable 'project_config'",
+        # blaming the scan for something the step above had already reported.
+        project_config = None
         rich_print_section_separator(f"Step 3/{total_steps}: Validating project configuration")
         try:
-            if not dry_run:
-                if is_template_mode and template_resolved_config is not None:
-                    # Template mode: use resolved config dict
-                    from depictio.cli.cli.utils.config import validate_template_project_config
+            # Runs under --dry-run too, offline. Validation is read-only, and
+            # skipping it made the dry run's "validation passed" line mean
+            # nothing was checked, on top of leaving the later steps with no
+            # project config to preview.
+            if is_template_mode and template_resolved_config is not None:
+                # Template mode: use resolved config dict
+                from depictio.cli.cli.utils.config import validate_template_project_config
 
-                    CLI_config, validation_response = validate_template_project_config(
-                        CLI_config_path=CLI_config_path,
-                        resolved_config=template_resolved_config,
-                    )
-                else:
-                    # Standard mode: load from YAML file
-                    CLI_config, validation_response = validate_project_config_and_check_S3_storage(
-                        CLI_config_path=CLI_config_path,
-                        project_config_path=project_config_path,
-                    )
-                if not validation_response["success"]:
-                    raise Exception("Project configuration validation failed")
-                project_config = validation_response["project_config"]
+                CLI_config, validation_response = validate_template_project_config(
+                    CLI_config_path=CLI_config_path,
+                    resolved_config=template_resolved_config,
+                    offline=dry_run,
+                )
+            else:
+                # Standard mode: load from YAML file
+                CLI_config, validation_response = validate_project_config_and_check_S3_storage(
+                    CLI_config_path=CLI_config_path,
+                    project_config_path=project_config_path,
+                    offline=dry_run,
+                )
+            if not validation_response["success"]:
+                raise Exception("Project configuration validation failed")
+            project_config = validation_response["project_config"]
             rich_print_checked_statement("Project configuration validation passed", "success")
             success_count += 1
             _rec("validate_config", "success", "config valid")
@@ -707,6 +807,10 @@ def register_run_command(app: typer.Typer):
         if not skip_scan:
             rich_print_section_separator(f"Step 5/{total_steps}: Scanning data files")
             try:
+                if project_config is None:
+                    raise Exception(
+                        "no validated project configuration, see the validation step above"
+                    )
                 if not dry_run:
                     # Get remote project configuration to compare hashes
                     remote_project_config = api_get_project_from_name(
@@ -747,8 +851,12 @@ def register_run_command(app: typer.Typer):
                             raise Exception("Local and remote project configurations do not match")
                     else:
                         raise Exception("Failed to fetch remote project configuration")
+                    rich_print_checked_statement("Data scanning completed", "success")
+                elif _print_dry_run_scan_preview(project_config):
+                    rich_print_checked_statement(
+                        "Scan preview completed, nothing was ingested", "success"
+                    )
 
-                rich_print_checked_statement("Data scanning completed", "success")
                 success_count += 1
                 _rec("scan", "success", "data files scanned")
             except Exception as e:

--- a/depictio/cli/cli/utils/config.py
+++ b/depictio/cli/cli/utils/config.py
@@ -14,27 +14,37 @@ from depictio.models.utils import get_config, validate_model_config
 
 
 @validate_call
-def validate_project_config_and_check_S3_storage(CLI_config_path: str, project_config_path: str):
+def validate_project_config_and_check_S3_storage(
+    CLI_config_path: str, project_config_path: str, offline: bool = False
+):
     """
     Validate the project configuration and check S3 storage.
+
+    ``offline`` skips every server call (the login and the remote id merge).
+    That is what ``--dry-run`` needs: the merged ids only matter to a run that
+    is going to write, and a dry run that demanded a reachable server could no
+    longer be used to sanity-check a config before touching anything.
     """
     logger.info(f"Creating workflow from {CLI_config_path}...")
     logger.info(f"Validating pipeline configuration from {project_config_path}...")
 
-    response = api_login(CLI_config_path)
-    logger.info(response)
+    if not offline:
+        response = api_login(CLI_config_path)
+        logger.info(response)
 
-    if response["success"]:
-        # Reload the config from the YAML rather than from api_login's return:
-        # that payload is a ``mode="json"`` dump whose SecretStr S3 secret is
-        # MASKED ('**********') — rebuilding CLIConfig from it silently breaks
-        # every downstream direct-to-S3 Delta write (SignatureDoesNotMatch).
-        CLI_config = load_depictio_config(yaml_config_path=CLI_config_path)
-        # Validate the project configuration
-        response_validation = local_validate_project_config(CLI_config, project_config_path)
-        return CLI_config, response_validation
-    else:
-        raise typer.Exit(code=1)
+        if not response["success"]:
+            raise typer.Exit(code=1)
+
+    # Reload the config from the YAML rather than from api_login's return:
+    # that payload is a ``mode="json"`` dump whose SecretStr S3 secret is
+    # MASKED ('**********') — rebuilding CLIConfig from it silently breaks
+    # every downstream direct-to-S3 Delta write (SignatureDoesNotMatch).
+    CLI_config = load_depictio_config(yaml_config_path=CLI_config_path)
+    # Validate the project configuration
+    response_validation = local_validate_project_config(
+        CLI_config, project_config_path, offline=offline
+    )
+    return CLI_config, response_validation
 
 
 def find_matching_entry(collection, new_item):
@@ -148,9 +158,14 @@ def load_and_prepare_config(CLI_config: CLIConfig, project_yaml_config_path: str
 
 
 @validate_call
-def local_validate_project_config(CLI_config: CLIConfig, project_yaml_config_path: str) -> dict:
+def local_validate_project_config(
+    CLI_config: CLIConfig, project_yaml_config_path: str, offline: bool = False
+) -> dict:
     """
     Validate the pipeline configuration locally and update the metadata.
+
+    ``offline`` skips the lookup that reconciles ids with the project already on
+    the server, leaving freshly generated ids in place.
     """
     try:
         logger.info("Validating pipeline configuration...")
@@ -164,16 +179,17 @@ def local_validate_project_config(CLI_config: CLIConfig, project_yaml_config_pat
 
         # Load existing metadata and merge IDs if necessary
         # local_metadata = load_metadata()
-        response = api_get_project_from_name(project_config["name"], CLI_config)
-        if response.status_code == 200:
-            remote_project = response.json()
-            logger.info(f"Remote project : {remote_project}")
-            logger.info(f"Validated config : {validated_config}")
-            logger.info(f"Validated config : {validated_config}")
-            validated_config = merge_existing_ids(
-                remote_project, convert_objectid_to_str(validated_config.model_dump())
-            )
-            validated_config = Project.from_mongo(validated_config)
+        if not offline:
+            response = api_get_project_from_name(project_config["name"], CLI_config)
+            if response.status_code == 200:
+                remote_project = response.json()
+                logger.info(f"Remote project : {remote_project}")
+                logger.info(f"Validated config : {validated_config}")
+                logger.info(f"Validated config : {validated_config}")
+                validated_config = merge_existing_ids(
+                    remote_project, convert_objectid_to_str(validated_config.model_dump())
+                )
+                validated_config = Project.from_mongo(validated_config)
 
         logger.info(f"Pipeline configuration validated: {validated_config}")
 
@@ -191,6 +207,7 @@ def local_validate_project_config(CLI_config: CLIConfig, project_yaml_config_pat
 def validate_template_project_config(
     CLI_config_path: str,
     resolved_config: dict[str, Any],
+    offline: bool = False,
 ) -> tuple[CLIConfig, dict[str, Any]]:
     """Validate a template-resolved config dict (already resolved, not from YAML file).
 
@@ -201,6 +218,8 @@ def validate_template_project_config(
     Args:
         CLI_config_path: Path to CLI config YAML.
         resolved_config: Template-resolved project config dict.
+        offline: Skip every server call (login and the remote id merge), as
+            ``--dry-run`` does.
 
     Returns:
         Tuple of (CLIConfig, validation_response dict).
@@ -208,11 +227,12 @@ def validate_template_project_config(
     Raises:
         typer.Exit: If login fails.
     """
-    response = api_login(CLI_config_path)
-    logger.info(response)
+    if not offline:
+        response = api_login(CLI_config_path)
+        logger.info(response)
 
-    if not response["success"]:
-        raise typer.Exit(code=1)
+        if not response["success"]:
+            raise typer.Exit(code=1)
 
     # Reload from YAML — api_login's returned payload carries a MASKED
     # SecretStr S3 secret (see validate_project_config_and_check_S3_storage).
@@ -237,16 +257,17 @@ def validate_template_project_config(
         validated_config = validate_model_config(resolved_config, Project)
 
         # Merge existing IDs if project already exists on server
-        api_response = api_get_project_from_name(resolved_config["name"], CLI_config)
-        if api_response.status_code == 200:
-            remote_project = api_response.json()
-            validated_config_dict = merge_existing_ids(
-                remote_project, convert_objectid_to_str(validated_config.model_dump())
-            )
-            validated_config = Project.from_mongo(validated_config_dict)
+        if not offline:
+            api_response = api_get_project_from_name(resolved_config["name"], CLI_config)
+            if api_response.status_code == 200:
+                remote_project = api_response.json()
+                validated_config_dict = merge_existing_ids(
+                    remote_project, convert_objectid_to_str(validated_config.model_dump())
+                )
+                validated_config = Project.from_mongo(validated_config_dict)
 
-            # Re-resolve link tags now that we have real DC IDs
-            _resolve_link_tags_after_id_assignment(validated_config)
+                # Re-resolve link tags now that we have real DC IDs
+                _resolve_link_tags_after_id_assignment(validated_config)
 
         logger.info(f"Template project configuration validated: {validated_config}")
         return CLI_config, {

--- a/depictio/cli/cli/utils/scan.py
+++ b/depictio/cli/cli/utils/scan.py
@@ -1,5 +1,4 @@
 import os
-import re
 from datetime import datetime
 
 from bson import ObjectId
@@ -20,7 +19,12 @@ from depictio.cli.cli.utils.rich_utils import (
     rich_print_summary_scan_table_enhanced,
 )
 from depictio.cli.cli.utils.scan_utils import (
+    collect_run_candidates,
     construct_full_regex,
+    data_collection_full_regex,
+    describe_empty_scan_outcome,
+    describe_unmatched_run_scan,
+    file_matches_data_collection,
     generate_file_hash,
     generate_run_hash,
     regex_match,
@@ -379,18 +383,12 @@ def scan_run_for_multiple_data_collections(
         )
 
         # Build regex for this data collection (only for recursive scans)
-        if not dc.config.scan or not hasattr(dc.config.scan.scan_parameters, "regex_config"):
+        full_regex = data_collection_full_regex(dc)
+        if full_regex is None:
             logger.warning(
                 f"Data collection {dc.data_collection_tag} does not have scan config or regex_config (likely single-file scan or MultiQC)"
             )
             continue
-
-        regex_config = dc.config.scan.scan_parameters.regex_config
-        full_regex = (
-            construct_full_regex(regex=regex_config)  # type: ignore[invalid-argument-type]
-            if getattr(regex_config, "wildcards", False)
-            else regex_config.pattern  # type: ignore[unresolved-attribute]
-        )
         logger.debug(f"Regex for DC {dc.data_collection_tag}: {full_regex}")
 
         # A temporary run used only for file association — invariant across
@@ -412,19 +410,10 @@ def scan_run_for_multiple_data_collections(
         # Process files that match this data collection's regex
         dc_file_scan_results = []
         for file_location in all_files_in_run:
+            if not file_matches_data_collection(file_location, run_location, full_regex):
+                continue
+
             file_name = os.path.basename(file_location)
-
-            # Check regex match against basename first
-            match, _ = regex_match(file_name, full_regex)
-            if not match:
-                # If the pattern contains path separators (e.g., "variants/bowtie2/..."),
-                # try matching against the relative path from the run directory
-                if "/" in full_regex:
-                    rel_path = os.path.relpath(file_location, run_location)
-                    match, _ = regex_match(rel_path, full_regex)
-                if not match:
-                    continue
-
             logger.debug(f"File {file_name} matches DC {dc.data_collection_tag}")
 
             # skip_regex=True because we already matched in the loop above
@@ -686,6 +675,9 @@ def scan_files_for_workflow(
 
     # Scan runs once and collect files for all data collections
     all_workflow_runs = []
+    # Runs recognised but already ingested. A scan that skips every run is a
+    # legitimate no-op; only one that recognises nothing has a data-root problem.
+    runs_skipped_as_existing = 0
 
     # Get locations from the workflow config
     locations = workflow.data_location.locations
@@ -709,6 +701,7 @@ def scan_files_for_workflow(
             run_tag = os.path.basename(os.path.normpath(location))
             if run_tag in existing_runs_reformated and not rescan_folders:
                 logger.debug(f"Skipping existing run {run_tag}.")
+                runs_skipped_as_existing += 1
                 continue
 
             if workflow.config is None:
@@ -746,15 +739,25 @@ def scan_files_for_workflow(
                 logger.error("runs_regex is required for sequencing-runs structure but was None")
                 continue
 
-            # Collect all valid runs first to show accurate progress
+            # Collect all valid runs first to show accurate progress. The
+            # candidates carry every subdirectory, matching or not, so matching
+            # nothing can say *why*: a wrong --data-root level reads very
+            # differently from everything matched but already ingested, which is
+            # a legitimate no-op.
+            candidates = collect_run_candidates(location, "sequencing-runs", runs_regex)
+            if not candidates.matched:
+                rich_print_checked_statement(
+                    describe_unmatched_run_scan(location, runs_regex, candidates.subdirectories),
+                    "warning",
+                )
+
             valid_runs = []
-            for run in sorted(os.listdir(location)):
-                run_path = os.path.join(location, run)
-                if os.path.isdir(run_path) and re.match(runs_regex, run):
-                    if run in existing_runs_reformated and not rescan_folders:
-                        logger.debug(f"Skipping existing run {run}.")
-                        continue
-                    valid_runs.append((run_path, run))
+            for run, run_path in candidates.matched:
+                if run in existing_runs_reformated and not rescan_folders:
+                    logger.debug(f"Skipping existing run {run}.")
+                    runs_skipped_as_existing += 1
+                    continue
+                valid_runs.append((run_path, run))
 
             # Process runs with progress bar
             if valid_runs:
@@ -841,12 +844,29 @@ def scan_files_for_workflow(
     else:
         rich_print_data_collection_light(all_workflow_runs, workflow)
 
-    rich_print_checked_statement(
-        f"Scanned {len(all_workflow_runs)} runs in workflow {workflow.workflow_tag}",
-        "success",
+    files_found = sum(len(run.files_id or []) for run in all_workflow_runs if run)
+    empty_outcome = describe_empty_scan_outcome(
+        len(all_workflow_runs), files_found, runs_skipped_as_existing
     )
+    if empty_outcome:
+        # Reported as a warning rather than a failed result: the caller treats
+        # anything but "success" as fatal, and one empty workflow must not
+        # abort the other workflows and single-file data collections that may
+        # well have ingested fine. The user needs to see this now all the same,
+        # instead of debugging an empty dashboard later.
+        rich_print_checked_statement(empty_outcome, "warning")
+    else:
+        rich_print_checked_statement(
+            f"Scanned {len(all_workflow_runs)} runs in workflow {workflow.workflow_tag}",
+            "success",
+        )
 
-    return {"result": "success", "runs_scanned": len(all_workflow_runs)}
+    return {
+        "result": "success",
+        "runs_scanned": len(all_workflow_runs),
+        "files_found": files_found,
+        "warning": empty_outcome,
+    }
 
 
 def scan_files_for_data_collection(

--- a/depictio/cli/cli/utils/scan_utils.py
+++ b/depictio/cli/cli/utils/scan_utils.py
@@ -1,13 +1,14 @@
 import collections
 import hashlib
+import os
 import re
 from functools import lru_cache
-from typing import Any, DefaultDict
+from typing import Any, DefaultDict, NamedTuple
 
 from depictio.cli.cli_logging import logger
 from depictio.models.models.data_collections import Regex
 from depictio.models.models.files import File
-from depictio.models.models.workflows import WorkflowRun
+from depictio.models.models.workflows import Workflow, WorkflowRun
 
 
 @lru_cache(maxsize=512)
@@ -63,6 +64,41 @@ def construct_full_regex(regex: Regex) -> str:
         logger.debug(f"Files Regex: {files_regex}")
 
     return files_regex
+
+
+def data_collection_full_regex(data_collection) -> str | None:
+    """The regex a recursive scan matches this data collection's files against.
+
+    ``None`` when the data collection has no regex to match with: a derived
+    collection with no scan at all, or a single-file/MultiQC one whose scan
+    parameters carry a filename instead of a regex.
+    """
+    scan = data_collection.config.scan
+    if scan is None or not hasattr(scan.scan_parameters, "regex_config"):
+        return None
+    regex_config = scan.scan_parameters.regex_config
+    return (
+        construct_full_regex(regex=regex_config)
+        if getattr(regex_config, "wildcards", False)
+        else regex_config.pattern
+    )
+
+
+def file_matches_data_collection(file_location: str, run_location: str, full_regex: str) -> bool:
+    """Whether a file inside a run belongs to a data collection.
+
+    The basename is tried first. Only a pattern that contains a path separator
+    (e.g. ``variants/bowtie2/...``) falls back to the run-relative path, so a
+    plain filename pattern cannot accidentally match through a directory name.
+
+    Shared with the dry-run preview on purpose: a preview that counted files by
+    its own rules would eventually disagree with the scan it claims to predict.
+    """
+    if regex_match(os.path.basename(file_location), full_regex)[0]:
+        return True
+    if "/" not in full_regex:
+        return False
+    return regex_match(os.path.relpath(file_location, run_location), full_regex)[0]
 
 
 def generate_file_hash(
@@ -182,3 +218,184 @@ def check_run_differences(
 
         return differences
     return {}
+
+
+# A scan finding nothing used to print "success" in green: the ingest block is
+# guarded by `if valid_runs:` and the summary line reports the number of runs
+# without ever asking whether that number is zero. The usual cause is a
+# `--data-root` pointing one directory above or below the run layout the
+# template expects, and the user's only clue was an empty dashboard much later.
+# The two describe_* helpers below turn that silence into a message.
+
+# Long enough to recognise the layout, short enough to read in a terminal.
+_MAX_LISTED_ENTRIES = 10
+
+
+def describe_unmatched_run_scan(
+    location: str,
+    runs_regex: str,
+    subdirectories: list[str],
+) -> str:
+    """Explain why a ``sequencing-runs`` scan matched no run directory.
+
+    Names the three things needed to fix it: where we looked, what we looked
+    for, and what was actually there. The listing is what turns "0 runs" into
+    "you are one level too high".
+    """
+    where = f"No run directory under '{location}' matched the pattern '{runs_regex}'."
+    if not subdirectories:
+        return f"{where} That directory contains no subdirectories at all."
+
+    shown = ", ".join(subdirectories[:_MAX_LISTED_ENTRIES])
+    remaining = len(subdirectories) - _MAX_LISTED_ENTRIES
+    if remaining > 0:
+        shown += f", and {remaining} more"
+    noun = "subdirectory" if len(subdirectories) == 1 else "subdirectories"
+    return (
+        f"{where} It contains {len(subdirectories)} {noun}: {shown}. "
+        "Check that --data-root points at the parent of the run directories."
+    )
+
+
+def describe_empty_scan_outcome(
+    runs_scanned: int,
+    files_found: int,
+    runs_skipped_as_existing: int = 0,
+) -> str | None:
+    """Warning to print when a scan completed but ingested nothing.
+
+    ``None`` means the scan needs no warning, which includes the common
+    legitimate no-op: every run in the directory was recognised and skipped
+    because it is already ingested. Only a scan that recognised *nothing* has
+    a data-root problem worth shouting about.
+
+    The two failing shapes are kept apart because their causes differ: no run
+    at all points at the directory level, while runs without files points at
+    the data collections' patterns.
+    """
+    if runs_scanned == 0 and runs_skipped_as_existing == 0:
+        return (
+            "No run was scanned, so nothing will be ingested. "
+            "This usually means --data-root points at the wrong directory level."
+        )
+    if runs_scanned > 0 and files_found == 0:
+        return (
+            f"{runs_scanned} run(s) were scanned but no file matched any data collection. "
+            "This usually means the data collections' patterns do not match this run's layout."
+        )
+    return None
+
+
+class RunCandidates(NamedTuple):
+    """What a location holds, from a scan's point of view.
+
+    ``subdirectories`` is every directory entry, matching or not, which is what
+    turns "0 runs" into a message the user can act on. ``matched`` is the
+    ``(run_tag, run_location)`` pairs a scan would actually visit.
+    """
+
+    subdirectories: list[str]
+    matched: list[tuple[str, str]]
+
+
+def collect_run_candidates(
+    location: str,
+    structure: str,
+    runs_regex: str | None = None,
+) -> RunCandidates:
+    """Enumerate the runs a scan would find under ``location``.
+
+    A ``flat`` location is itself one run. A ``sequencing-runs`` location holds
+    one run per subdirectory whose name matches ``runs_regex``. Shared between
+    the scanner and the dry-run preview so both agree on what counts as a run.
+    """
+    if structure == "flat":
+        return RunCandidates([], [(os.path.basename(os.path.normpath(location)), location)])
+
+    subdirectories: list[str] = []
+    matched: list[tuple[str, str]] = []
+    for entry in sorted(os.listdir(location)):
+        entry_path = os.path.join(location, entry)
+        if not os.path.isdir(entry_path):
+            continue
+        subdirectories.append(entry)
+        if runs_regex and re.match(runs_regex, entry):
+            matched.append((entry, entry_path))
+    return RunCandidates(subdirectories, matched)
+
+
+class ResolvedRuns(NamedTuple):
+    """Run directories a scan would walk, and why any location yielded none."""
+
+    locations: list[str]
+    warnings: list[str]
+
+
+def resolve_run_locations(workflow: Workflow) -> ResolvedRuns:
+    """Run directories a scan of ``workflow`` would walk, best-effort.
+
+    A location that does not exist, or that matches no run, becomes a warning
+    rather than an exception: this feeds a preview, and one bad path must not
+    hide every other data collection's count behind a traceback.
+    """
+    structure = workflow.data_location.structure
+    runs_regex = workflow.data_location.runs_regex
+    run_locations: list[str] = []
+    warnings: list[str] = []
+    for location in workflow.data_location.locations:
+        if not os.path.isdir(location):
+            warnings.append(f"Configured location '{location}' does not exist.")
+            continue
+        candidates = collect_run_candidates(location, structure, runs_regex)
+        if not candidates.matched and structure != "flat":
+            warnings.append(
+                describe_unmatched_run_scan(location, runs_regex or "", candidates.subdirectories)
+            )
+        run_locations.extend(run_location for _, run_location in candidates.matched)
+    return ResolvedRuns(run_locations, warnings)
+
+
+def count_data_collection_matches(data_collections, run_locations: list[str]) -> list[int | None]:
+    """How many local files a scan would match, one count per data collection.
+
+    ``None`` means there is nothing to count: a derived collection carries no
+    scan config, and a preview must show that as unknown rather than as a
+    misleading zero that sends the user hunting for a data-root problem.
+
+    ``mode`` is lowercased like the scanner does, so a config spelling it
+    ``Recursive`` is previewed the way it will be scanned.
+
+    Every run directory is walked once and each pattern tested against that one
+    listing, the way the scanner does it. Counting one collection at a time
+    would re-walk the whole data root once per collection, which on a project
+    with twenty collections is twenty times the I/O for the same answer.
+    """
+    counts: list[int | None] = []
+    regexes: list[str | None] = []
+    for data_collection in data_collections:
+        scan = data_collection.config.scan
+        mode = scan.mode.lower() if scan else None
+
+        if mode == "single":
+            filename = getattr(scan.scan_parameters, "filename", None)
+            counts.append(int(bool(filename) and os.path.isfile(filename)))
+            regexes.append(None)
+            continue
+
+        full_regex = data_collection_full_regex(data_collection) if mode == "recursive" else None
+        counts.append(0 if full_regex else None)
+        regexes.append(full_regex)
+
+    if not any(regexes):
+        return counts
+
+    for run_location in run_locations:
+        for root, _, files in os.walk(run_location):
+            for name in files:
+                file_location = os.path.join(root, name)
+                for index, full_regex in enumerate(regexes):
+                    if full_regex and file_matches_data_collection(
+                        file_location, run_location, full_regex
+                    ):
+                        counts[index] += 1  # type: ignore[operator]
+    return counts

--- a/depictio/tests/cli/commands/test_run_dry_run_preview.py
+++ b/depictio/tests/cli/commands/test_run_dry_run_preview.py
@@ -1,0 +1,108 @@
+"""Tests for the `--dry-run` scan preview helpers in the run command.
+
+The preview exists to answer "is --data-root pointing at the right level?"
+before anything is written, which the dry run could not do while every step was
+wrapped in `if not dry_run:`.
+"""
+
+import pytest
+
+from depictio.cli.cli.commands.run import (
+    _ingestion_data_collections,
+    _shorten_scan_pattern,
+)
+from depictio.models.models.data_collections import DataCollection
+from depictio.models.models.projects import Project
+from depictio.models.models.workflows import Workflow
+
+
+@pytest.fixture(autouse=True)
+def set_depictio_context(monkeypatch):
+    monkeypatch.setattr("depictio.models.config.DEPICTIO_CONTEXT", "server")
+    monkeypatch.setattr("depictio.models.models.files.DEPICTIO_CONTEXT", "server")
+
+
+class TestShortenScanPattern:
+    """A single-file pattern is an absolute path and truncates to the shared
+    data root in a terminal-width table, hiding the part that identifies it."""
+
+    def test_renders_a_path_relative_to_its_location(self):
+        assert _shorten_scan_pattern("/data/run_1/input/samplesheet.csv", ["/data/run_1"]) == (
+            "input/samplesheet.csv"
+        )
+
+    def test_tries_every_configured_location(self):
+        assert _shorten_scan_pattern("/data/b/x.csv", ["/data/a", "/data/b"]) == "x.csv"
+
+    def test_a_path_outside_every_location_is_left_alone(self):
+        assert _shorten_scan_pattern("/elsewhere/x.csv", ["/data/a"]) == "/elsewhere/x.csv"
+
+    def test_no_pattern_renders_as_a_dash(self):
+        assert _shorten_scan_pattern(None, ["/data/a"]) == "-"
+
+
+def _project_with_run(tmp_path) -> Project:
+    run = tmp_path / "run_1"
+    (run / "tables").mkdir(parents=True)
+    (run / "tables" / "counts.csv").write_text("a\n")
+    (run / "tables" / "notes.txt").write_text("a\n")
+    metadata = tmp_path / "run_1" / "metadata.csv"
+    metadata.write_text("a\n")
+
+    workflow = Workflow(
+        name="wf",
+        engine={"name": "python"},
+        data_location={"structure": "flat", "locations": [str(run)]},
+        data_collections=[
+            DataCollection(
+                data_collection_tag="counts",
+                config={
+                    "type": "table",
+                    "scan": {
+                        "mode": "recursive",
+                        "scan_parameters": {"regex_config": {"pattern": r".*\.csv"}},
+                    },
+                    "dc_specific_properties": {"format": "csv"},
+                },
+            ),
+            DataCollection(
+                data_collection_tag="metadata",
+                config={
+                    "type": "table",
+                    "scan": {"mode": "single", "scan_parameters": {"filename": str(metadata)}},
+                    "dc_specific_properties": {"format": "csv"},
+                },
+            ),
+        ],
+    )
+    return Project(
+        name="preview_project",
+        workflows=[workflow],
+        data_collections=[],
+        permissions={"owners": [], "editors": [], "viewers": []},
+    )
+
+
+class TestIngestionDataCollections:
+    def test_counting_is_off_by_default(self, tmp_path):
+        """The monitoring ledger is written after the scan, which already knows
+        the real counts, so pre-walking for it would be slower and less accurate."""
+        records = _ingestion_data_collections(_project_with_run(tmp_path))
+
+        assert [record["file_count"] for record in records] == [None, None]
+
+    def test_count_files_fills_real_counts(self, tmp_path):
+        records = _ingestion_data_collections(_project_with_run(tmp_path), count_files=True)
+
+        assert [(record["tag"], record["file_count"]) for record in records] == [
+            ("counts", 2),
+            ("metadata", 1),
+        ]
+
+    def test_records_carry_the_locations_the_preview_shortens_against(self, tmp_path):
+        records = _ingestion_data_collections(_project_with_run(tmp_path), count_files=True)
+
+        assert records[1]["locations"] == [str(tmp_path / "run_1")]
+        assert _shorten_scan_pattern(records[1]["scan_pattern"], records[1]["locations"]) == (
+            "metadata.csv"
+        )

--- a/depictio/tests/cli/utils/test_scan_utils.py
+++ b/depictio/tests/cli/utils/test_scan_utils.py
@@ -5,18 +5,25 @@ from unittest.mock import patch
 import pytest
 
 # Import the functions to test
+from depictio.cli.cli.utils import scan_utils
 from depictio.cli.cli.utils.scan_utils import (
     check_run_differences,
+    collect_run_candidates,
     construct_full_regex,
+    count_data_collection_matches,
+    describe_empty_scan_outcome,
+    describe_unmatched_run_scan,
+    file_matches_data_collection,
     generate_file_hash,
     generate_run_hash,
     regex_match,
+    resolve_run_locations,
 )
 from depictio.models.models.base import PyObjectId
-from depictio.models.models.data_collections import Regex, WildcardRegexBase
+from depictio.models.models.data_collections import DataCollection, Regex, WildcardRegexBase
 from depictio.models.models.files import File
 from depictio.models.models.users import Permission, UserBase
-from depictio.models.models.workflows import WorkflowRun
+from depictio.models.models.workflows import Workflow, WorkflowRun
 
 
 @pytest.fixture(autouse=True)
@@ -810,3 +817,301 @@ class TestCheckRunDifferences:
         warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert any("Hash mismatch" in call for call in warning_calls)
         assert any("Run location changed" in call for call in warning_calls)
+
+
+class TestDescribeUnmatchedRunScan:
+    """A `sequencing-runs` scan that matches nothing must say why."""
+
+    def test_names_the_location_the_pattern_and_what_was_there(self):
+        message = describe_unmatched_run_scan(
+            "/data/results", r"^run_\d+$", ["multiqc", "qiime2", "pipeline_info"]
+        )
+
+        assert "/data/results" in message
+        assert r"^run_\d+$" in message
+        # The listing is the part that turns "0 runs" into "wrong level".
+        assert "multiqc" in message and "qiime2" in message
+        assert "--data-root" in message
+
+    def test_an_empty_directory_says_so_rather_than_listing_nothing(self):
+        message = describe_unmatched_run_scan("/data/results", r"^run_\d+$", [])
+
+        assert "no subdirectories at all" in message
+        assert "--data-root" not in message, "there is no level to move to; say the simpler thing"
+
+    def test_a_long_listing_is_truncated_but_counted(self):
+        subdirs = [f"sample_{i}" for i in range(25)]
+
+        message = describe_unmatched_run_scan("/data", "^run", subdirs)
+
+        assert "25 subdirectories" in message
+        assert "and 15 more" in message
+        assert "sample_0" in message
+        assert "sample_24" not in message
+
+    def test_a_single_subdirectory_is_not_pluralised(self):
+        message = describe_unmatched_run_scan("/data", "^run", ["only_one"])
+
+        assert "1 subdirectory:" in message
+
+
+class TestDescribeEmptyScanOutcome:
+    """Distinguish a broken scan from a scan that had nothing new to do."""
+
+    def test_nothing_recognised_at_all_is_a_data_root_problem(self):
+        message = describe_empty_scan_outcome(runs_scanned=0, files_found=0)
+
+        assert message is not None
+        assert "--data-root" in message
+
+    def test_every_run_already_ingested_is_a_legitimate_no_op(self):
+        """The common case of re-running the CLI with nothing new. Warning here
+        would cry wolf on every repeat run and train the user to ignore it."""
+        assert (
+            describe_empty_scan_outcome(runs_scanned=0, files_found=0, runs_skipped_as_existing=12)
+            is None
+        )
+
+    def test_runs_without_files_blames_the_patterns_not_the_data_root(self):
+        message = describe_empty_scan_outcome(runs_scanned=3, files_found=0)
+
+        assert message is not None
+        assert "no file matched any data collection" in message
+        assert "--data-root" not in message
+
+    def test_a_scan_that_found_something_is_silent(self):
+        assert describe_empty_scan_outcome(runs_scanned=2, files_found=17) is None
+
+
+class TestFileMatchesDataCollection:
+    """The single matcher shared by the scanner and the dry-run preview."""
+
+    def test_matches_on_the_basename(self):
+        assert file_matches_data_collection(
+            "/runs/run_1/nested/sample.csv", "/runs/run_1", r".*\.csv"
+        )
+
+    def test_path_shaped_pattern_matches_the_run_relative_path(self):
+        assert file_matches_data_collection(
+            "/runs/run_1/variants/bowtie2/calls.vcf", "/runs/run_1", r"variants/bowtie2/.*\.vcf"
+        )
+
+    def test_a_plain_pattern_does_not_match_through_a_directory_name(self):
+        """Without a separator the pattern is a filename pattern. Falling back to
+        the relative path here would let a directory called `variants` pull in
+        every file beneath it."""
+        assert not file_matches_data_collection(
+            "/runs/run_1/variants/calls.vcf", "/runs/run_1", r"variants"
+        )
+
+    def test_no_match(self):
+        assert not file_matches_data_collection("/runs/run_1/sample.txt", "/runs/run_1", r".*\.csv")
+
+
+class TestCollectRunCandidates:
+    """Run enumeration, shared so the preview and the scan agree on what a run is."""
+
+    def test_a_flat_location_is_itself_one_run(self, tmp_path):
+        candidates = collect_run_candidates(str(tmp_path / "my_run"), "flat")
+
+        assert candidates.matched == [("my_run", str(tmp_path / "my_run"))]
+        assert candidates.subdirectories == []
+
+    def test_sequencing_runs_keeps_unmatched_subdirectories_for_the_error_message(self, tmp_path):
+        (tmp_path / "run_1").mkdir()
+        (tmp_path / "run_2").mkdir()
+        (tmp_path / "results").mkdir()
+        (tmp_path / "samplesheet.csv").write_text("a,b\n")
+
+        candidates = collect_run_candidates(str(tmp_path), "sequencing-runs", "^run_")
+
+        assert [tag for tag, _ in candidates.matched] == ["run_1", "run_2"]
+        assert candidates.subdirectories == ["results", "run_1", "run_2"]
+
+    def test_a_missing_regex_matches_nothing(self, tmp_path):
+        (tmp_path / "run_1").mkdir()
+
+        candidates = collect_run_candidates(str(tmp_path), "sequencing-runs", None)
+
+        assert candidates.matched == []
+        assert candidates.subdirectories == ["run_1"]
+
+
+class TestCountDataCollectionMatches:
+    """The dry-run file counts."""
+
+    @staticmethod
+    def _recursive_dc(pattern: str) -> DataCollection:
+        return DataCollection(
+            data_collection_tag="tab",
+            config={
+                "type": "table",
+                "scan": {
+                    "mode": "recursive",
+                    "scan_parameters": {"regex_config": {"pattern": pattern}},
+                },
+                "dc_specific_properties": {"format": "csv"},
+            },
+        )
+
+    def test_counts_matching_files_across_every_run(self, tmp_path):
+        for run in ("run_1", "run_2"):
+            nested = tmp_path / run / "tables"
+            nested.mkdir(parents=True)
+            (nested / "counts.csv").write_text("a\n")
+            (nested / "notes.txt").write_text("a\n")
+
+        counts = count_data_collection_matches(
+            [self._recursive_dc(r".*\.csv")],
+            [str(tmp_path / "run_1"), str(tmp_path / "run_2")],
+        )
+
+        assert counts == [2]
+
+    def test_a_pattern_that_matches_nothing_counts_zero(self, tmp_path):
+        (tmp_path / "run_1").mkdir()
+        (tmp_path / "run_1" / "counts.tsv").write_text("a\n")
+
+        counts = count_data_collection_matches(
+            [self._recursive_dc(r".*\.csv")], [str(tmp_path / "run_1")]
+        )
+
+        assert counts == [0]
+
+    def test_every_collection_is_counted_in_one_walk(self, tmp_path, monkeypatch):
+        """Each run directory is walked once and every pattern tested against
+        that one listing, as the scanner does. Walking per collection would be
+        N times the I/O for the same answer."""
+        nested = tmp_path / "run_1" / "tables"
+        nested.mkdir(parents=True)
+        (nested / "counts.csv").write_text("a\n")
+        (nested / "counts.tsv").write_text("a\n")
+        (nested / "notes.txt").write_text("a\n")
+
+        walked: list[str] = []
+        real_walk = scan_utils.os.walk
+        monkeypatch.setattr(
+            scan_utils.os,
+            "walk",
+            lambda top, *args, **kwargs: (walked.append(top), real_walk(top, *args, **kwargs))[1],
+        )
+
+        counts = count_data_collection_matches(
+            [self._recursive_dc(r".*\.csv"), self._recursive_dc(r".*\.tsv")],
+            [str(tmp_path / "run_1")],
+        )
+
+        assert counts == [1, 1]
+        assert walked == [str(tmp_path / "run_1")]
+
+    def test_a_single_file_collection_counts_its_one_file(self, tmp_path):
+        metadata = tmp_path / "metadata.csv"
+        metadata.write_text("a\n")
+        dc = DataCollection(
+            data_collection_tag="meta",
+            config={
+                "type": "table",
+                "scan": {"mode": "single", "scan_parameters": {"filename": str(metadata)}},
+                "dc_specific_properties": {"format": "csv"},
+            },
+        )
+
+        assert count_data_collection_matches([dc], []) == [1]
+
+        metadata.unlink()
+        assert count_data_collection_matches([dc], []) == [0]
+
+    def test_a_capitalised_mode_is_counted_the_way_it_is_scanned(self, tmp_path):
+        """The model stores the spelling the config used, while the scanner
+        compares `scan.mode.lower()`. A preview that did not would report
+        "unknown" for a collection the scan handles fine."""
+        run = tmp_path / "run_1"
+        run.mkdir()
+        (run / "counts.csv").write_text("a\n")
+        dc = DataCollection(
+            data_collection_tag="tab",
+            config={
+                "type": "table",
+                "scan": {
+                    "mode": "Recursive",
+                    "scan_parameters": {"regex_config": {"pattern": r".*\.csv"}},
+                },
+                "dc_specific_properties": {"format": "csv"},
+            },
+        )
+
+        assert count_data_collection_matches([dc], [str(run)]) == [1]
+
+    def test_a_collection_with_no_scan_is_unknown_rather_than_zero(self):
+        """A derived collection has no files to count. Reporting 0 would send the
+        user hunting for a data-root problem that does not exist."""
+        dc = DataCollection(
+            data_collection_tag="joined",
+            config={
+                "type": "table",
+                "source": "joined",
+                "dc_specific_properties": {"format": "parquet"},
+            },
+        )
+
+        assert count_data_collection_matches([dc], []) == [None]
+
+
+class TestResolveRunLocations:
+    """Run directories the preview walks, resolved from a workflow."""
+
+    @staticmethod
+    def _workflow(structure: str, locations: list[str], runs_regex: str | None = None) -> Workflow:
+        data_location: dict = {"structure": structure, "locations": locations}
+        if runs_regex:
+            data_location["runs_regex"] = runs_regex
+        return Workflow(
+            name="wf",
+            engine={"name": "snakemake"},
+            data_location=data_location,
+            data_collections=[],
+        )
+
+    def test_resolves_each_matching_run_directory(self, tmp_path):
+        (tmp_path / "run_1").mkdir()
+        (tmp_path / "run_2").mkdir()
+        (tmp_path / "logs").mkdir()
+
+        resolved = resolve_run_locations(
+            self._workflow("sequencing-runs", [str(tmp_path)], "^run_")
+        )
+
+        assert resolved.locations == [str(tmp_path / "run_1"), str(tmp_path / "run_2")]
+        assert resolved.warnings == []
+
+    def test_a_location_that_does_not_exist_is_a_warning_not_an_exception(self, tmp_path):
+        """The preview reports it; crashing would hide every other data
+        collection's count behind one bad path."""
+        workflow = self._workflow("flat", [str(tmp_path)])
+        workflow.data_location.locations = [str(tmp_path / "gone")]
+
+        resolved = resolve_run_locations(workflow)
+
+        assert resolved.locations == []
+        assert "does not exist" in resolved.warnings[0]
+
+    def test_a_data_root_one_level_too_deep_names_what_it_looked_at(self, tmp_path):
+        """The failure the dry run exists to catch: --data-root pointing inside a
+        run instead of at the parent of the runs."""
+        (tmp_path / "tables").mkdir()
+        (tmp_path / "multiqc").mkdir()
+
+        resolved = resolve_run_locations(
+            self._workflow("sequencing-runs", [str(tmp_path)], "^run_")
+        )
+
+        assert resolved.locations == []
+        assert "tables" in resolved.warnings[0]
+        assert "multiqc" in resolved.warnings[0]
+
+    def test_a_flat_workflow_is_never_warned_about(self, tmp_path):
+        """Its single location is the run, so there is no pattern to fail to match."""
+        resolved = resolve_run_locations(self._workflow("flat", [str(tmp_path)]))
+
+        assert resolved.locations == [str(tmp_path)]
+        assert resolved.warnings == []


### PR DESCRIPTION
## Two ways the CLI stayed quiet about doing nothing

**1. A scan that matched nothing reported success.**

A `sequencing-runs` scan whose `runs_regex` matches no subdirectory skips the ingest
block entirely and then prints `Scanned 0 runs ... success` in green. A `flat` scan
registers a run with zero matching files and reports the same green result. The usual
cause is `--data-root` pointing one directory level above or below the layout the
template expects, and the user's only clue was an empty dashboard, much later.

Zero matches is now a warning that names the three things needed to fix it: where we
looked, what we looked for, and what was actually there.

```
No run directory under '/data/ampliseq/run_A' matched the pattern '^run_'.
It contains 1 subdirectory: tables.
Check that --data-root points at the parent of the run directories.
```

It stays a `"success"` result rather than becoming an error, deliberately: the caller
treats anything else as fatal, and one empty workflow must not abort the other workflows
and single-file data collections that may well have ingested fine.

The warning also distinguishes "nothing was recognised at all" from the legitimate no-op
of "every run was recognised and skipped because it is already ingested". Without that
split it would fire on every repeat run and train people to ignore it.

**2. `--dry-run` previewed nothing.**

Every step was wrapped in `if not dry_run:` and then printed "Data scanning completed"
regardless. A dry run could not answer the one question it exists for.

It now validates the project config (offline, so a dry run still needs no server) and
prints what a real scan would match. Against the ampliseq template's own reference layout:

```
        Dry run: files each data collection would match
 data collection            | scan mode | pattern                  | files
 multiqc_data               | recursive | multiqc/multiqc_data/m... | 1
 samplesheet                | single    | input/samplesheet.csv     | 1
 alpha_rarefaction          | single    | alpha_rarefaction.tsv     | 1
 alpha_rarefaction_summary  | -         | -                         | n/a (no scan)
 taxonomy_composition       | single    | taxonomy_composition.tsv  | 1
 ... 18 more
 Scan preview completed, nothing was ingested
```

Point it at the wrong directory level and it says so instead:

```
 No run directory under '/data/ampliseq/run_A' matched the pattern '^run_'.
 It contains 1 subdirectory: tables.
 Check that --data-root points at the parent of the run directories.
 ...
 2 data collection(s) would match no file: counts, missing_tsv.
```

A derived collection, which has no scan config and so no files to count, shows
`n/a (no scan)` rather than a misleading `0` that would send you hunting for a data-root
problem. When something would match nothing, the step no longer follows the warning with
a green "completed".

Validating under `--dry-run` is a fix in itself: the dry run used to print "Project
configuration validation passed" without validating anything.

## The counts come from the scanner, not from a copy of it

A preview that counted files by its own rules would eventually disagree with the scan it
claims to predict. So the matcher, the regex construction and the run enumeration moved
into `scan_utils.py` and `scan.py` now calls them:

- `file_matches_data_collection` is the basename-then-relative-path test, extracted verbatim
- `data_collection_full_regex` is the wildcard expansion plus the `regex_config` guard
- `collect_run_candidates` is the flat / sequencing-runs run enumeration
- `count_data_collection_matches` and `resolve_run_locations` build the preview on top

`scan.py` is 10 lines shorter for it.

## Tests

24 new tests in `depictio/tests/cli/utils/test_scan_utils.py` covering the messages, the
shared matcher, the run enumeration and the counts, including the wrong-directory-level
case the whole change is about. The full CLI suite (433) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168MH2GPtdWxqJGwbXzTJVj
