### PR TITLE
feat(viewer): put the listing filters in the URL, so a scoped view can be shared

### DIFF
--- a/depictio/tests/e2e-playwright/tests/dashboards/shared-filter-links.spec.ts
+++ b/depictio/tests/e2e-playwright/tests/dashboards/shared-filter-links.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Shareable listing views: /dashboards and /projects read their filters out of
+ * the URL and write them back, so a link narrowed to one pipeline template can
+ * be handed to a reviewer.
+ *
+ * The template assertions need a project seeded from a template; they skip
+ * themselves when the target stack has none (not every CI leg seeds the
+ * nf-core projects). The search-scope assertions are data-independent and
+ * always run.
+ */
+
+import { test, expect, apiLogin, API_URL, API_PREFIX } from "@fixtures/auth";
+import { credentials } from "@fixtures/credentials";
+
+interface ProjectEntry {
+  name: string;
+  template_origin?: { template_id?: string } | string | null;
+}
+
+/** `source/repo` of the first templated project on the stack, or null. */
+async function findTemplateScope(
+  request: Parameters<typeof apiLogin>[0],
+): Promise<string | null> {
+  const admin = credentials.adminUser;
+  let token: string;
+  try {
+    token = (await apiLogin(request, admin.email, admin.password)).access_token;
+  } catch {
+    return null;
+  }
+  const res = await request.get(`${API_URL}${API_PREFIX}/projects/get/all`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok()) return null;
+  const projects = (await res.json()) as ProjectEntry[];
+  for (const p of projects ?? []) {
+    const origin = p.template_origin;
+    const raw = typeof origin === "string" ? origin : (origin?.template_id ?? "");
+    const parts = raw.split("/").filter(Boolean);
+    // Drop a trailing version segment: the filter is version-agnostic.
+    if (parts.length >= 3) parts.pop();
+    if (parts.length >= 2) return `${parts[0]}/${parts[1]}`;
+  }
+  return null;
+}
+
+const banner = "[data-testid=shared-view-banner]";
+
+test.describe("Shareable filter links", () => {
+  test("a bare listing shows no shared-view banner", async ({
+    loginAsAdmin,
+    page,
+  }) => {
+    await loginAsAdmin();
+    await page.goto("/dashboards");
+    await expect(page.getByTestId("new-dashboard-btn")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.locator(banner)).toHaveCount(0);
+  });
+
+  test("a search param scopes the page and can be cleared", async ({
+    loginAsAdmin,
+    page,
+  }) => {
+    await loginAsAdmin();
+    await page.goto("/dashboards?q=iris");
+
+    const scoped = page.locator(banner);
+    await expect(scoped).toBeVisible({ timeout: 30_000 });
+    await expect(scoped).toContainText('"iris"');
+    // The search box is filled from the URL, not just the filter state.
+    await expect(page.getByPlaceholder("Search dashboards…")).toHaveValue("iris");
+
+    await scoped.getByRole("button", { name: "Show everything" }).click();
+    await expect(page.locator(banner)).toHaveCount(0);
+    // Clearing the filters clears the link too: the address bar is the view.
+    await expect(page).not.toHaveURL(/[?&]q=/);
+  });
+
+  test("filtering in the UI writes the filter back into the URL", async ({
+    loginAsAdmin,
+    page,
+  }) => {
+    await loginAsAdmin();
+    await page.goto("/dashboards");
+    await expect(page.getByTestId("new-dashboard-btn")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.getByPlaceholder("Search dashboards…").fill("penguins");
+    await expect(page).toHaveURL(/[?&]q=penguins/);
+
+    // …and the share button offers that exact URL.
+    await expect(page.getByTestId("share-view-btn")).toBeVisible();
+  });
+
+  test("a template link scopes both listings to that pipeline", async ({
+    loginAsAdmin,
+    page,
+    request,
+  }) => {
+    const scope = await findTemplateScope(request);
+    test.skip(!scope, "no templated project seeded on this stack");
+
+    await loginAsAdmin();
+
+    await page.goto(`/dashboards?template=${encodeURIComponent(scope!)}`);
+    const dashboardBanner = page.locator(banner);
+    await expect(dashboardBanner).toBeVisible({ timeout: 30_000 });
+    await expect(dashboardBanner).toContainText(/of \d+ dashboards/);
+
+    // The same scope reads on the projects listing, one hop away.
+    await dashboardBanner
+      .getByRole("link", { name: /See the matching projects/ })
+      .click();
+    await expect(page).toHaveURL(/\/projects\?template=/);
+
+    const projectBanner = page.locator(banner);
+    await expect(projectBanner).toBeVisible({ timeout: 30_000 });
+    await expect(projectBanner).toContainText(/of \d+ projects/);
+  });
+});

--- a/depictio/viewer/src/components/listing/ShareViewButton.tsx
+++ b/depictio/viewer/src/components/listing/ShareViewButton.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { ActionIcon, Tooltip } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { Icon } from '@iconify/react';
+
+import { copyToClipboard } from '../../lib/listingUrl';
+
+interface ShareViewButtonProps {
+  /** What the copied link shows, for the confirmation notice: "12 dashboards"
+   *  or "the current view". */
+  describes: string;
+  /** Rendered in the tooltip above the description. */
+  label?: string;
+}
+
+/** Copies the current URL — which the listing keeps in step with its filters
+ *  — so the view on screen can be handed to someone else exactly as it is.
+ *
+ *  The address bar already holds the same string; the button exists because
+ *  "copy this link" is a far more discoverable instruction than "select the
+ *  address bar", and because the confirmation says what the recipient will
+ *  actually see. */
+const ShareViewButton: React.FC<ShareViewButtonProps> = ({ describes, label }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const url = window.location.href;
+    const ok = await copyToClipboard(url);
+    if (!ok) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not copy the link',
+        message: 'Copy it from the address bar instead.',
+      });
+      return;
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+    notifications.show({
+      color: 'teal',
+      title: 'Link copied',
+      message: `Opens ${describes}.`,
+      autoClose: 3000,
+    });
+  };
+
+  return (
+    <Tooltip label={label ?? 'Copy a link to this filtered view'} withinPortal>
+      <ActionIcon
+        variant="default"
+        size="lg"
+        radius="md"
+        onClick={handleCopy}
+        aria-label="Copy a link to this filtered view"
+        data-testid="share-view-btn"
+      >
+        <Icon icon={copied ? 'mdi:check' : 'mdi:link-variant'} width={18} />
+      </ActionIcon>
+    </Tooltip>
+  );
+};
+
+export default ShareViewButton;

--- a/depictio/viewer/src/components/listing/SharedViewBanner.tsx
+++ b/depictio/viewer/src/components/listing/SharedViewBanner.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { ActionIcon, Anchor, Badge, Button, Group, Paper, Text } from '@mantine/core';
 import { Icon } from '@iconify/react';
 
-import { useBrandAccents } from 'depictio-react-core';
-
 export interface SharedViewScope {
   key: string;
   label: string;
@@ -22,6 +20,10 @@ interface SharedViewBannerProps {
   noun: string;
   /** The same scope on the other listing, when it carries over. */
   crossLink?: { href: string; label: string };
+  /** Mantine color for the banner. Each listing passes its own page accent so
+   *  the banner reads as part of that page rather than as a stray alert:
+   *  Dashboards is the tertiary role, Projects the secondary one. */
+  color: string;
   onClearAll: () => void;
 }
 
@@ -40,9 +42,9 @@ const SharedViewBanner: React.FC<SharedViewBannerProps> = ({
   total,
   noun,
   crossLink,
+  color,
   onClearAll,
 }) => {
-  const accent = useBrandAccents();
   const hidden = Math.max(total - shown, 0);
 
   return (
@@ -52,8 +54,8 @@ const SharedViewBanner: React.FC<SharedViewBannerProps> = ({
       p="sm"
       data-testid="shared-view-banner"
       style={{
-        borderColor: `var(--mantine-color-${accent.tertiary}-4)`,
-        background: `var(--mantine-color-${accent.tertiary}-light)`,
+        borderColor: `var(--mantine-color-${color}-4)`,
+        background: `var(--mantine-color-${color}-light)`,
       }}
     >
       <Group justify="space-between" wrap="wrap" gap="sm">
@@ -61,7 +63,7 @@ const SharedViewBanner: React.FC<SharedViewBannerProps> = ({
           <Icon
             icon="mdi:link-variant"
             width={18}
-            color={`var(--mantine-color-${accent.tertiary}-7)`}
+            color={`var(--mantine-color-${color}-7)`}
           />
           <Text size="sm" fw={600}>
             Shared view
@@ -70,7 +72,7 @@ const SharedViewBanner: React.FC<SharedViewBannerProps> = ({
             <Badge
               key={s.key}
               variant="filled"
-              color={accent.tertiary}
+              color={color}
               radius="sm"
               rightSection={
                 <ActionIcon

--- a/depictio/viewer/src/components/listing/SharedViewBanner.tsx
+++ b/depictio/viewer/src/components/listing/SharedViewBanner.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { ActionIcon, Anchor, Badge, Button, Group, Paper, Text } from '@mantine/core';
+import { Icon } from '@iconify/react';
+
+import { useBrandAccents } from 'depictio-react-core';
+
+export interface SharedViewScope {
+  key: string;
+  label: string;
+  /** Drops just this one filter. The banner replaces the toolbar's chip row
+   *  while it is on screen, so it has to carry the same per-filter control. */
+  onRemove: () => void;
+}
+
+interface SharedViewBannerProps {
+  /** What the link narrowed to, one chip per filter value. */
+  scope: SharedViewScope[];
+  /** How many rows survive the filter, and how many exist in total. */
+  shown: number;
+  total: number;
+  /** "dashboard" / "project" — pluralised here. */
+  noun: string;
+  /** The same scope on the other listing, when it carries over. */
+  crossLink?: { href: string; label: string };
+  onClearAll: () => void;
+}
+
+const plural = (n: number, noun: string) => `${noun}${n === 1 ? '' : 's'}`;
+
+/** Shown when the visitor arrived on a link that already carried filters.
+ *
+ *  Someone handed this URL to a reviewer to say "look at these and not the
+ *  other eighty" — so the page states what it narrowed to and how much it is
+ *  hiding, rather than silently presenting a partial listing as if it were
+ *  everything. The escape hatch is deliberate: the scope is a starting point,
+ *  not a wall. */
+const SharedViewBanner: React.FC<SharedViewBannerProps> = ({
+  scope,
+  shown,
+  total,
+  noun,
+  crossLink,
+  onClearAll,
+}) => {
+  const accent = useBrandAccents();
+  const hidden = Math.max(total - shown, 0);
+
+  return (
+    <Paper
+      withBorder
+      radius="md"
+      p="sm"
+      data-testid="shared-view-banner"
+      style={{
+        borderColor: `var(--mantine-color-${accent.tertiary}-4)`,
+        background: `var(--mantine-color-${accent.tertiary}-light)`,
+      }}
+    >
+      <Group justify="space-between" wrap="wrap" gap="sm">
+        <Group gap="xs" wrap="wrap" style={{ minWidth: 0 }}>
+          <Icon
+            icon="mdi:link-variant"
+            width={18}
+            color={`var(--mantine-color-${accent.tertiary}-7)`}
+          />
+          <Text size="sm" fw={600}>
+            Shared view
+          </Text>
+          {scope.map((s) => (
+            <Badge
+              key={s.key}
+              variant="filled"
+              color={accent.tertiary}
+              radius="sm"
+              rightSection={
+                <ActionIcon
+                  size="xs"
+                  variant="transparent"
+                  color="white"
+                  onClick={s.onRemove}
+                  aria-label={`Remove filter ${s.label}`}
+                >
+                  <Icon icon="mdi:close" width={12} />
+                </ActionIcon>
+              }
+              style={{ paddingRight: 4 }}
+            >
+              {s.label}
+            </Badge>
+          ))}
+          <Text size="sm" c="dimmed">
+            {shown} of {total} {plural(total, noun)}
+            {hidden > 0 ? `, ${hidden} hidden by this link` : ''}
+          </Text>
+        </Group>
+
+        <Group gap="sm" wrap="nowrap">
+          {crossLink && (
+            <Anchor href={crossLink.href} size="sm" fw={500}>
+              {crossLink.label} →
+            </Anchor>
+          )}
+          <Button
+            variant="subtle"
+            color="gray"
+            size="compact-sm"
+            onClick={onClearAll}
+            leftSection={<Icon icon="mdi:close" width={14} />}
+          >
+            Show everything
+          </Button>
+        </Group>
+      </Group>
+    </Paper>
+  );
+};
+
+export default SharedViewBanner;

--- a/depictio/viewer/src/dashboards/DashboardsList.tsx
+++ b/depictio/viewer/src/dashboards/DashboardsList.tsx
@@ -15,7 +15,7 @@ import {
 import { Icon } from '@iconify/react';
 
 import type { DashboardListEntry, ProjectListEntry } from 'depictio-react-core';
-import { parseTemplateOrigin } from 'depictio-react-core';
+import { parseTemplateOrigin, useBrandAccents } from 'depictio-react-core';
 
 import DashboardsToolbar from './DashboardsToolbar';
 import SharedViewBanner from '../components/listing/SharedViewBanner';
@@ -146,6 +146,7 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
   onBulkExport,
   onBulkDelete,
 }) => {
+  const accent = useBrandAccents();
   const projectNames = useMemo(() => projectNameLookup(projects), [projects]);
   // Per-project template_origin so the cards can render a TemplateChip
   // without re-fetching the project. Only populated for projects that were
@@ -563,6 +564,7 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
           total={totalDashboards}
           noun="dashboard"
           crossLink={crossLink}
+          color={accent.tertiary}
           onClearAll={clearFilters}
         />
       )}

--- a/depictio/viewer/src/dashboards/DashboardsList.tsx
+++ b/depictio/viewer/src/dashboards/DashboardsList.tsx
@@ -15,8 +15,12 @@ import {
 import { Icon } from '@iconify/react';
 
 import type { DashboardListEntry, ProjectListEntry } from 'depictio-react-core';
+import { parseTemplateOrigin } from 'depictio-react-core';
 
 import DashboardsToolbar from './DashboardsToolbar';
+import SharedViewBanner from '../components/listing/SharedViewBanner';
+import type { SharedViewScope } from '../components/listing/SharedViewBanner';
+import { listingUrl } from '../lib/listingUrl';
 import DashboardThumbnailView from './views/DashboardThumbnailView';
 import DashboardListView from './views/DashboardListView';
 import DashboardTableView from './views/DashboardTableView';
@@ -152,6 +156,7 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
   );
   const {
     prefs,
+    arrivedScoped,
     setView,
     setGroupBy,
     setSortBy,
@@ -164,15 +169,32 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
   const { pinnedIds, recents, togglePin } = useDashboardPinsAndRecents();
 
   const filterCtx = useMemo(
-    () => ({ projectNames, currentUserEmail }),
-    [projectNames, currentUserEmail],
+    () => ({ projectNames, projectTemplates, currentUserEmail }),
+    [projectNames, projectTemplates, currentUserEmail],
   );
 
-  const { sections, totalAfterSearch } = useDashboardFilters(
-    dashboards,
-    prefs,
-    filterCtx,
-  );
+  const { sections, totalAfterSearch, totalMatching, totalDashboards } =
+    useDashboardFilters(dashboards, prefs, filterCtx);
+
+  // A link can name a project by id (what the share button emits) or by name
+  // (what a person types). Swap any name that resolves onto its id once the
+  // projects have loaded, so the toolbar's Project dropdown shows the chip
+  // selected rather than a stray unknown value. Idempotent: after the swap
+  // the entry is an id and matches nothing here.
+  useEffect(() => {
+    if (prefs.filters.projects.length === 0 || projectNames.size === 0) return;
+    const byName = new Map<string, string>();
+    for (const [id, name] of projectNames) byName.set(name.toLowerCase(), id);
+    let changed = false;
+    const resolved = prefs.filters.projects.map((value) => {
+      if (projectNames.has(value)) return value;
+      const id = byName.get(value.toLowerCase());
+      if (!id) return value;
+      changed = true;
+      return id;
+    });
+    if (changed) setFilters({ ...prefs.filters, projects: resolved });
+  }, [prefs.filters, projectNames, setFilters]);
 
   // Build the project / owner option lists for the toolbar dropdowns from the
   // currently-loaded dashboards (cheap, no extra fetch).
@@ -190,6 +212,48 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
       .map(([value, label]) => ({ value, label }))
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [dashboards, projectNames]);
+
+  // Template options come from the projects the listed dashboards actually
+  // belong to, so the dropdown never offers a pipeline that would filter down
+  // to nothing. Each source contributes an "all pipelines" entry alongside its
+  // individual pipelines.
+  const templateOptions = useMemo(() => {
+    const bySource = new Map<string, Set<string>>();
+    for (const d of dashboards) {
+      if (d.parent_dashboard_id) continue;
+      const pid = d.project_id ? String(d.project_id) : '';
+      if (!pid) continue;
+      const parsed = parseTemplateOrigin(projectTemplates.get(pid));
+      if (!parsed) continue;
+      const pipelines = bySource.get(parsed.source) ?? new Set<string>();
+      if (parsed.repo) pipelines.add(parsed.repo);
+      bySource.set(parsed.source, pipelines);
+    }
+    const options: { value: string; label: string }[] = [];
+    for (const source of Array.from(bySource.keys()).sort()) {
+      const pipelines = Array.from(bySource.get(source) ?? []).sort();
+      if (pipelines.length > 1) {
+        options.push({ value: source, label: `${source} (all pipelines)` });
+      }
+      for (const repo of pipelines) {
+        options.push({ value: `${source}/${repo}`, label: `${source} / ${repo}` });
+      }
+      if (pipelines.length === 0) options.push({ value: source, label: source });
+    }
+    return options;
+  }, [dashboards, projectTemplates]);
+
+  const workflowOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const d of dashboards) {
+      if (d.parent_dashboard_id) continue;
+      const wf = typeof d.workflow_system === 'string' ? d.workflow_system.trim() : '';
+      if (wf && wf !== 'none') set.add(wf);
+    }
+    return Array.from(set)
+      .sort()
+      .map((value) => ({ value, label: value }));
+  }, [dashboards]);
 
   const ownerOptions = useMemo(() => {
     const set = new Set<string>();
@@ -396,6 +460,80 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
 
   const noResults = totalAfterSearch === 0 && prefs.search.trim().length > 0;
 
+  // What the shared link narrowed to, spelled out for the banner. Only the
+  // filters that hide rows appear here — view mode and sort order travel in
+  // the URL too, but they change nothing about *what* the recipient sees.
+  const scopeChips: SharedViewScope[] = [];
+  const dropFrom = (key: 'templates' | 'projects' | 'workflows' | 'owners', value: string) =>
+    setFilters({
+      ...prefs.filters,
+      [key]: prefs.filters[key].filter((v) => v !== value),
+    });
+  for (const value of prefs.filters.templates) {
+    const opt = templateOptions.find((o) => o.value === value);
+    scopeChips.push({
+      key: `t:${value}`,
+      label: opt?.label ?? value,
+      onRemove: () => dropFrom('templates', value),
+    });
+  }
+  for (const id of prefs.filters.projects) {
+    scopeChips.push({
+      key: `p:${id}`,
+      label: projectNames.get(id) ?? id,
+      onRemove: () => dropFrom('projects', id),
+    });
+  }
+  for (const value of prefs.filters.workflows) {
+    scopeChips.push({
+      key: `w:${value}`,
+      label: value,
+      onRemove: () => dropFrom('workflows', value),
+    });
+  }
+  for (const owner of prefs.filters.owners) {
+    scopeChips.push({
+      key: `o:${owner}`,
+      label: owner === '__mine__' ? 'Mine' : owner,
+      onRemove: () => dropFrom('owners', owner),
+    });
+  }
+  if (prefs.filters.visibility !== 'all') {
+    scopeChips.push({
+      key: 'v',
+      label: prefs.filters.visibility === 'public' ? 'Public only' : 'Private only',
+      onRemove: () => setFilters({ ...prefs.filters, visibility: 'all' }),
+    });
+  }
+  if (prefs.onlyPinned) {
+    scopeChips.push({
+      key: 'pinned',
+      label: 'Favorites only',
+      onRemove: () => setOnlyPinned(false),
+    });
+  }
+  if (prefs.search.trim()) {
+    scopeChips.push({
+      key: 'q',
+      label: `"${prefs.search.trim()}"`,
+      onRemove: () => setSearch(''),
+    });
+  }
+
+  // The same template scope reads just as well on the projects listing, and
+  // "show me this pipeline" usually means both. One link per page was the
+  // call, so the pages point at each other instead of the share button
+  // offering a menu.
+  const crossLink =
+    prefs.filters.templates.length > 0
+      ? {
+          href: listingUrl('/projects', { template: prefs.filters.templates }),
+          label: 'See the matching projects',
+        }
+      : undefined;
+
+  const showBanner = arrivedScoped && scopeChips.length > 0;
+
   // Shared chrome: toolbar + optional banners + content.
   const chrome = (content: React.ReactNode) => (
     <Stack gap="md">
@@ -403,6 +541,10 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
         prefs={prefs}
         projectOptions={projectOptions}
         ownerOptions={ownerOptions}
+        templateOptions={templateOptions}
+        workflowOptions={workflowOptions}
+        matchingCount={totalMatching}
+        showFilterChips={!showBanner}
         pinnedCount={pinnedGroups.length}
         pinDisabled={pinDisabled}
         setView={setView}
@@ -413,6 +555,17 @@ const DashboardsList: React.FC<DashboardsListProps> = ({
         setOnlyPinned={setOnlyPinned}
         clearFilters={clearFilters}
       />
+
+      {showBanner && (
+        <SharedViewBanner
+          scope={scopeChips}
+          shown={totalMatching}
+          total={totalDashboards}
+          noun="dashboard"
+          crossLink={crossLink}
+          onClearAll={clearFilters}
+        />
+      )}
 
       {noResults ? (
         <Paper p="xl" radius="md" withBorder>

--- a/depictio/viewer/src/dashboards/DashboardsToolbar.tsx
+++ b/depictio/viewer/src/dashboards/DashboardsToolbar.tsx
@@ -23,12 +23,23 @@ import type {
   SortBy,
   ViewMode,
 } from './hooks/useDashboardViewPrefs';
+import { emptyDashboardFilters } from './hooks/useDashboardViewPrefs';
 import { useBrandAccents } from 'depictio-react-core';
+import ShareViewButton from '../components/listing/ShareViewButton';
+
+export type FilterOption = { value: string; label: string };
 
 export interface DashboardsToolbarProps {
   prefs: DashboardViewPrefs;
-  projectOptions: { value: string; label: string }[];
-  ownerOptions: { value: string; label: string }[];
+  projectOptions: FilterOption[];
+  ownerOptions: FilterOption[];
+  templateOptions: FilterOption[];
+  workflowOptions: FilterOption[];
+  /** Rows currently on screen, for the share confirmation's wording. */
+  matchingCount: number;
+  /** False while the shared-view banner is up: it lists the same filters, and
+   *  two identical chip rows one above the other reads as a bug. */
+  showFilterChips?: boolean;
   pinnedCount: number;
   pinDisabled: boolean;
   setView: (v: ViewMode) => void;
@@ -138,14 +149,25 @@ const ViewPicker: React.FC<{
 
 const FilterPopover: React.FC<{
   prefs: DashboardViewPrefs;
-  projectOptions: { value: string; label: string }[];
-  ownerOptions: { value: string; label: string }[];
+  projectOptions: FilterOption[];
+  ownerOptions: FilterOption[];
+  templateOptions: FilterOption[];
+  workflowOptions: FilterOption[];
   setFilters: (f: DashboardFilters) => void;
-}> = ({ prefs, projectOptions, ownerOptions, setFilters }) => {
+}> = ({
+  prefs,
+  projectOptions,
+  ownerOptions,
+  templateOptions,
+  workflowOptions,
+  setFilters,
+}) => {
   const accent = useBrandAccents();
   const activeCount =
     prefs.filters.projects.length +
     prefs.filters.owners.length +
+    prefs.filters.templates.length +
+    prefs.filters.workflows.length +
     (prefs.filters.visibility !== 'all' ? 1 : 0);
 
   return (
@@ -178,17 +200,28 @@ const FilterPopover: React.FC<{
               Filters
             </Text>
             {activeCount > 0 && (
-              <Button
-                variant="subtle"
-                size="compact-xs"
-                onClick={() =>
-                  setFilters({ projects: [], owners: [], visibility: 'all' })
-                }
-              >
+              <Button variant="subtle" size="compact-xs" onClick={() => setFilters(emptyDashboardFilters())}>
                 Clear all
               </Button>
             )}
           </Group>
+
+          <MultiSelect
+            label="Template"
+            placeholder={
+              templateOptions.length === 0
+                ? 'No templated projects loaded'
+                : 'Any template'
+            }
+            description="Pick a source for every pipeline under it, or one pipeline on its own."
+            data={templateOptions}
+            value={prefs.filters.templates}
+            onChange={(v) => setFilters({ ...prefs.filters, templates: v })}
+            disabled={templateOptions.length === 0}
+            searchable
+            clearable
+            comboboxProps={{ withinPortal: false }}
+          />
 
           <MultiSelect
             label="Project"
@@ -207,6 +240,20 @@ const FilterPopover: React.FC<{
             data={ownerOptions}
             value={prefs.filters.owners}
             onChange={(v) => setFilters({ ...prefs.filters, owners: v })}
+            searchable
+            clearable
+            comboboxProps={{ withinPortal: false }}
+          />
+
+          <MultiSelect
+            label="Workflow system"
+            placeholder={
+              workflowOptions.length === 0 ? 'No workflow tagged' : 'Any workflow'
+            }
+            data={workflowOptions}
+            value={prefs.filters.workflows}
+            onChange={(v) => setFilters({ ...prefs.filters, workflows: v })}
+            disabled={workflowOptions.length === 0}
             searchable
             clearable
             comboboxProps={{ withinPortal: false }}
@@ -236,6 +283,10 @@ const DashboardsToolbar: React.FC<DashboardsToolbarProps> = ({
   prefs,
   projectOptions,
   ownerOptions,
+  templateOptions,
+  workflowOptions,
+  matchingCount,
+  showFilterChips = true,
   pinnedCount,
   pinDisabled,
   setView,
@@ -251,6 +302,18 @@ const DashboardsToolbar: React.FC<DashboardsToolbarProps> = ({
   const showSort = prefs.view !== 'table';
 
   const activeFilterChips: { key: string; label: string; onRemove: () => void }[] = [];
+  for (const id of prefs.filters.templates) {
+    const opt = templateOptions.find((o) => o.value === id);
+    activeFilterChips.push({
+      key: `t:${id}`,
+      label: opt?.label ?? id,
+      onRemove: () =>
+        setFilters({
+          ...prefs.filters,
+          templates: prefs.filters.templates.filter((t) => t !== id),
+        }),
+    });
+  }
   for (const id of prefs.filters.projects) {
     const opt = projectOptions.find((o) => o.value === id);
     activeFilterChips.push({
@@ -272,6 +335,18 @@ const DashboardsToolbar: React.FC<DashboardsToolbarProps> = ({
         setFilters({
           ...prefs.filters,
           owners: prefs.filters.owners.filter((o) => o !== id),
+        }),
+    });
+  }
+  for (const id of prefs.filters.workflows) {
+    const opt = workflowOptions.find((o) => o.value === id);
+    activeFilterChips.push({
+      key: `w:${id}`,
+      label: opt?.label ?? id,
+      onRemove: () =>
+        setFilters({
+          ...prefs.filters,
+          workflows: prefs.filters.workflows.filter((w) => w !== id),
         }),
     });
   }
@@ -370,13 +445,23 @@ const DashboardsToolbar: React.FC<DashboardsToolbarProps> = ({
           prefs={prefs}
           projectOptions={projectOptions}
           ownerOptions={ownerOptions}
+          templateOptions={templateOptions}
+          workflowOptions={workflowOptions}
           setFilters={setFilters}
+        />
+
+        <ShareViewButton
+          describes={
+            hasAnyActive
+              ? `this filtered view (${matchingCount} dashboard${matchingCount === 1 ? '' : 's'})`
+              : 'the full dashboard list'
+          }
         />
 
         <ViewPicker value={prefs.view} onChange={setView} />
       </Group>
 
-      {activeFilterChips.length > 0 && (
+      {showFilterChips && activeFilterChips.length > 0 && (
         <Group gap="xs" wrap="wrap" align="center">
           {activeFilterChips.map((chip) => (
             <Badge

--- a/depictio/viewer/src/dashboards/hooks/useDashboardFilters.ts
+++ b/depictio/viewer/src/dashboards/hooks/useDashboardFilters.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import type { DashboardListEntry } from 'depictio-react-core';
+import { matchesTemplateFilter, parseTemplateOrigin } from 'depictio-react-core';
 import {
   type GroupedDashboards,
   groupByParent,
@@ -25,13 +26,27 @@ export interface DashboardSection {
 
 interface FilterContext {
   projectNames: Map<string, string>;
+  /** Raw `template_origin` per project id. Dashboards carry no template of
+   *  their own — the pipeline a dashboard belongs to is a property of the
+   *  project that owns it. */
+  projectTemplates: Map<string, unknown>;
   currentUserEmail: string | null;
+}
+
+/** The template a dashboard inherits from its project, or null when the
+ *  project wasn't built from one. */
+function templateOriginOf(
+  d: DashboardListEntry,
+  projectTemplates: Map<string, unknown>,
+): unknown {
+  const pid = d.project_id ? String(d.project_id) : '';
+  return pid ? (projectTemplates.get(pid) ?? null) : null;
 }
 
 function matchesSearch(
   group: GroupedDashboards,
   search: string,
-  projectNames: Map<string, string>,
+  ctx: FilterContext,
 ): boolean {
   if (!search.trim()) return true;
   const q = search.trim().toLowerCase();
@@ -40,9 +55,13 @@ function matchesSearch(
   if (d.title) haystack.push(String(d.title));
   if (typeof d.subtitle === 'string') haystack.push(d.subtitle);
   if (d.project_id) {
-    const name = projectNames.get(String(d.project_id));
+    const name = ctx.projectNames.get(String(d.project_id));
     if (name) haystack.push(name);
   }
+  // Typing "rnaseq" should find the pipeline's dashboards even when neither
+  // the title nor the project name spells it out.
+  const template = parseTemplateOrigin(templateOriginOf(d, ctx.projectTemplates));
+  if (template) haystack.push(template.full);
   const owner = d.permissions?.owners?.[0]?.email;
   if (owner) haystack.push(owner);
   if (typeof d.workflow_system === 'string') haystack.push(d.workflow_system);
@@ -52,17 +71,29 @@ function matchesSearch(
 function matchesFilters(
   group: GroupedDashboards,
   filters: DashboardFilters,
-  currentUserEmail: string | null,
+  ctx: FilterContext,
 ): boolean {
   const d = group.parent;
   if (filters.projects.length > 0) {
     const pid = d.project_id ? String(d.project_id) : '';
     if (!filters.projects.includes(pid)) return false;
   }
+  if (
+    !matchesTemplateFilter(
+      templateOriginOf(d, ctx.projectTemplates),
+      filters.templates,
+    )
+  ) {
+    return false;
+  }
+  if (filters.workflows.length > 0) {
+    const wf = typeof d.workflow_system === 'string' ? d.workflow_system : '';
+    if (!filters.workflows.includes(wf)) return false;
+  }
   if (filters.owners.length > 0) {
     const ownerEmail = d.permissions?.owners?.[0]?.email ?? '';
     const wantsMine = filters.owners.includes('__mine__');
-    const isMine = wantsMine && isOwnedByEmail(d, currentUserEmail);
+    const isMine = wantsMine && isOwnedByEmail(d, ctx.currentUserEmail);
     const explicit = filters.owners.includes(ownerEmail);
     if (!isMine && !explicit) return false;
   }
@@ -225,6 +256,11 @@ function groupByKey(
 export interface UseDashboardFiltersResult {
   sections: DashboardSection[];
   totalAfterSearch: number;
+  /** Dashboards left after search *and* filters — the numerator the shared-view
+   *  banner reports. */
+  totalMatching: number;
+  /** Every dashboard the user can see, before anything is narrowed. */
+  totalDashboards: number;
 }
 
 export function useDashboardFilters(
@@ -234,11 +270,9 @@ export function useDashboardFilters(
 ): UseDashboardFiltersResult {
   return useMemo(() => {
     const allGrouped = groupByParent(entries);
-    const afterSearch = allGrouped.filter((g) =>
-      matchesSearch(g, prefs.search, ctx.projectNames),
-    );
+    const afterSearch = allGrouped.filter((g) => matchesSearch(g, prefs.search, ctx));
     const afterFilters = afterSearch.filter((g) =>
-      matchesFilters(g, prefs.filters, ctx.currentUserEmail),
+      matchesFilters(g, prefs.filters, ctx),
     );
 
     const sections =
@@ -250,6 +284,11 @@ export function useDashboardFilters(
           )
         : groupByKey(afterFilters, prefs.groupBy, ctx, prefs.sortBy);
 
-    return { sections, totalAfterSearch: afterSearch.length };
-  }, [entries, prefs, ctx.projectNames, ctx.currentUserEmail]);
+    return {
+      sections,
+      totalAfterSearch: afterSearch.length,
+      totalMatching: afterFilters.length,
+      totalDashboards: allGrouped.length,
+    };
+  }, [entries, prefs, ctx.projectNames, ctx.projectTemplates, ctx.currentUserEmail]);
 }

--- a/depictio/viewer/src/dashboards/hooks/useDashboardViewPrefs.ts
+++ b/depictio/viewer/src/dashboards/hooks/useDashboardViewPrefs.ts
@@ -1,14 +1,39 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { asEnum, asList, asScalar } from 'depictio-react-core';
+
+import {
+  arrivedWithParams,
+  readListingParams,
+  replaceListingParams,
+} from '../../lib/listingUrl';
+
 export type ViewMode = 'thumbnails' | 'list' | 'table';
 export type GroupBy = 'none' | 'project' | 'owner' | 'visibility' | 'workflow';
 export type SortBy = 'recent' | 'name' | 'owner';
 export type Density = 'compact' | 'cozy';
+export type VisibilityFilter = 'all' | 'public' | 'private';
+
+const VIEW_MODES: readonly ViewMode[] = ['thumbnails', 'list', 'table'];
+const GROUP_BYS: readonly GroupBy[] = [
+  'none',
+  'project',
+  'owner',
+  'visibility',
+  'workflow',
+];
+const SORT_BYS: readonly SortBy[] = ['recent', 'name', 'owner'];
+const VISIBILITIES: readonly VisibilityFilter[] = ['all', 'public', 'private'];
 
 export interface DashboardFilters {
   projects: string[];
   owners: string[];
-  visibility: 'all' | 'public' | 'private';
+  /** Pipeline templates, as `source` or `source/repo` — see
+   *  `matchesTemplateFilter`. Resolved through the dashboard's owning
+   *  project, which is where `template_origin` lives. */
+  templates: string[];
+  workflows: string[];
+  visibility: VisibilityFilter;
 }
 
 export interface DashboardViewPrefs {
@@ -21,14 +46,38 @@ export interface DashboardViewPrefs {
   onlyPinned: boolean;
 }
 
+/** No filter at all. A factory rather than a constant: the toolbar's "Clear
+ *  all" and the hook's `clearFilters` both need one, and a shared object would
+ *  hand them the same arrays to hold. They can't drift as filters are added,
+ *  and they can't alias each other either. */
+export const emptyDashboardFilters = (): DashboardFilters => ({
+  projects: [],
+  owners: [],
+  templates: [],
+  workflows: [],
+  visibility: 'all',
+});
+
 const STORAGE_KEY = 'depictio.dashboards.viewPrefs.v1';
+
+/** URL params that narrow *what is listed*, as opposed to how it is laid out.
+ *  Arriving with one of these is what makes a page load a "shared view". */
+export const DASHBOARD_SCOPE_PARAMS = [
+  'q',
+  'template',
+  'project',
+  'owner',
+  'workflow',
+  'visibility',
+  'pinned',
+] as const;
 
 const DEFAULT_PREFS: DashboardViewPrefs = {
   view: 'thumbnails',
   groupBy: 'none',
   sortBy: 'recent',
   search: '',
-  filters: { projects: [], owners: [], visibility: 'all' },
+  filters: emptyDashboardFilters(),
   density: 'cozy',
   onlyPinned: false,
 };
@@ -48,8 +97,63 @@ function loadPrefs(): DashboardViewPrefs {
   }
 }
 
+/** Overlay whatever the URL asked for onto the stored preferences.
+ *
+ *  The link wins on every field it mentions and stays out of the way on the
+ *  rest: a reviewer opening `?template=nf-core/rnaseq` gets that scope on top
+ *  of their own habitual view mode and sort order, and a bare `/dashboards`
+ *  is unchanged from what they left behind. The one asymmetry is deliberate —
+ *  a link that names *any* filter clears the stored filters it doesn't
+ *  mention, so a scoped link never silently inherits the recipient's leftover
+ *  "owner: me" and shows them an empty page. */
+function applyUrlParams(base: DashboardViewPrefs): DashboardViewPrefs {
+  const params = readListingParams();
+  const next: DashboardViewPrefs = {
+    ...base,
+    filters: { ...base.filters },
+  };
+
+  next.view = asEnum(params.view, VIEW_MODES) ?? next.view;
+  next.groupBy = asEnum(params.group, GROUP_BYS) ?? next.groupBy;
+  next.sortBy = asEnum(params.sort, SORT_BYS) ?? next.sortBy;
+
+  const scoped = DASHBOARD_SCOPE_PARAMS.some(
+    (key) => (params[key]?.length ?? 0) > 0,
+  );
+  if (!scoped) return next;
+
+  next.search = asScalar(params.q) ?? '';
+  next.onlyPinned = asScalar(params.pinned) === '1';
+  next.filters = {
+    projects: asList(params.project),
+    owners: asList(params.owner),
+    templates: asList(params.template),
+    workflows: asList(params.workflow),
+    visibility: asEnum(params.visibility, VISIBILITIES) ?? 'all',
+  };
+  return next;
+}
+
+/** The query string that reproduces these preferences. */
+function toUrlParams(prefs: DashboardViewPrefs) {
+  return {
+    q: prefs.search.trim(),
+    template: prefs.filters.templates,
+    project: prefs.filters.projects,
+    owner: prefs.filters.owners,
+    workflow: prefs.filters.workflows,
+    visibility: prefs.filters.visibility === 'all' ? '' : prefs.filters.visibility,
+    pinned: prefs.onlyPinned,
+    view: prefs.view === DEFAULT_PREFS.view ? '' : prefs.view,
+    group: prefs.groupBy === DEFAULT_PREFS.groupBy ? '' : prefs.groupBy,
+    sort: prefs.sortBy === DEFAULT_PREFS.sortBy ? '' : prefs.sortBy,
+  };
+}
+
 export interface UseDashboardViewPrefsResult {
   prefs: DashboardViewPrefs;
+  /** True when the page was opened on a link that already carried a filter. */
+  arrivedScoped: boolean;
   setView: (v: ViewMode) => void;
   setGroupBy: (g: GroupBy) => void;
   setSortBy: (s: SortBy) => void;
@@ -61,7 +165,10 @@ export interface UseDashboardViewPrefsResult {
 }
 
 export function useDashboardViewPrefs(): UseDashboardViewPrefsResult {
-  const [prefs, setPrefs] = useState<DashboardViewPrefs>(loadPrefs);
+  const [prefs, setPrefs] = useState<DashboardViewPrefs>(() =>
+    applyUrlParams(loadPrefs()),
+  );
+  const [arrivedScoped] = useState(() => arrivedWithParams(DASHBOARD_SCOPE_PARAMS));
 
   useEffect(() => {
     try {
@@ -69,6 +176,9 @@ export function useDashboardViewPrefs(): UseDashboardViewPrefsResult {
     } catch {
       /* quota or private mode — silently ignore */
     }
+    // Keep the address bar showing the view on screen, so copying it out of
+    // the browser is always equivalent to pressing the share button.
+    replaceListingParams(toUrlParams(prefs));
   }, [prefs]);
 
   const setView = useCallback(
@@ -105,13 +215,14 @@ export function useDashboardViewPrefs(): UseDashboardViewPrefsResult {
         ...p,
         search: '',
         onlyPinned: false,
-        filters: { projects: [], owners: [], visibility: 'all' },
+        filters: emptyDashboardFilters(),
       })),
     [],
   );
 
   return {
     prefs,
+    arrivedScoped,
     setView,
     setGroupBy,
     setSortBy,

--- a/depictio/viewer/src/lib/listingUrl.ts
+++ b/depictio/viewer/src/lib/listingUrl.ts
@@ -1,0 +1,83 @@
+/**
+ * The browser half of a shareable listing view — everything in here touches
+ * `window.location`. The codec it builds on is pure and tested in
+ * `depictio-react-core/src/listingUrlState.ts`.
+ *
+ * Both listings keep the address bar in step with their filters, so the URL a
+ * user copies out of it is always the view they are looking at. Writes go
+ * through `replaceState`: narrowing a filter is not a navigation, and pushing
+ * a history entry per keystroke would bury the page the visitor arrived from
+ * under a pile of Back presses.
+ */
+import { decodeListingParams, encodeListingParams } from 'depictio-react-core';
+import type { ListingParams } from 'depictio-react-core';
+
+export type ListingParamValues = Record<
+  string,
+  string[] | string | boolean | null | undefined
+>;
+
+/** The params the current URL carries. Safe to call during render — it only
+ *  reads. */
+export function readListingParams(): ListingParams {
+  if (typeof window === 'undefined') return {};
+  return decodeListingParams(window.location.search);
+}
+
+/** Point the address bar at `params`, keeping the path and hash. A no-op when
+ *  the query string already says exactly this, so the effect that calls it on
+ *  every prefs change doesn't churn history state. */
+export function replaceListingParams(params: ListingParamValues): void {
+  if (typeof window === 'undefined') return;
+  const query = encodeListingParams(params);
+  const next = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (next === current) return;
+  window.history.replaceState(window.history.state, '', next);
+}
+
+/** Build a link to another listing carrying the same scope — the banner's
+ *  "see the matching projects" hop. Returns a root-relative URL. */
+export function listingUrl(path: string, params: ListingParamValues): string {
+  const query = encodeListingParams(params);
+  return query ? `${path}?${query}` : path;
+}
+
+/** Did this page load with a filter in its URL? Captured once at module scope
+ *  rather than read later, because the page immediately starts rewriting its
+ *  own query string and the answer would stop being about how the visitor
+ *  arrived. */
+const ARRIVAL_PARAMS = readListingParams();
+
+export function arrivedWithParams(keys: readonly string[]): boolean {
+  return keys.some((key) => (ARRIVAL_PARAMS[key]?.length ?? 0) > 0);
+}
+
+/** Copy `text` to the clipboard, falling back to a hidden textarea for the
+ *  browsers (and insecure origins) where `navigator.clipboard` is missing.
+ *  Resolves false rather than throwing so callers can show a plain failure
+ *  notice. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* fall through to the textarea path */
+  }
+  try {
+    const area = document.createElement('textarea');
+    area.value = text;
+    area.setAttribute('readonly', '');
+    area.style.position = 'fixed';
+    area.style.opacity = '0';
+    document.body.appendChild(area);
+    area.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(area);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/depictio/viewer/src/projects/ProjectsList.tsx
+++ b/depictio/viewer/src/projects/ProjectsList.tsx
@@ -20,7 +20,10 @@ import ProjectTableView from './views/ProjectTableView';
 import { useProjectViewPrefs } from './hooks/useProjectViewPrefs';
 import { useProjectPins } from './hooks/useProjectPins';
 import { parseTemplate } from './template';
-import { useBrandAccents } from 'depictio-react-core';
+import SharedViewBanner from '../components/listing/SharedViewBanner';
+import type { SharedViewScope } from '../components/listing/SharedViewBanner';
+import { listingUrl } from '../lib/listingUrl';
+import { matchesTemplateFilter, useBrandAccents } from 'depictio-react-core';
 
 interface ProjectsListProps {
   projects: ProjectListEntry[];
@@ -48,21 +51,42 @@ const ProjectsList: React.FC<ProjectsListProps> = ({
   onDelete,
 }) => {
   const accent = useBrandAccents();
-  const { prefs, setSearch, setFilters, setOnlyPinned, setDensity, clearFilters } =
-    useProjectViewPrefs();
+  const {
+    prefs,
+    arrivedScoped,
+    setSearch,
+    setFilters,
+    setOnlyPinned,
+    setDensity,
+    clearFilters,
+  } = useProjectViewPrefs();
   const { pinnedIds, togglePin } = useProjectPins();
 
-  // Template-source options for the filter popover — derived from the loaded
-  // projects so the dropdown only offers sources actually present.
-  const templateSourceOptions = useMemo(() => {
-    const set = new Set<string>();
+  // Template options for the filter popover, derived from the loaded projects
+  // so the dropdown only offers pipelines actually present. Each source
+  // contributes an "all pipelines" entry alongside its individual pipelines,
+  // which is what lets one link scope to a whole source or a single pipeline.
+  const templateOptions = useMemo(() => {
+    const bySource = new Map<string, Set<string>>();
     for (const p of projects) {
       const t = parseTemplate(p);
-      if (t?.source) set.add(t.source);
+      if (!t?.source) continue;
+      const pipelines = bySource.get(t.source) ?? new Set<string>();
+      if (t.repo) pipelines.add(t.repo);
+      bySource.set(t.source, pipelines);
     }
-    return Array.from(set)
-      .sort()
-      .map((s) => ({ value: s, label: s }));
+    const options: { value: string; label: string }[] = [];
+    for (const source of Array.from(bySource.keys()).sort()) {
+      const pipelines = Array.from(bySource.get(source) ?? []).sort();
+      if (pipelines.length > 1) {
+        options.push({ value: source, label: `${source} (all pipelines)` });
+      }
+      for (const repo of pipelines) {
+        options.push({ value: `${source}/${repo}`, label: `${source} / ${repo}` });
+      }
+      if (pipelines.length === 0) options.push({ value: source, label: source });
+    }
+    return options;
   }, [projects]);
 
   // Pipeline: search → filters → onlyPinned → split into sections.
@@ -89,9 +113,8 @@ const ProjectsList: React.FC<ProjectsListProps> = ({
       }
       if (prefs.filters.visibility === 'public' && !p.is_public) return false;
       if (prefs.filters.visibility === 'private' && p.is_public) return false;
-      if (prefs.filters.templateSources.length > 0) {
-        const t = parseTemplate(p);
-        if (!t || !prefs.filters.templateSources.includes(t.source)) return false;
+      if (!matchesTemplateFilter(p.template_origin, prefs.filters.templates)) {
+        return false;
       }
       if (prefs.onlyPinned) {
         const id = String(p._id ?? p.id ?? '');
@@ -167,19 +190,80 @@ const ProjectsList: React.FC<ProjectsListProps> = ({
     );
   }
 
+  // What the shared link narrowed to, spelled out for the banner.
+  const scopeChips: SharedViewScope[] = [];
+  for (const value of prefs.filters.templates) {
+    const opt = templateOptions.find((o) => o.value === value);
+    scopeChips.push({
+      key: `t:${value}`,
+      label: opt?.label ?? value,
+      onRemove: () =>
+        setFilters({
+          ...prefs.filters,
+          templates: prefs.filters.templates.filter((v) => v !== value),
+        }),
+    });
+  }
+  for (const t of prefs.filters.types) {
+    scopeChips.push({
+      key: `y:${t}`,
+      label: t === 'basic' ? 'Basic' : 'Advanced',
+      onRemove: () =>
+        setFilters({
+          ...prefs.filters,
+          types: prefs.filters.types.filter((v) => v !== t),
+        }),
+    });
+  }
+  if (prefs.filters.visibility !== 'all') {
+    scopeChips.push({
+      key: 'v',
+      label: prefs.filters.visibility === 'public' ? 'Public only' : 'Private only',
+      onRemove: () => setFilters({ ...prefs.filters, visibility: 'all' }),
+    });
+  }
+  if (prefs.onlyPinned) {
+    scopeChips.push({
+      key: 'pinned',
+      label: 'Favorites only',
+      onRemove: () => setOnlyPinned(false),
+    });
+  }
+  if (prefs.search.trim()) {
+    scopeChips.push({
+      key: 'q',
+      label: `"${prefs.search.trim()}"`,
+      onRemove: () => setSearch(''),
+    });
+  }
+
+  // A template scope reads just as well on the dashboards listing, and "show
+  // me this pipeline" usually means both.
+  const crossLink =
+    prefs.filters.templates.length > 0
+      ? {
+          href: listingUrl('/dashboards', { template: prefs.filters.templates }),
+          label: 'See the matching dashboards',
+        }
+      : undefined;
+
+  const showBanner = arrivedScoped && scopeChips.length > 0;
+
   const noResults =
     filtered.length === 0 &&
     (prefs.search.trim().length > 0 ||
       prefs.filters.types.length > 0 ||
       prefs.filters.visibility !== 'all' ||
-      prefs.filters.templateSources.length > 0 ||
+      prefs.filters.templates.length > 0 ||
       prefs.onlyPinned);
 
   return (
     <Stack gap="md">
       <ProjectsToolbar
         prefs={prefs}
-        templateSourceOptions={templateSourceOptions}
+        templateOptions={templateOptions}
+        matchingCount={filtered.length}
+        showFilterChips={!showBanner}
         pinnedCount={pinnedCount}
         pinDisabled={createDisabled}
         setSearch={setSearch}
@@ -187,6 +271,17 @@ const ProjectsList: React.FC<ProjectsListProps> = ({
         setOnlyPinned={setOnlyPinned}
         clearFilters={clearFilters}
       />
+
+      {showBanner && (
+        <SharedViewBanner
+          scope={scopeChips}
+          shown={filtered.length}
+          total={projects.length}
+          noun="project"
+          crossLink={crossLink}
+          onClearAll={clearFilters}
+        />
+      )}
 
       {createDisabled && (
         <Paper p="xs" radius="md" withBorder>

--- a/depictio/viewer/src/projects/ProjectsList.tsx
+++ b/depictio/viewer/src/projects/ProjectsList.tsx
@@ -279,6 +279,7 @@ const ProjectsList: React.FC<ProjectsListProps> = ({
           total={projects.length}
           noun="project"
           crossLink={crossLink}
+          color={accent.secondary}
           onClearAll={clearFilters}
         />
       )}

--- a/depictio/viewer/src/projects/ProjectsToolbar.tsx
+++ b/depictio/viewer/src/projects/ProjectsToolbar.tsx
@@ -21,11 +21,20 @@ import type {
   ProjectTypeFilter,
   VisibilityFilter,
 } from './hooks/useProjectViewPrefs';
+import { emptyProjectFilters } from './hooks/useProjectViewPrefs';
 import { useBrandAccents } from 'depictio-react-core';
+import ShareViewButton from '../components/listing/ShareViewButton';
+
+export type FilterOption = { value: string; label: string };
 
 export interface ProjectsToolbarProps {
   prefs: ProjectViewPrefs;
-  templateSourceOptions: { value: string; label: string }[];
+  templateOptions: FilterOption[];
+  /** Rows currently on screen, for the share confirmation's wording. */
+  matchingCount: number;
+  /** False while the shared-view banner is up: it lists the same filters, and
+   *  two identical chip rows one above the other reads as a bug. */
+  showFilterChips?: boolean;
   pinnedCount: number;
   pinDisabled: boolean;
   setSearch: (s: string) => void;
@@ -47,13 +56,13 @@ const VISIBILITY_DATA = [
 
 const FilterPopover: React.FC<{
   prefs: ProjectViewPrefs;
-  templateSourceOptions: { value: string; label: string }[];
+  templateOptions: FilterOption[];
   setFilters: (f: ProjectFilters) => void;
-}> = ({ prefs, templateSourceOptions, setFilters }) => {
+}> = ({ prefs, templateOptions, setFilters }) => {
   const accent = useBrandAccents();
   const activeCount =
     prefs.filters.types.length +
-    prefs.filters.templateSources.length +
+    prefs.filters.templates.length +
     (prefs.filters.visibility !== 'all' ? 1 : 0);
 
   return (
@@ -89,13 +98,7 @@ const FilterPopover: React.FC<{
               <Button
                 variant="subtle"
                 size="compact-xs"
-                onClick={() =>
-                  setFilters({
-                    types: [],
-                    visibility: 'all',
-                    templateSources: [],
-                  })
-                }
+                onClick={() => setFilters(emptyProjectFilters())}
               >
                 Clear all
               </Button>
@@ -130,16 +133,17 @@ const FilterPopover: React.FC<{
           />
 
           <MultiSelect
-            label="Template source"
+            label="Template"
             placeholder={
-              templateSourceOptions.length === 0
+              templateOptions.length === 0
                 ? 'No templated projects loaded'
                 : 'Any template'
             }
-            data={templateSourceOptions}
-            value={prefs.filters.templateSources}
-            onChange={(v) => setFilters({ ...prefs.filters, templateSources: v })}
-            disabled={templateSourceOptions.length === 0}
+            description="Pick a source for every pipeline under it, or one pipeline on its own."
+            data={templateOptions}
+            value={prefs.filters.templates}
+            onChange={(v) => setFilters({ ...prefs.filters, templates: v })}
+            disabled={templateOptions.length === 0}
             searchable
             clearable
             comboboxProps={{ withinPortal: false }}
@@ -152,7 +156,9 @@ const FilterPopover: React.FC<{
 
 const ProjectsToolbar: React.FC<ProjectsToolbarProps> = ({
   prefs,
-  templateSourceOptions,
+  templateOptions,
+  matchingCount,
+  showFilterChips = true,
   pinnedCount,
   pinDisabled,
   setSearch,
@@ -174,15 +180,15 @@ const ProjectsToolbar: React.FC<ProjectsToolbarProps> = ({
         }),
     });
   }
-  for (const s of prefs.filters.templateSources) {
-    const opt = templateSourceOptions.find((o) => o.value === s);
+  for (const s of prefs.filters.templates) {
+    const opt = templateOptions.find((o) => o.value === s);
     activeFilterChips.push({
       key: `s:${s}`,
       label: opt?.label ?? s,
       onRemove: () =>
         setFilters({
           ...prefs.filters,
-          templateSources: prefs.filters.templateSources.filter((x) => x !== s),
+          templates: prefs.filters.templates.filter((x) => x !== s),
         }),
     });
   }
@@ -257,12 +263,20 @@ const ProjectsToolbar: React.FC<ProjectsToolbarProps> = ({
 
         <FilterPopover
           prefs={prefs}
-          templateSourceOptions={templateSourceOptions}
+          templateOptions={templateOptions}
           setFilters={setFilters}
+        />
+
+        <ShareViewButton
+          describes={
+            hasAnyActive
+              ? `this filtered view (${matchingCount} project${matchingCount === 1 ? '' : 's'})`
+              : 'the full project list'
+          }
         />
       </Group>
 
-      {activeFilterChips.length > 0 && (
+      {showFilterChips && activeFilterChips.length > 0 && (
         <Group gap="xs" wrap="wrap" align="center">
           {activeFilterChips.map((chip) => (
             <Badge

--- a/depictio/viewer/src/projects/hooks/useProjectViewPrefs.ts
+++ b/depictio/viewer/src/projects/hooks/useProjectViewPrefs.ts
@@ -1,15 +1,29 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { asEnum, asList, asScalar } from 'depictio-react-core';
+
+import {
+  arrivedWithParams,
+  readListingParams,
+  replaceListingParams,
+} from '../../lib/listingUrl';
+
 export type ProjectTypeFilter = 'basic' | 'advanced';
 /** Row height for the projects table. Mirrors the dashboards table's setting
  *  so both listings offer the same compact/cozy choice. */
 export type Density = 'compact' | 'cozy';
 export type VisibilityFilter = 'all' | 'public' | 'private';
 
+const PROJECT_TYPES: readonly ProjectTypeFilter[] = ['basic', 'advanced'];
+const VISIBILITIES: readonly VisibilityFilter[] = ['all', 'public', 'private'];
+
 export interface ProjectFilters {
   types: ProjectTypeFilter[];
   visibility: VisibilityFilter;
-  templateSources: string[];
+  /** Pipeline templates, as `source` (`nf-core`) or `source/repo`
+   *  (`nf-core/rnaseq`). Superseded the source-only `templateSources`, which
+   *  could not tell one pipeline from another. */
+  templates: string[];
 }
 
 export interface ProjectViewPrefs {
@@ -21,9 +35,28 @@ export interface ProjectViewPrefs {
 
 const STORAGE_KEY = 'depictio.projects.viewPrefs.v1';
 
+/** No filter at all. A factory rather than a constant: the toolbar's "Clear
+ *  all" and `clearFilters` both need one, and a shared object would hand them
+ *  the same arrays to hold. */
+export const emptyProjectFilters = (): ProjectFilters => ({
+  types: [],
+  visibility: 'all',
+  templates: [],
+});
+
+/** URL params that narrow what is listed, as opposed to how it is laid out.
+ *  Arriving with one of these is what makes a page load a "shared view". */
+export const PROJECT_SCOPE_PARAMS = [
+  'q',
+  'template',
+  'type',
+  'visibility',
+  'pinned',
+] as const;
+
 const DEFAULT_PREFS: ProjectViewPrefs = {
   search: '',
-  filters: { types: [], visibility: 'all', templateSources: [] },
+  filters: emptyProjectFilters(),
   onlyPinned: false,
   density: 'cozy',
 };
@@ -33,18 +66,58 @@ function loadPrefs(): ProjectViewPrefs {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_PREFS;
     const parsed = JSON.parse(raw);
-    return {
-      ...DEFAULT_PREFS,
-      ...parsed,
-      filters: { ...DEFAULT_PREFS.filters, ...(parsed?.filters ?? {}) },
-    };
+    const filters = { ...emptyProjectFilters(), ...(parsed?.filters ?? {}) };
+    // Carry a preference saved before the filter learned about pipelines: the
+    // old field held bare sources, which are still valid values.
+    if (filters.templates.length === 0 && Array.isArray(parsed?.filters?.templateSources)) {
+      filters.templates = parsed.filters.templateSources;
+    }
+    delete (filters as { templateSources?: unknown }).templateSources;
+    return { ...DEFAULT_PREFS, ...parsed, filters };
   } catch {
     return DEFAULT_PREFS;
   }
 }
 
+/** Overlay whatever the URL asked for onto the stored preferences. A link
+ *  that names any filter replaces the stored filters wholesale, so a scoped
+ *  link never inherits the recipient's leftovers and shows them an empty
+ *  page; a bare `/projects` leaves their own view untouched. */
+function applyUrlParams(base: ProjectViewPrefs): ProjectViewPrefs {
+  const params = readListingParams();
+  const scoped = PROJECT_SCOPE_PARAMS.some((key) => (params[key]?.length ?? 0) > 0);
+  if (!scoped) return base;
+
+  const types = asList(params.type).filter((t): t is ProjectTypeFilter =>
+    (PROJECT_TYPES as readonly string[]).includes(t),
+  );
+  return {
+    ...base,
+    search: asScalar(params.q) ?? '',
+    onlyPinned: asScalar(params.pinned) === '1',
+    filters: {
+      types,
+      visibility: asEnum(params.visibility, VISIBILITIES) ?? 'all',
+      templates: asList(params.template),
+    },
+  };
+}
+
+/** The query string that reproduces these preferences. */
+function toUrlParams(prefs: ProjectViewPrefs) {
+  return {
+    q: prefs.search.trim(),
+    template: prefs.filters.templates,
+    type: prefs.filters.types,
+    visibility: prefs.filters.visibility === 'all' ? '' : prefs.filters.visibility,
+    pinned: prefs.onlyPinned,
+  };
+}
+
 export interface UseProjectViewPrefsResult {
   prefs: ProjectViewPrefs;
+  /** True when the page was opened on a link that already carried a filter. */
+  arrivedScoped: boolean;
   setSearch: (s: string) => void;
   setFilters: (f: ProjectFilters) => void;
   setOnlyPinned: (b: boolean) => void;
@@ -53,7 +126,10 @@ export interface UseProjectViewPrefsResult {
 }
 
 export function useProjectViewPrefs(): UseProjectViewPrefsResult {
-  const [prefs, setPrefs] = useState<ProjectViewPrefs>(loadPrefs);
+  const [prefs, setPrefs] = useState<ProjectViewPrefs>(() =>
+    applyUrlParams(loadPrefs()),
+  );
+  const [arrivedScoped] = useState(() => arrivedWithParams(PROJECT_SCOPE_PARAMS));
 
   useEffect(() => {
     try {
@@ -61,6 +137,9 @@ export function useProjectViewPrefs(): UseProjectViewPrefsResult {
     } catch {
       /* quota or private mode — silently ignore */
     }
+    // Keep the address bar showing the view on screen, so copying it out of
+    // the browser is always equivalent to pressing the share button.
+    replaceListingParams(toUrlParams(prefs));
   }, [prefs]);
 
   const setSearch = useCallback(
@@ -85,10 +164,18 @@ export function useProjectViewPrefs(): UseProjectViewPrefsResult {
         ...p,
         search: '',
         onlyPinned: false,
-        filters: { types: [], visibility: 'all', templateSources: [] },
+        filters: emptyProjectFilters(),
       })),
     [],
   );
 
-  return { prefs, setSearch, setFilters, setOnlyPinned, setDensity, clearFilters };
+  return {
+    prefs,
+    arrivedScoped,
+    setSearch,
+    setFilters,
+    setOnlyPinned,
+    setDensity,
+    clearFilters,
+  };
 }

--- a/depictio/viewer/src/projects/template.tsx
+++ b/depictio/viewer/src/projects/template.tsx
@@ -1,52 +1,21 @@
 import React from 'react';
 import { Anchor, Avatar, Badge, Box, Group, Stack, Text, Tooltip } from '@mantine/core';
 
-import type { ProjectListEntry } from 'depictio-react-core';
+import type { ParsedTemplate, ProjectListEntry } from 'depictio-react-core';
+import { parseTemplateOrigin } from 'depictio-react-core';
 
-export interface ParsedTemplate {
-  /** Original full identifier, e.g. `nf-core/viralrecon/3.0.0` */
-  full: string;
-  /** First slash-separated segment, e.g. `nf-core` */
-  source: string;
-  /** Middle segment if present, e.g. `viralrecon` */
-  repo: string;
-  /** Trailing segment if it looks like a semver, otherwise empty */
-  version: string;
-}
+/** Template identifiers are parsed and matched in `depictio-react-core`
+ *  (`templateFilter.ts`), where both listings' filters can share the rules and
+ *  a unit test can hold them still. Re-exported here so the components that
+ *  already reach for this module keep their import path. */
+export type { ParsedTemplate };
+export { parseTemplateOrigin };
 
-/** Parse `template_origin.template_id` (e.g. `nf-core/viralrecon/3.0.0`) into
- *  source/repo/version. Backwards-compatible with `template_origin` passed as
- *  a plain string and with shorter ids that omit the version segment. Returns
- *  null when the project wasn't created from a template. */
+/** Parse a project's `template_origin` (e.g. `nf-core/viralrecon/3.0.0`) into
+ *  source/repo/version. Returns null when the project wasn't created from a
+ *  template. */
 export function parseTemplate(project: ProjectListEntry): ParsedTemplate | null {
   return parseTemplateOrigin(project.template_origin);
-}
-
-/** Same as `parseTemplate` but accepts the raw `template_origin` value
- *  directly — for callers that already have it on hand (dashboard list
- *  cards, settings drawer) and don't want to fabricate a fake
- *  `ProjectListEntry` to call it. */
-export function parseTemplateOrigin(origin: unknown): ParsedTemplate | null {
-  let raw: string | null = null;
-  if (typeof origin === 'string') {
-    raw = origin.trim();
-  } else if (
-    origin &&
-    typeof origin === 'object' &&
-    typeof (origin as { template_id?: unknown }).template_id === 'string'
-  ) {
-    raw = ((origin as { template_id: string }).template_id || '').trim();
-  }
-  if (!raw) return null;
-  const parts = raw.split('/').map((s) => s.trim()).filter(Boolean);
-  const looksVersion = (s: string) => /^v?\d/.test(s);
-  let version = '';
-  if (parts.length >= 2 && looksVersion(parts[parts.length - 1])) {
-    version = parts.pop() || '';
-  }
-  const source = parts[0] || raw;
-  const repo = parts[1] || '';
-  return { full: raw, source, repo, version };
 }
 
 /** Build the depictio-docs page URL for a parsed template. Pattern:

--- a/docs/shareable-listing-links.md
+++ b/docs/shareable-listing-links.md
@@ -1,0 +1,109 @@
+# Sharing a filtered listing
+
+`/dashboards` and `/projects` keep their filters in the URL. Whatever the page
+is showing, the address bar is a link that reproduces it, so a view narrowed to
+one pipeline can be handed to someone else and land on their screen already
+narrowed.
+
+The link icon in either toolbar copies that URL and tells you what the
+recipient will see. The parameters are stable and readable, so they can also be
+written by hand.
+
+## What a recipient sees
+
+Opening a link that carries a filter puts a banner above the listing naming the
+scope, how many rows survived it, and how many the link is hiding, with a
+**Show everything** button that drops the filter. The scope is a starting
+point, not a wall: nothing is hidden from someone who wants to widen it.
+
+A link that names any filter replaces the recipient's own stored filters rather
+than combining with them. Otherwise a leftover "owner: me" in their browser
+would silently subtract from the set you sent, and they would see less than you
+meant without knowing why. Layout preferences they did not ask you to override
+(view mode, grouping, sort order) survive.
+
+## Parameters
+
+Every list accepts repeats (`?owner=a&owner=b`) or one comma-joined value
+(`?owner=a,b`). Values are matched case-insensitively.
+
+### `/dashboards`
+
+| Parameter | Value |
+| --- | --- |
+| `template` | Pipeline template, see below |
+| `project` | Project id, or the project's exact name |
+| `owner` | Owner email, or `__mine__` |
+| `workflow` | Workflow system, as tagged on the dashboard |
+| `visibility` | `public` or `private` |
+| `q` | Free-text search over title, subtitle, project, owner, template |
+| `pinned` | `1` for favorites only |
+| `view` | `thumbnails`, `list` or `table` |
+| `group` | `none`, `project`, `owner`, `visibility` or `workflow` |
+| `sort` | `recent`, `name` or `owner` |
+
+### `/projects`
+
+| Parameter | Value |
+| --- | --- |
+| `template` | Pipeline template, see below |
+| `type` | `basic` or `advanced` |
+| `visibility` | `public` or `private` |
+| `q` | Free-text search over name, owner and template |
+| `pinned` | `1` for favorites only |
+
+`view`, `group` and `sort` only change the layout, so a link carrying nothing
+else shows the full listing and no banner.
+
+## Template scoping
+
+A project instantiated from a pipeline template carries an identifier like
+`nf-core/rnaseq/3.26.0`. Dashboards inherit it from the project that owns them,
+which is what lets one link cover both listings.
+
+The filter is version-agnostic, on both sides. `nf-core/rnaseq` matches
+3.26.0 and every version that follows it. Pinning the version into the link
+would silently drop next quarter's project.
+
+| Link | Scope |
+| --- | --- |
+| `?template=nf-core` | Every nf-core pipeline |
+| `?template=nf-core/rnaseq` | rnaseq only, at any version |
+| `?template=rnaseq` | Any source's rnaseq, for links written by hand |
+| `?template=nf-core/rnaseq,nf-core/viralrecon` | Either pipeline |
+
+When a template scope is active, the banner also links across to the same scope
+on the other listing, so "show me this pipeline" reaches both the projects and
+their dashboards in two clicks.
+
+## Examples
+
+Every dashboard built from rnaseq, as a table:
+
+```
+/dashboards?template=nf-core/rnaseq&view=table
+```
+
+Two pipelines up for review, grouped by project:
+
+```
+/dashboards?template=nf-core/rnaseq,nf-core/viralrecon&group=project
+```
+
+The projects behind them:
+
+```
+/projects?template=nf-core/rnaseq,nf-core/viralrecon
+```
+
+Everything public one person owns:
+
+```
+/dashboards?owner=reviewer@example.org&visibility=public
+```
+
+## Access is unchanged
+
+A link narrows what is listed. It grants nothing: the recipient still sees only
+the dashboards and projects their own account can reach, so a scoped link sent
+to someone without access shows them an empty listing rather than your rows.

--- a/docs/shareable-listing-links.md
+++ b/docs/shareable-listing-links.md
@@ -27,6 +27,10 @@ meant without knowing why. Layout preferences they did not ask you to override
 Every list accepts repeats (`?owner=a&owner=b`) or one comma-joined value
 (`?owner=a,b`). Values are matched case-insensitively.
 
+Because a comma separates values, a project whose *name* contains one has to be
+addressed by its id. The link button always emits ids, so this only comes up in
+a link written by hand.
+
 ### `/dashboards`
 
 | Parameter | Value |

--- a/packages/depictio-react-core/src/index.ts
+++ b/packages/depictio-react-core/src/index.ts
@@ -631,3 +631,20 @@ export { COMPONENT_TYPE_VISUALS, componentTypeVisual } from './componentTypeMeta
 export type { ComponentTypeVisual } from './componentTypeMeta';
 export { brandColors } from './brandColors';
 export { catalogToolUrl } from './catalogLinks';
+
+// Shareable listing views: the /dashboards and /projects pages encode their
+// filters into the URL, and both narrow on the template a project came from.
+export {
+  matchesTemplateFilter,
+  parseTemplateOrigin,
+  templateFilterValues,
+} from './templateFilter';
+export type { ParsedTemplate } from './templateFilter';
+export {
+  asEnum,
+  asList,
+  asScalar,
+  decodeListingParams,
+  encodeListingParams,
+} from './listingUrlState';
+export type { ListingParams } from './listingUrlState';

--- a/packages/depictio-react-core/src/listingUrlState.test.ts
+++ b/packages/depictio-react-core/src/listingUrlState.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  asEnum,
+  asList,
+  asScalar,
+  decodeListingParams,
+  encodeListingParams,
+} from './listingUrlState';
+
+describe('decodeListingParams', () => {
+  it('collects repeated params into one entry', () => {
+    expect(decodeListingParams('?owner=a&owner=b')).toEqual({ owner: ['a', 'b'] });
+  });
+
+  it('tolerates the leading question mark being absent', () => {
+    expect(decodeListingParams('template=rnaseq')).toEqual({ template: ['rnaseq'] });
+  });
+
+  it('returns an empty map for an empty query string', () => {
+    expect(decodeListingParams('')).toEqual({});
+    expect(decodeListingParams('?')).toEqual({});
+  });
+
+  it('decodes percent-escaped values', () => {
+    expect(decodeListingParams('?template=nf-core%2Frnaseq')).toEqual({
+      template: ['nf-core/rnaseq'],
+    });
+  });
+});
+
+describe('asList', () => {
+  it('reads repeats and comma-joined values the same way', () => {
+    expect(asList(['a', 'b'])).toEqual(['a', 'b']);
+    expect(asList(['a,b'])).toEqual(['a', 'b']);
+  });
+
+  it('drops blanks and collapses duplicates', () => {
+    expect(asList([',a, ,a,b '])).toEqual(['a', 'b']);
+  });
+
+  it('reads a missing param as no filter', () => {
+    expect(asList(undefined)).toEqual([]);
+  });
+});
+
+describe('asScalar', () => {
+  it('takes the value verbatim, commas included', () => {
+    expect(asScalar(['rnaseq, salmon'])).toBe('rnaseq, salmon');
+  });
+
+  it('keeps the first occurrence and ignores blanks', () => {
+    expect(asScalar(['first', 'second'])).toBe('first');
+    expect(asScalar(['   '])).toBeUndefined();
+    expect(asScalar(undefined)).toBeUndefined();
+  });
+});
+
+describe('asEnum', () => {
+  const VIEWS = ['thumbnails', 'list', 'table'] as const;
+
+  it('accepts a known value', () => {
+    expect(asEnum(['table'], VIEWS)).toBe('table');
+  });
+
+  it('falls through on anything else, so the stored preference wins', () => {
+    expect(asEnum(['grid'], VIEWS)).toBeUndefined();
+    expect(asEnum(undefined, VIEWS)).toBeUndefined();
+  });
+});
+
+describe('encodeListingParams', () => {
+  it('joins lists with commas and preserves key order', () => {
+    expect(
+      encodeListingParams({ template: ['nf-core/rnaseq'], owner: ['a', 'b'] }),
+    ).toBe('template=nf-core%2Frnaseq&owner=a%2Cb');
+  });
+
+  it('omits everything empty so a cleared filter leaves no trace', () => {
+    expect(
+      encodeListingParams({
+        template: [],
+        q: '',
+        owner: null,
+        view: undefined,
+        pinned: false,
+      }),
+    ).toBe('');
+  });
+
+  it('writes a true flag as 1', () => {
+    expect(encodeListingParams({ pinned: true })).toBe('pinned=1');
+  });
+
+  it('round-trips through decode', () => {
+    const encoded = encodeListingParams({ template: ['a', 'b'], q: 'x, y' });
+    const decoded = decodeListingParams(`?${encoded}`);
+    expect(asList(decoded.template)).toEqual(['a', 'b']);
+    expect(asScalar(decoded.q)).toBe('x, y');
+  });
+});

--- a/packages/depictio-react-core/src/listingUrlState.ts
+++ b/packages/depictio-react-core/src/listingUrlState.ts
@@ -1,0 +1,94 @@
+/**
+ * The query-string half of a shareable listing view.
+ *
+ * `/dashboards` and `/projects` keep their filter state in the URL so a view
+ * can be pasted to someone else — "here is every dashboard built from
+ * nf-core/rnaseq" — and land on their screen already narrowed. This module is
+ * only the codec; reading and writing `window.location` lives in the viewer
+ * (`src/lib/listingUrl.ts`), which is what keeps this testable.
+ */
+
+/** Raw params, exactly as the query string spelled them: one entry per
+ *  occurrence, unsplit. `asList` / `asScalar` interpret them. */
+export type ListingParams = Record<string, string[]>;
+
+/** Split a query string into its raw repeated values. Never throws — a
+ *  malformed fragment yields an empty map rather than breaking a page load. */
+export function decodeListingParams(search: string): ListingParams {
+  const out: ListingParams = {};
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  } catch {
+    return out;
+  }
+  for (const [key, value] of params.entries()) {
+    (out[key] ??= []).push(value);
+  }
+  return out;
+}
+
+/** A multi-value filter. Both spellings mean the same thing — `?owner=a&owner=b`
+ *  and `?owner=a,b` — because people hand-write these links and both are
+ *  natural. Blanks are dropped and duplicates collapse, so `?template=,rnaseq,`
+ *  is just `['rnaseq']`. */
+export function asList(values: string[] | undefined): string[] {
+  if (!values) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of values) {
+    for (const part of raw.split(',')) {
+      const value = part.trim();
+      if (!value || seen.has(value)) continue;
+      seen.add(value);
+      out.push(value);
+    }
+  }
+  return out;
+}
+
+/** A single-value param — free text, or a one-of setting like `view=table`.
+ *  Taken verbatim (no comma splitting) so a search for "rnaseq, salmon"
+ *  survives the round trip. Later occurrences lose to the first. */
+export function asScalar(values: string[] | undefined): string | undefined {
+  const first = values?.[0]?.trim();
+  return first || undefined;
+}
+
+/** One of a fixed set of values, or undefined when the URL said something
+ *  this build doesn't know — an unrecognised `view=grid` should fall back to
+ *  the stored preference, not blank the page. */
+export function asEnum<T extends string>(
+  values: string[] | undefined,
+  allowed: readonly T[],
+): T | undefined {
+  const value = asScalar(values);
+  return value != null && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : undefined;
+}
+
+/** Serialize back to a query string, without the leading `?`.
+ *
+ *  Empty values are omitted entirely, so clearing a filter leaves no trace in
+ *  the address bar, and key order follows the object's own order so the same
+ *  view always produces a byte-identical link. */
+export function encodeListingParams(
+  params: Record<string, string[] | string | boolean | null | undefined>,
+): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value == null || value === false || value === '') continue;
+    if (value === true) {
+      search.set(key, '1');
+      continue;
+    }
+    if (Array.isArray(value)) {
+      const joined = value.map((v) => v.trim()).filter(Boolean).join(',');
+      if (joined) search.set(key, joined);
+      continue;
+    }
+    search.set(key, value);
+  }
+  return search.toString();
+}

--- a/packages/depictio-react-core/src/templateFilter.test.ts
+++ b/packages/depictio-react-core/src/templateFilter.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  matchesTemplateFilter,
+  parseTemplateOrigin,
+  templateFilterValues,
+} from './templateFilter';
+
+const RNASEQ = { template_id: 'nf-core/rnaseq/3.26.0' };
+const VIRALRECON = { template_id: 'nf-core/viralrecon/3.0.0' };
+const GALAXY = { template_id: 'galaxy/rnaseq' };
+
+describe('parseTemplateOrigin', () => {
+  it('splits a full id into source, repo and version', () => {
+    expect(parseTemplateOrigin(RNASEQ)).toEqual({
+      full: 'nf-core/rnaseq/3.26.0',
+      source: 'nf-core',
+      repo: 'rnaseq',
+      version: '3.26.0',
+    });
+  });
+
+  it('accepts the id as a plain string', () => {
+    expect(parseTemplateOrigin('nf-core/rnaseq/3.26.0')?.repo).toBe('rnaseq');
+  });
+
+  it('leaves version empty when the id omits it', () => {
+    expect(parseTemplateOrigin('nf-core/rnaseq')).toEqual({
+      full: 'nf-core/rnaseq',
+      source: 'nf-core',
+      repo: 'rnaseq',
+      version: '',
+    });
+  });
+
+  it('keeps a leading-v version out of the repo slot', () => {
+    expect(parseTemplateOrigin('nf-core/rnaseq/v3.26.0')?.version).toBe('v3.26.0');
+  });
+
+  it('returns null for a project that came from no template', () => {
+    expect(parseTemplateOrigin(null)).toBeNull();
+    expect(parseTemplateOrigin(undefined)).toBeNull();
+    expect(parseTemplateOrigin('')).toBeNull();
+    expect(parseTemplateOrigin('   ')).toBeNull();
+    expect(parseTemplateOrigin({})).toBeNull();
+  });
+});
+
+describe('templateFilterValues', () => {
+  it('offers the source and the source/repo pair, never the version', () => {
+    expect(templateFilterValues(parseTemplateOrigin(RNASEQ)!)).toEqual([
+      'nf-core',
+      'nf-core/rnaseq',
+    ]);
+  });
+
+  it('offers only the source when the id names no pipeline', () => {
+    expect(templateFilterValues(parseTemplateOrigin('depictio')!)).toEqual(['depictio']);
+  });
+});
+
+describe('matchesTemplateFilter', () => {
+  it('matches everything when nothing is selected', () => {
+    expect(matchesTemplateFilter(RNASEQ, [])).toBe(true);
+    expect(matchesTemplateFilter(null, [])).toBe(true);
+  });
+
+  it('scopes to a whole source', () => {
+    expect(matchesTemplateFilter(RNASEQ, ['nf-core'])).toBe(true);
+    expect(matchesTemplateFilter(VIRALRECON, ['nf-core'])).toBe(true);
+    expect(matchesTemplateFilter(GALAXY, ['nf-core'])).toBe(false);
+  });
+
+  it('scopes to one pipeline without catching its siblings', () => {
+    expect(matchesTemplateFilter(RNASEQ, ['nf-core/rnaseq'])).toBe(true);
+    expect(matchesTemplateFilter(VIRALRECON, ['nf-core/rnaseq'])).toBe(false);
+  });
+
+  it('ignores the version on both sides', () => {
+    expect(matchesTemplateFilter(RNASEQ, ['nf-core/rnaseq/1.0.0'])).toBe(true);
+    expect(matchesTemplateFilter('nf-core/rnaseq', ['nf-core/rnaseq/3.26.0'])).toBe(true);
+  });
+
+  it('accepts a hand-written bare pipeline name', () => {
+    expect(matchesTemplateFilter(RNASEQ, ['rnaseq'])).toBe(true);
+    expect(matchesTemplateFilter(VIRALRECON, ['rnaseq'])).toBe(false);
+    // A bare name is source-agnostic on purpose: it is what someone types.
+    expect(matchesTemplateFilter(GALAXY, ['rnaseq'])).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(matchesTemplateFilter(RNASEQ, ['NF-Core/RNAseq'])).toBe(true);
+  });
+
+  it('unions the selected values', () => {
+    const selected = ['nf-core/rnaseq', 'nf-core/viralrecon'];
+    expect(matchesTemplateFilter(RNASEQ, selected)).toBe(true);
+    expect(matchesTemplateFilter(VIRALRECON, selected)).toBe(true);
+    expect(matchesTemplateFilter(GALAXY, selected)).toBe(false);
+  });
+
+  it('excludes projects with no template once a selection exists', () => {
+    expect(matchesTemplateFilter(null, ['nf-core'])).toBe(false);
+    expect(matchesTemplateFilter({}, ['nf-core'])).toBe(false);
+  });
+});

--- a/packages/depictio-react-core/src/templateFilter.ts
+++ b/packages/depictio-react-core/src/templateFilter.ts
@@ -1,0 +1,98 @@
+/**
+ * Template identifiers, parsed and matched.
+ *
+ * A project instantiated from a pipeline template carries a `template_origin`
+ * stamped by the CLI (`depictio/cli/cli/utils/templates.py`) whose
+ * `template_id` looks like `nf-core/rnaseq/3.26.0`. Both listings — projects
+ * directly, dashboards through their owning project — filter on it, and the
+ * rules are subtle enough (version-agnostic matching, ids that omit segments)
+ * to be worth keeping in one tested place.
+ */
+
+export interface ParsedTemplate {
+  /** Original full identifier, e.g. `nf-core/viralrecon/3.0.0` */
+  full: string;
+  /** First slash-separated segment, e.g. `nf-core` */
+  source: string;
+  /** Middle segment if present, e.g. `viralrecon` */
+  repo: string;
+  /** Trailing segment if it looks like a semver, otherwise empty */
+  version: string;
+}
+
+/** Parse a raw `template_origin` into source/repo/version. Accepts the
+ *  object the API serves (`{template_id, template_version, ...}`) and a plain
+ *  string, and tolerates ids that omit the version segment. Returns null when
+ *  the project wasn't created from a template. */
+export function parseTemplateOrigin(origin: unknown): ParsedTemplate | null {
+  let raw: string | null = null;
+  if (typeof origin === 'string') {
+    raw = origin.trim();
+  } else if (
+    origin &&
+    typeof origin === 'object' &&
+    typeof (origin as { template_id?: unknown }).template_id === 'string'
+  ) {
+    raw = ((origin as { template_id: string }).template_id || '').trim();
+  }
+  if (!raw) return null;
+  const parts = raw.split('/').map((s) => s.trim()).filter(Boolean);
+  const looksVersion = (s: string) => /^v?\d/.test(s);
+  let version = '';
+  if (parts.length >= 2 && looksVersion(parts[parts.length - 1])) {
+    version = parts.pop() || '';
+  }
+  const source = parts[0] || raw;
+  const repo = parts[1] || '';
+  return { full: raw, source, repo, version };
+}
+
+/** The canonical filter values a template offers: its source (`nf-core`)
+ *  and, when the id names one, its pipeline (`nf-core/rnaseq`). These are the
+ *  values a listing puts in its Template dropdown and writes into the URL.
+ *
+ *  The version is deliberately absent. Someone sharing "every rnaseq
+ *  dashboard" means every version of rnaseq — pinning 3.26.0 into the link
+ *  would silently drop the 3.27.0 project the day it lands. */
+export function templateFilterValues(parsed: ParsedTemplate): string[] {
+  const values = [parsed.source];
+  if (parsed.repo) values.push(`${parsed.source}/${parsed.repo}`);
+  return values;
+}
+
+/** Every spelling a template answers to when a filter value is matched
+ *  against it: the canonical values above plus the bare pipeline name, so a
+ *  hand-written `?template=rnaseq` works as well as the full id the Share
+ *  button emits. */
+function templateMatchKeys(parsed: ParsedTemplate): string[] {
+  const keys = templateFilterValues(parsed);
+  if (parsed.repo) keys.push(parsed.repo);
+  return keys.map((k) => k.toLowerCase());
+}
+
+/** The one key a selected filter value stands for — its most specific
+ *  segment. `nf-core` scopes to the whole source; `nf-core/rnaseq` (and
+ *  `nf-core/rnaseq/3.26.0`, whose version is dropped on the way in) scopes to
+ *  that pipeline alone. */
+function selectionKey(selected: string): string | null {
+  const parsed = parseTemplateOrigin(selected);
+  if (!parsed) return null;
+  const values = templateFilterValues(parsed);
+  return values[values.length - 1].toLowerCase();
+}
+
+/** Does this template origin match any of the selected filter values?
+ *
+ *  Matching is case-insensitive and version-agnostic. An empty selection
+ *  matches everything — "no filter", not "nothing" — while an origin that
+ *  isn't from a template matches nothing once a selection exists. */
+export function matchesTemplateFilter(origin: unknown, selected: string[]): boolean {
+  if (selected.length === 0) return true;
+  const parsed = parseTemplateOrigin(origin);
+  if (!parsed) return false;
+  const keys = new Set(templateMatchKeys(parsed));
+  return selected.some((raw) => {
+    const key = selectionKey(raw);
+    return key != null && keys.has(key);
+  });
+}


### PR DESCRIPTION
## Why

Both listings kept their filters in `localStorage` and nowhere else, so there was no way to hand someone *"the dashboards built from rnaseq"* short of telling them which boxes to tick. Sharing a scoped view with reviewers meant sharing the whole catalogue and hoping they found the right rows.

## What

`/dashboards` and `/projects` now read their filters out of the query string on load and write them back on every change, so the address bar is always the shareable link. A link button in each toolbar copies it and says what the recipient will see.

```
/dashboards?template=nf-core/rnaseq          one pipeline, any version
/dashboards?template=nf-core                 every nf-core pipeline
/projects?template=nf-core/rnaseq,nf-core/viralrecon
/dashboards?project=<id or exact name>&view=table
```

**Filtering by pipeline template is new.** A project stamps its origin as `nf-core/rnaseq/3.26.0`, and dashboards inherit it through the project that owns them, so one scope covers both listings. Matching is version-agnostic on purpose: a link pinned to 3.26.0 would silently drop the 3.27.0 project the day it lands. `/dashboards` also gains a workflow-system filter, and `/projects` widens its source-only template filter (`nf-core`) to name a pipeline (`nf-core/rnaseq`).

Arriving on a scoped link raises a banner naming the scope, how many rows survived it and how many it is hiding, with a **Show everything** escape and a hop to the same scope on the other listing. The scope is a starting point, not a wall.

One deliberate asymmetry: a link that names any filter **replaces** the recipient's stored filters rather than combining with them, so their leftover "owner: me" cannot silently subtract from the set that was sent. Layout preferences they were not asked to override (view mode, grouping, sort) survive.

The full parameter contract is in `docs/shareable-listing-links.md`.

## Access is unchanged

A link narrows what is listed; it grants nothing. The filter runs client-side over rows the API already scoped to the caller, so a link sent to someone without access shows them an empty listing rather than your rows.

## Verification

Driven against a seeded instance with 85 dashboards across 14 projects, 11 of them from nf-core templates:

| Link | Result |
| --- | --- |
| `?template=nf-core/rnaseq` | 1 of 14, banner + cross-link |
| `?template=nf-core` | 11 of 14, the three non-templated projects hidden |
| `?template=rnaseq` (hand-written) | matched, version and source agnostic |
| `?project=RNA-seq%20Expression%20Analysis` | name resolved to its id, then scoped |
| `?type=basic&visibility=public` | both chips, combined |
| Editing filters in the toolbar | written straight back to the address bar |
| Show everything | filters and query string both cleared |

Light and dark both check out.

- 30 new unit tests in `depictio-react-core` (template matching, URL codec round-trips); the package's 87 tests pass.
- A Playwright spec covering the scope banner, the clear path, live URL sync, and the cross-listing hop. Its template assertions skip themselves on stacks that seed no templated project.
- `tsc --noEmit` clean; `pre-commit run --all-files` clean apart from the pre-existing shellcheck failures on untouched files.

## Notes for review

- Template parsing moves out of the viewer into `depictio-react-core` alongside the matching rules and the URL codec, where both listings share them and unit tests can hold them still. `projects/template.tsx` re-exports it, so no call site changed.
- URL writes go through `replaceState`, never `pushState`: narrowing a filter is not a navigation, and a history entry per keystroke would bury the page the visitor arrived from.
- The saved `templateSources` preference migrates into the new `templates` field; bare sources are still valid values.
- Follow-up: the user-facing page in `depictio-docs` is not updated yet.

## Screenshots

`/dashboards?template=nf-core`, every templated pipeline, three non-templated projects hidden:

<img width="1568" height="741" alt="shared-view-dashboards" src="https://github.com/user-attachments/assets/2a118d59-a838-4acb-8f84-0abaaa62bbef" />

`/projects?template=nf-core`, the same scope, one click away via the banner:

<img width="1481" height="812" alt="shared-view-projects" src="https://github.com/user-attachments/assets/4833ddb7-ab29-4205-9ebd-ed51e97e220a" />
