### PR TITLE
docs(templates): give the generated reference an Origin and Reads column

### DIFF
--- a/depictio/dev_scripts/gen_template_docs.py
+++ b/depictio/dev_scripts/gen_template_docs.py
@@ -52,6 +52,10 @@ _STYLE = """<style>
 .gtd-badge{display:inline-block;padding:0 .5em;border-radius:10px;font-size:.78em;font-weight:600;line-height:1.5;white-space:nowrap;}
 .gtd-scan{background:#eef1fb;color:#3949ab;}
 .gtd-transformed{background:#e6f7f5;color:#2a8c82;}
+.gtd-direct{background:#eaf2ff;color:#2563c9;}
+.gtd-derived{background:#f3e8fd;color:#8e44ad;}
+.gtd-recipe{background:#fbe9f1;color:#b4337a;}
+.gtd-file{background:#eef0f2;color:#5a6573;}
 .gtd-opt{background:#fff6e6;color:#b9770e;}
 .gtd-req{background:#e9f7ef;color:#1e8e5a;}
 .gtd-plus-chip{background:#e9f7ef;color:#1e8e5a;}
@@ -67,6 +71,8 @@ _STYLE = """<style>
    only the other columns' long paths may wrap. */
 .md-typeset table td:first-child{white-space:nowrap;}
 .md-typeset table td:not(:first-child) code{overflow-wrap:anywhere;}
+/* Reads-column paths: smaller monospace + wrap so long scan targets keep the row tidy. */
+.md-typeset table code.gtd-path{font-size:.62rem;overflow-wrap:anywhere;}
 .gtd-mtx{margin:.8rem 0;}
 .gtd-mtx table{border-collapse:separate;border-spacing:0;font-size:.7rem;}
 .gtd-mtx th,.gtd-mtx td{border:1px solid var(--md-default-fg-color--lightest,#e6e6e6);padding:2px 5px;text-align:center;}
@@ -214,31 +220,103 @@ def _render_variables(meta: TemplateMetadata) -> list[str]:
     return lines
 
 
+_DC_TYPE_ICON = {
+    "table": "material-table",
+    "jbrowse2": "material-dna",
+    "image": "material-image-outline",
+    "geojson": "material-map-marker-radius-outline",
+    "map": "material-map-marker-radius-outline",
+    "phylogeny": "material-graph-outline",
+}
+_DC_TYPE_FALLBACK = "material-file-document-outline"
+# Official MultiQC icon (the app renders this same SVG for MultiQC DCs).
+_MULTIQC_LOGO = "https://raw.githubusercontent.com/MultiQC/logo/main/logos/multiqc_icon_color.svg"
+
+
+def _dc_type_cell(dc_type: str) -> str:
+    """Render the Type cell as the depictio type icon (MultiQC logo) + the type label."""
+    if not dc_type or dc_type == "\u2014":
+        return "\u2014"
+    if dc_type.lower() == "multiqc":
+        return (
+            f'<img src="{_MULTIQC_LOGO}" alt="MultiQC" width="14" '
+            f'style="vertical-align:text-bottom;"> {_esc(dc_type)}'
+        )
+    icon = _DC_TYPE_ICON.get(dc_type.lower(), _DC_TYPE_FALLBACK)
+    return f":{icon}: {_esc(dc_type)}"
+
+
+def _dc_origin(dc: dict[str, Any], pipeline_version: str) -> str:
+    """Classify a DC as 'direct' or 'derived'.
+
+    *Direct* = a real pipeline output: either scanned straight off disk, or a recipe
+    that reads raw pipeline files. *Derived* = a recipe that reshapes one or more other
+    data collections (its recipe declares a ``dc_ref`` source) into the column layout a
+    specific visualization needs — it is a view of existing data, not new measurement.
+    """
+    config = dc.get("config") or {}
+    if config.get("source") != "transformed":
+        return "direct"
+    recipe = (config.get("transform") or {}).get("recipe")
+    if not recipe:
+        return "direct"
+    try:
+        module = load_recipe(recipe, pipeline_version)
+        if any(getattr(s, "dc_ref", None) for s in module.SOURCES):
+            return "derived"
+    except Exception:  # noqa: BLE001 — unresolved recipe falls back to 'direct'
+        pass
+    return "direct"
+
+
 def _badge(text: str, cls: str) -> str:
     return f'<span class="gtd-badge {cls}">{text}</span>'
 
 
-def _render_data_collections(dcs: list[dict[str, Any]]) -> list[str]:
+def _render_data_collections(dcs: list[dict[str, Any]], pipeline_version: str) -> list[str]:
     optional_count = sum(1 for dc in dcs if dc.get("optional"))
     required_count = len(dcs) - optional_count
+    origins = {dc["data_collection_tag"]: _dc_origin(dc, pipeline_version) for dc in dcs}
+    direct_count = sum(1 for o in origins.values() if o == "direct")
+    derived_count = len(origins) - direct_count
     lines = [
         "### Data collections",
         "",
         f"{len(dcs)} data collections — {_badge(f'{required_count} required', 'gtd-req')} "
-        f"{_badge(f'{optional_count} optional', 'gtd-opt')}.",
+        f"{_badge(f'{optional_count} optional', 'gtd-opt')} · "
+        f"{_badge(f'{direct_count} direct', 'gtd-direct')} "
+        f"{_badge(f'{derived_count} derived', 'gtd-derived')}.",
         "",
-        "| Tag | Type | Source | Recipe / scan target | Status |",
-        "|---|---|---|---|:--:|",
+        f"**Origin** tells you whether a collection is *real pipeline data* or a reshape of it: "
+        f"{_badge('direct', 'gtd-direct')} = a pipeline output (scanned, or a recipe that reads raw "
+        f"files); {_badge('derived', 'gtd-derived')} = a recipe that reshapes one or more *direct* "
+        f"collections into the layout a visualization needs (no new measurement). **Reads** shows "
+        f"what produces it: a {_badge('recipe', 'gtd-recipe')} `.py` transform, or a raw "
+        f"{_badge('file', 'gtd-file')} scanned off disk. (A `direct` collection can still have a "
+        f"recipe — one that merely parses/cleans the raw file; `derived` means the recipe reshapes "
+        f"another collection.)",
+        "",
+        "| Tag | Origin | Type | Reads | Status |",
+        "|---|:--:|---|---|:--:|",
     ]
     for dc in dcs:
-        source, detail = _dc_source_detail(dc)
+        source, target = _dc_source_detail(dc)
         dc_type = (dc.get("config") or {}).get("type", "—")
-        src = _badge(source, "gtd-transformed" if source == "transformed" else "gtd-scan")
+        origin = origins[dc["data_collection_tag"]]
+        origin_badge = _badge(origin, "gtd-direct" if origin == "direct" else "gtd-derived")
+        reads_badge = (
+            _badge("recipe", "gtd-recipe")
+            if source == "transformed"
+            else _badge("file", "gtd-file")
+        )
+        # Small monospace, wrap-anywhere so long scan paths don't blow out the row.
+        path = f'<code class="gtd-path">{_html(target)}</code>' if target else "—"
         status = (
             _badge("optional", "gtd-opt") if dc.get("optional") else _badge("required", "gtd-req")
         )
         lines.append(
-            f"| {_code(dc['data_collection_tag'])} | {dc_type} | {src} | {detail} | {status} |"
+            f"| {_code(dc['data_collection_tag'])} | {origin_badge} | {_dc_type_cell(dc_type)} | "
+            f"{reads_badge} {path} | {status} |"
         )
     lines.append("")
     return lines
@@ -410,7 +488,7 @@ def render_template(template_path: Path) -> str:
         _STYLE,
         "",
         *_render_variables(meta),
-        *_render_data_collections(dcs),
+        *_render_data_collections(dcs, pipeline_version),
         *_render_conditionals(meta, [dc["data_collection_tag"] for dc in dcs]),
         *_render_links(raw),
         *_render_recipes(recipe_refs, pipeline_version),


### PR DESCRIPTION
`depictio/dev_scripts/gen_template_docs.py` on `main` emits

```
| Tag | Type | Source | Recipe / scan target | Status |
```

while every partial committed in `depictio-docs` carries

```
| Tag | Origin | Type | Reads | Status |
```

That richer table was written on `chore/amplicon-viralrecon-validation` (#873), which is **661 commits behind main** and not landing soon. So the docs could not be regenerated from `main` at all without losing a column, and ampliseq **2.18.0**, which only exists here, had no reference partial as a consequence: the docs page still pins 2.16.0 in four places.

## What this ports

Only the data-collection table, from that same commit:

- `_dc_origin()`, which classifies a collection as **direct** (a pipeline output: scanned, or a recipe reading raw files) or **derived** (a recipe reshaping other collections through a `dc_ref` source)
- the **Reads** cell: a `recipe` / `file` badge plus the scan target in a small wrapping `<code>`
- `_dc_type_cell()`, so the Type column shows depictio's own icons and the real MultiQC logo
- the four badge colours and the `.gtd-path` rule

## What it deliberately leaves behind

The `if_var_equals` route rendering from the same commit. Neither `depictio/models` nor any template under `depictio/projects` on `main` has that field, so it would render nothing.

## Effect

Regenerating now produces all 11 partials consistently, including the three that did not exist: `ampliseq-2.18.0.md`, `ampliseq-latest.md` and `viralrecon-latest.md`. The variantbenchmarking partials added in depictio-docs#197 were in the old column format and are upgraded by the same run.

`ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqVeh14diR64xiHL4SRhHm