### PR TITLE
feat(viewer): an opt-in feedback link that carries the reader's context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,3 +132,18 @@ DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
 # variable of their own (the per-scheme chrome surfaces). Merged UNDER the flat
 # variables above.
 # DEPICTIO_BRANDING_THEME={"surfaces_light":{"app_bg":"#f8faf9","nav_bg":"#ffffff","heading":"#00514b"}}
+
+# ── Dashboard feedback link ───────────────────────────────────────────────────
+# An opt-in link in the dashboard header, and a row in its Settings drawer, that
+# sends a reader to wherever you collect feedback. Off unless both halves are
+# set: the flag alone renders nothing, and so does a URL without it.
+#
+# The URL is a template. {dashboard}, {dashboard_id}, {tab} and {url} are
+# filled in the browser and URL-encoded, so the remark arrives already saying
+# which dashboard, which tab and which page it is about, which is most of the
+# work of acting on it.
+# DEPICTIO_FEEDBACK_ENABLED=true
+# DEPICTIO_FEEDBACK_URL=https://github.com/<org>/<repo>/discussions/new?category=feedback&title={dashboard}&body={url}
+#
+# The wording: the tooltip on the header icon, and the label of the Settings row.
+# DEPICTIO_FEEDBACK_LABEL=Report an issue

--- a/.env.example
+++ b/.env.example
@@ -142,8 +142,16 @@ DEPICTIO_BOOTSTRAP_ADMIN_PASSWORD=CHANGEME_GENERATE_WITH_openssl_rand_base64_24
 # filled in the browser and URL-encoded, so the remark arrives already saying
 # which dashboard, which tab and which page it is about, which is most of the
 # work of acting on it.
+#
+# The example below points at a GitHub issue form, whose field ids are settable
+# from the query string. That is worth preferring over a blank issue or
+# discussion: the form asks what kind of remark it is, so what arrives is
+# already sorted rather than free prose someone has to read and classify. This
+# repo ships one at .github/ISSUE_TEMPLATE/dashboard_feedback.yml. Point it at
+# a helpdesk, a form, or a mailto: instead if your readers have no GitHub
+# account.
 # DEPICTIO_FEEDBACK_ENABLED=true
-# DEPICTIO_FEEDBACK_URL=https://github.com/<org>/<repo>/discussions/new?category=feedback&title={dashboard}&body={url}
+# DEPICTIO_FEEDBACK_URL=https://github.com/<org>/<repo>/issues/new?template=dashboard_feedback.yml&dashboard={dashboard}&tab={tab}&page={url}
 #
 # The wording: the tooltip on the header icon, and the label of the Settings row.
 # DEPICTIO_FEEDBACK_LABEL=Report an issue

--- a/.github/ISSUE_TEMPLATE/dashboard_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/dashboard_feedback.yml
@@ -1,5 +1,5 @@
 name: Dashboard feedback
-description: Something on a dashboard is wrong, missing, or reading a stale path
+description: Something on a dashboard is wrong, missing, or does not load
 title: "[FEEDBACK] "
 labels: ["dashboard-mgt"]
 body:
@@ -7,22 +7,41 @@ body:
     attributes:
       value: |
         Opened from the feedback link in a dashboard header, which fills in the
-        three context fields at the bottom. Leave them as they are, say what you
-        saw, and send. Nothing else is needed.
+        three context fields at the bottom. Leave those as they are, answer the
+        two questions, say what you saw, and send.
+
+        Both questions ask about what you can see. Whether the fix belongs in
+        the template, in Depictio or in the pipeline itself is not yours to
+        work out, and gets decided when the report is triaged.
 
   - type: dropdown
-    id: kind
+    id: symptom
     attributes:
-      label: What kind of remark is this?
+      label: What is wrong with it?
       description: >
-        The same four buckets used when a pipeline's maintainers review a
-        template, so everything that arrives is sorted the same way.
+        The same list a pipeline's maintainers work through when they review a
+        template, so every report is sorted the same way whichever way it came
+        in.
       options:
-        - "Wrong: a number or a plot is incorrect or misleading"
+        - "Wrong number: a value or a figure does not match the run"
+        - "Empty panel: something did not load, or is blank"
+        - "Hard to read: the panel is right, but the scale, colours or labels mislead"
         - "Missing: something I always look at is not here"
-        - "Moved: an output path changed and the dashboard reads the old one"
-        - "Conventions: it breaks a house rule for presenting these results"
-        - "Something else"
+        - "Conventions: not how this pipeline usually presents these results"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: How much does it get in your way?
+      description: >
+        This is the one call only you can make, and it is what decides the
+        order things get looked at.
+      options:
+        - "Blocking: I cannot trust this dashboard until it is fixed"
+        - "Workaround: wrong, but I can still get what I need"
+        - "Polish: a nit worth writing down"
     validations:
       required: true
 
@@ -31,8 +50,8 @@ body:
     attributes:
       label: What did you see?
       description: >
-        The panel or figure, and what is off about it. A screenshot goes a long
-        way, and you can paste one straight into this box.
+        Name the panel or figure, and say what is off about it. A screenshot
+        goes a long way, and you can paste one straight into this box.
       placeholder: >
         The "Reads per sample" bar chart shows every sample at zero, but the
         MultiQC report for the same run has real counts.

--- a/.github/ISSUE_TEMPLATE/dashboard_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/dashboard_feedback.yml
@@ -1,0 +1,66 @@
+name: Dashboard feedback
+description: Something on a dashboard is wrong, missing, or reading a stale path
+title: "[FEEDBACK] "
+labels: ["dashboard-mgt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Opened from the feedback link in a dashboard header, which fills in the
+        three context fields at the bottom. Leave them as they are, say what you
+        saw, and send. Nothing else is needed.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of remark is this?
+      description: >
+        The same four buckets used when a pipeline's maintainers review a
+        template, so everything that arrives is sorted the same way.
+      options:
+        - "Wrong: a number or a plot is incorrect or misleading"
+        - "Missing: something I always look at is not here"
+        - "Moved: an output path changed and the dashboard reads the old one"
+        - "Conventions: it breaks a house rule for presenting these results"
+        - "Something else"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What did you see?
+      description: >
+        The panel or figure, and what is off about it. A screenshot goes a long
+        way, and you can paste one straight into this box.
+      placeholder: >
+        The "Reads per sample" bar chart shows every sample at zero, but the
+        MultiQC report for the same run has real counts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+      description: Skip this if the answer is obvious from the box above.
+
+  - type: input
+    id: dashboard
+    attributes:
+      label: Dashboard
+      description: Filled in by the feedback link.
+
+  - type: input
+    id: tab
+    attributes:
+      label: Tab
+      description: Filled in by the feedback link.
+
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      description: >
+        Filled in by the feedback link. The address is what lets a maintainer
+        open the same view you were on.

--- a/depictio/api/v1/configs/settings_models.py
+++ b/depictio/api/v1/configs/settings_models.py
@@ -1378,6 +1378,45 @@ class GoogleAnalyticsConfig(BaseSettings):
         return self.enabled and self.tracking_id is not None
 
 
+class FeedbackConfig(BaseSettings):
+    """An opt-in "give feedback" link in the dashboard header.
+
+    A deployment that is showing dashboards to an audience it wants to hear
+    from — a pipeline template shared with its maintainers, a facility instance
+    shared with its users — needs the ask to sit where the reader is looking.
+    A message sent separately arrives without context: "the plot is wrong" with
+    no way to tell which dashboard, which tab, or which version it was.
+
+    url is a template. {project}, {dashboard}, {tab} and
+    {url} are substituted client-side and URL-encoded, so a GitHub
+    discussion or issue link can arrive pre-filled with what the reader was
+    looking at::
+
+        DEPICTIO_FEEDBACK_ENABLED=true
+        DEPICTIO_FEEDBACK_URL='https://github.com/org/repo/discussions/new?category=feedback&title=[{project}]&body={url}'
+
+    Off by default: a deployment that has nowhere to send feedback must not
+    grow a button that goes nowhere.
+    """
+
+    enabled: bool = Field(default=False, description="Show the feedback link in dashboard headers")
+    url: Optional[str] = Field(
+        default=None,
+        description=(
+            "URL template opened by the link. {dashboard}, {dashboard_id}, {tab} and {url} "
+            "are substituted and URL-encoded."
+        ),
+    )
+    label: str = Field(default="Feedback", description="Text on the link")
+
+    model_config = SettingsConfigDict(env_prefix="DEPICTIO_FEEDBACK_")
+
+    @property
+    def is_configured(self) -> bool:
+        """Enabled *and* pointed somewhere. Either half alone renders nothing."""
+        return self.enabled and bool(self.url)
+
+
 class BrandingConfig(BaseSettings):
     """Instance-level branding, the deployment-defaults layer (issue #397).
 
@@ -1654,6 +1693,7 @@ class Settings(BaseSettings):
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
     google_analytics: GoogleAnalyticsConfig = Field(default_factory=GoogleAnalyticsConfig)
     branding: BrandingConfig = Field(default_factory=BrandingConfig)
+    feedback: FeedbackConfig = Field(default_factory=FeedbackConfig)
     profiling: ProfilingConfig = Field(default_factory=ProfilingConfig)
 
     disable_example_dashboards: bool = Field(

--- a/depictio/api/v1/endpoints/utils_endpoints/routes.py
+++ b/depictio/api/v1/endpoints/utils_endpoints/routes.py
@@ -155,6 +155,15 @@ async def public_config():
         # added for. A store that is down still degrades to env defaults
         # inside get_effective_brand_theme rather than failing the request.
         "branding": resolve_effective_brand_theme(use_cache=False).model_dump(exclude_none=True),
+        # Opt-in "give feedback" link (off unless a deployment points it
+        # somewhere). The URL is a template the SPA fills with what the reader
+        # is looking at; it is already public config, since anyone who can open
+        # the dashboard can read the link off the button.
+        "feedback": {
+            "enabled": settings.feedback.is_configured,
+            "url": settings.feedback.url if settings.feedback.is_configured else None,
+            "label": settings.feedback.label,
+        },
     }
 
 

--- a/depictio/tests/unit/test_feedback_config.py
+++ b/depictio/tests/unit/test_feedback_config.py
@@ -1,0 +1,48 @@
+"""The opt-in dashboard feedback link, as the frontend receives it."""
+
+from __future__ import annotations
+
+import pytest
+
+from depictio.api.v1.configs.settings_models import FeedbackConfig
+
+
+def test_off_by_default() -> None:
+    """A deployment that set nothing must not grow a button that goes nowhere."""
+    config = FeedbackConfig()
+    assert config.enabled is False
+    assert config.url is None
+    assert config.is_configured is False
+
+
+@pytest.mark.parametrize(
+    ("enabled", "url"),
+    [
+        # Enabled but pointed nowhere: the flag alone renders no link.
+        (True, None),
+        (True, ""),
+        # Pointed somewhere but not enabled: the URL alone renders no link.
+        (False, "https://example.org/feedback"),
+    ],
+)
+def test_half_configured_is_not_configured(enabled: bool, url: str | None) -> None:
+    assert FeedbackConfig(enabled=enabled, url=url).is_configured is False
+
+
+def test_fully_configured() -> None:
+    config = FeedbackConfig(enabled=True, url="https://example.org/feedback", label="Tell us")
+    assert config.is_configured is True
+    assert config.label == "Tell us"
+
+
+def test_reads_its_env_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEPICTIO_FEEDBACK_ENABLED", "true")
+    monkeypatch.setenv("DEPICTIO_FEEDBACK_URL", "https://example.org/f?d={dashboard}")
+    monkeypatch.setenv("DEPICTIO_FEEDBACK_LABEL", "Feedback")
+
+    config = FeedbackConfig()
+
+    assert config.is_configured is True
+    # The template reaches the client verbatim — substitution happens there,
+    # where the dashboard and tab on screen are known.
+    assert config.url == "https://example.org/f?d={dashboard}"

--- a/depictio/viewer/src/chrome/Header.tsx
+++ b/depictio/viewer/src/chrome/Header.tsx
@@ -134,14 +134,6 @@ const Header: React.FC<HeaderProps> = ({
   const addColor = useBrandAccent('primary', 'green');
   const saveColor = useBrandAccent('secondary', 'teal');
   const editColor = useBrandAccent('primary', 'blue');
-  // The reader's context travels with the link: which dashboard, which tab,
-  // which page. Without it a remark arrives as "that plot is wrong" with
-  // nothing saying where.
-  const feedback = useFeedbackLink({
-    dashboard: dashboard?.title ?? null,
-    dashboardId,
-    tab: activeTab?.title ?? null,
-  });
   const resolvedColor = resolveTabColor(activeTab, brand);
   const tabIconColor = resolvedColor || 'gray';
   // Title text color:
@@ -174,6 +166,21 @@ const Header: React.FC<HeaderProps> = ({
   const titleText = dashboardName
     ? `${dashboardName} / ${activeLabel}`
     : activeLabel;
+  // The pill label the reader is actually looking at, or nothing when this tab
+  // has none of its own. `activeTab.title` is the dashboard's own title on a
+  // parent tab, so reading it here sent "nf-core/ampliseq" as both the
+  // dashboard and the tab; an empty field says less but says it truthfully.
+  const tabLabel = (isChild ? activeTab?.title : activeTab?.main_tab_name) || null;
+
+  // The reader's context travels with the link: which dashboard, which tab,
+  // which page. Without it a remark arrives as "that plot is wrong" with
+  // nothing saying where. Both names are the ones on screen, taken from the
+  // breadcrumb rather than the raw fields, so the link and the header agree.
+  const feedback = useFeedbackLink({
+    dashboard: dashboardName ?? null,
+    dashboardId,
+    tab: tabLabel,
+  });
 
   const handleEdit = () => {
     if (dashboardId) {

--- a/depictio/viewer/src/chrome/Header.tsx
+++ b/depictio/viewer/src/chrome/Header.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@iconify/react';
 
 import type { BrandTheme, DashboardData, DashboardSummary } from 'depictio-react-core';
 import PoweredBy from './PoweredBy';
+import { useFeedbackLink } from '../feedback';
 
 /** True for path-like icon values (PNG/SVG file URLs) — these came from the
  *  Dash YAML and aren't valid Iconify names. */
@@ -133,6 +134,14 @@ const Header: React.FC<HeaderProps> = ({
   const addColor = useBrandAccent('primary', 'green');
   const saveColor = useBrandAccent('secondary', 'teal');
   const editColor = useBrandAccent('primary', 'blue');
+  // The reader's context travels with the link: which dashboard, which tab,
+  // which page. Without it a remark arrives as "that plot is wrong" with
+  // nothing saying where.
+  const feedback = useFeedbackLink({
+    dashboard: dashboard?.title ?? null,
+    dashboardId,
+    tab: activeTab?.title ?? null,
+  });
   const resolvedColor = resolveTabColor(activeTab, brand);
   const tabIconColor = resolvedColor || 'gray';
   // Title text color:
@@ -367,6 +376,29 @@ const Header: React.FC<HeaderProps> = ({
           >
             Exit Edit
           </Button>
+        )}
+        {/* An aside, not an action on the dashboard, so it is an icon rather
+            than a sixth button: findable by someone who wants to say something,
+            without competing with Edit / Save / Settings. The tooltip carries
+            the label, which is the whole reason an icon can stand alone here.
+            The same link is repeated as a labelled row in the Settings drawer
+            for anyone who goes looking rather than reacting. */}
+        {feedback && (
+          <Tooltip label={feedback.label} withArrow>
+            <ActionIcon
+              component="a"
+              href={feedback.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={feedback.label}
+              color="gray"
+              variant="subtle"
+              size="md"
+              data-testid="dashboard-feedback"
+            >
+              <Icon icon="mdi:comment-quote-outline" width={18} />
+            </ActionIcon>
+          </Tooltip>
         )}
         <Button
           leftSection={<Icon icon="ic:baseline-settings" width={14} />}

--- a/depictio/viewer/src/chrome/Header.tsx
+++ b/depictio/viewer/src/chrome/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ActionIcon, Badge, Box, Button, Group, Loader, Menu, Title, Tooltip, useMantineColorScheme } from '@mantine/core';
+import { ActionIcon, Badge, Box, Button, Divider, Group, Loader, Menu, Title, Tooltip, useMantineColorScheme } from '@mantine/core';
 import { BRAND_PALETTES, useBrandAccent, useBranding } from 'depictio-react-core';
 import { Icon } from '@iconify/react';
 
@@ -377,29 +377,6 @@ const Header: React.FC<HeaderProps> = ({
             Exit Edit
           </Button>
         )}
-        {/* An aside, not an action on the dashboard, so it is an icon rather
-            than a sixth button: findable by someone who wants to say something,
-            without competing with Edit / Save / Settings. The tooltip carries
-            the label, which is the whole reason an icon can stand alone here.
-            The same link is repeated as a labelled row in the Settings drawer
-            for anyone who goes looking rather than reacting. */}
-        {feedback && (
-          <Tooltip label={feedback.label} withArrow>
-            <ActionIcon
-              component="a"
-              href={feedback.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={feedback.label}
-              color="gray"
-              variant="subtle"
-              size="md"
-              data-testid="dashboard-feedback"
-            >
-              <Icon icon="mdi:comment-quote-outline" width={18} />
-            </ActionIcon>
-          </Tooltip>
-        )}
         <Button
           leftSection={<Icon icon="ic:baseline-settings" width={14} />}
           color="gray"
@@ -409,6 +386,36 @@ const Header: React.FC<HeaderProps> = ({
         >
           Settings
         </Button>
+        {/* An aside, not an action on the dashboard, so it is an icon rather
+            than a sixth button: findable by someone who wants to say something,
+            without competing with Edit / Save / Settings. It sits past the
+            divider, at the end of the row, because it is about the dashboard
+            rather than a thing you can do to it. The subtle grey icon button
+            is the same treatment as the hamburgers at the other end of the
+            header, and the tooltip carries the label, which is the whole
+            reason an icon can stand alone here. The same link is repeated as a
+            labelled row in the Settings drawer for anyone who goes looking
+            rather than reacting. */}
+        {feedback && (
+          <>
+            <Divider orientation="vertical" my={6} />
+            <Tooltip label={feedback.label} withArrow>
+              <ActionIcon
+                component="a"
+                href={feedback.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={feedback.label}
+                color="gray"
+                variant="subtle"
+                size="md"
+                data-testid="dashboard-feedback"
+              >
+                <Icon icon="mdi:comment-quote" width={22} />
+              </ActionIcon>
+            </Tooltip>
+          </>
+        )}
       </Group>
     </Group>
   );

--- a/depictio/viewer/src/chrome/SettingsDrawer.tsx
+++ b/depictio/viewer/src/chrome/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   ActionIcon,
+  Anchor,
   Button,
   Divider,
   Drawer,
@@ -25,6 +26,7 @@ import {
 } from 'depictio-react-core';
 import DashboardInfoBody from './DashboardInfoBody';
 import { useBranding } from '../branding';
+import { useFeedbackLink } from '../feedback';
 import { useUiScalePref } from '../hooks/useUiScalePref';
 
 /** Client-side mirror of the server's upload cap (routes.py). */
@@ -299,6 +301,49 @@ const BrandingBlock: React.FC<{
   );
 };
 
+/**
+ * The deployment's feedback link, as a labelled row.
+ *
+ * The header carries the same link as a bare icon, for reacting in the moment.
+ * This is the other half: somewhere to find it when you went looking for it,
+ * with the label and a line saying what it is for. Both read the one config,
+ * so there is a single place the URL can be wrong.
+ */
+const FeedbackBlock: React.FC<{ dashboard: DashboardData | null }> = ({ dashboard }) => {
+  const feedback = useFeedbackLink({
+    dashboard: dashboard?.title ?? null,
+    dashboardId: dashboard?.dashboard_id ?? dashboard?._id ?? null,
+    tab: null,
+  });
+  if (!feedback) return null;
+  return (
+    <>
+      <Divider />
+      <Stack gap={6} data-testid="feedback-section">
+        <Group gap="xs">
+          <Icon icon="mdi:comment-quote-outline" width={18} />
+          <Text fw={600} size="sm">
+            Feedback
+          </Text>
+        </Group>
+        <Text size="xs" c="dimmed">
+          Tell us what this dashboard gets wrong, or what it is missing. The link carries which
+          dashboard you were on.
+        </Text>
+        <Anchor
+          href={feedback.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          size="sm"
+          data-testid="feedback-link"
+        >
+          {feedback.label}
+        </Anchor>
+      </Stack>
+    </>
+  );
+};
+
 interface SettingsDrawerProps {
   opened: boolean;
   onClose: () => void;
@@ -358,6 +403,8 @@ const SettingsDrawer: React.FC<SettingsDrawerProps> = ({
           />
         </>
       )}
+      <Divider />
+      <FeedbackBlock dashboard={dashboard} />
       <Divider />
       <Stack gap="sm" data-testid="appearance-section">
         <Group gap="xs">

--- a/depictio/viewer/src/feedback.ts
+++ b/depictio/viewer/src/feedback.ts
@@ -1,0 +1,85 @@
+import React from 'react';
+
+/**
+ * The deployment's opt-in feedback link, served by `/utils/public-config`.
+ *
+ * A dashboard shown to an audience you want to hear from needs the ask to sit
+ * where the reader is looking. Feedback that arrives through some other channel
+ * arrives without context: "that plot is wrong" with nothing saying which
+ * dashboard, which tab, or which version — which is most of the work of acting
+ * on it.
+ *
+ * The config lands after first paint (the `/utils/public-config` fetch is
+ * fire-and-forget), so it flows through a tiny external store rather than React
+ * state that may not exist yet — the same pattern branding uses. There is no
+ * localStorage cache here on purpose: an un-rendered button for one frame costs
+ * nothing, and a stale cached link outliving the deployment that set it does.
+ */
+export interface FeedbackConfig {
+  enabled: boolean;
+  /** Template; `{dashboard}`, `{dashboard_id}`, `{tab}` and `{url}` are substituted. */
+  url: string | null;
+  label: string;
+}
+
+let currentFeedback: FeedbackConfig | null = null;
+const subscribers = new Set<() => void>();
+
+export function getFeedback(): FeedbackConfig | null {
+  return currentFeedback;
+}
+
+export function setFeedback(config: FeedbackConfig | null): void {
+  const normalized = config?.enabled && config.url ? config : null;
+  if (JSON.stringify(normalized) === JSON.stringify(currentFeedback)) return;
+  currentFeedback = normalized;
+  subscribers.forEach((fn) => fn());
+}
+
+export function subscribeFeedback(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+export interface FeedbackContext {
+  /** The dashboard's own title — what a reader would name it in an issue. */
+  dashboard?: string | null;
+  dashboardId?: string | null;
+  /** The tab that is on screen, which is usually what the remark is about. */
+  tab?: string | null;
+}
+
+/**
+ * Fill the deployment's URL template with what the reader is looking at.
+ *
+ * Every value is URL-encoded, so a template can drop `{dashboard}` straight
+ * into a query string (a dashboard titled "CUT&RUN Chromatin Profiling" would
+ * otherwise truncate the parameter). `{url}` is the current page, the one value
+ * that still identifies what was on screen when the rest are blank.
+ */
+export function resolveFeedbackUrl(template: string, context: FeedbackContext): string {
+  const values: Record<string, string> = {
+    dashboard: context.dashboard ?? '',
+    dashboard_id: context.dashboardId ?? '',
+    tab: context.tab ?? '',
+    url: typeof window === 'undefined' ? '' : window.location.href,
+  };
+  return template.replace(/\{(dashboard_id|dashboard|tab|url)\}/g, (_match, key: string) =>
+    encodeURIComponent(values[key] ?? ''),
+  );
+}
+
+/** The resolved link, or null when the deployment configured none. */
+export function useFeedbackLink(context: FeedbackContext): { href: string; label: string } | null {
+  const config = React.useSyncExternalStore(subscribeFeedback, getFeedback);
+  const { dashboard, dashboardId, tab } = context;
+  return React.useMemo(() => {
+    if (!config?.url) return null;
+    return {
+      href: resolveFeedbackUrl(config.url, { dashboard, dashboardId, tab }),
+      label: config.label || 'Feedback',
+    };
+  }, [config, dashboard, dashboardId, tab]);
+}

--- a/depictio/viewer/src/main.tsx
+++ b/depictio/viewer/src/main.tsx
@@ -63,6 +63,7 @@ import { brandCssVariablesResolver, buildDepictioTheme } from './theme';
 import { readStoredScheme } from './hooks/useColorScheme';
 import { useUiScalePref } from './hooks/useUiScalePref';
 import { BrandingContext, getBranding, setBranding, subscribeBranding } from './branding';
+import { setFeedback } from './feedback';
 import { initGoogleAnalytics } from './googleAnalytics';
 import { WalkthroughHost } from './walkthrough';
 
@@ -308,6 +309,9 @@ function bootstrapPublicConfig(): void {
       if (config.branding !== undefined) {
         setBranding(config.branding);
       }
+      // Opt-in feedback link. Absent on a backend that predates it, which is
+      // the same as a deployment that configured none: no button.
+      setFeedback(config.feedback ?? null);
     })
     .catch(() => undefined);
 }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -118,6 +118,14 @@ services:
         # the numbers useless. The shipped docker-compose.yaml has it on.
         DEPICTIO_TELEMETRY_ENABLED: "${DEPICTIO_TELEMETRY_ENABLED:-false}"
         DEPICTIO_TELEMETRY_DEPLOYMENT_KIND: "${DEPICTIO_TELEMETRY_DEPLOYMENT_KIND:-docker-compose-dev}"
+        # Dashboard feedback link, served to the SPA through
+        # /utils/public-config. Off unless both halves are set: the flag alone
+        # renders nothing, and so does a URL without it. The URL is a template
+        # whose {dashboard}, {dashboard_id}, {tab} and {url} are filled in the
+        # browser, so the link arrives carrying what the reader was looking at.
+        DEPICTIO_FEEDBACK_ENABLED: "${DEPICTIO_FEEDBACK_ENABLED:-false}"
+        DEPICTIO_FEEDBACK_URL: "${DEPICTIO_FEEDBACK_URL:-}"
+        DEPICTIO_FEEDBACK_LABEL: "${DEPICTIO_FEEDBACK_LABEL:-Feedback}"
         # Belt-and-suspenders: the editable plotly-upset / plotly-complexheatmap
         # packages are installed into the venv at image build (uv sync). If the
         # build re-used a cached layer (pre-dating the package addition), the

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,14 @@ services:
       # look identical from the inside.
       DEPICTIO_TELEMETRY_ENABLED: "${DEPICTIO_TELEMETRY_ENABLED:-true}"
       DEPICTIO_TELEMETRY_DEPLOYMENT_KIND: "${DEPICTIO_TELEMETRY_DEPLOYMENT_KIND:-docker-compose}"
+      # Dashboard feedback link, served to the SPA through /utils/public-config.
+      # Off unless both halves are set: the flag alone renders nothing, and so
+      # does a URL without it. The URL is a template whose {dashboard},
+      # {dashboard_id}, {tab} and {url} are filled in the browser, so the link
+      # arrives carrying what the reader was looking at.
+      DEPICTIO_FEEDBACK_ENABLED: "${DEPICTIO_FEEDBACK_ENABLED:-false}"
+      DEPICTIO_FEEDBACK_URL: "${DEPICTIO_FEEDBACK_URL:-}"
+      DEPICTIO_FEEDBACK_LABEL: "${DEPICTIO_FEEDBACK_LABEL:-Feedback}"
       # Forwarded so the automatic CI suppression works through the container
       # boundary. These are set on the machine running Compose, not inside the
       # container, so without this a pipeline that brings Depictio up on every

--- a/helm-charts/depictio/templates/configmaps.yaml
+++ b/helm-charts/depictio/templates/configmaps.yaml
@@ -105,6 +105,13 @@ data:
   DEPICTIO_TELEMETRY_MEMORY_LIMIT: {{ .Values.backend.env.DEPICTIO_TELEMETRY_MEMORY_LIMIT | default .Values.backend.resources.limits.memory | quote }}
   DEPICTIO_TELEMETRY_INCLUDE_USAGE_METRICS: {{ .Values.backend.env.DEPICTIO_TELEMETRY_INCLUDE_USAGE_METRICS | default "true" | quote }}
   DEPICTIO_TELEMETRY_DEBUG: {{ .Values.backend.env.DEPICTIO_TELEMETRY_DEBUG | default "false" | quote }}
+  # Dashboard feedback link, served to the SPA through /utils/public-config.
+  # Both halves are required: the flag alone renders nothing, and so does a URL
+  # without it. The URL is a template the browser fills with {dashboard},
+  # {dashboard_id}, {tab} and {url}.
+  DEPICTIO_FEEDBACK_ENABLED: {{ .Values.backend.env.DEPICTIO_FEEDBACK_ENABLED | default "false" | quote }}
+  DEPICTIO_FEEDBACK_URL: {{ .Values.backend.env.DEPICTIO_FEEDBACK_URL | default "" | quote }}
+  DEPICTIO_FEEDBACK_LABEL: {{ .Values.backend.env.DEPICTIO_FEEDBACK_LABEL | default "Feedback" | quote }}
   DEPICTIO_GOOGLE_ANALYTICS_ENABLED: {{ .Values.backend.env.DEPICTIO_GOOGLE_ANALYTICS_ENABLED | default "false" | quote }}
   {{- if .Values.googleAnalytics }}
   DEPICTIO_GOOGLE_ANALYTICS_TRACKING_ID: {{ .Values.googleAnalytics.DEPICTIO_GOOGLE_ANALYTICS_TRACKING_ID | default "G-XXXXXXXXXX" | quote }}

--- a/helm-charts/depictio/values.yaml
+++ b/helm-charts/depictio/values.yaml
@@ -320,6 +320,15 @@ backend:
     # Set true to log the payload instead of sending it.
     DEPICTIO_TELEMETRY_DEBUG: "false"
 
+    # Dashboard feedback link, served to the SPA through /utils/public-config.
+    # Both halves are required: the flag alone renders nothing, and so does a URL
+    # without it. The URL is a template whose {dashboard}, {dashboard_id}, {tab}
+    # and {url} are filled in the browser, so a remark arrives already carrying
+    # what the reader was looking at.
+    DEPICTIO_FEEDBACK_ENABLED: "false"
+    DEPICTIO_FEEDBACK_URL: ""
+    DEPICTIO_FEEDBACK_LABEL: "Feedback"
+
     # Google Analytics configuration (GA4)
     # Enable to track page views, user interactions, and engagement metrics
     # Get your tracking ID from Google Analytics dashboard (Property → Data Streams)

--- a/packages/depictio-react-core/src/api.ts
+++ b/packages/depictio-react-core/src/api.ts
@@ -1723,6 +1723,14 @@ export interface PublicConfigResponse {
    *  materialised and defaults made explicit, so the client never re-derives
    *  a palette. Empty-ish object on an unbranded deployment. */
   branding?: BrandTheme;
+  /** Opt-in feedback link for dashboard headers. `url` is a template the SPA
+   *  fills with what the reader is looking at ({project}, {dashboard}, {tab},
+   *  {url}); absent or disabled on a deployment that set none. */
+  feedback?: {
+    enabled: boolean;
+    url: string | null;
+    label: string;
+  };
 }
 
 export async function fetchPublicConfig(): Promise<PublicConfigResponse> {


### PR DESCRIPTION
A dashboard shown to an audience you want to hear from needs the ask to sit where the reader is looking. Feedback that arrives through some other channel arrives without context: "that plot is wrong" with nothing saying which dashboard, which tab, or which version, which is most of the work of acting on it.

This adds an opt-in link that carries that context with it. Off by default: the flag alone renders nothing, and so does a URL without it.

## What it looks like

An icon at the end of the header row, past a vertical divider, with the deployment's label as its tooltip. The same link appears as a labelled row in the Settings drawer, for someone who goes looking rather than reacting.

## How a deployment turns it on

```
DEPICTIO_FEEDBACK_ENABLED=true
DEPICTIO_FEEDBACK_URL='https://github.com/<org>/<repo>/issues/new?template=dashboard_feedback.yml&dashboard={dashboard}&tab={tab}&page={url}'
DEPICTIO_FEEDBACK_LABEL='Send feedback'
```

`{dashboard}`, `{dashboard_id}`, `{tab}` and `{url}` are substituted in the browser and URL-encoded, so a dashboard titled "CUT&RUN Chromatin Profiling" does not truncate the parameter. The config reaches the SPA through `/utils/public-config`, and flows through a small external store rather than React state, because that fetch lands after first paint. There is no localStorage cache on purpose: an unrendered button for one frame costs nothing, a stale link outliving the deployment that set it does.

The tab value is the pill label the reader sees, not `activeTab.title`, which on a parent tab is the dashboard's own title and would have sent the same string twice.

## Where it can point

Anywhere. It is a URL template, so an instance serving wet-lab users points it at a helpdesk or a `mailto:`. `.github/ISSUE_TEMPLATE/dashboard_feedback.yml` is what this repo points it at: an issue form whose field ids are settable from the query string, so the context arrives in fields rather than prose, and whose two dropdowns ask what the reader can see. What is wrong with it (wrong number, empty panel, hard to read, missing, conventions) and how much it gets in their way (blocking, workaround, polish). Whether the fix belongs in the template, in Depictio or in the pipeline is left to triage, and the form says so.

Four of those buckets are shared word for word with the nf-core template review round, so a report that arrives through a dashboard header and one that arrives through a review thread sort into the same pile.

## Deployment wiring

The compose `environment:` blocks and the Helm configmap are explicit key allowlists, so the three variables are added to each. Without that, setting `DEPICTIO_FEEDBACK_ENABLED` in `.env.instance` would have been silently dropped and the feature unreachable in any real deployment. Verified against the rendered chart.

## Testing

- `depictio/tests/unit/test_feedback_config.py`: 6 tests covering the default-off posture, both half-configured states, and the env prefix.
- `tsc --noEmit` clean, `pre-commit` clean on every changed file.
- The issue form validates against the published GitHub issue-forms schema.

## What this does not do

No in-app submission, no server-side token, no storage. The button opens a URL. If click-through turns out to be the bottleneck, that is measurable (clicks versus issues filed) and would be the moment to reconsider, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBinJi3qMoxZzuXX7T19mJ
